### PR TITLE
Config / Handle used on networks check for smart accounts

### DIFF
--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -564,7 +564,24 @@ export class AccountAdderController extends EventEmitter {
         )
 
         accountState.forEach((acc: AccountOnchainState) => {
-          if (acc.balance > BigInt(0) || acc.nonce > BigInt(0)) {
+          const isUsedOnThisNetwork =
+            // Known limitation: checks only the native token balance. If this
+            // account has any other tokens than native ones, this check will
+            // fail to detect that the account was used on this network.
+            acc.balance > BigInt(0) ||
+            (acc.isEOA
+              ? acc.nonce > BigInt(0)
+              : // For smart accounts, check for 'isDeployed' instead because in
+                // the erc-4337 scenario many cases might be missed with checking
+                // the `acc.nonce`. For instance, `acc.nonce` could be 0, but user
+                // might be actively using the account. This is because in erc-4337,
+                // we use the entry point nonce. However, detecting the entry point
+                // nonce is also not okay, because for various cases we do not use
+                // sequential nonce - i.e., the entry point nonce could still be 0,
+                // but the account is deployed. So the 'isDeployed' check is the
+                // only reliable way to detect if account is used on network.
+                acc.isDeployed)
+          if (isUsedOnThisNetwork) {
             accountsObj[acc.accountAddr].account.usedOnNetworks.push(network)
           }
         })


### PR DESCRIPTION
The check if an account is used on a network for smart accounts should be based on the `isDeployed`. See the comment above the code for more details.