### PR TITLE
Bug / Filter and paginate accountsOps and signedMessages only after Activity Controller gets initialized (and has filters)

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -123,6 +123,13 @@ export class ActivityController extends EventEmitter {
     this.#accountsOps = accountsOps
     this.#signedMessages = signedMessages
 
+    this.emitUpdate()
+  }
+
+  init({ filters }: { filters: Filters }) {
+    this.filters = filters
+    this.isInitialized = true
+
     this.accountsOps = this.filterAndPaginateAccountOps(
       this.#accountsOps,
       this.accountsOpsPagination
@@ -132,12 +139,6 @@ export class ActivityController extends EventEmitter {
       this.signedMessagesPagination
     )
 
-    this.emitUpdate()
-  }
-
-  init({ filters }: { filters: Filters }) {
-    this.filters = filters
-    this.isInitialized = true
     this.emitUpdate()
   }
 


### PR DESCRIPTION
Solves an issue in the logic where in the constructor the `accountsOps` and `signedMessages` gets filtered and paginated, but the Activity Controller is not initialized yet. Which should not be the case.