### PR TITLE
Config / Fill-in more missing TS types + disable TS check for `usePortfolio` hook

### DIFF
--- a/src/hooks/usePortfolio/types.ts
+++ b/src/hooks/usePortfolio/types.ts
@@ -1,8 +1,7 @@
 // TODO: fill in the collectibles types
 
-import { NETWORKS } from 'constants/networks'
-import { SupportedProtocolType } from 'constants/supportedProtocols'
-
+import { NETWORKS } from '../../constants/networks'
+import { SupportedProtocolType } from '../../constants/supportedProtocols'
 import { UseStorageType } from '../useStorage'
 import { UseToastsReturnType } from '../useToasts'
 
@@ -24,7 +23,7 @@ export interface TokenWithIsHiddenFlag extends Token {
   isHidden: boolean
 }
 
-type Network = keyof typeof NETWORKS
+export type Network = keyof typeof NETWORKS
 
 export type Balance = {
   network: Network

--- a/src/hooks/usePortfolio/usePortfolio.ts
+++ b/src/hooks/usePortfolio/usePortfolio.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import networks from '../../constants/networks'
+import networks, { NetworkId } from '../../constants/networks'
 import supportedProtocols from '../../constants/supportedProtocols'
 import { checkTokenList, getTokenListBalance, tokenList } from '../../services/balanceOracle'
 import { roundFloatingNumber } from '../../services/formatter'
@@ -135,7 +135,7 @@ export default function usePortfolio({
   )
 
   const getExtraTokensAssets = useCallback(
-    (account, network) =>
+    (account: string, network: NetworkId) =>
       extraTokens
         .filter((extra: Token) => extra.account === account && extra.network === network)
         .map((extraToken: Token) => ({
@@ -149,7 +149,7 @@ export default function usePortfolio({
   )
 
   const fetchSupplementTokenData = useCallback(
-    async (updatedTokens) => {
+    async (updatedTokens: any[]) => {
       const currentNetworkTokens = updatedTokens.find(
         ({ network }: Token) => network === currentNetwork
       ) || { network: currentNetwork, meta: [], assets: [] }
@@ -164,7 +164,9 @@ export default function usePortfolio({
           walletAddr: account,
           network: currentNetwork,
           tokensData: currentNetworkTokens
-            ? currentNetworkTokens.assets.filter(({ isExtraToken }) => !isExtraToken)
+            ? currentNetworkTokens.assets.filter(
+                ({ isExtraToken }: { isExtraToken: boolean }) => !isExtraToken
+              )
             : [], // Filter out extraTokens
           extraTokens: extraTokensAssets,
           hiddenTokens
@@ -193,7 +195,12 @@ export default function usePortfolio({
 
   const fetchTokens = useCallback(
     // eslint-disable-next-line default-param-last
-    async (account, currentNetwork = false, showLoadingState = false, tokensByNetworks = []) => {
+    async (
+      account: string,
+      currentNetwork: NetworkId,
+      showLoadingState = false,
+      tokensByNetworks = []
+    ) => {
       // Prevent race conditions
       if (currentAccount.current !== account) return
 
@@ -232,9 +239,9 @@ export default function usePortfolio({
                 const extraTokensAssets = getExtraTokensAssets(account, network) // Add user added extra token to handle
                 let assets = [
                   ...products
-                    .map(({ assets }) =>
-                      assets.map(({ tokens }) =>
-                        tokens.map((token) => ({
+                    .map(({ assets }: any) =>
+                      assets.map(({ tokens }: any) =>
+                        tokens.map((token: any) => ({
                           ...token,
                           // balanceOracle fixes the number to the 10 decimal places, so here we should also fix it
                           balance: Number(token.balance.toFixed(10)),
@@ -277,7 +284,7 @@ export default function usePortfolio({
           return (networkTokens.assets = filterByHiddenTokens(networkTokens.assets, hiddenTokens))
         })
 
-        const updatedNetworks = updatedTokens.map(({ network }) => network)
+        const updatedNetworks = updatedTokens.map(({ network }: any) => network)
 
         // Prevent race conditions
         if (currentAccount.current !== account) return
@@ -291,7 +298,7 @@ export default function usePortfolio({
 
         if (failedRequests >= requestsCount) throw new Error('Failed to fetch Tokens from API')
         return true
-      } catch (error) {
+      } catch (error: any) {
         console.error(error)
         addToast(error.message, { error: true })
         // In case of error set all loading indicators to false

--- a/src/hooks/usePortfolio/usePortfolio.ts
+++ b/src/hooks/usePortfolio/usePortfolio.ts
@@ -6,7 +6,13 @@ import { checkTokenList, getTokenListBalance, tokenList } from '../../services/b
 import { roundFloatingNumber } from '../../services/formatter'
 import { setKnownAddresses, setKnownTokens } from '../../services/humanReadableTransactions'
 import usePrevious from '../usePrevious'
-import { Network, Token, UsePortfolioProps, UsePortfolioReturnType } from './types'
+import {
+  Network,
+  Token,
+  TokenWithIsHiddenFlag,
+  UsePortfolioProps,
+  UsePortfolioReturnType
+} from './types'
 
 let lastOtherProtocolsRefresh: number = 0
 
@@ -21,7 +27,7 @@ function paginateArray(input: any[], limit: number) {
   return pages
 }
 
-const filterByHiddenTokens = (tokens: Token[], hiddenTokens: Token[]) => {
+const filterByHiddenTokens = (tokens: Token[], hiddenTokens: TokenWithIsHiddenFlag[]) => {
   return tokens
     .map((t) => {
       return hiddenTokens.find((ht) => t.address === ht.address) || { ...t, isHidden: false }
@@ -42,7 +48,7 @@ async function supplementTokensDataFromNetwork({
   tokensData: Token[]
   extraTokens: Token[]
   updateBalance?: string
-  hiddenTokens: Token[]
+  hiddenTokens: TokenWithIsHiddenFlag[]
 }) {
   if (!walletAddr || walletAddr === '' || !network) return []
   // eslint-disable-next-line no-param-reassign
@@ -52,6 +58,7 @@ async function supplementTokensDataFromNetwork({
 
   // concat predefined token list with extraTokens list (extraTokens are certainly ERC20)
   const fullTokenList = [
+    // @ts-ignore figure out how to add types for the `tokenList`
     ...new Set(tokenList[network] ? tokenList[network].concat(extraTokens) : [...extraTokens])
   ]
   const tokens = fullTokenList.map((t: any) => {

--- a/src/hooks/usePortfolio/usePortfolio.ts
+++ b/src/hooks/usePortfolio/usePortfolio.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck TODO: Fill in all missing types before enabling the TS check again
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import networks, { NetworkId } from '../../constants/networks'


### PR DESCRIPTION
Disabled the TS check as a whole for the `usePortfolio` hook, otherwise it fires up a million error logs on the web app.