### PR TITLE
Config / Resolve TypeScript annoying bad type warnings (errors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "adex-protocol-eth": "git+https://git@github.com/AmbireTech/adex-protocol-eth.git",
     "url": "^0.11.0",
     "validator": "^13.7.0",
-    "bip44-constants": "^128.0.0"
+    "bip44-constants": "^128.0.0",
+    "@types/validator": "^13.7.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.14.11",
+  "version": "0.14.12",
   "name": "ambire-common",
   "description": "Common ground for the Ambire apps",
   "scripts": {

--- a/src/hooks/useDapps/useDapps.ts
+++ b/src/hooks/useDapps/useDapps.ts
@@ -155,22 +155,24 @@ export default function useDapps({ useStorage, fetch }: UseDappsProps): UseDapps
   }, [])
 
   const onSearchChange = useCallback((val: string | null) => {
-    setSearch(val)
+    setSearch(val || '')
   }, [])
 
   // refresh list from filters
   useEffect(() => {
     setFilteredItems(
-      [...catalog].sort((a, b) => Number(!!b.featured) - Number(!!a.featured)).filter((item: any) => {
-        let match = true
-        if (categoryFilter) {
-          match = categoryFilter.filter(item, favorites)
-        }
-        if (search && match) {
-          match = item.name.toLowerCase().includes(search?.toLowerCase())
-        }
-        return match
-      })
+      [...catalog]
+        .sort((a, b) => Number(!!b.featured) - Number(!!a.featured))
+        .filter((item: any) => {
+          let match = true
+          if (categoryFilter) {
+            match = categoryFilter.filter(item, favorites)
+          }
+          if (search && match) {
+            match = item.name.toLowerCase().includes(search?.toLowerCase())
+          }
+          return match
+        })
     )
   }, [catalog, search, categoryFilter, favorites])
 

--- a/src/services/validations/importedAccountProps.ts
+++ b/src/services/validations/importedAccountProps.ts
@@ -1,5 +1,6 @@
 // TODO: add types
 
+import { Account } from 'ambire-common/src/hooks/useAccounts'
 import { getAddress, hexDataLength } from 'ethers/lib/utils'
 
 import { isEmail } from './validate'
@@ -24,7 +25,7 @@ const isValidTimeLock = (timelock: any) => {
   )
 }
 const isValidSalt = (salt: any) => hexDataLength(salt) === HEX_DATA_LENGTH
-const validateAccountProps = (acc: any) =>
+const validateAccountProps = (acc: Account) =>
   NEEDED_KEYS.every((key) => Object.keys(acc).includes(key))
 const fileSizeValidator = (file: any) => {
   if (file.size > MAX_FILE_SIZE) {
@@ -37,7 +38,7 @@ const fileSizeValidator = (file: any) => {
   return null
 }
 
-const validateImportedAccountProps = (acc) => {
+const validateImportedAccountProps = (acc: Account) => {
   if (!(acc && validateAccountProps(acc))) {
     return {
       success: false,


### PR DESCRIPTION
Resolve all the recent (4) TypeScript warnings. Otherwise, the web app compilation process (`npm start`) throws the following annoying errors:

```
Compiled with warnings.

/Users/kalo/Sites/ambire-wallet/node_modules/ambire-common/src/hooks/useDapps/useDapps.ts
TypeScript error in /Users/kalo/Sites/ambire-wallet/node_modules/ambire-common/src/hooks/useDapps/useDapps.ts(158,15):
Argument of type 'string | null' is not assignable to parameter of type 'SetStateAction<string>'.
  Type 'null' is not assignable to type 'SetStateAction<string>'.  TS2345

    156 |
    157 |   const onSearchChange = useCallback((val: string | null) => {
  > 158 |     setSearch(val)
        |               ^
    159 |   }, [])
    160 |
    161 |   // refresh list from filters

/Users/kalo/Sites/ambire-wallet/node_modules/ambire-common/src/services/validations/dapps.ts
TypeScript error in /Users/kalo/Sites/ambire-wallet/node_modules/ambire-common/src/services/validations/dapps.ts(1,19):
Could not find a declaration file for module 'validator/es/lib/isURL'. '/Users/kalo/Sites/ambire-wallet/node_modules/validator/es/lib/isURL.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/validator` if it exists or add a new declaration (.d.ts) file containing `declare module 'validator/es/lib/isURL';`  TS7016

  > 1 | import isURL from 'validator/es/lib/isURL'
      |                   ^
    2 |
    3 | import { AmbireDappManifest } from '../dappCatalog/types'
    4 |

/Users/kalo/Sites/ambire-wallet/node_modules/ambire-common/src/services/validations/importedAccountProps.ts
TypeScript error in /Users/kalo/Sites/ambire-wallet/node_modules/ambire-common/src/services/validations/importedAccountProps.ts(40,39):
Parameter 'acc' implicitly has an 'any' type.  TS7006

    38 | }
    39 |
  > 40 | const validateImportedAccountProps = (acc) => {
       |                                       ^
    41 |   if (!(acc && validateAccountProps(acc))) {
    42 |     return {
    43 |       success: false,

/Users/kalo/Sites/ambire-wallet/node_modules/ambire-common/src/services/validations/validate.ts
TypeScript error in /Users/kalo/Sites/ambire-wallet/node_modules/ambire-common/src/services/validations/validate.ts(2,21):
Could not find a declaration file for module 'validator/es/lib/isEmail'. '/Users/kalo/Sites/ambire-wallet/node_modules/validator/es/lib/isEmail.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/validator` if it exists or add a new declaration (.d.ts) file containing `declare module 'validator/es/lib/isEmail';`  TS7016

    1 | import { parseUnits } from 'ethers/lib/utils'
  > 2 | import isEmail from 'validator/es/lib/isEmail'
      |                     ^
    3 |
    4 | import { isKnownTokenOrContract, isValidAddress } from '../address'
    5 |
```

With valid TS, the compilation step finishes without errors:

<img width="367" alt="Screenshot 2022-09-09 at 11 10 16" src="https://user-images.githubusercontent.com/2548061/189303599-82ab08a3-9cb2-446d-b4f2-a182a5cfa98e.png">
