### PR TITLE
Bug/ Main controller test racing condition

### DIFF
--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -193,12 +193,15 @@ describe('Main Controller ', () => {
     }
 
     let emitCounter = 0
-
-    if (controller.isReady) {
-      addAccounts()
+    // The `isReady` flag on the MainController gets set in async manner.
+    // If the property of the main controller `isReady` becomes true before
+    // reaching await new Promise..., the code inside the onUpdate won't run,
+    // because there is nothing that will trigger an update. To prevent this,
+    // check if the controller is ready outside of the onUpdate first and add the accounts.
+    if (controller.isReady && emitCounter === 0) {
       emitCounter++
+      addAccounts()
     }
-
     await new Promise((resolve) => {
       const unsubscribe = controller.onUpdate(() => {
         emitCounter++


### PR DESCRIPTION
## Fails:
https://github.com/AmbireTech/ambire-common/actions/runs/6615125472/job/17966614727
https://github.com/AmbireTech/ambire-common/actions/runs/6585863157/job/17893083548

## Problem:

If the property of the main controller `isReady` becomes true before reaching `await new Promise...`, the code inside the onUpdate won't run, because there is nothing that will trigger an update.

## Fix:

Check if the controller is ready outside of the onUpdate first and add the accounts.