### PR TITLE
Fix / User Request Removal

### DIFF
--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -90,6 +90,25 @@ describe('Main Controller ', () => {
       }
     }
     await controller.addUserRequest(req)
+    expect(Object.keys(controller.accountOpsToBeSigned).length).toBe(1)
+    // console.dir(controller.accountOpsToBeSigned, { depth: null })
+    // @TODO test if nonce is correctly set
+  })
+  test('Remove a user request', async () => {
+    const req: UserRequest = {
+      id: 1,
+      accountAddr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
+      networkId: 'ethereum',
+      forceNonce: null,
+      action: {
+        kind: 'call',
+        to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        value: BigInt(0),
+        data: '0xa9059cbb000000000000000000000000e5a4dad2ea987215460379ab285df87136e83bea00000000000000000000000000000000000000000000000000000000005040aa'
+      }
+    }
+    await controller.removeUserRequest(req.id)
+    expect(Object.keys(controller.accountOpsToBeSigned).length).toBe(0)
     // console.dir(controller.accountOpsToBeSigned, { depth: null })
     // @TODO test if nonce is correctly set
   })

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -333,12 +333,19 @@ export class MainController extends EventEmitter {
     if (action.kind === 'call') {
       // @TODO ensure acc info, re-estimate
       const accountOp = this.makeAccountOpFromUserRequests(accountAddr, networkId)
-      if (accountOp)
+      if (accountOp) {
         this.accountOpsToBeSigned[accountAddr][networkId] = { accountOp, estimation: null }
+      } else {
+        delete this.accountOpsToBeSigned[accountAddr][networkId]
+        if (!Object.keys(this.accountOpsToBeSigned[accountAddr] || {}).length)
+          delete this.accountOpsToBeSigned[accountAddr]
+      }
     } else {
       this.messagesToBeSigned[accountAddr] = this.messagesToBeSigned[accountAddr].filter(
         (x) => x.fromUserRequestId !== id
       )
+      if (!Object.keys(this.messagesToBeSigned[accountAddr] || {}).length)
+        delete this.messagesToBeSigned[accountAddr]
     }
     this.emitUpdate()
   }


### PR DESCRIPTION
Fix accountOpsToBeSigned and messagesToBeSigned cleanup after userRequest removal - there was an issue with the object props cleanup after all records from that prop were removed and there is a key left with an empty value