### PR TITLE
Feature/FeeCall

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -10,7 +10,7 @@ import { Key, KeystoreSignerType } from '../../interfaces/keystore'
 import { NetworkDescriptor, NetworkId } from '../../interfaces/networkDescriptor'
 import { Storage } from '../../interfaces/storage'
 import { Message, UserRequest } from '../../interfaces/userRequest'
-import { AccountOp, Call as AccountOpCall, callToTuple } from '../../libs/accountOp/accountOp'
+import { AccountOp, Call as AccountOpCall, getSignableCalls } from '../../libs/accountOp/accountOp'
 import { getAccountState } from '../../libs/accountState/accountState'
 import {
   getAccountOpBannersForEOA,
@@ -571,7 +571,7 @@ export class MainController extends EventEmitter {
         const ambireAccount = new ethers.Interface(AmbireAccount.abi)
         to = accountOp.accountAddr
         data = ambireAccount.encodeFunctionData('execute', [
-          accountOp.calls.map((call) => callToTuple(call)),
+          getSignableCalls(accountOp),
           accountOp.signature
         ])
       } else {
@@ -580,7 +580,7 @@ export class MainController extends EventEmitter {
         data = ambireFactory.encodeFunctionData('deployAndExecute', [
           account.creation.bytecode,
           account.creation.salt,
-          accountOp.calls.map((call) => callToTuple(call)),
+          getSignableCalls(accountOp),
           accountOp.signature
         ])
       }
@@ -627,7 +627,7 @@ export class MainController extends EventEmitter {
       try {
         const body = {
           gasLimit: Number(accountOp.gasFeePayment!.simulatedGasLimit),
-          txns: accountOp.calls.map((call) => callToTuple(call)),
+          txns: getSignableCalls(accountOp),
           signature: accountOp.signature,
           signer: {
             address: accountOp.signingKeyAddr

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -472,7 +472,7 @@ export class SignAccountOpController extends EventEmitter {
           // @TODO - config/const
           const feeToken = this.#getPortfolioToken(this.accountOp.gasFeePayment.inToken)
 
-          const call = {
+          this.accountOp.feeCall = {
             to: feeCollector,
             value: 0n,
             data: abiCoder.encode(
@@ -480,30 +480,28 @@ export class SignAccountOpController extends EventEmitter {
               ['gasTank', this.accountOp.gasFeePayment.amount, feeToken?.symbol]
             )
           }
-
-          this.accountOp.calls.push(call)
         } else if (this.accountOp.gasFeePayment.inToken) {
           // TODO: add the fee payment only if it hasn't been added already
           if (
             this.accountOp.gasFeePayment.inToken == '0x0000000000000000000000000000000000000000'
           ) {
             // native payment
-            this.accountOp.calls.push({
+            this.accountOp.feeCall = {
               to: feeCollector,
               value: this.accountOp.gasFeePayment.amount,
               data: '0x'
-            })
+            }
           } else {
             // token payment
             const ERC20Interface = new ethers.Interface(ERC20.abi)
-            this.accountOp.calls.push({
+            this.accountOp.feeCall = {
               to: this.accountOp.gasFeePayment.inToken,
               value: 0n,
               data: ERC20Interface.encodeFunctionData('transfer', [
                 feeCollector,
                 this.accountOp.gasFeePayment.amount
               ])
-            })
+            }
           }
         }
 

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -50,7 +50,11 @@ export interface AccountOp {
   // this is a number and not a bigint because of ethers (it uses number for nonces)
   nonce: bigint | null
   // @TODO: nonce namespace? it is dependent on gasFeePayment
-  calls: Call[]
+  calls: Call[],
+  // the feeCall is an extra call we add manually when there's a
+  // relayer/paymaster transaction so that the relayer/paymaster
+  // can authorize the payment
+  feeCall?: Call,
   gasLimit: number | null
   signature: string | null
   gasFeePayment: GasFeePayment | null
@@ -151,9 +155,15 @@ export function accountOpSignableHash(op: AccountOp): Uint8Array {
           op.accountAddr,
           opNetworks[0].chainId,
           op.nonce ?? 0n,
-          op.calls.map((call: Call) => callToTuple(call))
+          getSignableCalls(op)
         ]
       )
     )
   )
+}
+
+export function getSignableCalls(op: AccountOp) {
+  const callsToSign = op.calls.map((call: Call) => callToTuple(call))
+  if (op.feeCall) callsToSign.push(callToTuple(op.feeCall))
+  return callsToSign
 }

--- a/src/libs/userOperation/userOperation.ts
+++ b/src/libs/userOperation/userOperation.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { Account, AccountOnchainState } from "../../interfaces/account";
-import { AccountOp, callToTuple } from "../accountOp/accountOp";
+import { AccountOp, getSignableCalls } from "../accountOp/accountOp";
 import AmbireAccount from "../../../contracts/compiled/AmbireAccount.json";
 import { EstimateResult } from "libs/estimate/estimate";
 
@@ -80,7 +80,7 @@ export function toUserOperation(
     ]))
   }
 
-  const callData = ambireAccount.interface.encodeFunctionData('executeBySender', [accountOp.calls.map(call => callToTuple(call))])
+  const callData = ambireAccount.interface.encodeFunctionData('executeBySender', [getSignableCalls(accountOp)])
   const preVerificationGas = getPreverificationGas(callData)
   const verificationGasLimit = getVerificationGasLimit(initCode)
   const callGasLimit = estimation.gasUsed - (BigInt(verificationGasLimit) + BigInt(preVerificationGas))


### PR DESCRIPTION
This is a suggestion that adds a `feeCall?` to `accountOp` to clearly separate the main calls from the fee call that we manually add when we use the relayer/paymaster.

Pros:
* clear separation, easier readability
* removed the bug where we added multiple fee calls on sign if the first sign attempt failed

Cons:
* added complexity. We introduce `getSignableCalls` method which returns the main calls and the `feeCall` if any for sign/broadcast
* possibility for bugs if something else is used instead of `getSignableCalls`