### PR TITLE
keystore: add a leaveUnlocked option to addSecret

### DIFF
--- a/src/libs/keystore/keystore.ts
+++ b/src/libs/keystore/keystore.ts
@@ -135,7 +135,7 @@ export class Keystore {
     this.#mainKey = { key: decrypted.slice(0, 16), iv: decrypted.slice(16, 32) }
   }
 
-  async addSecret(secretId: string, secret: string, extraEntropy: string = '') {
+  async addSecret(secretId: string, secret: string, extraEntropy: string = '', leaveUnlocked: boolean = false) {
     const secrets = await this.getMainKeyEncryptedWithSecrets()
     // @TODO test
     if (secrets.find((x) => x.id === secretId))
@@ -154,6 +154,10 @@ export class Keystore {
           iv: randomBytes(16)
         }
       } else throw new Error('keystore: must unlock keystore before adding secret')
+
+      if (leaveUnlocked) {
+        this.#mainKey = mainKey
+      }
     }
 
     const salt = randomBytes(32)


### PR DESCRIPTION
## Summary
this avoids making two `scrypt` calls when adding a secret and then unlocking with the same secret

use case: settitng up the keystore passphrase for the first time