### PR TITLE
Feature / Coingecko PRO API key .env configuration

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,6 @@
+# You need to create a new copy of this file, called .env
+
+# Coingecko pro API key that will increase the rate limits and allow the use of the pro API endpoint.
+# If the value is not set, the application codebase will fallback and use the free API.
+# [Optional]
+COINGECKO_PRO_API_KEY=''

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "dependencies": {
     "@jest/globals": "^29.6.1",
+    "aes-js": "^3.1.2",
     "dotenv": "^16.3.1",
     "ethers": "^6.3.0",
-    "scrypt-js": "^3.0.1",
-    "aes-js": "^3.1.2"
+    "scrypt-js": "^3.0.1"
   },
   "peerDependencies": {
     "@ambire/signature-validator": "^1.0.3",


### PR DESCRIPTION
- [x] Add: Make it possible to set Coingecko PRO api key via .env. If the value is not set, the application codebase will fallback and use the free API.

Everything is working as before, tested via `npx jest src/libs/estimate/`