### PR TITLE
Hotfix/ Updated gnosis chain explorer url

### DIFF
--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -175,7 +175,7 @@ const networks: NetworkType[] = [
     chainId: 100,
     nativeAssetSymbol: 'XDAI',
     name: 'Gnosis Chain',
-    explorerUrl: 'https://blockscout.com',
+    explorerUrl: 'https://gnosisscan.io',
     unstoppableDomainsChain: 'ERC20',
     isGasTankAvailable: true,
     relayerlessOnly: false,


### PR DESCRIPTION
Changes:

- Updated the gnosis explorer url from https://blockscout.com/ to https://gnosisscan.io/