### PR TITLE
Add: applicationType property on dappCatalog

### DIFF
--- a/src/hooks/useDapps/types.ts
+++ b/src/hooks/useDapps/types.ts
@@ -1,9 +1,10 @@
-import { AmbireDappManifest } from '../../services/dappCatalog/types'
+import { AmbireDappManifest, ApplicationType } from '../../services/dappCatalog/types'
 import { UseStorageType } from '../useStorage'
 
 export type UseDappsProps = {
   useStorage: UseStorageType
   fetch: any
+  applicationType: ApplicationType
 }
 
 export type DappManifestData = AmbireDappManifest & { custom?: boolean }

--- a/src/hooks/useDapps/useDapps.ts
+++ b/src/hooks/useDapps/useDapps.ts
@@ -32,7 +32,11 @@ const withCategory = (dapp: DappManifestData) => ({
   category: dapp.connectionType === 'gnosis' ? 'integrated' : dapp.connectionType
 })
 
-export default function useDapps({ useStorage, fetch }: UseDappsProps): UseDappsReturnType {
+export default function useDapps({
+  useStorage,
+  fetch,
+  applicationType
+}: UseDappsProps): UseDappsReturnType {
   const categories = useMemo(() => CATEGORIES, [])
   const [defaultCatalog, setDefaultCatalog] = useState<Array<AmbireDappManifest>>([])
   const [isDappMode, setIsDappMode] = useStorage<boolean>({ key: 'isDappMode' })
@@ -62,11 +66,16 @@ export default function useDapps({ useStorage, fetch }: UseDappsProps): UseDapps
   useEffect(() => {
     async function getCatalog() {
       const walletCatalog = await getWalletDappCatalog(fetch)
-      setDefaultCatalog(walletCatalog)
+      const catalogDapp =
+        walletCatalog.filter((el: AmbireDappManifest) =>
+          el.applicationType.includes(applicationType)
+        ) || []
+
+      setDefaultCatalog(catalogDapp)
     }
 
     getCatalog()
-  }, [fetch])
+  }, [fetch, applicationType])
 
   const toggleDappMode = useCallback(() => {
     setIsDappMode(!isDappMode)

--- a/src/services/dappCatalog/types.ts
+++ b/src/services/dappCatalog/types.ts
@@ -11,6 +11,11 @@ export enum SupportedWeb3Connectivity {
   'injected' = 'injected'
 }
 
+export enum ApplicationType {
+  'web' = 'web',
+  'mobile' = 'mobile'
+}
+
 export type Web3ConnectivityId = keyof typeof SupportedWeb3Connectivity
 
 export type AmbireDappManifest = {
@@ -30,4 +35,5 @@ export type AmbireDappManifest = {
   isWalletPlugin?: boolean
   featured?: boolean
   forceInternal?: boolean
+  applicationType: Array<keyof typeof ApplicationType>
 }


### PR DESCRIPTION
Applying an applicationType array [here](https://github.com/AmbireTech/wallet-dapp-catalog/pull/15) so we could exclude dApps for mobile and web.

Corresponding PR for web: [here](https://github.com/AmbireTech/ambire-wallet/pull/1408)