### PR TITLE
Config / Allow more flexible versions for the adex-protocol-eth and ethereumjs-util packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@walletconnect/client": "^1.7.1",
     "react": "^17.0.0",
     "ethers": "^5.5.2",
-    "ethereumjs-util": "^7.1.3",
+    "ethereumjs-util": "^6.1.0",
     "adex-protocol-eth": "git+https://git@github.com/AmbireTech/adex-protocol-eth.git",
     "validator": "^13.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react": "^17.0.0",
     "ethers": "^5.5.2",
     "ethereumjs-util": "^7.1.3",
-    "adex-protocol-eth": "git+https://git@github.com/AmbireTech/adex-protocol-eth.git#e507e75ac4ddbec2aa4a444c675b38ee9d26190c",
+    "adex-protocol-eth": "git+https://git@github.com/AmbireTech/adex-protocol-eth.git",
     "validator": "^13.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The web and mobile apps use different versions for these packages. Until aligned sometime in the future, allow flexible versions for both.