### PR TITLE
Config / Store network id under "networkId" key in the (cache) storage

### DIFF
--- a/src/hooks/useNetwork/useNetwork.ts
+++ b/src/hooks/useNetwork/useNetwork.ts
@@ -8,7 +8,7 @@ export default function useNetwork({
   useStorage
 }: UseNetworkProps): UseNetworkReturnType {
   const [networkId, setNetworkId] = useStorage({
-    key: 'network',
+    key: 'networkId',
     defaultValue: defaultNetwork,
     isStringStorage: true,
     // @ts-ignore FIXME: Figure out why TypeScript complains


### PR DESCRIPTION
Otherwise, we also have network (which is the full network object) and they conflict.