### PR TITLE
badges-rewards-apy

### DIFF
--- a/src/constants/multiplierBadges.ts
+++ b/src/constants/multiplierBadges.ts
@@ -35,7 +35,7 @@ export const multiplierBadges: MultiplierBadge[] = [
     link: 'https://blog.ambire.com/win-a-cryptotesters-nft-with-ambire-and-get-into-one-of-the-hottest-web3-communities-c9d7185760b1',
     icon_svg: 'rewards-crypto-tester'
   },
-  {
+  /*{
     id: 'gasTankNft',
     name: 'GasTankNFT',
     icon: '⛽',
@@ -43,7 +43,7 @@ export const multiplierBadges: MultiplierBadge[] = [
     multiplier: 1.25,
     link: 'https://blog.ambire.com/ambire-gas-tank-launches-with-exclusive-nft-drop-2a4eb29f2f07',
     icon_svg: 'rewards-gas-tank'
-  },
+  },*/
   {
     id: 'powerUserMultiplier',
     name: 'Power User',

--- a/src/constants/multiplierBadges.ts
+++ b/src/constants/multiplierBadges.ts
@@ -49,19 +49,7 @@ export const multiplierBadges: MultiplierBadge[] = [
     color: '#658f3f',
     multiplier: 1.25,
     link: 'https://blog.ambire.com/new-wallet-rewards-multiplier-live-in-ambire-power-users-now-get-special-perks-e47bb1000aeb'
-  },
-  /*
-  Originally planned to display the ADX bonus badge.
-  No icon / badge asset for ADX at the moment.
-  ADX Data is used in the table below in web app for now.
-  {
-    id: 'adxStakingApy',
-    name: 'ADX staking rewards',
-    icon: 'ADX',
-    color: '#28879c',
-    multiplier: 0,
-    link: 'https://blog.ambire.com/new-wallet-rewards-multiplier-live-in-ambire-power-users-now-get-special-perks-e47bb1000aeb'
-  },*/
+  }
 ]
 
 export const MULTIPLIERS_READ_MORE_URL =

--- a/src/constants/multiplierBadges.ts
+++ b/src/constants/multiplierBadges.ts
@@ -14,7 +14,8 @@ export const multiplierBadges: MultiplierBadge[] = [
     icon: '🧪',
     color: '#6000FF',
     multiplier: 1.25,
-    link: 'https://blog.ambire.com/announcing-the-wallet-token-a137aeda9747'
+    link: 'https://blog.ambire.com/announcing-the-wallet-token-a137aeda9747',
+    icon_svg: 'rewards-beta-tester'
   },
   {
     id: 'lobsters',
@@ -22,7 +23,8 @@ export const multiplierBadges: MultiplierBadge[] = [
     icon: '🦞',
     color: '#E82949',
     multiplier: 1.5,
-    link: 'https://blog.ambire.com/ambire-wallet-to-partner-with-lobsterdao-10b57e6da0-53c59c88726b'
+    link: 'https://blog.ambire.com/ambire-wallet-to-partner-with-lobsterdao-10b57e6da0-53c59c88726b',
+    icon_svg: 'rewards-lobster'
   },
   {
     id: 'cryptoTesters',
@@ -30,7 +32,8 @@ export const multiplierBadges: MultiplierBadge[] = [
     icon: '🧑‍🔬',
     color: '#b200e1',
     multiplier: 1.25,
-    link: 'https://blog.ambire.com/win-a-cryptotesters-nft-with-ambire-and-get-into-one-of-the-hottest-web3-communities-c9d7185760b1'
+    link: 'https://blog.ambire.com/win-a-cryptotesters-nft-with-ambire-and-get-into-one-of-the-hottest-web3-communities-c9d7185760b1',
+    icon_svg: 'rewards-crypto-tester'
   },
   {
     id: 'gasTankNft',
@@ -38,7 +41,8 @@ export const multiplierBadges: MultiplierBadge[] = [
     icon: '⛽',
     color: '#b18045',
     multiplier: 1.25,
-    link: 'https://blog.ambire.com/ambire-gas-tank-launches-with-exclusive-nft-drop-2a4eb29f2f07'
+    link: 'https://blog.ambire.com/ambire-gas-tank-launches-with-exclusive-nft-drop-2a4eb29f2f07',
+    icon_svg: 'rewards-gas-tank'
   },
   {
     id: 'powerUserMultiplier',
@@ -46,16 +50,17 @@ export const multiplierBadges: MultiplierBadge[] = [
     icon: '💸',
     color: '#658f3f',
     multiplier: 1.25,
-    link: 'https://blog.ambire.com/new-wallet-rewards-multiplier-live-in-ambire-power-users-now-get-special-perks-e47bb1000aeb'
+    link: 'https://blog.ambire.com/new-wallet-rewards-multiplier-live-in-ambire-power-users-now-get-special-perks-e47bb1000aeb',
+    icon_svg: 'reward-power-user'
   },
-  {
+  /*{
     id: 'adxStakingApy',
     name: 'ADX staking rewards',
     icon: 'ADX',
     color: '#28879c',
     multiplier: 0,
     link: 'https://blog.ambire.com/wallet-rewards-mechanism-explained-start-accumulating-value-before-the-token-is-launched-5e9ee36cefdd'
-  },
+  },*/
 ]
 
 export const MULTIPLIERS_READ_MORE_URL =

--- a/src/constants/multiplierBadges.ts
+++ b/src/constants/multiplierBadges.ts
@@ -36,7 +36,9 @@ export const multiplierBadges: MultiplierBadge[] = [
     link: 'https://blog.ambire.com/win-a-cryptotesters-nft-with-ambire-and-get-into-one-of-the-hottest-web3-communities-c9d7185760b1',
     icon_svg: 'rewards-crypto-tester'
   },
-  /*{
+  /*
+  NFT Multiplier incentive not activated at the moment
+  {
     id: 'gasTankNft',
     name: 'GasTankNFT',
     icon: '⛽',
@@ -54,7 +56,11 @@ export const multiplierBadges: MultiplierBadge[] = [
     link: 'https://blog.ambire.com/new-wallet-rewards-multiplier-live-in-ambire-power-users-now-get-special-perks-e47bb1000aeb',
     icon_svg: 'reward-power-user'
   },
-  /*{
+  /*
+  Originally planned to display the ADX bonus badge.
+  No icon / badge asset for ADX at the moment.
+  ADX Data is used in the table below in web app for now.
+  {
     id: 'adxStakingApy',
     name: 'ADX staking rewards',
     icon: 'ADX',

--- a/src/constants/multiplierBadges.ts
+++ b/src/constants/multiplierBadges.ts
@@ -47,7 +47,15 @@ export const multiplierBadges: MultiplierBadge[] = [
     color: '#658f3f',
     multiplier: 1.25,
     link: 'https://blog.ambire.com/new-wallet-rewards-multiplier-live-in-ambire-power-users-now-get-special-perks-e47bb1000aeb'
-}
+  },
+  {
+    id: 'adxStakingApy',
+    name: 'ADX staking rewards',
+    icon: 'ADX',
+    color: '#28879c',
+    multiplier: 0,
+    link: 'https://blog.ambire.com/wallet-rewards-mechanism-explained-start-accumulating-value-before-the-token-is-launched-5e9ee36cefdd'
+  },
 ]
 
 export const MULTIPLIERS_READ_MORE_URL =

--- a/src/constants/multiplierBadges.ts
+++ b/src/constants/multiplierBadges.ts
@@ -5,6 +5,7 @@ export type MultiplierBadge = {
   color: string
   multiplier: number
   link: string
+  icon_svg: string
 }
 
 export const multiplierBadges: MultiplierBadge[] = [

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -45,6 +45,12 @@ export type Promo = {
   }
 }
 
+export type RelayerRewardsBalance = {
+  balanceFromADX: number
+  balanceInUSD: number
+  effectiveBalanceInUSD: number
+}
+
 export type RelayerRewardsData = {
   data: {
     adxTokenAPY: number
@@ -55,6 +61,7 @@ export type RelayerRewardsData = {
     walletTokenAPY: number
     xWALLETAPY: number
     promo?: null | Promo
+    balance: RelayerRewardsBalance
   }
   errMsg: null
   isLoading: boolean
@@ -72,6 +79,7 @@ export type RewardsState = {
   xWALLETAPYPercentage: string
   totalLifetimeRewards: number
   promo?: null | Promo
+  balance: RelayerRewardsBalance
 }
 
 export interface UseRewardsReturnType {

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -49,6 +49,9 @@ export type RelayerRewardsBalance = {
   balanceFromADX: number
   balanceInUSD: number
   effectiveBalanceInUSD: number
+  adxRewards?: number
+  balanceRewards?: number
+  adxTokenAPY?: number
 }
 
 export type RelayerRewardsData = {
@@ -74,6 +77,7 @@ export type RewardsState = {
   walletTokenAPY: number
   walletTokenAPYPercentage: string
   adxTokenAPYPercentage: string
+  adxTokenAPY: number
   walletUsdPrice: number
   xWALLETAPY: number
   xWALLETAPYPercentage: string

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import useCacheBreak from '../useCacheBreak'
 import {
   Multiplier,
-  Promo,
+  Promo, RelayerRewardsBalance,
   RelayerRewardsData,
   RewardIds,
   RewardsState,
@@ -20,7 +20,12 @@ const initialState = {
     usdPrice: 0,
     walletTokenAPY: 0,
     xWALLETAPY: 0,
-    promo: null
+    promo: null,
+    balance: {
+      balanceFromADX: 0,
+      balanceInUSD: 0,
+      effectiveBalanceInUSD: 0
+    }
   },
   errMsg: null,
   isLoading: true
@@ -38,7 +43,12 @@ const rewardsInitialState = {
   xWALLETAPY: 0,
   xWALLETAPYPercentage: '...',
   totalLifetimeRewards: 0,
-  promo: null
+  promo: null,
+  balance: {
+    balanceFromADX: 0,
+    balanceInUSD: 0,
+    effectiveBalanceInUSD: 0
+  }
 }
 
 export default function useRewards({
@@ -62,7 +72,7 @@ export default function useRewards({
     if (errMsg || !data?.success || isLoading) return
 
     const rewardsDetails = Object.fromEntries<
-      string | number | Multiplier[] | Promo | { [key in RewardIds]: number }
+      string | number | Multiplier[] | Promo | { [key in RewardIds]: number | RelayerRewardsBalance }
     >(data.rewards.map(({ _id, rewards: r }) => [_id, r[accountId] || 0]))
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY // TODO: Remove if not used anyhwere else raw
@@ -81,6 +91,8 @@ export default function useRewards({
       ? `${(data.xWALLETAPY * 100).toFixed(2)}%`
       : // TODO: Check if displaying 0 is better
         '...'
+
+    rewardsDetails.balance = data.balance
 
     rewardsDetails.totalLifetimeRewards = data.rewards
       .map((x) => (typeof x.rewards[accountId] === 'number' ? x.rewards[accountId] : 0))

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -72,7 +72,7 @@ export default function useRewards({
     if (errMsg || !data?.success || isLoading) return
 
     const rewardsDetails = Object.fromEntries<
-      string | number | Multiplier[] | Promo | { [key in RewardIds]: number | RelayerRewardsBalance }
+      string | number | Multiplier[] | Promo | { [key in RewardIds]: number } | RelayerRewardsBalance
     >(data.rewards.map(({ _id, rewards: r }) => [_id, r[accountId] || 0]))
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY // TODO: Remove if not used anyhwere else raw


### PR DESCRIPTION
Update : added SVG images + commented ADX badge, until we know what we do with it


in concordance with PR 
https://github.com/AmbireTech/ambire-wallet/pull/1015

adding ADX staking rewards badge

adds some logic for multiplier badges (until now only static multipliers),  having a possibility to display APY (see wallet logic), passing APY data through multiplier badge id.

If we want more custom logic for badges in the future, we should refactor the wallet logic as well.
I adjusted with a minimal code change for the moment