### PR TITLE
Config / Option to pass a (TypeScript) type for the useStorage hook value

### DIFF
--- a/src/hooks/useStorage/types.ts
+++ b/src/hooks/useStorage/types.ts
@@ -4,12 +4,12 @@ interface Storage {
   removeItem(key: string): void
 }
 
-export type UseStorageProps = {
+export type UseStorageProps<ValueType> = {
   storage: Storage
   key: string
-  defaultValue?: any
+  defaultValue?: ValueType | null
   isStringStorage?: boolean
-  setInit?: (item: any) => any
+  setInit?: (item: ValueType | null) => ValueType
 }
 
 export type UseStorageReturnType<ValueType> = [ValueType, (item: ValueType) => void, () => void]

--- a/src/hooks/useStorage/types.ts
+++ b/src/hooks/useStorage/types.ts
@@ -12,4 +12,4 @@ export type UseStorageProps = {
   setInit?: (item: any) => any
 }
 
-export type UseStorageReturnType = [any, (item: any) => void, () => void]
+export type UseStorageReturnType<ValueType> = [ValueType, (item: ValueType) => void, () => void]

--- a/src/hooks/useStorage/useStorage.ts
+++ b/src/hooks/useStorage/useStorage.ts
@@ -15,14 +15,14 @@ const setInitDefault = (item: any): any => item
  * @param setInit - In some advanced cases, we need to perform additional logic for setting the defaultValue, based on the Storage item parsed value.
  * setInit function will provide us quick access to the parsed Storage item and based on its value we can return the needed default/init value of the hook.
  */
-export default function useStorage({
+export default function useStorage<ValueType>({
   storage,
   key,
   defaultValue = null,
   isStringStorage = false,
   setInit = setInitDefault
-}: UseStorageProps): UseStorageReturnType {
-  const [item, set] = useState(() => {
+}: UseStorageProps): UseStorageReturnType<ValueType | null> {
+  const [item, set] = useState<ValueType | null>(() => {
     // In case the item is not set in the storage, we just fall back to `defaultValue`
     if (!storage.getItem(key)) return setInit(defaultValue)
 
@@ -44,7 +44,7 @@ export default function useStorage({
   })
 
   const setItem = useCallback(
-    (value: any): void => {
+    (value: ValueType | null): void => {
       set((prevState: any) => {
         const itemValue = typeof value === 'function' ? value(prevState) : value
 

--- a/src/hooks/useStorage/useStorage.ts
+++ b/src/hooks/useStorage/useStorage.ts
@@ -21,7 +21,7 @@ export default function useStorage<ValueType>({
   defaultValue = null,
   isStringStorage = false,
   setInit = setInitDefault
-}: UseStorageProps): UseStorageReturnType<ValueType | null> {
+}: UseStorageProps<ValueType>): UseStorageReturnType<ValueType | null> {
   const [item, set] = useState<ValueType | null>(() => {
     // In case the item is not set in the storage, we just fall back to `defaultValue`
     if (!storage.getItem(key)) return setInit(defaultValue)


### PR DESCRIPTION
Otherwise, TypeScript assumes the value is `any` and there is no other way to manipulate it from the outside.