### PR TITLE
Bug / Await initially updating `accountStates` after newly added accounts

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -509,7 +509,7 @@ export class MainController extends EventEmitter {
     const nextAccounts = [...this.accounts, ...newAccounts]
     await this.#storage.set('accounts', nextAccounts)
     this.accounts = nextAccounts
-    this.updateAccountStates()
+    await this.updateAccountStates()
 
     this.emitUpdate()
   }


### PR DESCRIPTION
Otherwise, the under may land to another part of the extension, but the `accountsStates` could be still missing (race condition). So make sure to await the first call before emitting an update indicating new accounts were added.