### PR TITLE
Fix: Now it checks if claimableRewardsData.addr is equal to accountId…

### DIFF
--- a/src/hooks/useClaimableWalletToken/types.ts
+++ b/src/hooks/useClaimableWalletToken/types.ts
@@ -24,9 +24,9 @@ export type UseClaimableWalletTokenReturnType = {
   shouldDisplayMintableVesting: boolean
   currentClaimStatus: {
     loading: boolean
-    claimed: number
-    mintableVesting: number
-    claimedInitial: number
+    claimed: number | null
+    mintableVesting: number | null
+    claimedInitial: number | null
     error: null | any
     lastUpdated: null | number
   }

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -57,6 +57,21 @@ const useClaimableWalletToken = ({
   const { cacheBreak } = useCacheBreak({ refreshInterval: 300000, breakPoint: 5000 })
   useEffect(() => {
     const accountChanged = !!prevAccountId && prevAccountId !== accountId
+    // Check if the claimableRewardsData response data is for the current account.
+    // If not sets all the values to null.
+    // That's how we don't show claimableRewards data for previous account.
+    if (!claimableRewardsData || (claimableRewardsData && !(claimableRewardsData.addr.toLowerCase() === accountId.toLowerCase()))) {
+      setCurrentClaimStatus((prev) => ({
+        ...prev,
+        claimed: null,
+        mintableVesting: null,
+        claimedInitial: null,
+        loading: true,
+        error: null,
+        lastUpdated: accountChanged ? null : prev.lastUpdated
+      }))
+      return
+    }
     // Wait before the rewards are loaded first, because the claimable amount
     // is calculated based on the rewards. If the rewards are not loaded yet,
     // we don't want to show the claimable amount as 0.
@@ -85,25 +100,25 @@ const useClaimableWalletToken = ({
     }))
     ;(async () => {
       const toNum = (x: string | number) => parseInt(x.toString(), 10) / 1e18
-      const [mintableVesting, claimed] = await Promise.all([
-        // Checks if the vestingEntry.addr and claimableRewardsData.addr
-        // are equal to the current account address.
-        // That's how we prevent making RPC calls for the previous selected account
-        // and receiving wrong data.
-        vestingEntry && vestingEntry.addr.toLowerCase() === accountId.toLowerCase()
-          ? await supplyController
-              .mintableVesting(vestingEntry.addr, vestingEntry.end, vestingEntry.rate)
-              .then(toNum)
-          : null,
-        claimableRewardsData && claimableRewardsData.addr.toLowerCase() === accountId.toLowerCase()
-          ? await supplyController.claimed(claimableRewardsData.addr).then(toNum)
-          : null
-      ])
+      // Checks if the vestingEntry.addr and claimableRewardsData.addr
+      // are equal to the current account address.
+      // That's how we prevent making RPC calls for the previous selected account
+      // and receiving wrong data.
+      const mintableVesting = (vestingEntry && (vestingEntry.addr.toLowerCase() === accountId.toLowerCase()))
+        ? await supplyController
+            .mintableVesting(vestingEntry.addr, vestingEntry.end, vestingEntry.rate)
+            .then(toNum)
+        : null
+
+      const claimed = claimableRewardsData
+        ? await supplyController.claimed(claimableRewardsData.addr).then(toNum)
+        : null
+
       // fromBalanceClaimable - all time claimable from balance
       // fromADXClaimable - all time claimable from ADX Staking
       // totalClaimable - all time claimable tolkens + already claimed from prev versions of supplyController contract
       const claimedInitial =
-        claimableRewardsData && claimableRewardsData.addr.toLowerCase() === accountId.toLowerCase()
+        claimableRewardsData
           ? (claimableRewardsData.fromBalanceClaimable || 0) +
             (claimableRewardsData.fromADXClaimable || 0) -
             toNum(claimableRewardsData.totalClaimable || 0)

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -86,6 +86,10 @@ const useClaimableWalletToken = ({
     ;(async () => {
       const toNum = (x: string | number) => parseInt(x.toString(), 10) / 1e18
       const [mintableVesting, claimed] = await Promise.all([
+        // Checks if the vestingEntry.addr and claimableRewardsData.addr
+        // are equal to the current account address.
+        // That's how we prevent making RPC calls for the previous selected account
+        // and receiving wrong data.
         vestingEntry && vestingEntry.addr.toLowerCase() === accountId.toLowerCase()
           ? await supplyController
               .mintableVesting(vestingEntry.addr, vestingEntry.end, vestingEntry.rate)

--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -60,7 +60,11 @@ const useClaimableWalletToken = ({
     // Check if the claimableRewardsData response data is for the current account.
     // If not sets all the values to null.
     // That's how we don't show claimableRewards data for previous account.
-    if (!claimableRewardsData || (claimableRewardsData && !(claimableRewardsData.addr.toLowerCase() === accountId.toLowerCase()))) {
+    if (
+      !claimableRewardsData ||
+      (claimableRewardsData &&
+        !(claimableRewardsData.addr.toLowerCase() === accountId.toLowerCase()))
+    ) {
       setCurrentClaimStatus((prev) => ({
         ...prev,
         claimed: null,
@@ -104,11 +108,12 @@ const useClaimableWalletToken = ({
       // are equal to the current account address.
       // That's how we prevent making RPC calls for the previous selected account
       // and receiving wrong data.
-      const mintableVesting = (vestingEntry && (vestingEntry.addr.toLowerCase() === accountId.toLowerCase()))
-        ? await supplyController
-            .mintableVesting(vestingEntry.addr, vestingEntry.end, vestingEntry.rate)
-            .then(toNum)
-        : null
+      const mintableVesting =
+        vestingEntry && vestingEntry.addr.toLowerCase() === accountId.toLowerCase()
+          ? await supplyController
+              .mintableVesting(vestingEntry.addr, vestingEntry.end, vestingEntry.rate)
+              .then(toNum)
+          : null
 
       const claimed = claimableRewardsData
         ? await supplyController.claimed(claimableRewardsData.addr).then(toNum)
@@ -117,12 +122,11 @@ const useClaimableWalletToken = ({
       // fromBalanceClaimable - all time claimable from balance
       // fromADXClaimable - all time claimable from ADX Staking
       // totalClaimable - all time claimable tolkens + already claimed from prev versions of supplyController contract
-      const claimedInitial =
-        claimableRewardsData
-          ? (claimableRewardsData.fromBalanceClaimable || 0) +
-            (claimableRewardsData.fromADXClaimable || 0) -
-            toNum(claimableRewardsData.totalClaimable || 0)
-          : null
+      const claimedInitial = claimableRewardsData
+        ? (claimableRewardsData.fromBalanceClaimable || 0) +
+          (claimableRewardsData.fromADXClaimable || 0) -
+          toNum(claimableRewardsData.totalClaimable || 0)
+        : null
 
       return { mintableVesting, claimed, claimedInitial }
     })()

--- a/src/hooks/useRewards/types.ts
+++ b/src/hooks/useRewards/types.ts
@@ -56,6 +56,7 @@ export type RelayerRewardsBalance = {
 
 export type RelayerRewardsData = {
   data: {
+    claimableRewardsData: any
     adxTokenAPY: number
     multipliers: Multiplier[]
     rewards: Reward[]

--- a/src/hooks/useRewards/useRewards.ts
+++ b/src/hooks/useRewards/useRewards.ts
@@ -32,6 +32,7 @@ const initialState = {
 }
 
 const rewardsInitialState = {
+  accountAddr: '',
   [RewardIds.ADX_REWARDS]: 0,
   [RewardIds.BALANCE_REWARDS]: 0,
   [RewardIds.ADX_TOKEN_APY]: 0,
@@ -75,6 +76,7 @@ export default function useRewards({
     const rewardsDetails = Object.fromEntries<
       string | number | Multiplier[] | Promo | { [key in RewardIds]: number } | RelayerRewardsBalance
     >(data.rewards.map(({ _id, rewards: r }) => [_id, r[accountId] || 0]))
+    rewardsDetails.accountAddr = data.claimableRewardsData.addr
     rewardsDetails.multipliers = data.multipliers
     rewardsDetails.walletTokenAPY = data.walletTokenAPY // TODO: Remove if not used anyhwere else raw
     rewardsDetails.walletTokenAPYPercentage = data.walletTokenAPY


### PR DESCRIPTION
Now it checks if claimableRewardsData.addr is equal to accountId to make sure that mintableVesting and claimed values are for the current account