### PR TITLE
Bug / Reestimate and update prices sometimes crashes

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -695,7 +695,6 @@ export class MainController extends EventEmitter {
     const gasPrices = this.gasPrices[networkId]
     const estimation = this.accountOpsToBeSigned[accountAddr]?.[networkId]?.estimation
     this.signAccountOp.update({ gasPrices, ...(estimation && { estimation }) })
-
     this.emitUpdate()
   }
 


### PR DESCRIPTION
It breaks because the `this.accountOpsToBeSigned[accountAddr]` is not always defined.

To make sure it is:

- Set to `{}` before setting nested values (like `this.accountOpsToBeSigned[accountAddr][networkId]`)
- Make sure to optional chain it when accessing nested values