### PR TITLE
Bug / Glitches in the Account Op init procedure (part of the so called "monster bug")

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -532,6 +532,16 @@ export class SignAccountOpController extends EventEmitter {
       return null
     }
 
+    if (!this.feeSpeeds.length) {
+      this.emitError({
+        level: 'silent',
+        message: '',
+        error: new Error('SignAccountOpController: fee speeds not available')
+      })
+
+      return null
+    }
+
     const chosenSpeed = this.feeSpeeds.find((speed) => speed.type === this.selectedFeeSpeed)
     if (!chosenSpeed) {
       this.emitError({

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -205,8 +205,15 @@ export class SignAccountOpController extends EventEmitter {
     if (!this.accountOp?.signingKeyType || !this.accountOp?.signingKeyAddr)
       errors.push('Please select a signer to sign the transaction.')
 
-    if (!this.feeSpeeds.length)
-      errors.push('Estimating the transaction fee failed. Please try again later.')
+    const currentPortfolioNetwork =
+      this.#portfolio.latest[this.accountOp.accountAddr][this.accountOp.networkId]
+    const currentPortfolioNetworkNative = currentPortfolioNetwork?.result?.tokens.find(
+      (token) => token.address === '0x0000000000000000000000000000000000000000'
+    )
+    if (currentPortfolioNetwork?.criticalError || !currentPortfolioNetworkNative)
+      errors.push(
+        'Unable to estimate transaction fee as fetching the latest price updates failed. Please try again later.'
+      )
 
     if (!this.accountOp?.gasFeePayment && this.feeSpeeds.length) {
       errors.push('Please select a token and an account for paying the gas fee.')

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -212,7 +212,11 @@ export class SignAccountOpController extends EventEmitter {
     )
     if (currentPortfolioNetwork?.criticalError || !currentPortfolioNetworkNative)
       errors.push(
-        'Unable to estimate transaction fee as fetching the latest price updates failed. Please try again later.'
+        `Unable to estimate transaction fee as fetching the latest price updates failed. Please try again later. ${
+          currentPortfolioNetwork?.criticalError
+            ? `\n${currentPortfolioNetwork?.criticalError}`
+            : ''
+        }`
       )
 
     if (!this.accountOp?.gasFeePayment && this.feeSpeeds.length) {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -210,13 +210,9 @@ export class SignAccountOpController extends EventEmitter {
     const currentPortfolioNetworkNative = currentPortfolioNetwork?.result?.tokens.find(
       (token) => token.address === '0x0000000000000000000000000000000000000000'
     )
-    if (currentPortfolioNetwork?.criticalError || !currentPortfolioNetworkNative)
+    if (!currentPortfolioNetworkNative)
       errors.push(
-        `Unable to estimate transaction fee as fetching the latest price updates failed. Please try again later. ${
-          currentPortfolioNetwork?.criticalError
-            ? `\n${currentPortfolioNetwork?.criticalError}`
-            : ''
-        }`
+        'Unable to estimate the transaction fee as fetching the latest price updates for the network native token failed. Please try again later.'
       )
 
     if (!this.accountOp?.gasFeePayment && this.feeSpeeds.length) {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -212,7 +212,7 @@ export class SignAccountOpController extends EventEmitter {
     )
     if (!currentPortfolioNetworkNative)
       errors.push(
-        'Unable to estimate the transaction fee as fetching the latest price updates for the network native token failed. Please try again later.'
+        'Unable to estimate the transaction fee as fetching the latest price update for the network native token failed. Please try again later.'
       )
 
     if (!this.accountOp?.gasFeePayment && this.feeSpeeds.length) {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -704,6 +704,7 @@ export class SignAccountOpController extends EventEmitter {
         let amountInWei = gasFeePayment.amount
         if (this.feeTokenResult?.address !== '0x0000000000000000000000000000000000000000') {
           const nativeRatio = this.#getNativeToFeeTokenRatio(this.feeTokenResult!)
+          if (!nativeRatio) throw new Error('Could not retrieve the native token price.')
           amountInWei =
             (gasFeePayment.amount * BigInt(10 ** (18 + 18 - this.feeTokenResult!.decimals))) /
             nativeRatio

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -75,6 +75,7 @@ export async function getGasPriceRecommendations(
   blockTag: string | number = -1
 ): Promise<GasRecommendation[]> {
   const lastBlock = await provider.getBlock(blockTag, true)
+  // FIXME: Figure out why sometimes this condition clicks when initiating Account Op
   if (lastBlock == null) throw new Error('unable to retrieve block')
   // https://github.com/ethers-io/ethers.js/issues/3683#issuecomment-1436554995
   const txns = lastBlock.prefetchedTransactions

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -75,7 +75,6 @@ export async function getGasPriceRecommendations(
   blockTag: string | number = -1
 ): Promise<GasRecommendation[]> {
   const lastBlock = await provider.getBlock(blockTag, true)
-  // FIXME: Figure out why sometimes this condition clicks when initiating Account Op
   if (lastBlock == null) throw new Error('unable to retrieve block')
   // https://github.com/ethers-io/ethers.js/issues/3683#issuecomment-1436554995
   const txns = lastBlock.prefetchedTransactions


### PR DESCRIPTION
Part of the fixes related to https://github.com/AmbireTech/ambire-app/issues/1567

- Fixed: Handle the case when the native fee token price is missing (could happen when CoinGecko is down) and display an appropriate error
- Fixed: Handle the case then the `feeSpeeds` are missing (could happen when the native fee token price is missing and therefore - we can't calculate them)
- Fixed: Infinite loop when the `feeSpeeds` getter errors (because of an emitError in the error handling logic)