### PR TITLE
Fix / SupplyController RPC Calls

### DIFF
--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -126,7 +126,9 @@ const useClaimableWalletToken = ({
     claimableRewardsData,
     cacheBreak,
     rewardsLastUpdated,
-    accountId
+    accountId,
+    prevAccountId,
+    currentClaimStatus?.lastUpdated
   ])
 
   const initialClaimable = claimableRewardsData ? +claimableRewardsData.totalClaimable / 1e18 : 0


### PR DESCRIPTION
Fix: check lastUpdate timestamp on supplyController calls, so we don't call them every 30 seconds, but 10 minutes and on account change