### PR TITLE
Bug / Handle `undefined` for chain id when signing a message

### DIFF
--- a/src/services/getNetwork/getNetwork.ts
+++ b/src/services/getNetwork/getNetwork.ts
@@ -1,7 +1,9 @@
 import networks from '../../constants/networks'
 
-export const getNetworkByChainId = (chainId: string | number) => {
-  return networks.find((n) => n.chainId === parseInt(chainId.toString()))
+export const getNetworkByChainId = (chainId?: string | number) => {
+  if (!chainId) return null
+
+  return networks.find((n) => n.chainId === parseInt(chainId.toString(), 10))
 }
 
 export const getNetworkById = (id: string | number) => {


### PR DESCRIPTION
Looks like the chain id can also be undefined in one case (when signing a message), which breaks the logic.