### PR TITLE
HotFix / Dont Request Estimation If Only Eligible Transaction Is Approve

### DIFF
--- a/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
+++ b/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
@@ -248,6 +248,14 @@ export default function useBalanceOracleFetch({
         rpc: true
       }
     }))
+    // This is a fix to not fetch balance oracle if there is
+    // only one approve transaction in pending state.
+    // Sometimes when we stake tokens we have 2 transactions:
+    // 1. approve, 2. stake
+    // Because we trigger the request on each new transaction
+    // there is an edge case where the 1. approve is slower
+    // than the 2. stake transaction and the response from balance oracle
+    // overrides the correct one
     const shouldWaitForPending =
       eligibleRequests.length === 1 && eligibleRequests[0].id.includes('approve')
 


### PR DESCRIPTION
Fixes: do not request estimation if the transactions length is only one and is the first pending transaction for approve.

This is an edge case which was visible with Ambire staking transactions. Since we call balance oracle for estimation on each new transaction we experience an edge case where the call with first approve transaction is slower then the second stake transaction (which really changes the balance) and overrides the estimation changes.