### PR TITLE
Feature / Migrate `useRewards`, `useClaimableWalletToken` and `useStakedWalletToken` hooks

### DIFF
--- a/src/hooks/useClaimableWalletToken/index.ts
+++ b/src/hooks/useClaimableWalletToken/index.ts
@@ -1,0 +1,3 @@
+import useClaimableWalletToken from './useClaimableWalletToken'
+
+export default useClaimableWalletToken

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -18,6 +18,7 @@ export type UseClaimableWalletTokenReturnType = {
     loading: boolean
     claimed: number
     mintableVesting: number
+    claimedInitial: number
     error: null | any
   }
   claimableNow: number

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -1,10 +1,11 @@
-import { UseAccountsReturnType } from 'ambire-common/src/hooks/useAccounts'
 import { UseNetworkReturnType } from 'ambire-common/src/hooks/useNetwork'
 
+import { Account } from '../useAccounts'
+
 export type UseClaimableWalletTokenProps = {
-  useAccounts: () => UseAccountsReturnType
-  useNetwork: () => UseNetworkReturnType
-  useRequests: () => any // TODO
+  accountId: Account['id']
+  network: UseNetworkReturnType['network']
+  addRequest: any // TODO
   totalLifetimeRewards: number
   walletUsdPrice: number
 }

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -6,6 +6,7 @@ export type UseClaimableWalletTokenProps = {
   useNetwork: () => UseNetworkReturnType
   useRequests: () => any // TODO
   totalLifetimeRewards: number
+  walletUsdPrice: number
 }
 
 export type UseClaimableWalletTokenReturnType = {
@@ -28,4 +29,6 @@ export type UseClaimableWalletTokenReturnType = {
   claimEarlyRewards: (withoutBurn: boolean) => void
   claimVesting: () => void
   pendingTokensTotal: string
+  claimableNowUsd: string
+  mintableVestingUsd: string
 }

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -16,6 +16,7 @@ export type UseClaimableWalletTokenReturnType = {
     start: number
     end: number
   }
+  shouldDisplayMintableVesting: boolean
   currentClaimStatus: {
     loading: boolean
     claimed: number

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -5,6 +5,7 @@ export type UseClaimableWalletTokenProps = {
   useAccounts: () => UseAccountsReturnType
   useNetwork: () => UseNetworkReturnType
   useRequests: () => any // TODO
+  totalLifetimeRewards: number
 }
 
 export type UseClaimableWalletTokenReturnType = {
@@ -26,4 +27,5 @@ export type UseClaimableWalletTokenReturnType = {
   claimDisabledReason: string
   claimEarlyRewards: (withoutBurn: boolean) => void
   claimVesting: () => void
+  pendingTokensTotal: string
 }

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -1,0 +1,8 @@
+import { UseAccountsReturnType } from 'ambire-common/src/hooks/useAccounts'
+import { UseNetworkReturnType } from 'ambire-common/src/hooks/useNetwork'
+
+export type UseClaimableWalletTokenProps = {
+  useAccounts: () => UseAccountsReturnType
+  useNetwork: () => UseNetworkReturnType
+  useRequests: () => any // TODO
+}

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -6,3 +6,23 @@ export type UseClaimableWalletTokenProps = {
   useNetwork: () => UseNetworkReturnType
   useRequests: () => any // TODO
 }
+
+export type UseClaimableWalletTokenReturnType = {
+  vestingEntry?: {
+    addr: string
+    rate: string
+    start: number
+    end: number
+  }
+  currentClaimStatus: {
+    loading: boolean
+    claimed: number
+    mintableVesting: number
+    error: null | any
+  }
+  claimableNow: number
+  disabledReason: string
+  claimDisabledReason: string
+  claimEarlyRewards: (withoutBurn: boolean) => void
+  claimVesting: () => void
+}

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -32,4 +32,5 @@ export type UseClaimableWalletTokenReturnType = {
   pendingTokensTotal: string
   claimableNowUsd: string
   mintableVestingUsd: string
+  claimingDisabled: boolean
 }

--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -27,7 +27,7 @@ export type UseClaimableWalletTokenReturnType = {
   claimableNow: number
   disabledReason: string
   claimDisabledReason: string
-  claimEarlyRewards: (withoutBurn: boolean) => void
+  claimEarlyRewards: (withoutBurn?: boolean) => void
   claimVesting: () => void
   pendingTokensTotal: string
   claimableNowUsd: string

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -4,10 +4,11 @@ import { Interface } from 'ethers/lib/utils'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import WALLETSupplyControllerABI from '../../constants/abis/WALLETSupplyControllerABI.json'
+import { NETWORKS } from '../../constants/networks'
 import WALLETInitialClaimableRewards from '../../constants/WALLETInitialClaimableRewards.json'
 import WALLETVestings from '../../constants/WALLETVestings.json'
 import { getProvider } from '../../services/provider'
-import { UseClaimableWalletTokenProps } from './types'
+import { UseClaimableWalletTokenProps, UseClaimableWalletTokenReturnType } from './types'
 
 const supplyControllerAddress = '0xc53af25f831f31ad6256a742b3f0905bc214a430'
 const supplyControllerInterface = new Interface(WALLETSupplyControllerABI)
@@ -16,7 +17,7 @@ const useClaimableWalletToken = ({
   useAccounts,
   useNetwork,
   useRequests
-}: UseClaimableWalletTokenProps) => {
+}: UseClaimableWalletTokenProps): UseClaimableWalletTokenReturnType => {
   const { selectedAcc } = useAccounts()
   const { network } = useNetwork()
   const { addRequest } = useRequests()
@@ -42,7 +43,7 @@ const useClaimableWalletToken = ({
   useEffect(() => {
     setCurrentClaimStatus({ loading: true, claimed: 0, mintableVesting: 0, error: null })
     ;(async () => {
-      const toNum = (x) => parseInt(x.toString()) / 1e18
+      const toNum = (x: string | number) => parseInt(x.toString(), 10) / 1e18
       const [mintableVesting, claimed] = await Promise.all([
         vestingEntry
           ? await supplyController
@@ -62,10 +63,16 @@ const useClaimableWalletToken = ({
 
       return { mintableVesting, claimed, claimedInitial }
     })()
-      .then((status) => setCurrentClaimStatus(status))
+      .then((status) => setCurrentClaimStatus({ error: null, loading: false, ...status }))
       .catch((e) => {
         console.error('getting claim status', e)
-        setCurrentClaimStatus({ error: e.message || e })
+
+        setCurrentClaimStatus({
+          error: e.message || e,
+          loading: false,
+          claimed: 0,
+          mintableVesting: 0
+        })
       })
   }, [supplyController, vestingEntry, initialClaimableEntry, cacheBreak])
 
@@ -73,51 +80,52 @@ const useClaimableWalletToken = ({
     initialClaimable - (currentClaimStatus.claimed || 0) < 0
       ? 0
       : initialClaimable - (currentClaimStatus.claimed || 0)
-  const disabledReason =
-    network.id !== 'ethereum'
-      ? 'Switch to Ethereum to claim'
-      : currentClaimStatus.error
-      ? `Claim status error: ${currentClaimStatus.error}`
-      : null
-  const claimDisabledReason = claimableNow === 0 ? 'No rewards are claimable' : null
+
+  let disabledReason = ''
+  if (network?.id !== NETWORKS.ethereum) {
+    disabledReason = 'Switch to Ethereum to claim'
+  } else if (currentClaimStatus.error) {
+    disabledReason = `Claim status error: ${currentClaimStatus.error}`
+  }
+  const claimDisabledReason = claimableNow === 0 ? 'No rewards are claimable' : ''
   const claimEarlyRewards = useCallback(
     (withoutBurn = true) => {
       addRequest({
         id: `claim_${Date.now()}`,
-        chainId: network.chainId,
+        chainId: network?.chainId,
         type: 'eth_sendTransaction',
         account: selectedAcc,
         txn: {
           to: supplyControllerAddress,
           value: '0x0',
           data: supplyControllerInterface.encodeFunctionData('claim', [
-            initialClaimableEntry.totalClaimable,
-            initialClaimableEntry.proof,
+            initialClaimableEntry?.totalClaimable,
+            initialClaimableEntry?.proof,
             withoutBurn ? 0 : 3000, // penalty bps, at the moment we run with 0; it's a safety feature to hardcode it
             '0x47cd7e91c3cbaaf266369fe8518345fc4fc12935' // staking pool addr
           ])
         }
       })
     },
-    [initialClaimableEntry, network.chainId, selectedAcc, addRequest]
+    [initialClaimableEntry, network?.chainId, selectedAcc, addRequest]
   )
   const claimVesting = useCallback(() => {
     addRequest({
       id: `claimVesting_${Date.now()}`,
-      chainId: network.chainId,
+      chainId: network?.chainId,
       account: selectedAcc,
       type: 'eth_sendTransaction',
       txn: {
         to: supplyControllerAddress,
         value: '0x0',
         data: supplyControllerInterface.encodeFunctionData('mintVesting', [
-          vestingEntry.addr,
-          vestingEntry.end,
-          vestingEntry.rate
+          vestingEntry?.addr,
+          vestingEntry?.end,
+          vestingEntry?.rate
         ])
       }
     })
-  }, [vestingEntry, network.chainId, selectedAcc, addRequest])
+  }, [vestingEntry, network?.chainId, selectedAcc, addRequest])
 
   return {
     vestingEntry,

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -14,30 +14,23 @@ const supplyControllerAddress = '0xc53af25f831f31ad6256a742b3f0905bc214a430'
 const supplyControllerInterface = new Interface(WALLETSupplyControllerABI)
 
 const useClaimableWalletToken = ({
-  useAccounts,
-  useNetwork,
-  useRequests,
+  accountId,
+  network,
+  addRequest,
   totalLifetimeRewards,
   walletUsdPrice
 }: UseClaimableWalletTokenProps): UseClaimableWalletTokenReturnType => {
-  const { selectedAcc } = useAccounts()
-  const { network } = useNetwork()
-  const { addRequest } = useRequests()
-
   const provider = useMemo(() => getProvider('ethereum'), [])
   const supplyController = useMemo(
     () => new Contract(supplyControllerAddress, WALLETSupplyControllerABI, provider),
     [provider]
   )
   const initialClaimableEntry = useMemo(
-    () => WALLETInitialClaimableRewards.find((x) => x.addr === selectedAcc),
-    [selectedAcc]
+    () => WALLETInitialClaimableRewards.find((x) => x.addr === accountId),
+    [accountId]
   )
 
-  const vestingEntry = useMemo(
-    () => WALLETVestings.find((x) => x.addr === selectedAcc),
-    [selectedAcc]
-  )
+  const vestingEntry = useMemo(() => WALLETVestings.find((x) => x.addr === accountId), [accountId])
 
   const [currentClaimStatus, setCurrentClaimStatus] = useState({
     loading: true,
@@ -125,7 +118,7 @@ const useClaimableWalletToken = ({
         id: `claim_${Date.now()}`,
         chainId: network?.chainId,
         type: 'eth_sendTransaction',
-        account: selectedAcc,
+        account: accountId,
         txn: {
           to: supplyControllerAddress,
           value: '0x0',
@@ -138,13 +131,13 @@ const useClaimableWalletToken = ({
         }
       })
     },
-    [initialClaimableEntry, network?.chainId, selectedAcc, addRequest]
+    [initialClaimableEntry, network?.chainId, accountId, addRequest]
   )
   const claimVesting = useCallback(() => {
     addRequest({
       id: `claimVesting_${Date.now()}`,
       chainId: network?.chainId,
-      account: selectedAcc,
+      account: accountId,
       type: 'eth_sendTransaction',
       txn: {
         to: supplyControllerAddress,
@@ -156,7 +149,7 @@ const useClaimableWalletToken = ({
         ])
       }
     })
-  }, [vestingEntry, network?.chainId, selectedAcc, addRequest])
+  }, [vestingEntry, network?.chainId, accountId, addRequest])
 
   return {
     vestingEntry,

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -117,6 +117,8 @@ const useClaimableWalletToken = ({
     disabledReason = `Claim status error: ${currentClaimStatus.error}`
   }
   const claimDisabledReason = claimableNow === 0 ? 'No rewards are claimable' : ''
+  const claimingDisabled = !!(claimDisabledReason || disabledReason)
+
   const claimEarlyRewards = useCallback(
     (withoutBurn = true) => {
       addRequest({
@@ -167,7 +169,8 @@ const useClaimableWalletToken = ({
     claimVesting,
     pendingTokensTotal,
     claimableNowUsd,
-    mintableVestingUsd
+    mintableVestingUsd,
+    claimingDisabled
   }
 }
 

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -108,6 +108,8 @@ const useClaimableWalletToken = ({
     currentClaimStatus.mintableVesting
   ).toFixed(3)
 
+  const shouldDisplayMintableVesting = !!currentClaimStatus.mintableVesting && !!vestingEntry
+
   let disabledReason = ''
   if (network?.id !== NETWORKS.ethereum) {
     disabledReason = 'Switch to Ethereum to claim'
@@ -156,6 +158,7 @@ const useClaimableWalletToken = ({
 
   return {
     vestingEntry,
+    shouldDisplayMintableVesting,
     currentClaimStatus,
     claimableNow,
     disabledReason,

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -6,11 +6,16 @@ import WALLETSupplyControllerABI from '../../constants/abis/WALLETSupplyControll
 import WALLETInitialClaimableRewards from '../../constants/WALLETInitialClaimableRewards.json'
 import WALLETVestings from '../../constants/WALLETVestings.json'
 import { getProvider } from '../../services/provider'
+import { UseClaimableWalletTokenProps } from './types'
 
 const supplyControllerAddress = '0xc53af25f831f31ad6256a742b3f0905bc214a430'
 const supplyControllerInterface = new Interface(WALLETSupplyControllerABI)
 
-const useClaimableWalletToken = ({ useAccounts, useNetwork, useRequests }) => {
+const useClaimableWalletToken = ({
+  useAccounts,
+  useNetwork,
+  useRequests
+}: UseClaimableWalletTokenProps) => {
   const { account } = useAccounts()
   const { network } = useNetwork()
   const { addRequest } = useRequests()

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -35,13 +35,20 @@ const useClaimableWalletToken = ({
     loading: true,
     claimed: 0,
     mintableVesting: 0,
+    claimedInitial: 0,
     error: null
   })
 
   // By adding this to the deps, we make it refresh every 10 mins
   const { cacheBreak } = useCacheBreak({ refreshInterval: 10000, breakPoint: 5000 })
   useEffect(() => {
-    setCurrentClaimStatus({ loading: true, claimed: 0, mintableVesting: 0, error: null })
+    setCurrentClaimStatus({
+      loading: true,
+      claimed: 0,
+      mintableVesting: 0,
+      claimedInitial: 0,
+      error: null
+    })
     ;(async () => {
       const toNum = (x: string | number) => parseInt(x.toString(), 10) / 1e18
       const [mintableVesting, claimed] = await Promise.all([
@@ -59,7 +66,7 @@ const useClaimableWalletToken = ({
         ? (initialClaimableEntry.fromBalanceClaimable || 0) +
           (initialClaimableEntry.fromADXClaimable || 0) -
           toNum(initialClaimableEntry.totalClaimable || 0)
-        : null
+        : 0
 
       return { mintableVesting, claimed, claimedInitial }
     })()
@@ -71,7 +78,8 @@ const useClaimableWalletToken = ({
           error: e.message || e,
           loading: false,
           claimed: 0,
-          mintableVesting: 0
+          mintableVesting: 0,
+          claimedInitial: 0
         })
       })
   }, [supplyController, vestingEntry, initialClaimableEntry, cacheBreak])

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -16,7 +16,8 @@ const supplyControllerInterface = new Interface(WALLETSupplyControllerABI)
 const useClaimableWalletToken = ({
   useAccounts,
   useNetwork,
-  useRequests
+  useRequests,
+  totalLifetimeRewards
 }: UseClaimableWalletTokenProps): UseClaimableWalletTokenReturnType => {
   const { selectedAcc } = useAccounts()
   const { network } = useNetwork()
@@ -96,6 +97,13 @@ const useClaimableWalletToken = ({
       ? 0
       : initialClaimable - (currentClaimStatus.claimed || 0)
 
+  const pendingTokensTotal = (
+    totalLifetimeRewards -
+    currentClaimStatus.claimed -
+    currentClaimStatus.claimedInitial +
+    currentClaimStatus.mintableVesting
+  ).toFixed(3)
+
   let disabledReason = ''
   if (network?.id !== NETWORKS.ethereum) {
     disabledReason = 'Switch to Ethereum to claim'
@@ -149,7 +157,8 @@ const useClaimableWalletToken = ({
     disabledReason,
     claimDisabledReason,
     claimEarlyRewards,
-    claimVesting
+    claimVesting,
+    pendingTokensTotal
   }
 }
 

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -27,7 +27,7 @@ const useClaimableWalletToken = ({
     [provider]
   )
   const initialClaimableEntry = WALLETInitialClaimableRewards.find((x) => x.addr === selectedAcc)
-  const initialClaimable = initialClaimableEntry ? initialClaimableEntry.totalClaimable / 1e18 : 0
+  const initialClaimable = initialClaimableEntry ? +initialClaimableEntry.totalClaimable / 1e18 : 0
   const vestingEntry = WALLETVestings.find((x) => x.addr === selectedAcc)
 
   const [currentClaimStatus, setCurrentClaimStatus] = useState({

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -17,7 +17,8 @@ const useClaimableWalletToken = ({
   useAccounts,
   useNetwork,
   useRequests,
-  totalLifetimeRewards
+  totalLifetimeRewards,
+  walletUsdPrice
 }: UseClaimableWalletTokenProps): UseClaimableWalletTokenReturnType => {
   const { selectedAcc } = useAccounts()
   const { network } = useNetwork()
@@ -97,6 +98,9 @@ const useClaimableWalletToken = ({
       ? 0
       : initialClaimable - (currentClaimStatus.claimed || 0)
 
+  const claimableNowUsd = (walletUsdPrice * claimableNow).toFixed(2)
+  const mintableVestingUsd = (walletUsdPrice * currentClaimStatus.mintableVesting).toFixed(2)
+
   const pendingTokensTotal = (
     totalLifetimeRewards -
     currentClaimStatus.claimed -
@@ -158,7 +162,9 @@ const useClaimableWalletToken = ({
     claimDisabledReason,
     claimEarlyRewards,
     claimVesting,
-    pendingTokensTotal
+    pendingTokensTotal,
+    claimableNowUsd,
+    mintableVestingUsd
   }
 }
 

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -27,9 +27,15 @@ const useClaimableWalletToken = ({
     () => new Contract(supplyControllerAddress, WALLETSupplyControllerABI, provider),
     [provider]
   )
-  const initialClaimableEntry = WALLETInitialClaimableRewards.find((x) => x.addr === selectedAcc)
-  const initialClaimable = initialClaimableEntry ? +initialClaimableEntry.totalClaimable / 1e18 : 0
-  const vestingEntry = WALLETVestings.find((x) => x.addr === selectedAcc)
+  const initialClaimableEntry = useMemo(
+    () => WALLETInitialClaimableRewards.find((x) => x.addr === selectedAcc),
+    [selectedAcc]
+  )
+
+  const vestingEntry = useMemo(
+    () => WALLETVestings.find((x) => x.addr === selectedAcc),
+    [selectedAcc]
+  )
 
   const [currentClaimStatus, setCurrentClaimStatus] = useState({
     loading: true,
@@ -84,6 +90,7 @@ const useClaimableWalletToken = ({
       })
   }, [supplyController, vestingEntry, initialClaimableEntry, cacheBreak])
 
+  const initialClaimable = initialClaimableEntry ? +initialClaimableEntry.totalClaimable / 1e18 : 0
   const claimableNow =
     initialClaimable - (currentClaimStatus.claimed || 0) < 0
       ? 0

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -1,0 +1,126 @@
+import { Contract } from 'ethers'
+import { Interface } from 'ethers/lib/utils'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import WALLETSupplyControllerABI from '../../constants/abis/WALLETSupplyControllerABI.json'
+import WALLETInitialClaimableRewards from '../../constants/WALLETInitialClaimableRewards.json'
+import WALLETVestings from '../../constants/WALLETVestings.json'
+import { getProvider } from '../../services/provider'
+
+const supplyControllerAddress = '0xc53af25f831f31ad6256a742b3f0905bc214a430'
+const supplyControllerInterface = new Interface(WALLETSupplyControllerABI)
+
+const useClaimableWalletToken = ({ useAccounts, useNetwork, useRequests }) => {
+  const { account } = useAccounts()
+  const { network } = useNetwork()
+  const { addRequest } = useRequests()
+
+  const provider = useMemo(() => getProvider('ethereum'), [])
+  const supplyController = useMemo(
+    () => new Contract(supplyControllerAddress, WALLETSupplyControllerABI, provider),
+    [provider]
+  )
+  const initialClaimableEntry = WALLETInitialClaimableRewards.find((x) => x.addr === account.id)
+  const initialClaimable = initialClaimableEntry ? initialClaimableEntry.totalClaimable / 1e18 : 0
+  const vestingEntry = WALLETVestings.find((x) => x.addr === account.id)
+
+  const [currentClaimStatus, setCurrentClaimStatus] = useState({
+    loading: true,
+    claimed: 0,
+    mintableVesting: 0,
+    error: null
+  })
+  // by adding this to the deps, we make it refresh every 10 mins
+  const refreshSlot = Math.floor(Date.now() / 60000)
+  useEffect(() => {
+    setCurrentClaimStatus({ loading: true, claimed: 0, mintableVesting: 0, error: null })
+    ;(async () => {
+      const toNum = (x) => parseInt(x.toString()) / 1e18
+      const [mintableVesting, claimed] = await Promise.all([
+        vestingEntry
+          ? await supplyController
+              .mintableVesting(vestingEntry.addr, vestingEntry.end, vestingEntry.rate)
+              .then(toNum)
+          : null,
+        initialClaimableEntry
+          ? await supplyController.claimed(initialClaimableEntry.addr).then(toNum)
+          : null
+      ])
+
+      const claimedInitial = initialClaimableEntry
+        ? (initialClaimableEntry.fromBalanceClaimable || 0) +
+          (initialClaimableEntry.fromADXClaimable || 0) -
+          toNum(initialClaimableEntry.totalClaimable || 0)
+        : null
+
+      return { mintableVesting, claimed, claimedInitial }
+    })()
+      .then((status) => setCurrentClaimStatus(status))
+      .catch((e) => {
+        console.error('getting claim status', e)
+        setCurrentClaimStatus({ error: e.message || e })
+      })
+  }, [supplyController, vestingEntry, initialClaimableEntry, refreshSlot])
+
+  const claimableNow =
+    initialClaimable - (currentClaimStatus.claimed || 0) < 0
+      ? 0
+      : initialClaimable - (currentClaimStatus.claimed || 0)
+  const disabledReason =
+    network.id !== 'ethereum'
+      ? 'Switch to Ethereum to claim'
+      : currentClaimStatus.error
+      ? `Claim status error: ${currentClaimStatus.error}`
+      : null
+  const claimDisabledReason = claimableNow === 0 ? 'No rewards are claimable' : null
+  const claimEarlyRewards = useCallback(
+    (withoutBurn = true) => {
+      addRequest({
+        id: `claim_${Date.now()}`,
+        chainId: network.chainId,
+        type: 'eth_sendTransaction',
+        account: account.id,
+        txn: {
+          to: supplyControllerAddress,
+          value: '0x0',
+          data: supplyControllerInterface.encodeFunctionData('claim', [
+            initialClaimableEntry.totalClaimable,
+            initialClaimableEntry.proof,
+            withoutBurn ? 0 : 3000, // penalty bps, at the moment we run with 0; it's a safety feature to hardcode it
+            '0x47cd7e91c3cbaaf266369fe8518345fc4fc12935' // staking pool addr
+          ])
+        }
+      })
+    },
+    [initialClaimableEntry, network.chainId, account.id, addRequest]
+  )
+  const claimVesting = useCallback(() => {
+    addRequest({
+      id: `claimVesting_${Date.now()}`,
+      chainId: network.chainId,
+      account: account.id,
+      type: 'eth_sendTransaction',
+      txn: {
+        to: supplyControllerAddress,
+        value: '0x0',
+        data: supplyControllerInterface.encodeFunctionData('mintVesting', [
+          vestingEntry.addr,
+          vestingEntry.end,
+          vestingEntry.rate
+        ])
+      }
+    })
+  }, [vestingEntry, network.chainId, account.id, addRequest])
+
+  return {
+    vestingEntry,
+    currentClaimStatus,
+    claimableNow,
+    disabledReason,
+    claimDisabledReason,
+    claimEarlyRewards,
+    claimVesting
+  }
+}
+
+export default useClaimableWalletToken

--- a/src/hooks/useGasTankData/types.ts
+++ b/src/hooks/useGasTankData/types.ts
@@ -1,6 +1,6 @@
 import { UseNetworkReturnType } from 'hooks/useNetwork'
 import { UsePortfolioReturnType } from 'hooks/usePortfolio'
-import { UseRelayerDataReturnType } from 'hooks/useRelayerData'
+import { UseRelayerDataProps, UseRelayerDataReturnType } from 'hooks/useRelayerData'
 
 import { UseAccountsReturnType } from '../useAccounts'
 
@@ -9,7 +9,7 @@ export interface UseGasTankDataProps {
   useAccounts: () => UseAccountsReturnType
   useNetwork: () => UseNetworkReturnType
   usePortfolio: () => UsePortfolioReturnType
-  useRelayerData: (url: string | null) => UseRelayerDataReturnType
+  useRelayerData: (props: Omit<UseRelayerDataProps, 'fetch'>) => UseRelayerDataReturnType
 }
 
 // TODO: add return types

--- a/src/hooks/useGasTankData/useGasTankData.ts
+++ b/src/hooks/useGasTankData/useGasTankData.ts
@@ -27,9 +27,9 @@ export default function useGasTankData({
     ? `${relayerURL}/identity/${account}/${network?.id}/transactions`
     : null
 
-  const { data: balancesRes, isLoading } = useRelayerData(urlGetBalance)
-  const { data: feeAssetsRes } = useRelayerData(urlGetFeeAssets)
-  const { data: executedTxnsRes } = useRelayerData(urlGetTransactions)
+  const { data: balancesRes, isLoading } = useRelayerData({ url: urlGetBalance })
+  const { data: feeAssetsRes } = useRelayerData({ url: urlGetFeeAssets })
+  const { data: executedTxnsRes } = useRelayerData({ url: urlGetTransactions })
 
   const gasTankBalances = useMemo(
     () =>

--- a/src/hooks/useRelayerData/types.ts
+++ b/src/hooks/useRelayerData/types.ts
@@ -1,3 +1,9 @@
+export interface UseRelayerDataProps {
+  fetch: any
+  url: string | null | boolean
+  initialState?: any
+}
+
 export interface UseRelayerDataReturnType {
   data: any
   isLoading: boolean

--- a/src/hooks/useRelayerData/useRelayerData.tsx
+++ b/src/hooks/useRelayerData/useRelayerData.tsx
@@ -28,7 +28,7 @@ export default function useRelayerData({
   }, [url])
 
   useEffect(() => {
-    if (!url) return
+    if (!url || typeof url !== 'string') return
 
     // Data reset: if some time passes before we load the next piece of data, and the URL is different,
     // we will reset the data so that the UI knows to display a loading indicator
@@ -58,7 +58,7 @@ export default function useRelayerData({
   // In case we want to refetch the data without changing the url prop
   // e.g. pull to refresh
   const forceRefresh = useCallback(() => {
-    if (!url) return
+    if (!url || typeof url !== 'string') return
 
     // Data reset: if some time passes before we load the next piece of data, and the URL is different,
     // we will reset the data so that the UI knows to display a loading indicator

--- a/src/hooks/useRelayerData/useRelayerData.tsx
+++ b/src/hooks/useRelayerData/useRelayerData.tsx
@@ -11,10 +11,11 @@ const RESET_DATA_AFTER = 250
 // TODO: Figure out if a package like https://use-http.com will fit better
 export default function useRelayerData(
   fetch: any,
-  url: string | null | boolean
+  url: string | null | boolean,
+  initialState: any = null
 ): UseRelayerDataReturnType {
   const [isLoading, setLoading] = useState<boolean>(true)
-  const [data, setData] = useState<any>(null)
+  const [data, setData] = useState<any>(initialState)
   const [err, setErr] = useState<any>(null)
   const prevUrl = useRef('')
 
@@ -34,7 +35,7 @@ export default function useRelayerData(
     let resetDataTimer: any = null
     const stripQuery = (x: any) => x.split('?')[0]
     if (stripQuery(prevUrl.current) !== stripQuery(url)) {
-      resetDataTimer = setTimeout(() => setData(null), RESET_DATA_AFTER)
+      resetDataTimer = setTimeout(() => setData(initialState), RESET_DATA_AFTER)
     }
     prevUrl.current = url
 
@@ -61,7 +62,7 @@ export default function useRelayerData(
 
     // Data reset: if some time passes before we load the next piece of data, and the URL is different,
     // we will reset the data so that the UI knows to display a loading indicator
-    const resetDataTimer: any = setTimeout(() => setData(null), RESET_DATA_AFTER)
+    const resetDataTimer: any = setTimeout(() => setData(initialState), RESET_DATA_AFTER)
     setLoading(true)
     setErr(null)
     updateData()

--- a/src/hooks/useRelayerData/useRelayerData.tsx
+++ b/src/hooks/useRelayerData/useRelayerData.tsx
@@ -8,6 +8,7 @@ import { UseRelayerDataReturnType } from './types'
 const RESET_DATA_AFTER = 250
 
 // TODO: Figure out if hook is the best approach for implementing this one.
+// TODO: Figure out if a package like https://use-http.com will fit better
 export default function useRelayerData(fetch: any, url: string | null): UseRelayerDataReturnType {
   const [isLoading, setLoading] = useState<boolean>(true)
   const [data, setData] = useState<any>(null)

--- a/src/hooks/useRelayerData/useRelayerData.tsx
+++ b/src/hooks/useRelayerData/useRelayerData.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { fetchCaught } from '../../services/fetch'
-import { UseRelayerDataReturnType } from './types'
+import { UseRelayerDataProps, UseRelayerDataReturnType } from './types'
 
 // Threshold after a load of another URL is triggered, we will clear the data
 // so that the component that uses this hook can display the loading spinner.
@@ -9,11 +9,11 @@ const RESET_DATA_AFTER = 250
 
 // TODO: Figure out if hook is the best approach for implementing this one.
 // TODO: Figure out if a package like https://use-http.com will fit better
-export default function useRelayerData(
-  fetch: any,
-  url: string | null | boolean,
-  initialState: any = null
-): UseRelayerDataReturnType {
+export default function useRelayerData({
+  fetch,
+  url,
+  initialState = null
+}: UseRelayerDataProps): UseRelayerDataReturnType {
   const [isLoading, setLoading] = useState<boolean>(true)
   const [data, setData] = useState<any>(initialState)
   const [err, setErr] = useState<any>(null)

--- a/src/hooks/useRelayerData/useRelayerData.tsx
+++ b/src/hooks/useRelayerData/useRelayerData.tsx
@@ -9,7 +9,10 @@ const RESET_DATA_AFTER = 250
 
 // TODO: Figure out if hook is the best approach for implementing this one.
 // TODO: Figure out if a package like https://use-http.com will fit better
-export default function useRelayerData(fetch: any, url: string | null): UseRelayerDataReturnType {
+export default function useRelayerData(
+  fetch: any,
+  url: string | null | boolean
+): UseRelayerDataReturnType {
   const [isLoading, setLoading] = useState<boolean>(true)
   const [data, setData] = useState<any>(null)
   const [err, setErr] = useState<any>(null)

--- a/src/hooks/useRelayerData/useRelayerData.tsx
+++ b/src/hooks/useRelayerData/useRelayerData.tsx
@@ -7,6 +7,7 @@ import { UseRelayerDataReturnType } from './types'
 // so that the component that uses this hook can display the loading spinner.
 const RESET_DATA_AFTER = 250
 
+// TODO: Figure out if hook is the best approach for implementing this one.
 export default function useRelayerData(fetch: any, url: string | null): UseRelayerDataReturnType {
   const [isLoading, setLoading] = useState<boolean>(true)
   const [data, setData] = useState<any>(null)

--- a/src/hooks/useRewards/index.ts
+++ b/src/hooks/useRewards/index.ts
@@ -1,0 +1,4 @@
+import useRewards from './useRewards'
+
+export * from './useRewards'
+export default useRewards

--- a/src/hooks/useRewards/index.ts
+++ b/src/hooks/useRewards/index.ts
@@ -1,4 +1,3 @@
 import useRewards from './useRewards'
 
-export * from './useRewards'
 export default useRewards

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -1,6 +1,6 @@
 import { UseAccountsReturnType } from '../useAccounts'
 import { Account } from '../useAccounts/types'
-import { UseRelayerDataReturnType } from '../useRelayerData'
+import { UseRelayerDataProps, UseRelayerDataReturnType } from '../useRelayerData'
 
 export enum RewardIds {
   ADX_REWARDS = 'adx-rewards',
@@ -11,7 +11,7 @@ export enum RewardIds {
 export type UseRewardsProps = {
   relayerURL: string
   useAccounts: () => UseAccountsReturnType
-  useRelayerData: (url: string | null | boolean, initialState?: any) => UseRelayerDataReturnType
+  useRelayerData: (props: Omit<UseRelayerDataProps, 'fetch'>) => UseRelayerDataReturnType
 }
 
 export type Multiplier = {

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -1,4 +1,14 @@
+import { UseAccountsReturnType } from '../useAccounts'
+import { UseRelayerDataReturnType } from '../useRelayerData'
+
 export enum RewardIds {
   ADX_REWARDS = 'adx-rewards',
   BALANCE_REWARDS = 'balance-rewards'
+}
+
+export type UseRewardsProps = {
+  relayerURL: string
+  useAccounts: () => UseAccountsReturnType
+  useRelayerData: () => UseRelayerDataReturnType
+  useClaimableWalletToken: () => any // TODO
 }

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -28,7 +28,7 @@ type Reward = {
   updated: string // timestamp
 }
 
-export type RewardsData = {
+export type RelayerRewardsData = {
   data: {
     adxTokenAPY: number
     multipliers: Multiplier[]

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -9,6 +9,6 @@ export enum RewardIds {
 export type UseRewardsProps = {
   relayerURL: string
   useAccounts: () => UseAccountsReturnType
-  useRelayerData: () => UseRelayerDataReturnType
+  useRelayerData: (url: string | null) => UseRelayerDataReturnType
   useClaimableWalletToken: () => any // TODO
 }

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -12,7 +12,6 @@ export type UseRewardsProps = {
   relayerURL: string
   useAccounts: () => UseAccountsReturnType
   useRelayerData: (url: string | null | boolean, initialState?: any) => UseRelayerDataReturnType
-  useClaimableWalletToken: () => any // TODO
 }
 
 export type Multiplier = {

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -1,0 +1,4 @@
+export enum RewardIds {
+  ADX_REWARDS = 'adx-rewards',
+  BALANCE_REWARDS = 'balance-rewards'
+}

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -4,17 +4,18 @@ import { UseRelayerDataReturnType } from '../useRelayerData'
 
 export enum RewardIds {
   ADX_REWARDS = 'adx-rewards',
-  BALANCE_REWARDS = 'balance-rewards'
+  BALANCE_REWARDS = 'balance-rewards',
+  ADX_TOKEN_APY = 'adxTokenAPY'
 }
 
 export type UseRewardsProps = {
   relayerURL: string
   useAccounts: () => UseAccountsReturnType
-  useRelayerData: (url: string | null | boolean) => UseRelayerDataReturnType
+  useRelayerData: (url: string | null | boolean, initialState?: any) => UseRelayerDataReturnType
   useClaimableWalletToken: () => any // TODO
 }
 
-type Multiplier = {
+export type Multiplier = {
   mul: number
   name: Text
 }

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -10,7 +10,7 @@ export enum RewardIds {
 export type UseRewardsProps = {
   relayerURL: string
   useAccounts: () => UseAccountsReturnType
-  useRelayerData: (url: string | null) => UseRelayerDataReturnType
+  useRelayerData: (url: string | null | boolean) => UseRelayerDataReturnType
   useClaimableWalletToken: () => any // TODO
 }
 

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -54,7 +54,7 @@ export type RelayerRewardsData = {
     usdPrice: number
     walletTokenAPY: number
     xWALLETAPY: number
-    promo?: Promo[]
+    promo?: null | Promo
   }
   errMsg: null
   isLoading: boolean
@@ -71,6 +71,7 @@ export type RewardsState = {
   xWALLETAPY: number
   xWALLETAPYPercentage: string
   totalLifetimeRewards: number
+  promo?: null | Promo
 }
 
 export interface UseRewardsReturnType {

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -1,4 +1,3 @@
-import { UseAccountsReturnType } from '../useAccounts'
 import { Account } from '../useAccounts/types'
 import { UseRelayerDataProps, UseRelayerDataReturnType } from '../useRelayerData'
 
@@ -10,7 +9,7 @@ export enum RewardIds {
 
 export type UseRewardsProps = {
   relayerURL: string
-  useAccounts: () => UseAccountsReturnType
+  accountId: Account['id']
   useRelayerData: (props: Omit<UseRelayerDataProps, 'fetch'>) => UseRelayerDataReturnType
 }
 

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -1,4 +1,5 @@
 import { UseAccountsReturnType } from '../useAccounts'
+import { Account } from '../useAccounts/types'
 import { UseRelayerDataReturnType } from '../useRelayerData'
 
 export enum RewardIds {
@@ -11,4 +12,31 @@ export type UseRewardsProps = {
   useAccounts: () => UseAccountsReturnType
   useRelayerData: (url: string | null) => UseRelayerDataReturnType
   useClaimableWalletToken: () => any // TODO
+}
+
+type Multiplier = {
+  mul: number
+  name: Text
+}
+
+type Reward = {
+  _id: string
+  rewards: {
+    [key in Account['id']]: number
+  }
+  updated: string // timestamp
+}
+
+export type RewardsData = {
+  data: {
+    adxTokenAPY: number
+    multipliers: Multiplier[]
+    rewards: Reward[]
+    success: boolean
+    usdPrice: number
+    walletTokenAPY: number
+    xWALLETAPY: number
+  }
+  errMsg: null
+  isLoading: boolean
 }

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -26,6 +26,25 @@ type Reward = {
   updated: string // timestamp
 }
 
+export type Promo = {
+  // TODO: Double-check if these are all incoming props fro the Relayer
+  text: string
+  resources: {
+    link1: {
+      href: string
+      label: string
+    }
+    emojies?: {
+      [key in 'e1' | 'e2' | 'e3']: { text: string; size: string }
+    }
+  }
+  period: {
+    from: number
+    to: number
+    timer: boolean
+  }
+}
+
 export type RelayerRewardsData = {
   data: {
     adxTokenAPY: number
@@ -35,6 +54,7 @@ export type RelayerRewardsData = {
     usdPrice: number
     walletTokenAPY: number
     xWALLETAPY: number
+    promo?: Promo[]
   }
   errMsg: null
   isLoading: boolean

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -40,3 +40,22 @@ export type RelayerRewardsData = {
   errMsg: null
   isLoading: boolean
 }
+
+export type RewardsState = {
+  [key in RewardIds]: number
+} & {
+  multipliers: Multiplier[]
+  walletTokenAPY: number
+  walletTokenAPYPercentage: string
+  adxTokenAPYPercentage: string
+  walletUsdPrice: number
+  xWALLETAPY: number
+  xWALLETAPYPercentage: string
+  totalLifetimeRewards: number
+}
+
+export interface UseRewardsReturnType {
+  isLoading: boolean
+  errMsg: null | any
+  rewards: RewardsState
+}

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -19,7 +19,8 @@ const initialState = {
     success: true,
     usdPrice: 0,
     walletTokenAPY: 0,
-    xWALLETAPY: 0
+    xWALLETAPY: 0,
+    promo: []
   },
   errMsg: null,
   isLoading: true
@@ -36,8 +37,7 @@ const rewardsInitialState = {
   walletUsdPrice: 0,
   xWALLETAPY: 0,
   xWALLETAPYPercentage: '...',
-  totalLifetimeRewards: 0,
-  promo: []
+  totalLifetimeRewards: 0
 }
 
 export default function useRewards({

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+
+import useCacheBreak from '../useCacheBreak'
+
+export enum RewardIds {
+  ADX_REWARDS = 'adx-rewards',
+  BALANCE_REWARDS = 'balance-rewards'
+}
+
+export default function useRewards({ useAccounts, useRelayerData, useClaimableWalletToken }) {
+  const claimableWalletToken = useClaimableWalletToken()
+  const { account, selectedAcc } = useAccounts()
+  const { cacheBreak } = useCacheBreak()
+
+  const rewardsUrl =
+    CONFIG.RELAYER_URL && selectedAcc
+      ? `${CONFIG.RELAYER_URL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
+      : null
+  const rewardsData = useRelayerData(rewardsUrl)
+
+  const totalLifetimeRewards = rewardsData.data?.rewards
+    ?.map((x) => (typeof x.rewards[account.id] === 'number' ? x.rewards[account.id] : 0))
+    .reduce((a, b) => a + b, 0)
+
+  const pendingTokensTotal =
+    claimableWalletToken.currentClaimStatus && !claimableWalletToken.currentClaimStatus.loading
+      ? (
+          (totalLifetimeRewards || 0) -
+          (claimableWalletToken.currentClaimStatus.claimed || 0) -
+          (claimableWalletToken.currentClaimStatus.claimedInitial || 0) +
+          (claimableWalletToken.currentClaimStatus.mintableVesting || 0)
+        ).toFixed(3)
+      : '...'
+  const [rewards, setRewards] = useState({})
+  const { isLoading, data, errMsg } = rewardsData
+
+  // const showWalletTokenModal = useDynamicModal(
+  //   WalletTokenModal,
+  //   { claimableWalletToken, accountId: account.id },
+  //   { rewards }
+  // )
+
+  useEffect(() => {
+    if (errMsg || !data || !data.success) return
+
+    if (!data.rewards.length) return
+
+    const rewardsDetails = Object.fromEntries(
+      data.rewards.map(({ _id, rewards }) => [_id, rewards[account.id] || 0])
+    )
+    rewardsDetails.multipliers = data.multipliers
+    rewardsDetails.walletTokenAPY = data.walletTokenAPY
+    rewardsDetails.adxTokenAPY = data.adxTokenAPY
+    rewardsDetails.walletUsdPrice = data.usdPrice
+    rewardsDetails.xWALLETAPY = data.xWALLETAPY
+    setRewards(rewardsDetails)
+  }, [data, errMsg, account])
+
+  return {
+    isLoading,
+    errMsg,
+    data,
+    rewards,
+    pendingTokensTotal,
+    claimableWalletToken
+  }
+}

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -104,7 +104,6 @@ export default function useRewards({
   return {
     isLoading,
     errMsg,
-    data,
     rewards,
     pendingTokensTotal,
     claimableWalletToken

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -51,7 +51,10 @@ export default function useRewards({
     !!relayerURL &&
     !!selectedAcc &&
     `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
-  const { isLoading, data, errMsg } = useRelayerData(rewardsUrl, initialState) as RelayerRewardsData
+  const { isLoading, data, errMsg } = useRelayerData({
+    url: rewardsUrl,
+    initialState
+  }) as RelayerRewardsData
 
   useEffect(() => {
     if (errMsg || !data.success || isLoading) return

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -26,19 +26,15 @@ export default function useRewards({
   const claimableWalletToken = useClaimableWalletToken()
   const { account, selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
-  const [{ isLoading, data, errMsg }, setRewardsData] = useState<RewardsData>(rewardsInitialState)
   // TODO: type for this state
   const [rewards, setRewards] = useState({})
 
-  useEffect(() => {
-    if (!relayerURL || !selectedAcc) return
-
-    const rewardsUrl = `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
-    // FIXME: This breaks the hooks concept
-    const rewardsData = useRelayerData(rewardsUrl) as RewardsData
-
-    setRewardsData(rewardsData)
-  }, [selectedAcc, relayerURL, cacheBreak, useRelayerData])
+  const rewardsUrl =
+    !!relayerURL &&
+    !!selectedAcc &&
+    `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
+  const { isLoading, data, errMsg } =
+    (useRelayerData(rewardsUrl) as RewardsData) || rewardsInitialState
 
   useEffect(() => {
     if (errMsg || !data || !data.success) return

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -20,7 +20,7 @@ const initialState = {
     usdPrice: 0,
     walletTokenAPY: 0,
     xWALLETAPY: 0,
-    promo: []
+    promo: null
   },
   errMsg: null,
   isLoading: true
@@ -38,7 +38,7 @@ const rewardsInitialState = {
   xWALLETAPY: 0,
   xWALLETAPYPercentage: '...',
   totalLifetimeRewards: 0,
-  promo: []
+  promo: null
 }
 
 export default function useRewards({
@@ -62,7 +62,7 @@ export default function useRewards({
     if (errMsg || !data?.success || isLoading) return
 
     const rewardsDetails = Object.fromEntries<
-      string | number | Multiplier[] | Promo[] | { [key in RewardIds]: number }
+      string | number | Multiplier[] | Promo | { [key in RewardIds]: number }
     >(data.rewards.map(({ _id, rewards: r }) => [_id, r[accountId] || 0]))
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY // TODO: Remove if not used anyhwere else raw
@@ -86,7 +86,7 @@ export default function useRewards({
       .map((x) => (typeof x.rewards[accountId] === 'number' ? x.rewards[accountId] : 0))
       .reduce((a, b) => a + b, 0)
 
-    rewardsDetails.promo = data.promo || []
+    rewardsDetails.promo = (data.promo as Promo) || null
 
     setRewards(rewardsDetails as RewardsState)
   }, [accountId, data, errMsg, isLoading])

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import useCacheBreak from '../useCacheBreak'
 import {
   Multiplier,
+  Promo,
   RelayerRewardsData,
   RewardIds,
   RewardsState,
@@ -35,7 +36,8 @@ const rewardsInitialState = {
   walletUsdPrice: 0,
   xWALLETAPY: 0,
   xWALLETAPYPercentage: '...',
-  totalLifetimeRewards: 0
+  totalLifetimeRewards: 0,
+  promo: []
 }
 
 export default function useRewards({
@@ -59,7 +61,7 @@ export default function useRewards({
     if (errMsg || !data?.success || isLoading) return
 
     const rewardsDetails = Object.fromEntries<
-      string | number | Multiplier[] | { [key in RewardIds]: number }
+      string | number | Multiplier[] | Promo[] | { [key in RewardIds]: number }
     >(data.rewards.map(({ _id, rewards: r }) => [_id, r[accountId] || 0]))
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY // TODO: Remove if not used anyhwere else raw
@@ -82,6 +84,8 @@ export default function useRewards({
     rewardsDetails.totalLifetimeRewards = data.rewards
       .map((x) => (typeof x.rewards[accountId] === 'number' ? x.rewards[accountId] : 0))
       .reduce((a, b) => a + b, 0)
+
+    rewardsDetails.promo = data.promo || []
 
     setRewards(rewardsDetails as RewardsState)
   }, [accountId, data, errMsg, isLoading])

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -66,9 +66,9 @@ export default function useRewards({
     // if (!data.rewards.length) return
     // if (account?.id) return
 
-    const rewardsDetails = Object.fromEntries<string | number | Multiplier[]>(
-      data.rewards.map(({ _id, rewards: r }) => [_id, r[selectedAcc] || 0])
-    )
+    const rewardsDetails = Object.fromEntries<
+      string | number | Multiplier[] | { [key in RewardIds]: number }
+    >(data.rewards.map(({ _id, rewards: r }) => [_id, r[selectedAcc] || 0]))
     // TODO: Figure out why types mismatch
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY
@@ -83,12 +83,12 @@ export default function useRewards({
         '...'
     rewardsDetails.walletUsdPrice = data.usdPrice || 0
     rewardsDetails.xWALLETAPY = data.xWALLETAPY
-    rewardsDetails.xWALLETAPYPercentage = rewards.xWALLETAPY
+    rewardsDetails.xWALLETAPYPercentage = data.xWALLETAPY
       ? (data.xWALLETAPY * 100).toFixed(2)
       : // TODO: Check if displaying 0 is better
         '...'
 
-    setRewards(rewardsDetails)
+    setRewards(rewardsDetails as RewardsState)
   }, [selectedAcc, data, errMsg])
 
   const totalLifetimeRewards = data.rewards

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -40,17 +40,16 @@ const rewardsInitialState = {
 
 export default function useRewards({
   relayerURL,
-  useAccounts,
+  accountId,
   useRelayerData
 }: UseRewardsProps): UseRewardsReturnType {
-  const { selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
   const [rewards, setRewards] = useState<RewardsState>(rewardsInitialState)
 
   const rewardsUrl =
     !!relayerURL &&
-    !!selectedAcc &&
-    `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
+    !!accountId &&
+    `${relayerURL}/wallet-token/rewards/${accountId}?cacheBreak=${cacheBreak}`
   const { isLoading, data, errMsg } = useRelayerData({
     url: rewardsUrl,
     initialState
@@ -61,7 +60,7 @@ export default function useRewards({
 
     const rewardsDetails = Object.fromEntries<
       string | number | Multiplier[] | { [key in RewardIds]: number }
-    >(data.rewards.map(({ _id, rewards: r }) => [_id, r[selectedAcc] || 0]))
+    >(data.rewards.map(({ _id, rewards: r }) => [_id, r[accountId] || 0]))
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY // TODO: Remove if not used anyhwere else raw
     rewardsDetails.walletTokenAPYPercentage = data.walletTokenAPY
@@ -81,11 +80,11 @@ export default function useRewards({
         '...'
 
     rewardsDetails.totalLifetimeRewards = data.rewards
-      .map((x) => (typeof x.rewards[selectedAcc] === 'number' ? x.rewards[selectedAcc] : 0))
+      .map((x) => (typeof x.rewards[accountId] === 'number' ? x.rewards[accountId] : 0))
       .reduce((a, b) => a + b, 0)
 
     setRewards(rewardsDetails as RewardsState)
-  }, [selectedAcc, data, errMsg, isLoading])
+  }, [accountId, data, errMsg, isLoading])
 
   return {
     isLoading,

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -55,7 +55,6 @@ export default function useRewards({
 
   useEffect(() => {
     if (errMsg || !data.success || isLoading) return
-    if (!data.rewards.length) return
 
     const rewardsDetails = Object.fromEntries<
       string | number | Multiplier[] | { [key in RewardIds]: number }

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import useCacheBreak from '../useCacheBreak'
-import { RewardsData, UseRewardsProps } from './types'
+import { Multiplier, RewardIds, RewardsData, UseRewardsProps } from './types'
 
 const rewardsInitialState = {
   data: {
@@ -27,19 +27,29 @@ export default function useRewards({
   const { account, selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
   // TODO: type for this state
-  const [rewards, setRewards] = useState({})
+  const [rewards, setRewards] = useState<
+    | {
+        [key in RewardIds]: number
+      }
+    | {
+        multipliers: Multiplier[]
+        walletTokenAPY: number
+        walletUsdPrice: number
+        xWALLETAPY: number
+      }
+  >({})
 
   const rewardsUrl =
     !!relayerURL &&
     !!selectedAcc &&
     `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
-  const { isLoading, data, errMsg } =
-    (useRelayerData(rewardsUrl) as RewardsData) || rewardsInitialState
+  const { isLoading, data, errMsg } = useRelayerData(rewardsUrl, rewardsInitialState) as RewardsData
 
   useEffect(() => {
     if (errMsg || !data || !data.success) return
-    if (!data?.rewards?.length) return
-    if (account?.id) return
+    // TODO: Figure out if these are still needed
+    // if (!data.rewards.length) return
+    // if (account?.id) return
 
     const rewardsDetails = Object.fromEntries(
       data.rewards.map(({ _id, rewards: r }) => [_id, r[account.id] || 0])

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -1,7 +1,49 @@
 import { useEffect, useState } from 'react'
 
+import { Account } from '../useAccounts/types'
 import useCacheBreak from '../useCacheBreak'
 import { UseRewardsProps } from './types'
+
+type Multiplier = {
+  mul: number
+  name: Text
+}
+
+type Reward = {
+  _id: string
+  rewards: {
+    [key in Account['id']]: number
+  }
+  updated: string // timestamp
+}
+
+type RewardsData = {
+  data: {
+    adxTokenAPY: number
+    multipliers: Multiplier[]
+    rewards: Reward[]
+    success: boolean
+    usdPrice: number
+    walletTokenAPY: number
+    xWALLETAPY: number
+  }
+  errMsg: null
+  isLoading: boolean
+}
+
+const rewardsInitialState = {
+  data: {
+    adxTokenAPY: 0,
+    multipliers: [],
+    rewards: [],
+    success: false,
+    usdPrice: 0,
+    walletTokenAPY: 0,
+    xWALLETAPY: 0
+  },
+  errMsg: null,
+  isLoading: true
+}
 
 export default function useRewards({
   relayerURL,
@@ -22,7 +64,7 @@ export default function useRewards({
   // TODO: Skip if `null`.
   const rewardsData = useRelayerData(rewardsUrl)
 
-  const totalLifetimeRewards = rewardsData.data?.rewards
+  const totalLifetimeRewards = rewardsData.data.rewards
     ?.map((x) => (typeof x.rewards[account.id] === 'number' ? x.rewards[account.id] : 0))
     .reduce((a, b) => a + b, 0)
 

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -56,7 +56,7 @@ export default function useRewards({
   }) as RelayerRewardsData
 
   useEffect(() => {
-    if (errMsg || !data.success || isLoading) return
+    if (errMsg || !data?.success || isLoading) return
 
     const rewardsDetails = Object.fromEntries<
       string | number | Multiplier[] | { [key in RewardIds]: number }

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -1,7 +1,14 @@
 import { useEffect, useState } from 'react'
 
 import useCacheBreak from '../useCacheBreak'
-import { Multiplier, RelayerRewardsData, RewardIds, UseRewardsProps } from './types'
+import {
+  Multiplier,
+  RelayerRewardsData,
+  RewardIds,
+  RewardsState,
+  UseRewardsProps,
+  UseRewardsReturnType
+} from './types'
 
 const initialState = {
   data: {
@@ -31,20 +38,11 @@ const rewardsInitialState = {
   totalLifetimeRewards: 0
 }
 
-type RewardsState = {
-  [key in RewardIds]: number
-} & {
-  multipliers: Multiplier[]
-  walletTokenAPY: number
-  walletTokenAPYPercentage: string
-  adxTokenAPYPercentage: string
-  walletUsdPrice: number
-  xWALLETAPY: number
-  xWALLETAPYPercentage: string
-  totalLifetimeRewards: number
-}
-
-export default function useRewards({ relayerURL, useAccounts, useRelayerData }: UseRewardsProps) {
+export default function useRewards({
+  relayerURL,
+  useAccounts,
+  useRelayerData
+}: UseRewardsProps): UseRewardsReturnType {
   const { selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
   const [rewards, setRewards] = useState<RewardsState>(rewardsInitialState)

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -43,7 +43,7 @@ export default function useRewards({
   useClaimableWalletToken
 }: UseRewardsProps) {
   const claimableWalletToken = useClaimableWalletToken()
-  const { account, selectedAcc } = useAccounts()
+  const { selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
   // TODO: type for this state
   const [rewards, setRewards] = useState<RewardsState>(rewardsInitialState)
@@ -61,7 +61,7 @@ export default function useRewards({
     // if (account?.id) return
 
     const rewardsDetails = Object.fromEntries(
-      data.rewards.map(({ _id, rewards: r }) => [_id, r[account.id] || 0])
+      data.rewards.map(({ _id, rewards: r }) => [_id, r[selectedAcc] || 0])
     )
     // TODO: Figure out why types mismatch
     rewardsDetails.multipliers = data.multipliers
@@ -70,10 +70,10 @@ export default function useRewards({
     rewardsDetails.walletUsdPrice = data.usdPrice
     rewardsDetails.xWALLETAPY = data.xWALLETAPY
     setRewards(rewardsDetails)
-  }, [account.id, data, errMsg])
+  }, [selectedAcc, data, errMsg])
 
   const totalLifetimeRewards = data.rewards
-    ?.map((x) => (typeof x.rewards[account.id] === 'number' ? x.rewards[account.id] : 0))
+    ?.map((x) => (typeof x.rewards[selectedAcc] === 'number' ? x.rewards[selectedAcc] : 0))
     .reduce((a, b) => a + b, 0)
 
   const pendingTokensTotal =

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react'
 
 import useCacheBreak from '../useCacheBreak'
-import { Multiplier, RewardIds, RewardsData, UseRewardsProps } from './types'
+import { Multiplier, RelayerRewardsData, RewardIds, UseRewardsProps } from './types'
 
-const rewardsInitialState = {
+const initialState = {
   data: {
     adxTokenAPY: 0,
     multipliers: [],
@@ -17,6 +17,25 @@ const rewardsInitialState = {
   isLoading: true
 }
 
+const rewardsInitialState = {
+  [RewardIds.ADX_REWARDS]: 0,
+  [RewardIds.BALANCE_REWARDS]: 0,
+  [RewardIds.ADX_TOKEN_APY]: 0,
+  multipliers: [],
+  walletTokenAPY: 0,
+  walletUsdPrice: 0,
+  xWALLETAPY: 0
+}
+
+type RewardsState = {
+  [key in RewardIds]: number
+} & {
+  multipliers: Multiplier[]
+  walletTokenAPY: number
+  walletUsdPrice: number
+  xWALLETAPY: number
+}
+
 export default function useRewards({
   relayerURL,
   useAccounts,
@@ -27,23 +46,13 @@ export default function useRewards({
   const { account, selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
   // TODO: type for this state
-  const [rewards, setRewards] = useState<
-    | {
-        [key in RewardIds]: number
-      }
-    | {
-        multipliers: Multiplier[]
-        walletTokenAPY: number
-        walletUsdPrice: number
-        xWALLETAPY: number
-      }
-  >({})
+  const [rewards, setRewards] = useState<RewardsState>(rewardsInitialState)
 
   const rewardsUrl =
     !!relayerURL &&
     !!selectedAcc &&
     `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
-  const { isLoading, data, errMsg } = useRelayerData(rewardsUrl, rewardsInitialState) as RewardsData
+  const { isLoading, data, errMsg } = useRelayerData(rewardsUrl, initialState) as RelayerRewardsData
 
   useEffect(() => {
     if (errMsg || !data || !data.success) return

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -34,7 +34,6 @@ export default function useRewards({
     if (!relayerURL || !selectedAcc) return
 
     const rewardsUrl = `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
-    console.log('fire')
     // FIXME: This breaks the hooks concept
     const rewardsData = useRelayerData(rewardsUrl) as RewardsData
 
@@ -49,6 +48,7 @@ export default function useRewards({
     const rewardsDetails = Object.fromEntries(
       data.rewards.map(({ _id, rewards: r }) => [_id, r[account.id] || 0])
     )
+    // TODO: Figure out why types mismatch
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY
     rewardsDetails.adxTokenAPY = data.adxTokenAPY

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -42,13 +42,7 @@ type RewardsState = {
   xWALLETAPYPercentage: string
 }
 
-export default function useRewards({
-  relayerURL,
-  useAccounts,
-  useRelayerData,
-  useClaimableWalletToken
-}: UseRewardsProps) {
-  const claimableWalletToken = useClaimableWalletToken()
+export default function useRewards({ relayerURL, useAccounts, useRelayerData }: UseRewardsProps) {
   const { selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
   const [rewards, setRewards] = useState<RewardsState>(rewardsInitialState)
@@ -88,24 +82,13 @@ export default function useRewards({
   }, [selectedAcc, data, errMsg, isLoading])
 
   const totalLifetimeRewards = data.rewards
-    ?.map((x) => (typeof x.rewards[selectedAcc] === 'number' ? x.rewards[selectedAcc] : 0))
+    .map((x) => (typeof x.rewards[selectedAcc] === 'number' ? x.rewards[selectedAcc] : 0))
     .reduce((a, b) => a + b, 0)
-
-  const pendingTokensTotal =
-    claimableWalletToken.currentClaimStatus && !claimableWalletToken.currentClaimStatus.loading
-      ? (
-          (totalLifetimeRewards || 0) -
-          (claimableWalletToken.currentClaimStatus.claimed || 0) -
-          (claimableWalletToken.currentClaimStatus.claimedInitial || 0) +
-          (claimableWalletToken.currentClaimStatus.mintableVesting || 0)
-        ).toFixed(3)
-      : '...'
 
   return {
     isLoading,
     errMsg,
     rewards,
-    pendingTokensTotal,
-    claimableWalletToken
+    totalLifetimeRewards
   }
 }

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -23,8 +23,11 @@ const rewardsInitialState = {
   [RewardIds.ADX_TOKEN_APY]: 0,
   multipliers: [],
   walletTokenAPY: 0,
+  walletTokenAPYPercentage: '...',
+  adxTokenAPYPercentage: '...',
   walletUsdPrice: 0,
-  xWALLETAPY: 0
+  xWALLETAPY: 0,
+  xWALLETAPYPercentage: '...'
 }
 
 type RewardsState = {
@@ -32,8 +35,11 @@ type RewardsState = {
 } & {
   multipliers: Multiplier[]
   walletTokenAPY: number
+  walletTokenAPYPercentage: string
+  adxTokenAPYPercentage: string
   walletUsdPrice: number
   xWALLETAPY: number
+  xWALLETAPYPercentage: string
 }
 
 export default function useRewards({
@@ -60,15 +66,28 @@ export default function useRewards({
     // if (!data.rewards.length) return
     // if (account?.id) return
 
-    const rewardsDetails = Object.fromEntries(
+    const rewardsDetails = Object.fromEntries<string | number | Multiplier[]>(
       data.rewards.map(({ _id, rewards: r }) => [_id, r[selectedAcc] || 0])
     )
     // TODO: Figure out why types mismatch
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY
+    rewardsDetails.walletTokenAPYPercentage = data.walletTokenAPY
+      ? `${(data.walletTokenAPY * 100).toFixed(2)}%`
+      : // TODO: Check if displaying 0 is better
+        '...'
     rewardsDetails.adxTokenAPY = data.adxTokenAPY
-    rewardsDetails.walletUsdPrice = data.usdPrice
+    rewardsDetails.adxTokenAPYPercentage = data.adxTokenAPY
+      ? (data.adxTokenAPY * 100).toFixed(2)
+      : // TODO: Check if displaying 0 is better
+        '...'
+    rewardsDetails.walletUsdPrice = data.usdPrice || 0
     rewardsDetails.xWALLETAPY = data.xWALLETAPY
+    rewardsDetails.xWALLETAPYPercentage = rewards.xWALLETAPY
+      ? (data.xWALLETAPY * 100).toFixed(2)
+      : // TODO: Check if displaying 0 is better
+        '...'
+
     setRewards(rewardsDetails)
   }, [selectedAcc, data, errMsg])
 

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -37,7 +37,8 @@ const rewardsInitialState = {
   walletUsdPrice: 0,
   xWALLETAPY: 0,
   xWALLETAPYPercentage: '...',
-  totalLifetimeRewards: 0
+  totalLifetimeRewards: 0,
+  promo: []
 }
 
 export default function useRewards({

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -8,7 +8,7 @@ const initialState = {
     adxTokenAPY: 0,
     multipliers: [],
     rewards: [],
-    success: false,
+    success: true,
     usdPrice: 0,
     walletTokenAPY: 0,
     xWALLETAPY: 0
@@ -51,7 +51,6 @@ export default function useRewards({
   const claimableWalletToken = useClaimableWalletToken()
   const { selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
-  // TODO: type for this state
   const [rewards, setRewards] = useState<RewardsState>(rewardsInitialState)
 
   const rewardsUrl =
@@ -61,15 +60,12 @@ export default function useRewards({
   const { isLoading, data, errMsg } = useRelayerData(rewardsUrl, initialState) as RelayerRewardsData
 
   useEffect(() => {
-    if (errMsg || !data || !data.success) return
-    // TODO: Figure out if these are still needed
-    // if (!data.rewards.length) return
-    // if (account?.id) return
+    if (errMsg || !data.success || isLoading) return
+    if (!data.rewards.length) return
 
     const rewardsDetails = Object.fromEntries<
       string | number | Multiplier[] | { [key in RewardIds]: number }
     >(data.rewards.map(({ _id, rewards: r }) => [_id, r[selectedAcc] || 0]))
-    // TODO: Figure out why types mismatch
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY
     rewardsDetails.walletTokenAPYPercentage = data.walletTokenAPY
@@ -89,7 +85,7 @@ export default function useRewards({
         '...'
 
     setRewards(rewardsDetails as RewardsState)
-  }, [selectedAcc, data, errMsg])
+  }, [selectedAcc, data, errMsg, isLoading])
 
   const totalLifetimeRewards = data.rewards
     ?.map((x) => (typeof x.rewards[selectedAcc] === 'number' ? x.rewards[selectedAcc] : 0))

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -2,19 +2,19 @@ import { useEffect, useState } from 'react'
 
 import useCacheBreak from '../useCacheBreak'
 
-export enum RewardIds {
-  ADX_REWARDS = 'adx-rewards',
-  BALANCE_REWARDS = 'balance-rewards'
-}
-
-export default function useRewards({ useAccounts, useRelayerData, useClaimableWalletToken }) {
+export default function useRewards({
+  relayerURL,
+  useAccounts,
+  useRelayerData,
+  useClaimableWalletToken
+}) {
   const claimableWalletToken = useClaimableWalletToken()
   const { account, selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
 
   const rewardsUrl =
-    CONFIG.RELAYER_URL && selectedAcc
-      ? `${CONFIG.RELAYER_URL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
+    relayerURL && selectedAcc
+      ? `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
       : null
   const rewardsData = useRelayerData(rewardsUrl)
 

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -13,10 +13,13 @@ export default function useRewards({
   const { account, selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()
 
+  // TODO: Convert this to a `useEffect` hook
   const rewardsUrl =
     relayerURL && selectedAcc
       ? `${relayerURL}/wallet-token/rewards/${selectedAcc}?cacheBreak=${cacheBreak}`
       : null
+  // TODO: Types of the rewards data.
+  // TODO: Skip if `null`.
   const rewardsData = useRelayerData(rewardsUrl)
 
   const totalLifetimeRewards = rewardsData.data?.rewards
@@ -32,9 +35,11 @@ export default function useRewards({
           (claimableWalletToken.currentClaimStatus.mintableVesting || 0)
         ).toFixed(3)
       : '...'
+  // TODO: type for this state
   const [rewards, setRewards] = useState({})
   const { isLoading, data, errMsg } = rewardsData
 
+  // TODO: Double check if this is disabled on the web app too
   // const showWalletTokenModal = useDynamicModal(
   //   WalletTokenModal,
   //   { claimableWalletToken, accountId: account.id },

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -74,13 +74,13 @@ export default function useRewards({
         '...'
     rewardsDetails.adxTokenAPY = data.adxTokenAPY
     rewardsDetails.adxTokenAPYPercentage = data.adxTokenAPY
-      ? (data.adxTokenAPY * 100).toFixed(2)
+      ? `${(data.adxTokenAPY * 100).toFixed(2)}%`
       : // TODO: Check if displaying 0 is better
         '...'
     rewardsDetails.walletUsdPrice = data.usdPrice || 0
     rewardsDetails.xWALLETAPY = data.xWALLETAPY
     rewardsDetails.xWALLETAPYPercentage = data.xWALLETAPY
-      ? (data.xWALLETAPY * 100).toFixed(2)
+      ? `${(data.xWALLETAPY * 100).toFixed(2)}%`
       : // TODO: Check if displaying 0 is better
         '...'
 

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react'
 
 import useCacheBreak from '../useCacheBreak'
+import { UseRewardsProps } from './types'
 
 export default function useRewards({
   relayerURL,
   useAccounts,
   useRelayerData,
   useClaimableWalletToken
-}) {
+}: UseRewardsProps) {
   const claimableWalletToken = useClaimableWalletToken()
   const { account, selectedAcc } = useAccounts()
   const { cacheBreak } = useCacheBreak()

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -27,7 +27,8 @@ const rewardsInitialState = {
   adxTokenAPYPercentage: '...',
   walletUsdPrice: 0,
   xWALLETAPY: 0,
-  xWALLETAPYPercentage: '...'
+  xWALLETAPYPercentage: '...',
+  totalLifetimeRewards: 0
 }
 
 type RewardsState = {
@@ -40,6 +41,7 @@ type RewardsState = {
   walletUsdPrice: number
   xWALLETAPY: number
   xWALLETAPYPercentage: string
+  totalLifetimeRewards: number
 }
 
 export default function useRewards({ relayerURL, useAccounts, useRelayerData }: UseRewardsProps) {
@@ -61,34 +63,33 @@ export default function useRewards({ relayerURL, useAccounts, useRelayerData }: 
       string | number | Multiplier[] | { [key in RewardIds]: number }
     >(data.rewards.map(({ _id, rewards: r }) => [_id, r[selectedAcc] || 0]))
     rewardsDetails.multipliers = data.multipliers
-    rewardsDetails.walletTokenAPY = data.walletTokenAPY
+    rewardsDetails.walletTokenAPY = data.walletTokenAPY // TODO: Remove if not used anyhwere else raw
     rewardsDetails.walletTokenAPYPercentage = data.walletTokenAPY
       ? `${(data.walletTokenAPY * 100).toFixed(2)}%`
       : // TODO: Check if displaying 0 is better
         '...'
-    rewardsDetails.adxTokenAPY = data.adxTokenAPY
+    rewardsDetails.adxTokenAPY = data.adxTokenAPY // TODO: Remove if not used anyhwere else raw
     rewardsDetails.adxTokenAPYPercentage = data.adxTokenAPY
       ? `${(data.adxTokenAPY * 100).toFixed(2)}%`
       : // TODO: Check if displaying 0 is better
         '...'
-    rewardsDetails.walletUsdPrice = data.usdPrice || 0
+    rewardsDetails.walletUsdPrice = data.usdPrice || 0 // TODO: Remove if not used anyhwere else raw
     rewardsDetails.xWALLETAPY = data.xWALLETAPY
     rewardsDetails.xWALLETAPYPercentage = data.xWALLETAPY
       ? `${(data.xWALLETAPY * 100).toFixed(2)}%`
       : // TODO: Check if displaying 0 is better
         '...'
 
+    rewardsDetails.totalLifetimeRewards = data.rewards
+      .map((x) => (typeof x.rewards[selectedAcc] === 'number' ? x.rewards[selectedAcc] : 0))
+      .reduce((a, b) => a + b, 0)
+
     setRewards(rewardsDetails as RewardsState)
   }, [selectedAcc, data, errMsg, isLoading])
-
-  const totalLifetimeRewards = data.rewards
-    .map((x) => (typeof x.rewards[selectedAcc] === 'number' ? x.rewards[selectedAcc] : 0))
-    .reduce((a, b) => a + b, 0)
 
   return {
     isLoading,
     errMsg,
-    rewards,
-    totalLifetimeRewards
+    rewards
   }
 }

--- a/src/hooks/useStakedWalletToken/index.ts
+++ b/src/hooks/useStakedWalletToken/index.ts
@@ -1,0 +1,3 @@
+import useStakedWalletToken from './useStakedWalletToken'
+
+export default useStakedWalletToken

--- a/src/hooks/useStakedWalletToken/types.ts
+++ b/src/hooks/useStakedWalletToken/types.ts
@@ -1,0 +1,9 @@
+import { UseAccountsReturnType } from '../useAccounts'
+
+export type UseStakedWalletTokenProps = {
+  useAccounts: () => UseAccountsReturnType
+}
+
+export type UseStakedWalletTokenReturnType = {
+  stakedAmount: number
+}

--- a/src/hooks/useStakedWalletToken/types.ts
+++ b/src/hooks/useStakedWalletToken/types.ts
@@ -1,7 +1,7 @@
-import { UseAccountsReturnType } from '../useAccounts'
+import { Account } from '../useAccounts'
 
 export type UseStakedWalletTokenProps = {
-  useAccounts: () => UseAccountsReturnType
+  accountId: Account['id']
 }
 
 export type UseStakedWalletTokenReturnType = {

--- a/src/hooks/useStakedWalletToken/useStakedWalletToken.tsx
+++ b/src/hooks/useStakedWalletToken/useStakedWalletToken.tsx
@@ -18,15 +18,14 @@ const stakingWalletContract = new Contract(
 )
 
 const useStakedWalletToken = ({
-  useAccounts
+  accountId
 }: UseStakedWalletTokenProps): UseStakedWalletTokenReturnType => {
-  const { selectedAcc } = useAccounts()
   const [stakedAmount, setStakedAmount] = useState(0)
 
   const fetchStakedWalletData = useCallback(async () => {
     try {
       const [balanceOf, shareValue] = await Promise.all([
-        stakingWalletContract.balanceOf(selectedAcc),
+        stakingWalletContract.balanceOf(accountId),
         stakingWalletContract.shareValue()
       ])
 
@@ -35,7 +34,7 @@ const useStakedWalletToken = ({
     } catch (e) {
       // Fail silently
     }
-  }, [selectedAcc])
+  }, [accountId])
 
   useEffect(() => {
     fetchStakedWalletData()

--- a/src/hooks/useStakedWalletToken/useStakedWalletToken.tsx
+++ b/src/hooks/useStakedWalletToken/useStakedWalletToken.tsx
@@ -1,6 +1,6 @@
 import { Contract } from 'ethers'
 import { formatUnits, Interface } from 'ethers/lib/utils'
-import React, { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import WalletStakingPoolABI from '../../constants/abis/WalletStakingPoolABI.json'
 import { NETWORKS } from '../../constants/networks'

--- a/src/hooks/useStakedWalletToken/useStakedWalletToken.tsx
+++ b/src/hooks/useStakedWalletToken/useStakedWalletToken.tsx
@@ -1,0 +1,47 @@
+import { Contract } from 'ethers'
+import { formatUnits, Interface } from 'ethers/lib/utils'
+import React, { useCallback, useEffect, useState } from 'react'
+
+import WalletStakingPoolABI from '../../constants/abis/WalletStakingPoolABI.json'
+import { NETWORKS } from '../../constants/networks'
+import { getProvider } from '../../services/provider'
+import { UseStakedWalletTokenProps, UseStakedWalletTokenReturnType } from './types'
+
+const WALLET_STAKING_ADDRESS = '0x47cd7e91c3cbaaf266369fe8518345fc4fc12935'
+const WALLET_STAKING_POOL_INTERFACE = new Interface(WalletStakingPoolABI)
+
+const provider = getProvider(NETWORKS.ethereum)
+const stakingWalletContract = new Contract(
+  WALLET_STAKING_ADDRESS,
+  WALLET_STAKING_POOL_INTERFACE,
+  provider
+)
+
+const useStakedWalletToken = ({
+  useAccounts
+}: UseStakedWalletTokenProps): UseStakedWalletTokenReturnType => {
+  const { selectedAcc } = useAccounts()
+  const [stakedAmount, setStakedAmount] = useState(0)
+
+  const fetchStakedWalletData = useCallback(async () => {
+    try {
+      const [balanceOf, shareValue] = await Promise.all([
+        stakingWalletContract.balanceOf(selectedAcc),
+        stakingWalletContract.shareValue()
+      ])
+
+      const amount = +formatUnits(balanceOf.toString(), 18) * +formatUnits(shareValue, 18)
+      setStakedAmount(amount)
+    } catch (e) {
+      // Fail silently
+    }
+  }, [selectedAcc])
+
+  useEffect(() => {
+    fetchStakedWalletData()
+  }, [fetchStakedWalletData])
+
+  return { stakedAmount }
+}
+
+export default useStakedWalletToken


### PR DESCRIPTION
Implements the rewards related logic, currently pulled over from the mobile app from the 3 hooks used there: `useRewards`, `useClaimableWalletToken` and `useStakedWalletToken`.

Additionally, moves more logic (related to calculations and states) from the local components to the ambire-common hooks, so that both apps can ref it.