### PR TITLE
Bug / Fetch supplement tokens sometimes crashing when catching errors (part 2)

### DIFF
--- a/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
+++ b/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
@@ -194,6 +194,11 @@ export default function useBalanceOracleFetch({
       resolve && resolve(rcpTokenData)
     } catch (e) {
       console.error('supplementTokensDataFromNetwork failed', e)
+      // For some reason the `e` (error) reference gets lost when trying to
+      // access it in the `setAssetsByAccount` function below. Alternatively,
+      // storing it in a string variable (errorMessage) works. Could be a Hermes
+      // engine specific issue because I had troubles reproducing this problem
+      // on the web app (V8 engine), but on mobile it was troublesome.
       const errorMessage = e?.message || 'Error with no message.'
       // In case of error set loading indicator to false
       setAssetsByAccount((prev) => ({


### PR DESCRIPTION
Continues the efforts in #418 to prevent app crash when fetching the supplement tokens fails.

For some reason the `e` (error) reference gets lost when trying to access it in the `setAssetsByAccount` function. Alternatively, storing it in a string variable (errorMessage) works. Could be a Hermes engine specific issue because I had troubles reproducing this problem on the web app (V8 engine), but on mobile it was troublesome.