### PR TITLE
Feature / V2 UID and exportKeyWithPasscode in keyStore

### DIFF
--- a/src/libs/keystore/keystore.test.ts
+++ b/src/libs/keystore/keystore.test.ts
@@ -87,7 +87,7 @@ describe('Keystore', () => {
     try {
       await keystore.getKeyStoreUid()
     } catch (e: any) {
-      expect(e.message).toBe('keystore: adding secret before get uid')
+      expect(e.message).toBe('keystore: uid unavailable before adding the first secret')
     }
   })
 

--- a/src/libs/keystore/keystore.ts
+++ b/src/libs/keystore/keystore.ts
@@ -271,6 +271,7 @@ export class Keystore {
     const storedKey: StoredKey = keys.find((x: StoredKey) => x.id === keyId)
 
     if (!storedKey) throw new Error('keystore: key not found')
+    if (storedKey.type !== 'internal') throw new Error('keystore: key does not have privateKey')
 
     const encryptedBytes = getBytes(storedKey.privKey as string)
     // @ts-ignore


### PR DESCRIPTION
#### create keyStore UID on add the first secret 
#### added exportKeyWithPasscode method to export 
#### added following tests:
- should export key backup, create wallet and compare public address
- should return uid
- should not return uid until there are no secrets yet