### PR TITLE
Bug / Fetch supplement tokens sometimes crashing when catching errors (part 1)

### DIFF
--- a/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
+++ b/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
@@ -7,8 +7,8 @@ import networks, { coingeckoNets } from '../../../constants/networks'
 import { getTransactionSummary } from '../../../services/humanReadableTransactions/transactionSummary'
 import { getProvider } from '../../../services/provider'
 import { toBundleTxn } from '../../../services/requestToBundleTxn'
-import { ConstantsType } from '../../hooks/useConstants'
-import { Network, Token } from '../hooks/usePortfolio/types'
+import { ConstantsType } from '../../useConstants'
+import { Network, Token } from '../types'
 
 // use Balance Oracle
 function paginateArray(input: any[], limit: number) {


### PR DESCRIPTION
Sometimes the `e` error does not exist and a javascript reference error gets thrown when the mobile app is trying to access `e.message`.

This happened to me when I swapped some tokens on Polygon and changed the network to Ethereum.