### PR TITLE
Fix/ mintableVesting not converted to number

### DIFF
--- a/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
+++ b/src/hooks/useClaimableWalletToken/useClaimableWalletToken.ts
@@ -171,7 +171,6 @@ const useClaimableWalletToken = ({
   const claimableNowUsd = (walletUsdPrice * claimableNow).toFixed(2)
   const mintableVestingUsd = (walletUsdPrice * (currentClaimStatus.mintableVesting || 0)).toFixed(2)
 
-  console.log(currentClaimStatus)
   const pendingTokensTotal = (
     totalLifetimeRewards -
     (currentClaimStatus.claimed || 0) -


### PR DESCRIPTION
Changes:

- Added back missing code(mintable vesting not converted to number)

Linked to https://github.com/AmbireTech/ambire-wallet/pull/1437