### PR TITLE
Feature / Split the two constants-related endpoints into separate calls

### DIFF
--- a/src/hooks/useConstants/types.ts
+++ b/src/hooks/useConstants/types.ts
@@ -84,7 +84,7 @@ export interface UseConstantsReturnType {
   constants: ConstantsType | null
   isLoading: boolean
   retryFetch: () => void
-  getAdexToStakingTransfersLogsType: () => Promise<AdexToStakingTransfersLogsType | null>
+  getAdexToStakingTransfersLogs: () => Promise<AdexToStakingTransfersLogsType | null>
   hasError: boolean
 }
 

--- a/src/hooks/useConstants/types.ts
+++ b/src/hooks/useConstants/types.ts
@@ -74,7 +74,6 @@ export interface AdexToStakingTransfersLogsType {
 }
 
 export interface ConstantsType {
-  adexToStakingTransfersLogs: AdexToStakingTransfersLogsType
   WALLETInitialClaimableRewards: WALLETInitialClaimableRewardsType[]
   tokenList: object
   humanizerInfo: HumanizerInfoType
@@ -85,6 +84,7 @@ export interface UseConstantsReturnType {
   constants: ConstantsType | null
   isLoading: boolean
   retryFetch: () => void
+  getAdexToStakingTransfersLogsType: () => Promise<AdexToStakingTransfersLogsType | null>
   hasError: boolean
 }
 

--- a/src/hooks/useConstants/useConstants.ts
+++ b/src/hooks/useConstants/useConstants.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { fetchCaught } from '../../services/fetch'
 import {
+  AdexToStakingTransfersLogsType,
   ConstantsType,
   ResultEndpointResponse,
   UseConstantsProps,
@@ -10,19 +11,22 @@ import {
 
 const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsReturnType => {
   const [data, setData] = useState<ConstantsType | null>(null)
+  const [adexToStakingTransfers, setAdexToStakingTransfers] =
+    useState<AdexToStakingTransfersLogsType | null>(null)
   const [hasError, setHasError] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(true)
 
   const fetchConstants = useCallback(async () => {
     try {
       const [
-        { tokenList, humanizerInfo, WALLETInitialClaimableRewards },
-        adexToStakingTransfersLogs
+        { tokenList, humanizerInfo, WALLETInitialClaimableRewards }
+        // adexToStakingTransfersLogs
       ] = await Promise.all<
-        [Promise<ResultEndpointResponse>, Promise<ConstantsType['adexToStakingTransfersLogs']>]
+        // [Promise<ResultEndpointResponse>, Promise<ConstantsType['adexToStakingTransfersLogs']>]
+        [Promise<ResultEndpointResponse>]
       >([
-        fetchCaught(fetch, `${endpoint}/result.json`).then((res) => res.body),
-        fetchCaught(fetch, `${endpoint}/adexToStakingTransfers.json`).then((res) => res.body)
+        fetchCaught(fetch, `${endpoint}/result.json`).then((res) => res.body)
+        // fetchCaught(fetch, `${endpoint}/adexToStakingTransfers.json`).then((res) => res.body)
       ])
 
       setIsLoading(() => {
@@ -30,7 +34,7 @@ const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsRetur
           tokenList,
           humanizerInfo,
           WALLETInitialClaimableRewards,
-          adexToStakingTransfersLogs,
+          // adexToStakingTransfersLogs,
           lastFetched: Date.now()
         })
         setHasError(false)
@@ -47,8 +51,24 @@ const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsRetur
     fetchConstants()
   }, [fetchConstants])
 
+  const getAdexToStakingTransfers = async () => {
+    if (adexToStakingTransfers) return adexToStakingTransfers
+
+    try {
+      const [adexToStakingTransfersLogs] = await Promise.all<
+        [Promise<AdexToStakingTransfersLogsType>]
+      >([fetchCaught(fetch, `${endpoint}/adexToStakingTransfers.json`).then((res) => res.body)])
+
+      setAdexToStakingTransfers(adexToStakingTransfersLogs)
+      return adexToStakingTransfersLogs
+    } catch (e) {
+      return null
+    }
+  }
+
   return {
     constants: data,
+    getAdexToStakingTransfers,
     isLoading,
     retryFetch: fetchConstants,
     hasError

--- a/src/hooks/useConstants/useConstants.ts
+++ b/src/hooks/useConstants/useConstants.ts
@@ -18,10 +18,14 @@ const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsRetur
 
   const fetchConstants = useCallback(async () => {
     try {
-      const { tokenList, humanizerInfo, WALLETInitialClaimableRewards } =
-        await fetchCaught<ResultEndpointResponse>(fetch, `${endpoint}/result.json`).then(
-          (res) => res.body
-        )
+      const response = await fetchCaught<ResultEndpointResponse>(
+        fetch,
+        `${endpoint}/result.json`
+      ).then((res) => res.body)
+
+      if (!response) throw new Error('Failed to get the constants.')
+
+      const { tokenList, humanizerInfo, WALLETInitialClaimableRewards } = response
 
       setIsLoading(() => {
         setData({
@@ -51,7 +55,7 @@ const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsRetur
       const adexToStakingTransfersLogs = await fetchCaught<AdexToStakingTransfersLogsType>(
         fetch,
         `${endpoint}/adexToStakingTransfers.json`
-      ).then((res) => res.body)
+      ).then((res) => res.body || null)
 
       setAdexToStakingTransfers(adexToStakingTransfersLogs)
       return adexToStakingTransfersLogs

--- a/src/hooks/useConstants/useConstants.ts
+++ b/src/hooks/useConstants/useConstants.ts
@@ -18,23 +18,16 @@ const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsRetur
 
   const fetchConstants = useCallback(async () => {
     try {
-      const [
-        { tokenList, humanizerInfo, WALLETInitialClaimableRewards }
-        // adexToStakingTransfersLogs
-      ] = await Promise.all<
-        // [Promise<ResultEndpointResponse>, Promise<ConstantsType['adexToStakingTransfersLogs']>]
-        [Promise<ResultEndpointResponse>]
-      >([
-        fetchCaught(fetch, `${endpoint}/result.json`).then((res) => res.body)
-        // fetchCaught(fetch, `${endpoint}/adexToStakingTransfers.json`).then((res) => res.body)
-      ])
+      const { tokenList, humanizerInfo, WALLETInitialClaimableRewards } =
+        await fetchCaught<ResultEndpointResponse>(fetch, `${endpoint}/result.json`).then(
+          (res) => res.body
+        )
 
       setIsLoading(() => {
         setData({
           tokenList,
           humanizerInfo,
           WALLETInitialClaimableRewards,
-          // adexToStakingTransfersLogs,
           lastFetched: Date.now()
         })
         setHasError(false)
@@ -51,13 +44,14 @@ const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsRetur
     fetchConstants()
   }, [fetchConstants])
 
-  const getAdexToStakingTransfers = async () => {
+  const getAdexToStakingTransfersLogs = async () => {
     if (adexToStakingTransfers) return adexToStakingTransfers
 
     try {
-      const [adexToStakingTransfersLogs] = await Promise.all<
-        [Promise<AdexToStakingTransfersLogsType>]
-      >([fetchCaught(fetch, `${endpoint}/adexToStakingTransfers.json`).then((res) => res.body)])
+      const adexToStakingTransfersLogs = await fetchCaught<AdexToStakingTransfersLogsType>(
+        fetch,
+        `${endpoint}/adexToStakingTransfers.json`
+      ).then((res) => res.body)
 
       setAdexToStakingTransfers(adexToStakingTransfersLogs)
       return adexToStakingTransfersLogs
@@ -68,7 +62,7 @@ const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsRetur
 
   return {
     constants: data,
-    getAdexToStakingTransfers,
+    getAdexToStakingTransfersLogs,
     isLoading,
     retryFetch: fetchConstants,
     hasError

--- a/src/services/fetch/fetch.ts
+++ b/src/services/fetch/fetch.ts
@@ -18,7 +18,15 @@ export async function fetchGet(_fetch: any, url: string) {
   return response.json()
 }
 
-export async function fetchCaught(_fetch: any, url: any, params?: any) {
+export async function fetchCaught<R>(
+  _fetch: any,
+  url: any,
+  params?: any
+): Promise<{
+  body?: R
+  resp?: any
+  errMsg: string
+}> {
   let resp
   try {
     resp = await _fetch(url, params)


### PR DESCRIPTION
Split the two constants-related endpoints into one mandatory call, initiated immediately (result.json) and one secondary, initiated only by request (adexToStakingTransfersLogs).