### PR TITLE
Fix: infinite estimation

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -84,7 +84,7 @@ export class SignAccountOpController extends EventEmitter {
 
   accountOp: AccountOp
 
-  #gasPrices: GasRecommendation[] | null = null
+  gasPrices: GasRecommendation[] | null = null
 
   #estimation: EstimateResult | null = null
 
@@ -194,8 +194,9 @@ export class SignAccountOpController extends EventEmitter {
     if (!this.accountOp?.signingKeyType || !this.accountOp?.signingKeyAddr)
       errors.push('Please select a signer to sign the transaction.')
 
-    if (!this.accountOp?.gasFeePayment)
+    if (!this.accountOp?.gasFeePayment && this.feeSpeeds.length) {
       errors.push('Please select a token and an account for paying the gas fee.')
+    }
 
     if (this.accountOp?.gasFeePayment && this.availableFeeOptions.length) {
       const feeToken = this.availableFeeOptions.find(
@@ -254,7 +255,7 @@ export class SignAccountOpController extends EventEmitter {
     signingKeyAddr?: Key['addr']
     signingKeyType?: Key['type']
   }) {
-    if (gasPrices) this.#gasPrices = gasPrices
+    if (gasPrices) this.gasPrices = gasPrices
 
     if (estimation) this.#estimation = estimation
 
@@ -294,7 +295,7 @@ export class SignAccountOpController extends EventEmitter {
   }
 
   reset() {
-    this.#gasPrices = null
+    this.gasPrices = null
     this.#estimation = null
     this.selectedFeeSpeed = FeeSpeed.Fast
     this.paidBy = null
@@ -376,7 +377,7 @@ export class SignAccountOpController extends EventEmitter {
     amountUsd: string
     maxPriorityFeePerGas?: bigint
   }[] {
-    if (!this.isInitialized || !this.#gasPrices || !this.paidBy || !this.feeTokenResult) return []
+    if (!this.isInitialized || !this.gasPrices || !this.paidBy || !this.feeTokenResult) return []
 
     const gasUsed = this.#estimation!.gasUsed
     const feeTokenEstimation = this.#estimation!.feePaymentOptions.find(
@@ -401,7 +402,7 @@ export class SignAccountOpController extends EventEmitter {
       this.#accountStates![this.accountOp!.accountAddr][this.accountOp!.networkId]
     )
 
-    return this.#gasPrices.map((gasRecommendation) => {
+    return this.gasPrices.map((gasRecommendation) => {
       let amount
       let simulatedGasLimit
 


### PR DESCRIPTION
The problem with infinite estimation was caused in times where the estimate() function was slower than the other state update functions. In those cases, the state of the signAccountOp controller was not updated and the SignAccountOpScreen not re-rerendered. The solution is to update the sign account op controller whenever the estimation finishes if the controller is initialized:
```
if (this.signAccountOp) this.signAccountOp.update({ estimation })
```

We also expose the `gasPrices` in `singAccountOp` so that we could use it in the sing account op screen to determine whether estimation is complete. It should be complete when we have two things: fee payment options and gas price