### PR TITLE
Config / Callback for the `useAccounts` hook that catches a route change + missing types

### DIFF
--- a/src/hooks/useAccounts/types.ts
+++ b/src/hooks/useAccounts/types.ts
@@ -23,6 +23,8 @@ export type Account = {
     // Sometimes passed as an extra prop
     address?: string
   }
+  cloudBackupOptout?: boolean
+  downloadedBackup?: boolean
 }
 
 export interface UseAccountsProps {

--- a/src/hooks/useAccounts/types.ts
+++ b/src/hooks/useAccounts/types.ts
@@ -30,6 +30,7 @@ export type Account = {
 export interface UseAccountsProps {
   onAdd: (opts: OnAddAccountOptions) => void
   onRemoveLastAccount: () => void
+  onRemoveAccountWithoutBackingItUp?: () => void
   useStorage: UseStorageType
   useToasts: () => UseToastsReturnType
 }

--- a/src/hooks/useAccounts/useAccounts.ts
+++ b/src/hooks/useAccounts/useAccounts.ts
@@ -9,7 +9,7 @@ export default function useAccounts({
   useToasts
 }: UseAccountsProps): UseAccountsReturnType {
   const { addToast } = useToasts()
-  const [accounts, setAccounts] = useStorage({
+  const [accounts, setAccounts] = useStorage<Account[]>({
     key: 'accounts',
     defaultValue: [],
     setInit: (initialAccounts) => {
@@ -22,7 +22,7 @@ export default function useAccounts({
       return initialAccounts
     }
   })
-  const [selectedAcc, setSelectedAcc] = useStorage({
+  const [selectedAcc, setSelectedAcc] = useStorage<string>({
     key: 'selectedAcc',
     defaultValue: '',
     isStringStorage: true,
@@ -36,7 +36,7 @@ export default function useAccounts({
   })
 
   const onSelectAcc = useCallback(
-    (selected) => {
+    (selected: Account['id']) => {
       setSelectedAcc(selected)
     },
     [setSelectedAcc]
@@ -65,7 +65,7 @@ export default function useAccounts({
         )
       }
 
-      const existingIdx = accounts.indexOf(existing)
+      const existingIdx = existing ? accounts.indexOf(existing) : -1
       if (existingIdx === -1) accounts.push(acc)
       else accounts[existingIdx] = acc
 
@@ -81,15 +81,18 @@ export default function useAccounts({
   )
 
   const onRemoveAccount = useCallback(
-    (id) => {
+    (id: Account['id']) => {
       if (!id) throw new Error('account: internal err: missing ID/Address')
 
       const account = accounts.find((account: Account) => account.id === id)
-      if (account && account.email && account.cloudBackupOptout && !account.downloadedBackup)
-        return addToast(
+      if (account && account.email && account.cloudBackupOptout && !account.downloadedBackup) {
+        addToast(
           'You have opted out of Ambire Cloud Backup. Please backup your account before logging out.',
           { error: true, route: '/wallet/security' }
         )
+
+        return
+      }
 
       const clearedAccounts = accounts.filter((account: Account) => account.id !== id)
       setAccounts([...clearedAccounts])
@@ -102,7 +105,7 @@ export default function useAccounts({
     [accounts, onSelectAcc, addToast, onRemoveLastAccount, setAccounts, setSelectedAcc]
   )
 
-  const account: Account = useMemo(
+  const account: Account | {} = useMemo(
     () => accounts.find((x: Account) => x.id === selectedAcc) || {},
     [selectedAcc, accounts]
   )

--- a/src/hooks/useAccounts/useAccounts.ts
+++ b/src/hooks/useAccounts/useAccounts.ts
@@ -5,6 +5,7 @@ import { Account, OnAddAccountOptions, UseAccountsProps, UseAccountsReturnType }
 export default function useAccounts({
   onAdd,
   onRemoveLastAccount,
+  onRemoveAccountWithoutBackingItUp = () => {},
   useStorage,
   useToasts
 }: UseAccountsProps): UseAccountsReturnType {
@@ -88,8 +89,9 @@ export default function useAccounts({
       if (account && account.email && account.cloudBackupOptout && !account.downloadedBackup) {
         addToast(
           'You have opted out of Ambire Cloud Backup. Please backup your account before logging out.',
-          { error: true, route: '/wallet/security' }
+          { error: true }
         )
+        onRemoveAccountWithoutBackingItUp()
 
         return
       }


### PR DESCRIPTION
Introduces one new callback, `onRemoveAccountWithoutBackingItUp`, needed for a route change on the web app.