### PR TITLE
Bug / Handle accounts with missing identity

### DIFF
--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -528,6 +528,23 @@ export class AccountAdderController extends EventEmitter {
       data.accounts
     )
       .map((addr: any) => {
+        // In extremely rare cases, on the Relayer, the identity data could be
+        // missing in the identities table but could exist in the logs table.
+        // When this happens, the account data will be `null`.
+        const isIdentityDataMissing = !data.accounts[addr]
+        if (isIdentityDataMissing) {
+          // Same error for both cases, because most prob
+          this.emitError({
+            level: 'minor',
+            message: `The address ${addr} is not linked to an Ambire account. Please try again later or contact support if the problem persists.`,
+            error: new Error(
+              `The address ${addr} is not linked to an Ambire account. This could be because the identity data is missing in the identities table but could exist in the logs table.`
+            )
+          })
+
+          return null
+        }
+
         const { factoryAddr, bytecode, salt, associatedKeys } = data.accounts[addr]
         // Checks whether the account.addr matches the addr generated from the
         // factory. Should never happen, but could be a possible attack vector.


### PR DESCRIPTION
In extremely rare cases, on the Relayer, the identity data could be missing in the identities table but could exist in the logs table. When this happens, the account data comes as `null` from the Relayer.