### PR TITLE
Bug / Converting to Buffer when `generateAddress2` gets executed

### DIFF
--- a/src/services/humanizers/AmbireFactory.ts
+++ b/src/services/humanizers/AmbireFactory.ts
@@ -11,7 +11,12 @@ const FactoryMapping = {
   [iface.getSighash('deploy')]: (txn, network) => {
     const [code, salt] = iface.parseTransaction(txn).args
     const addr = getAddress(
-      `0x${generateAddress2(txn.to, hexConcat([salt]), code).toString('hex')}`
+      `0x${generateAddress2(
+        // Converting to buffer is required in ethereumjs-util version: 7.1.3
+        Buffer.from(txn.to.slice(2), 'hex'),
+        Buffer.from(hexConcat([salt]).slice(2), 'hex'),
+        Buffer.from(code.slice(2), 'hex')
+      ).toString('hex')}`
     )
     return [`Deploy contract with address ${addr}`]
   }


### PR DESCRIPTION
Converting to Buffer is required in `ethereumjs-util` version 7.1.3. It was migrated on the other places, but this one was left behind 🤞 