### PR TITLE
Replace etherface with 4bytes api

### DIFF
--- a/src/libs/humanizer/humanizerFuncs.test.ts
+++ b/src/libs/humanizer/humanizerFuncs.test.ts
@@ -310,7 +310,7 @@ describe('module tests', () => {
     })
   })
 
-  test.skip('fallback', async () => {
+  test('fallback', async () => {
     accountOp.calls = [...transactions.generic]
     delete accountOp.humanizerMeta?.['funcSelectors:0x095ea7b3']
     let irCalls: IrCall[] = accountOp.calls

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -270,7 +270,7 @@ describe('Humanizer main function', () => {
     expect(onUpdate).toHaveBeenCalledTimes(1)
   })
 
-  test.skip('unknown func selector humanize with asyncop', async () => {
+  test('unknown func selector humanize with asyncop', async () => {
     const expectedVisualizations = [
       { type: 'action', content: 'Call buy(uint256)' },
       { type: 'label', content: 'from' },

--- a/src/libs/humanizer/modules/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/fallBackHumanizer.ts
@@ -56,6 +56,64 @@ async function fetchFuncEtherface(
   return null
 }
 
+async function fetchFunc4bytes(selector: string, options: any): Promise<HumanizerFragment | null> {
+  if (!options.fetch)
+    return options.emitError({
+      message: 'fetchFunc4bytes: no fetch function passed',
+      error: new Error('No fetch function passed to fetchFunc4bytes'),
+      level: 'major'
+    })
+  let res
+  // often fails due to timeout => loop for retrying
+  for (let i = 0; i < 3; i++) {
+    try {
+      res = await (
+        await options.fetch(
+          `https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=${selector.slice(
+            2,
+            10
+          )}`,
+          {
+            // test allow aup to 25000 ms (this value * iterations of the loop)
+            timeout: 7500
+          }
+        )
+      ).json()
+      break
+    } catch (e: any) {
+      options.emitError({
+        message: 'fetchFunc4bytes: problem with 4bytes api',
+        error: e,
+        level: 'silent'
+      })
+    }
+  }
+  let func
+  try {
+    func = res.results.reduce((minObject: any, currentObject: any) => {
+      return currentObject.id < minObject.id ? currentObject : minObject
+    }, res.results[0])
+  } catch (e) {
+    options.emitError({
+      message: `fetchFunc4bytes: Err with 4bytes api, selector ${selector.slice(0, 10)}`,
+      error: new Error(`Failed to fetch info from 4bytes's api about ${selector.slice(0, 10)}`),
+      level: 'silent'
+    })
+  }
+  if (func)
+    return {
+      key: `funcSelectors:${func.hex_signature}`,
+      isGlobal: true,
+      value: func.text_signature
+    }
+  options.emitError({
+    message: `fetchFunc4bytes: Err with 4bytes api, selector ${selector.slice(0, 10)}`,
+    error: new Error(`Failed to fetch info from 4bytes's api about ${selector.slice(0, 10)}`),
+    level: 'silent'
+  })
+  return null
+}
+
 export const fallbackHumanizer: HumanizerCallModule = (
   accountOp: AccountOp,
   currentIrCalls: IrCall[],
@@ -74,7 +132,8 @@ export const fallbackHumanizer: HumanizerCallModule = (
           getAddress(call.to)
         )
       } else {
-        const promise = fetchFuncEtherface(call.data.slice(0, 10), options)
+        // const promise = fetchFuncEtherface(call.data.slice(0, 10), options)
+        const promise = fetchFunc4bytes(call.data.slice(0, 10), options)
         asyncOps.push(promise)
 
         visualization.push(getAction('Unknown action'), getLabel('to'), getAddress(call.to))


### PR DESCRIPTION
We used etherface as part of our fallback humanization module. Everytime we get unparsable txn with unknown sigHash we should query an api for the unknown sighash.

Etherface seems to have a problem so we now use 4bytes
