### PR TITLE
Config / Remove `WALLETInitialClaimableRewards` incoming constants

### DIFF
--- a/src/hooks/useConstants/types.ts
+++ b/src/hooks/useConstants/types.ts
@@ -20,7 +20,6 @@ export interface AdexToStakingTransfersLogsType {
 export interface ResultEndpointResponse {
   tokenList: ConstantsType['tokenList']
   humanizerInfo: ConstantsType['humanizerInfo']
-  WALLETInitialClaimableRewards: ConstantsType['WALLETInitialClaimableRewards']
 }
 
 // All the below types are generated with the help of QuickType app.
@@ -30,7 +29,6 @@ export interface ResultEndpointResponse {
 // {@link https://app.quicktype.io/}
 export interface ConstantsType {
   tokenList: { [key: string]: TokenList[] }
-  WALLETInitialClaimableRewards: WALLETInitialClaimableRewardsType[]
   humanizerInfo: HumanizerInfoType
   lastFetched: number
 }
@@ -41,15 +39,6 @@ interface TokenList {
   coingeckoId?: null | string
   decimals?: number
   decmals?: number
-}
-
-interface WALLETInitialClaimableRewardsType {
-  addr: string
-  fromBalanceClaimable: number
-  fromADXClaimable: number
-  totalClaimable: string
-  leaf: string
-  proof: string[]
 }
 
 export interface HumanizerInfoType {

--- a/src/hooks/useConstants/useConstants.ts
+++ b/src/hooks/useConstants/useConstants.ts
@@ -25,13 +25,12 @@ const useConstants = ({ fetch, endpoint }: UseConstantsProps): UseConstantsRetur
 
       if (!response) throw new Error('Failed to get the constants.')
 
-      const { tokenList, humanizerInfo, WALLETInitialClaimableRewards } = response
+      const { tokenList, humanizerInfo } = response
 
       setIsLoading(() => {
         setData({
           tokenList,
           humanizerInfo,
-          WALLETInitialClaimableRewards,
           lastFetched: Date.now()
         })
         setHasError(false)


### PR DESCRIPTION
They are not needed anymore, after the changes introduced in: #139 