### PR TITLE
Bug / Sign Account Op status (in progress) glitches

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -283,7 +283,7 @@ export class SignAccountOpController extends EventEmitter {
   updateStatusToReadyToSign() {
     const isInTheMiddleOfSigning =
       this.status &&
-      ![SigningStatus.InProgress, SigningStatus.InProgressAwaitingUserInput].includes(
+      [SigningStatus.InProgress, SigningStatus.InProgressAwaitingUserInput].includes(
         this.status?.type
       )
 


### PR DESCRIPTION
When user starts signing with hardware wallet, the account op status changes to in progress (so the progress indicators appear). But after a couple of seconds - the status was flipping back to ready to sign which resets all progress indicators. This PR handles this case.