### PR TITLE
Config / Enable Arbitrum network

### DIFF
--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -96,15 +96,15 @@ const networks: NetworkType[] = [
     explorerUrl: 'https://moonriver.moonscan.io/',
     unstoppableDomainsChain: 'ERC20'
   },
-  // {
-  // 	id: NETWORKS.arbitrum,
-  // 	chainId: 42161,
-  // 	rpc: 'https://arb1.arbitrum.io/rpc',
-  // 	nativeAssetSymbol: 'AETH',
-  // 	name: 'Arbitrum',
-  // 	explorerUrl: 'https://arbiscan.io',
-  // 	unstoppableDomainsChain: 'ERC20'
-  // },
+  {
+    id: NETWORKS.arbitrum,
+    chainId: 42161,
+    rpc: 'https://arb1.arbitrum.io/rpc',
+    nativeAssetSymbol: 'AETH',
+    name: 'Arbitrum',
+    explorerUrl: 'https://arbiscan.io',
+    unstoppableDomainsChain: 'ERC20'
+  },
   {
     id: NETWORKS.gnosis,
     chainId: 100,


### PR DESCRIPTION
It was disabled before for whatever reason. Now it's back live on the web. So sync up the logic in here too.