### PR TITLE
Bug / E-mail validation check when validating JSON imported account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.21.3",
+  "version": "0.22.1",
   "name": "ambire-common",
   "description": "Common ground for the Ambire apps",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.21.2",
+  "version": "0.21.3",
   "name": "ambire-common",
   "description": "Common ground for the Ambire apps",
   "peerDependencies": {

--- a/src/services/validations/importedAccountProps.ts
+++ b/src/services/validations/importedAccountProps.ts
@@ -53,13 +53,6 @@ const validateImportedAccountProps = (acc: Account) => {
     }
   }
 
-  if (!(acc.email && isEmail(acc.email))) {
-    return {
-      success: false,
-      message: 'Failed to import JSON file: invalid email'
-    }
-  }
-
   if (!(acc.signer && isValidAddress(acc.signer.address || acc.signer.quickAccManager))) {
     return {
       success: false,
@@ -68,6 +61,12 @@ const validateImportedAccountProps = (acc: Account) => {
   }
 
   if (acc.signer.quickAccManager) {
+    if (typeof acc.email !== 'string' || !isEmail(acc.email)) {
+      return {
+        success: false,
+        message: 'Failed to import JSON file: invalid email'
+      }
+    }
     if (!(acc.signer.timelock && isValidTimeLock(acc.signer.timelock))) {
       return {
         success: false,


### PR DESCRIPTION
The is valid email check should be triggered only when importing quickAcc. It was prev executed on all types of accounts.