### PR TITLE
Config / Utilities for adding and removing a hex and checking if a string has hex prefix

### DIFF
--- a/src/utils/addHexPrefix.ts
+++ b/src/utils/addHexPrefix.ts
@@ -1,0 +1,12 @@
+import { isHexPrefixed } from './isHexPrefixed'
+
+/**
+ * Adds "0x" to a given `String` if it does not already start with "0x".
+ */
+export const addHexPrefix = (str: string) => {
+  if (typeof str !== 'string') {
+    return str
+  }
+
+  return isHexPrefixed(str) ? str : `0x${str}`
+}

--- a/src/utils/isHexPrefixed.ts
+++ b/src/utils/isHexPrefixed.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns a `Boolean` on whether or not the a `String` starts with '0x'
+ */
+export const isHexPrefixed = (str: string) => {
+  if (typeof str !== 'string') {
+    throw new Error(
+      `isHexPrefixed \`str\` value must be type 'string', is currently type ${typeof str}`
+    )
+  }
+
+  return str.slice(0, 2) === '0x'
+}

--- a/src/utils/stripHexPrefix.ts
+++ b/src/utils/stripHexPrefix.ts
@@ -1,0 +1,10 @@
+import { isHexPrefixed } from './isHexPrefixed'
+
+/**
+ * Removes '0x' from a given `String` if present
+ */
+export const stripHexPrefix = (str: string) => {
+  if (typeof str !== 'string') return str
+
+  return isHexPrefixed(str) ? str.slice(2) : str
+}


### PR DESCRIPTION
Utils are needed in order to remove the ethereumjs-utils lib as a dep in the Ambire apps.