### PR TITLE
Fix/get broadcast key only for EOA pays for SA

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -640,13 +640,6 @@ export class MainController extends EventEmitter {
 
     const provider: JsonRpcProvider = this.#providers[accountOp.networkId]
     const account = this.accounts.find((acc) => acc.addr === accountOp.accountAddr)
-    const broadcastKeys = this.keystore.keys.filter(
-      (key) => key.addr === accountOp.gasFeePayment!.paidBy
-    )
-    const broadcastKey =
-      // Temporarily prioritize the key with the same type as the signing key.
-      // TODO: Implement a way to choose the key type to broadcast with.
-      broadcastKeys.find((key) => key.type === accountOp.signingKeyType) || broadcastKeys[0]
     const network = this.settings.networks.find((n) => n.id === accountOp.networkId)
 
     if (!provider) {
@@ -658,16 +651,6 @@ export class MainController extends EventEmitter {
     if (!account) {
       return this.#throwAccountOpBroadcastError(
         new Error(`Account with address: ${accountOp.accountAddr} not found`)
-      )
-    }
-
-    if (!broadcastKey) {
-      return this.#throwAccountOpBroadcastError(
-        new Error(
-          `Key with address: ${accountOp.gasFeePayment!.paidBy} for account with address: ${
-            accountOp.accountAddr
-          } not found`
-        )
       )
     }
 
@@ -698,6 +681,23 @@ export class MainController extends EventEmitter {
       if (!estimation) {
         return this.#throwAccountOpBroadcastError(
           new Error(`Estimation not done for account with address: ${accountOp.accountAddr}`)
+        )
+      }
+
+      const broadcastKeys = this.keystore.keys.filter(
+        (key) => key.addr === accountOp.gasFeePayment!.paidBy
+      )
+      const broadcastKey =
+        // Temporarily prioritize the key with the same type as the signing key.
+        // TODO: Implement a way to choose the key type to broadcast with.
+        broadcastKeys.find((key) => key.type === accountOp.signingKeyType) || broadcastKeys[0]
+      if (!broadcastKey) {
+        return this.#throwAccountOpBroadcastError(
+          new Error(
+            `Key with address: ${accountOp.gasFeePayment!.paidBy} for account with address: ${
+              accountOp.accountAddr
+            } not found`
+          )
         )
       }
 


### PR DESCRIPTION
Fix: get the broadcast key only in the relevant case of EOA pays for SA

Reason for this fix: when paidBy is the smart account, the key is not found and it stops the broadcast. A key with the SA account address does not exist and paidBy is the smart account when using the relayer / erc4337