### PR TITLE
Fix/Keystore toQuantity

### DIFF
--- a/v2/libs/keystore/keystore.ts
+++ b/v2/libs/keystore/keystore.ts
@@ -1,6 +1,6 @@
 import aes from 'aes-js'
 import scrypt from 'scrypt-js'
-import { getBytes, toQuantity, isHexString, keccak256, randomBytes, toUtf8Bytes, toUtf8String, UnicodeNormalizationForm, concat } from 'ethers'
+import { getBytes, keccak256, randomBytes, toUtf8Bytes, concat, hexlify } from 'ethers'
 import { Wallet } from 'ethers'
 
 const scryptDefaults = { N: 262144, r: 8, p: 1, dkLen: 64 }
@@ -145,8 +145,8 @@ export class Keystore {
 
 		secrets.push({
 			id: secretId,
-			scryptParams: { salt: toQuantity(salt), ...scryptDefaults },
-			aesEncrypted: { cipherType: CIPHER, ciphertext: toQuantity(ciphertext), iv: toQuantity(iv), mac: toQuantity(mac) }
+			scryptParams: { salt: hexlify(salt), ...scryptDefaults },
+			aesEncrypted: { cipherType: CIPHER, ciphertext: hexlify(ciphertext), iv: hexlify(iv), mac: hexlify(mac) }
 		})
 		// Persist the new secrets
 		await this.storage.set('keystoreSecrets', secrets)
@@ -191,7 +191,7 @@ export class Keystore {
 			type: 'internal',
 			label,
 			// @TODO: consider an MAC?
-			privKey: toQuantity(aesCtr.encrypt(getBytes(privateKey))),
+			privKey: hexlify(aesCtr.encrypt(getBytes(privateKey))),
 			meta: null
 		})
 		await this.storage.set('keystoreKeys', keys)


### PR DESCRIPTION
`toQuantity` trims leading zero from the bytes number if any. This is really problematic as its opposite function, `getBytes`, is expecting a 66 length BytesLike number.  
We have this script:
```
const salt = randomBytes(32)
const scryptParams: { salt: toQuantity(salt), ...scryptDefaults }
const other = getBytes(scryptParams.salt)
```
If randomBytes generates a number with a leading 0 like `0x023a...`, the 0 gets cut when hexing with `toQuantity`:
```
export function toQuantity(value: BytesLike | BigNumberish): string {
    let result = hexlify(isBytesLike(value) ? value: toBeArray(value)).substring(2);
    while (result.startsWith("0")) { result = result.substring(1); } // it happens here
    if (result === "") { result = "0"; }
    return "0x" + result;
}
```

Therefore, we end up in a bad situation where sometimes `randomBytes` generates a number without a leading 0 and the script working while some other times it generates a number with a leading 0 and it breaks!

Replacing `toQuantity` and `hexlify` resolves the issue. It does the same... it just doesn't remove the 0s.