### PR TITLE
[ON-HOLD ]Fix: sign account op missing native price

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -28,6 +28,7 @@ import {
 } from '../../libs/banners/banners'
 import { estimate, EstimateResult, getEstimationFailure } from '../../libs/estimate/estimate'
 import { GasRecommendation, getGasPriceRecommendations } from '../../libs/gasPrice/gasPrice'
+import { getNativePrice } from '../../libs/humanizer/utils'
 import { shouldGetAdditionalPortfolio } from '../../libs/portfolio/helpers'
 import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import { isErc4337Broadcast, toUserOperation } from '../../libs/userOperation/userOperation'
@@ -334,7 +335,6 @@ export class MainController extends EventEmitter {
 
     this.signAccountOp = new SignAccountOpController(
       this.keystore,
-      this.portfolio,
       this.settings,
       this.#externalSignerControllers,
       account,
@@ -344,7 +344,8 @@ export class MainController extends EventEmitter {
       accountOpToBeSigned,
       this.#storage,
       this.#fetch,
-      this.#callRelayer
+      this.#callRelayer,
+      () => getNativePrice(network, this.#fetch)
     )
 
     const broadcastSignedAccountOpIfNeeded = async () => {

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -337,7 +337,6 @@ const init = async (
   settings.providers = { [op.networkId]: provider }
   const controller = new SignAccountOpController(
     keystore,
-    portfolio,
     settings,
     {},
     account,
@@ -347,7 +346,11 @@ const init = async (
     op,
     storage,
     fetch,
-    callRelayer
+    callRelayer,
+    () =>
+      new Promise((resolve) => {
+        resolve(1000.0)
+      })
   )
 
   return { controller, prices, estimation }


### PR DESCRIPTION
Fix: 
* sign account op missing native because of missing portfolio; remove the portfolio and refetch the native price until we have it