### PR TITLE
Release 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.0",
+  "version": "0.11.2",
   "name": "ambire-common",
   "description": "Common ground for the Ambire apps",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0",
+  "version": "0.11.0",
   "name": "ambire-common",
   "description": "Common ground for the Ambire apps",
   "private": true,


### PR DESCRIPTION
Changelog:

- Add `ensName` as an optional network param
- Change: andromeda unstoppable domain chain to `ERC20`