### PR TITLE
Bug / Request portfolio additional data for Ambire smart accounts only

### DIFF
--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -1,5 +1,6 @@
 import feeTokens from '../../consts/feeTokens'
 import gasTankFeeTokens from '../../consts/gasTankFeeTokens'
+import { Account } from '../../interfaces/account'
 import { NetworkId } from '../../interfaces/networkDescriptor'
 
 export function getFlags(
@@ -34,4 +35,9 @@ export function getFlags(
     canTopUpGasTank,
     isFeeToken
   }
+}
+
+export const shouldGetAdditionalPortfolio = (account?: Account) => {
+  // portfolio additional data is available only for smart accounts
+  return !!account?.creation
 }


### PR DESCRIPTION
The portfolio additional data is intended for smart accounts only. EOA accounts requesting this endpoint receive 404 and are logging errors (which is misleading).