### PR TITLE
Refactor / Keep the `accountStates` reference link between the MainController and the ActivityController

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -399,15 +399,6 @@ export class ActivityController extends EventEmitter {
     this.emitUpdate()
   }
 
-  setAccounts(accounts: AccountStates) {
-    if (!this.isInitialized) {
-      this.#throwNotInitialized()
-      return
-    }
-
-    this.#accounts = accounts
-  }
-
   #throwNotInitialized() {
     this.emitError({
       level: 'major',

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -415,9 +415,15 @@ export class MainController extends EventEmitter {
     blockTag: string | number = 'latest',
     networks: NetworkDescriptor['id'][] = []
   ) {
-    this.accountStates = await this.#getAccountsInfo(this.accounts, blockTag, networks)
+    const nextAccountStates = await this.#getAccountsInfo(this.accounts, blockTag, networks)
+    // Use `Object.assign` to update `this.accountStates` on purpose! That's
+    // in order NOT to break the the reference link between `this.accountStates`
+    // in the MainController and in the ActivityController. Reassigning
+    // `this.accountStates` to a new object would break the reference link which
+    // is crucial for ensuring that updates to account states are synchronized
+    // across both classes.
+    Object.assign(this.accountStates, {}, nextAccountStates)
     this.lastUpdate = new Date()
-    if (this.accounts.length) this.activity.setAccounts(this.accountStates)
     this.emitUpdate()
   }
 


### PR DESCRIPTION
Introduces a better sync mechanism than https://github.com/AmbireTech/ambire-common/pull/507

In order to keep the `accountStates` in sync between the MainController and the ActivityController, keep the reference link instead of reassigning (and updating) the two instances every time.