### PR TITLE
Bug / TypeScript not compatible with `.findLast` breaks tests

### DIFF
--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -79,9 +79,11 @@ export const getKnownAddressLabels = (
 
   // Check if the address is in the key preferences (lowest priority)
   keys.forEach((key) => {
+    // Note: not using .findLast, because it's not compatible with TypeScript, blah
+    const filteredKeyPreferences = keyPreferences.filter((x) => x.addr === key.addr && !!x.label)
     // There could be more than one, since there could be more than one key
     // with the same address. In that case, the last (probably newest) one wins.
-    const currentKeyPreferences = keyPreferences.findLast((x) => x.addr === key.addr && !!x.label)
+    const currentKeyPreferences = filteredKeyPreferences[filteredKeyPreferences.length - 1]
     if (currentKeyPreferences) {
       knownAddressLabels[key.addr] = currentKeyPreferences.label
     }


### PR DESCRIPTION
Rewrite the `.findLast` logic with `.filter`, because TypeScript is not compatible with `.findLast` and throws:

```
src/libs/account/account.ts:84:50 - error TS2339: Property 'findLast' does not exist on type 'KeyPreferences'.
```

and

```
 src/libs/account/account.ts:84:60 - error TS7006: Parameter 'x' implicitly has an 'any' type.
```