### PR TITLE
Bug / Update account states immediately after adding new accounts

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -351,6 +351,7 @@ export class MainController extends EventEmitter {
     const nextAccounts = [...this.accounts, ...newAccounts]
     await this.#storage.set('accounts', nextAccounts)
     this.accounts = nextAccounts
+    this.updateAccountStates()
 
     this.emitUpdate()
   }


### PR DESCRIPTION
Without this, the account state for the accounts that were just added was missing in the first 5 minutes after their addition (until the update account state interval clicks). Until then, signing a message (and probably a transaction would too) was firing this error:

![image](https://github.com/AmbireTech/ambire-common/assets/2548061/0d18db45-c2da-4e12-9966-83782d4adaf0)
