### PR TITLE
EIP712 signatures

### DIFF
--- a/contracts/AmbireAccount.sol
+++ b/contracts/AmbireAccount.sol
@@ -245,8 +245,8 @@ contract AmbireAccount {
 	 * @return  bytes4  is it a success or a failure
 	 */
 	function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4) {
-		(address recovered, bool usedUnbound) = SignatureValidator.recoverAddrAllowUnbound(hash, signature, false);
-		if (uint256(privileges[recovered]) > (usedUnbound ? 1 : 0)) {
+		(address recovered, bool usedUnprotected) = SignatureValidator.recoverAddrAllowUnprotected(hash, signature, false);
+		if (uint256(privileges[recovered]) > (usedUnprotected ? 1 : 0)) {
 			// bytes4(keccak256("isValidSignature(bytes32,bytes)")
 			return 0x1626ba7e;
 		} else {


### PR DESCRIPTION
Wraps all signatures in a 712 message, which solves two things:
- the user always knows when they're signing an ambire interaction
- prevents 1271 signature replay

However, to prevent this breaking traditional 712 messages, we introduce a new signature type (actually it is old, but it was called "EIP712", perhaps wrongly), called "Unprotected" - in this sig mode, the hash is not additionally wrapped, which means that it can be replayed unless the key itself is guaranteed to be unique. Which is why we only allow it if `privileges[key`] value is **over 1**