### PR TITLE
Bug / Error toast with `undefined` when fetching tokens

### DIFF
--- a/src/hooks/usePortfolio/usePortfolio.ts
+++ b/src/hooks/usePortfolio/usePortfolio.ts
@@ -178,7 +178,7 @@ export default function usePortfolio({
 
   const fetchTokens = useCallback(
     // eslint-disable-next-line default-param-last
-    async (account, currentNetwork = false, showLoadingState, tokensByNetworks) => {
+    async (account, currentNetwork = false, showLoadingState, tokensByNetworks = []) => {
       // Prevent race conditions
       if (currentAccount.current !== account) return
 


### PR DESCRIPTION
Fixes the annoying error toast appearing after 5-10 min of app inactivity. Caused by a missing default in a corner case with the `usePortfolio` hook.