### PR TITLE
Feature/add-account-op-signable-hash

### DIFF
--- a/dist/consts/networks.js
+++ b/dist/consts/networks.js
@@ -25,6 +25,14 @@ const networks = [
         rpcUrl: 'https://rpc.ankr.com/optimism',
         rpcNoStateOverride: false,
         chainId: 10n
+    },
+    {
+        id: 'hardhat',
+        name: 'hardhat',
+        nativeAssetSymbol: 'ETH',
+        rpcUrl: '',
+        rpcNoStateOverride: true,
+        chainId: 31337n
     }
 ];
 exports.networks = networks;

--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -24,6 +24,14 @@ const networks: NetworkDescriptor[] = [
     rpcUrl: 'https://rpc.ankr.com/optimism',
     rpcNoStateOverride: false,
     chainId: 10n
+  },
+  {
+    id: 'hardhat',
+    name: 'hardhat',
+    nativeAssetSymbol: 'ETH',
+    rpcUrl: '',
+    rpcNoStateOverride: true,
+    chainId: 31337n
   }
 ]
 

--- a/src/libs/accountOp/accountOp.test.ts
+++ b/src/libs/accountOp/accountOp.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from '@jest/globals'
+import { AccountOp, Call, accountOpSignableHash } from './accountOp'
+import { ethers } from 'ethers'
+
+describe('AccountOp', () => {
+  test('should generate a valid hash for signing', async () => {
+    const nonce = 0
+    const ambireAccountAddress = '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5'
+    const signerAddr = '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5'
+    const abiCoder = new ethers.AbiCoder()
+    const txns: Call[] = [
+      {to: signerAddr, value: ethers.parseEther('0.01'), data: '0x00'},
+    ]
+    const op: AccountOp = {
+      accountAddr: ambireAccountAddress,
+      networkId: 'hardhat',
+      signingKeyAddr: null,
+      nonce,
+      calls: txns,
+      gasLimit: null,
+      signature: null,
+      gasFeePayment: null,
+      accountOpToExecuteBefore: null
+    }
+    const accountOpHash = accountOpSignableHash(op)
+    const standardHash = ethers.getBytes(
+      ethers.keccak256(
+        abiCoder.encode(
+        ['address', 'uint', 'uint', 'tuple(address, uint, bytes)[]'],
+        [ambireAccountAddress, 31337n, nonce, txns.map((call: Call) => ([call.to, call.value, call.data]))]
+        )
+      )
+    )
+
+    expect(ethers.hexlify(accountOpHash)).toBe(ethers.hexlify(standardHash))
+  })
+  test('should pass null as nonce in AccountOp and it should generate a valid hash with nonce 0', async () => {
+    const ambireAccountAddress = '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5'
+    const signerAddr = '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5'
+    const txns: Call[] = [
+      {to: signerAddr, value: ethers.parseEther('0.01'), data: '0x00'},
+    ]
+    const op: AccountOp = {
+      accountAddr: ambireAccountAddress,
+      networkId: 'hardhat',
+      signingKeyAddr: null,
+      nonce: null,
+      calls: txns,
+      gasLimit: null,
+      signature: null,
+      gasFeePayment: null,
+      accountOpToExecuteBefore: null
+    }
+    const accountOpHash = accountOpSignableHash(op)
+    // if the above statement does not throw an error, we're good
+    expect(ethers.hexlify(accountOpHash)).not.toBe(null)
+  })
+})

--- a/test/AmbireAccount/BasicTest.ts
+++ b/test/AmbireAccount/BasicTest.ts
@@ -13,6 +13,7 @@ import {
 import { sendFunds, getPriviledgeTxn, getTimelockData } from '../helpers'
 import { wrapEthSign } from '../ambireSign'
 import { deployAmbireAccountHardhatNetwork } from '../implementations'
+import { AccountOp, Call, accountOpSignableHash } from '../../src/libs/accountOp/accountOp'
 
 let ambireAccountAddress: string
 
@@ -205,5 +206,54 @@ describe('Basic Ambire Account tests', function () {
     const receipt = await multipleTxn.wait()
     const postBalance = await provider.getBalance(ambireAccountAddress, receipt.blockNumber)
     expect(balance - postBalance).to.equal(ethers.parseEther('0.04'))
+  })
+  it('should successfully execute a txn using accountOpSignableHash', async function () {
+    const [signer] = await ethers.getSigners()
+    const contract: any = new ethers.BaseContract(ambireAccountAddress, AmbireAccount.abi, signer)
+    await sendFunds(ambireAccountAddress, 1)
+    const nonce = await contract.nonce()
+    const txns: Call[] = [
+      {to: addressTwo, value: ethers.parseEther('0.01'), data: '0x00'},
+      {to: addressThree, value: ethers.parseEther('0.01'), data: '0x00'},
+    ]
+    const op: AccountOp = {
+      accountAddr: ambireAccountAddress,
+      networkId: 'hardhat',
+      signingKeyAddr: null,
+      nonce,
+      calls: txns,
+      gasLimit: null,
+      signature: null,
+      gasFeePayment: null,
+      accountOpToExecuteBefore: null
+    }
+    const msg = accountOpSignableHash(op)
+    const s = wrapEthSign(await signer.signMessage(msg))
+    const balance = await provider.getBalance(ambireAccountAddress)
+    const txn = await contract.execute(txns, s)
+    const receipt = await txn.wait()
+    const postBalance = await provider.getBalance(ambireAccountAddress, receipt.blockNumber)
+    expect(balance - postBalance).to.equal(ethers.parseEther('0.02'))
+  })
+  it('should revert with INSUFFICIENT_PRIVILEGE when executing a txn if the hash is not signed as Uint8Array', async function () {
+    const [signer] = await ethers.getSigners()
+    const contract: any = new ethers.BaseContract(ambireAccountAddress, AmbireAccount.abi, signer)
+    await sendFunds(ambireAccountAddress, 1)
+    const nonce = await contract.nonce()
+    const txns = [
+      [addressTwo, ethers.parseEther('0.01'), '0x00'],
+      [addressThree, ethers.parseEther('0.01'), '0x00']
+    ]
+    // we skip calling ethers.getBytes to confirm it is not
+    // working without it
+    const msg = ethers.keccak256(
+      abiCoder.encode(
+        ['address', 'uint', 'uint', 'tuple(address, uint, bytes)[]'],
+        [ambireAccountAddress, chainId, nonce, txns]
+      )
+    )
+    const s = wrapEthSign(await signer.signMessage(msg))
+    await expect(contract.execute(txns, s))
+      .to.be.revertedWith('INSUFFICIENT_PRIVILEGE')
   })
 })


### PR DESCRIPTION
Change log:
* add: accountOpSignableHash method
* hardhat network in networks to allow for contract testing of the above method

I would kindly ask the reviewers to read the comments above `accountOpSignableHash` and comprehend why we need to return a `Uint8Array` out of it instead of a `string`. If there are any doubts, let's discuss.

I've proven that signing a message without transforming the hash from string to `Uint8Array` does not work in `BasicTest.ts` "should revert with INSUFFICIENT_PRIVILEGE when executing a txn if the hash is not signed as Uint8Array"