### PR TITLE
Bug / Do not return `allNetworks` from `useNetworks` because it is misleading

### DIFF
--- a/src/hooks/useNetwork/types.ts
+++ b/src/hooks/useNetwork/types.ts
@@ -4,11 +4,9 @@ import { UseStorageType } from '../useStorage'
 export type UseNetworkProps = {
   defaultNetwork?: NetworkId
   useStorage: UseStorageType
-  allNetworks?: NetworkType[]
 }
 
 export type UseNetworkReturnType = {
   setNetwork: (networkIdentifier: string | number) => void
   network: NetworkType | undefined
-  allNetworks: NetworkType[]
 }

--- a/src/hooks/useNetwork/useNetwork.ts
+++ b/src/hooks/useNetwork/useNetwork.ts
@@ -5,20 +5,19 @@ import { UseNetworkProps, UseNetworkReturnType } from './types'
 
 export default function useNetwork({
   defaultNetwork = NETWORKS.ethereum,
-  useStorage,
-  allNetworks = networks
+  useStorage
 }: UseNetworkProps): UseNetworkReturnType {
   const [networkId, setNetworkId] = useStorage({
     key: 'network',
     defaultValue: defaultNetwork,
     isStringStorage: true,
     setInit: (_networkId: NetworkType['id']) =>
-      allNetworks.find((n) => n.id === _networkId) ? _networkId : defaultNetwork
+      networks.find((n) => n.id === _networkId) ? _networkId : defaultNetwork
   })
 
   const setNetwork = useCallback(
     (networkIdentifier: string | number) => {
-      const network = allNetworks.find(
+      const network = networks.find(
         (n) =>
           n.id === networkIdentifier ||
           n.name === networkIdentifier ||
@@ -33,7 +32,6 @@ export default function useNetwork({
 
   return {
     setNetwork,
-    network: allNetworks.find((n) => n.id === networkId),
-    allNetworks
+    network: networks.find((n) => n.id === networkId)
   }
 }


### PR DESCRIPTION
For the web app, the `networks` constants are mapped over enhanced with icon path.