### PR TITLE
Config / Temporary disable ERC 4337 for Optimism

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -41,7 +41,7 @@ const networks: NetworkDescriptor[] = [
     chainId: 10n,
     explorerUrl: 'https://optimistic.etherscan.io',
     erc4337: {
-      enabled: true,
+      enabled: false,
       entryPointAddr: ERC_4337_ENTRYPOINT,
       entryPointMarker: ENTRY_POINT_MARKER
     },


### PR DESCRIPTION
To solve the problem with addresses misleadingly appearing as "used on" Optimism.