### PR TITLE
Add ambire constants to dependencies and update humanizer controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@jest/globals": "^29.6.1",
         "aes-js": "^3.1.2",
-        "ambire-constants": "github:AmbireTech/ambire-constants#humanizer-v2",
+        "ambire-constants": "github:AmbireTech/ambire-constants",
         "dotenv": "^16.3.1",
         "ethers": "^6.3.0",
         "scrypt-js": "^3.0.1"
@@ -5926,7 +5926,7 @@
     },
     "node_modules/ambire-constants": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/AmbireTech/ambire-constants.git#ecf87ed02f7be62dee4ccc01a1d00d387c5e6953",
+      "resolved": "git+ssh://git@github.com/AmbireTech/ambire-constants.git#f76bae5ad85ff06e0b3527300984aedcec7d3718",
       "license": "MIT",
       "dependencies": {
         "adex-protocol-eth": "git+https://git@github.com/AmbireTech/adex-protocol-eth.git",
@@ -25894,8 +25894,8 @@
       }
     },
     "ambire-constants": {
-      "version": "git+ssh://git@github.com/AmbireTech/ambire-constants.git#ecf87ed02f7be62dee4ccc01a1d00d387c5e6953",
-      "from": "ambire-constants@AmbireTech/ambire-constants#humanizer-v2",
+      "version": "git+ssh://git@github.com/AmbireTech/ambire-constants.git#f76bae5ad85ff06e0b3527300984aedcec7d3718",
+      "from": "ambire-constants@AmbireTech/ambire-constants",
       "requires": {
         "adex-protocol-eth": "git+https://git@github.com/AmbireTech/adex-protocol-eth.git",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@jest/globals": "^29.6.1",
     "aes-js": "^3.1.2",
-    "ambire-constants": "github:AmbireTech/ambire-constants#humanizer-v2",
+    "ambire-constants": "github:AmbireTech/ambire-constants",
     "dotenv": "^16.3.1",
     "ethers": "^6.3.0",
     "scrypt-js": "^3.0.1"

--- a/src/controllers/humanizer/humanizer.ts
+++ b/src/controllers/humanizer/humanizer.ts
@@ -52,7 +52,6 @@ const parsingModules: HumanizerParsingModule[] = [nameParsing, tokenParsing]
 const humanizerTMModules = [erc20Module, erc721Module, permit2Module, fallbackEIP712Humanizer]
 
 function initHumanizerMeta(humanizerMeta: { [key: string]: any }) {
-  console.log(Object.keys(humanizerMeta))
   const newHumanizerMeta: { [key: string]: any } = {}
   Object.keys(humanizerMeta?.tokens).forEach((k2) => {
     newHumanizerMeta[`tokens:${ethers.getAddress(k2)}`] = humanizerMeta.tokens?.[k2]


### PR DESCRIPTION
Requires this [PR](https://github.com/AmbireTech/ambire-constants/pull/7)
Ater the merge of the aforementioned PR, the main branch of ambire-constants should be npm installed and not the **humanizer-v2** branch