### PR TITLE
Config / Require `ethereumjs-util` v7.x as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@walletconnect/client": "^1.7.1",
     "react": "^17.0.0",
     "ethers": "^5.5.2",
-    "ethereumjs-util": "^6.1.0",
+    "ethereumjs-util": "^7.1.3",
     "adex-protocol-eth": "git+https://git@github.com/AmbireTech/adex-protocol-eth.git",
     "validator": "^13.7.0"
   },


### PR DESCRIPTION
Now both web and mobile use v7.x