### PR TITLE
Feature / Tweak the `usePortfolio` refresh mechanism to handle showing or not showing loading state

### DIFF
--- a/src/hooks/usePortfolio/types.ts
+++ b/src/hooks/usePortfolio/types.ts
@@ -87,4 +87,5 @@ export type UsePortfolioReturnType = {
   isCurrNetworkProtocolsLoading: boolean
   loadBalance: () => void
   loadProtocols: () => void
+  refreshTokensIfVisible: () => void
 }

--- a/src/hooks/usePortfolio/types.ts
+++ b/src/hooks/usePortfolio/types.ts
@@ -87,5 +87,4 @@ export type UsePortfolioReturnType = {
   isCurrNetworkProtocolsLoading: boolean
   loadBalance: () => void
   loadProtocols: () => void
-  refreshTokensIfVisible: () => void
 }

--- a/src/hooks/usePortfolio/usePortfolio.ts
+++ b/src/hooks/usePortfolio/usePortfolio.ts
@@ -660,7 +660,8 @@ export default function usePortfolio({
     otherProtocolsByNetworksLoading,
     isCurrNetworkProtocolsLoading: otherProtocolsByNetworksLoading[currentNetwork],
     loadBalance,
-    loadProtocols
+    loadProtocols,
+    refreshTokensIfVisible
     // updatePortfolio//TODO find a non dirty way to be able to reply to getSafeBalances from the dapps, after the first refresh
   }
 }

--- a/src/hooks/usePrevious/index.ts
+++ b/src/hooks/usePrevious/index.ts
@@ -1,0 +1,3 @@
+import usePrevious from './usePrevious'
+
+export default usePrevious

--- a/src/hooks/usePrevious/usePrevious.ts
+++ b/src/hooks/usePrevious/usePrevious.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react'
+
+function usePrevious(value: any) {
+  // The ref object is a generic container whose current property is mutable ...
+  // ... and can hold any value, similar to an instance property on a class
+  const ref = useRef()
+  // Store current value in ref
+  useEffect(() => {
+    ref.current = value
+  }, [value]) // Only re-run if value changes
+  // Return previous value (happens before update in useEffect above)
+  return ref.current
+}
+
+export default usePrevious


### PR DESCRIPTION
Previously, it was always showing the loading state (when the browser tab focus was changed or the network gets changed).

Now, it only shows it when the current network changes. In all other cases - it refreshes the balances without showing the loading state in between.