### PR TITLE
Config/ Disable react/react-in-jsx-scope eslint rule, because react's version is over 17

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     'no-plusplus': 'off',
     '@typescript-eslint/indent': 'off',
     'react/no-unstable-nested-components': 'off',
-    'react-hooks/exhaustive-deps': 'warn'
+    'react-hooks/exhaustive-deps': 'warn',
+    'react/react-in-jsx-scope': 'off'
   }
 }


### PR DESCRIPTION
## Changes:

- Disabled the react/react-in-jsx-scope Eslint rule

## Docs: 
https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
## From the docs:

> When Not To Use It
> 
> If you are not using JSX, or if you are setting React as a global variable.
> 
> If you are using the [new JSX transform from React 17](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports), you should disable this rule by extending [react/jsx-runtime](https://github.com/jsx-eslint/eslint-plugin-react/blob/8cf47a8ac2242ee00ea36eac4b6ae51956ba4411/index.js#L165-L179) in your eslint config (add "plugin:react/jsx-runtime" to "extends").