### PR TITLE
Fix/hide deadline option in uniswap humanizer

### DIFF
--- a/src/libs/humanizer/modules/Uniswap/index.ts
+++ b/src/libs/humanizer/modules/Uniswap/index.ts
@@ -11,12 +11,12 @@ export const uniswapHumanizer: HumanizerCallModule = (
   options?: any
 ) => {
   const matcher: { [x: string]: { [x: string]: (a: AccountOp, c: IrCall) => IrCall[] } } = {
-    '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D': uniV2Mapping(accountOp.humanizerMeta),
-    '0xE592427A0AEce92De3Edee1F18E0157C05861564': uniV3Mapping(accountOp.humanizerMeta),
+    '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D': uniV2Mapping(accountOp.humanizerMeta, options),
+    '0xE592427A0AEce92De3Edee1F18E0157C05861564': uniV3Mapping(accountOp.humanizerMeta, options),
     // Mainnet, Goerli, Arbitrum, Optimism, Polygon Address
-    '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45': uniV32Mapping(accountOp.humanizerMeta),
+    '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45': uniV32Mapping(accountOp.humanizerMeta, options),
     // same as above line but on on base (https://docs.uniswap.org/contracts/v3/reference/deployments)
-    '0x2626664c2603336E57B271c5C0b26F421741e481': uniV32Mapping(accountOp.humanizerMeta),
+    '0x2626664c2603336E57B271c5C0b26F421741e481': uniV32Mapping(accountOp.humanizerMeta, options),
     // empirical address from wallet txns
     '0x4C60051384bd2d3C01bfc845Cf5F4b44bcbE9de5': uniUniversalRouter(
       accountOp.humanizerMeta,

--- a/src/libs/humanizer/modules/Uniswap/uniUnivarsalRouter.ts
+++ b/src/libs/humanizer/modules/Uniswap/uniUnivarsalRouter.ts
@@ -92,7 +92,7 @@ export const uniUniversalRouter = (
               const params = extractParams(inputsDetails, inputs[index])
               const path = parsePath(params.path)
               const fullVisualization = [
-                getAction('Swap up  to'),
+                getAction('Swap up to'),
                 getToken(path[path.length - 1], params.amountInMax),
                 getLabel('for'),
                 getToken(path[0], params.amountOut)

--- a/src/libs/humanizer/modules/Uniswap/uniUnivarsalRouter.ts
+++ b/src/libs/humanizer/modules/Uniswap/uniUnivarsalRouter.ts
@@ -1,16 +1,17 @@
 import { ethers } from 'ethers'
+
+import { AccountOp } from '../../../accountOp/accountOp'
+import { IrCall } from '../../interfaces'
 import {
   getAction,
+  getAddress,
   getDeadline,
   getLabel,
   getRecipientText,
   getToken,
-  getWraping,
-  getAddress,
-  getUnknownVisualization
+  getUnknownVisualization,
+  getWraping
 } from '../../utils'
-import { AccountOp } from '../../../accountOp/accountOp'
-import { IrCall } from '../../interfaces'
 import { COMMANDS, COMMANDS_DESCRIPTIONS } from './Commands'
 import { parsePath } from './utils'
 
@@ -53,6 +54,7 @@ export const uniUniversalRouter = (
   options?: any
 ): { [x: string]: (a: AccountOp, c: IrCall) => IrCall[] } => {
   const ifaceUniversalRouter = new ethers.Interface(humanizerInfo?.['abis:UniswapUniversalRouter'])
+  const shouldShowDeadline = options?.uniswap?.showDeadline ?? true
   return {
     [`${
       ifaceUniversalRouter.getFunction(
@@ -71,30 +73,37 @@ export const uniUniversalRouter = (
               const { inputsDetails } = COMMANDS_DESCRIPTIONS.V3_SWAP_EXACT_IN
               const params = extractParams(inputsDetails, inputs[index])
               const path = parsePath(params.path)
+              const fullVisualization = [
+                getAction('Swap'),
+                getToken(path[0], params.amountIn),
+                getLabel('for at least'),
+                getToken(path[path.length - 1], params.amountOutMin)
+              ]
+              if (shouldShowDeadline) {
+                fullVisualization.push(getDeadline(deadline))
+              }
+
               parsed.push({
                 ...call,
-                fullVisualization: [
-                  getAction('Swap'),
-                  getToken(path[0], params.amountIn),
-                  getLabel('for at least'),
-                  getToken(path[path.length - 1], params.amountOutMin),
-                  getDeadline(deadline)
-                ]
+                fullVisualization
               })
             } else if (command === COMMANDS.V3_SWAP_EXACT_OUT) {
               const { inputsDetails } = COMMANDS_DESCRIPTIONS.V3_SWAP_EXACT_OUT
               const params = extractParams(inputsDetails, inputs[index])
               const path = parsePath(params.path)
+              const fullVisualization = [
+                getAction('Swap up  to'),
+                getToken(path[path.length - 1], params.amountInMax),
+                getLabel('for'),
+                getToken(path[0], params.amountOut)
+              ]
+              if (shouldShowDeadline) {
+                fullVisualization.push(getDeadline(deadline))
+              }
 
               parsed.push({
                 ...call,
-                fullVisualization: [
-                  getAction('Swap up  to'),
-                  getToken(path[path.length - 1], params.amountInMax),
-                  getLabel('for'),
-                  getToken(path[0], params.amountOut),
-                  getDeadline(deadline)
-                ]
+                fullVisualization
               })
             } else if (command === COMMANDS.SWEEP) {
               // @NOTE: no need to be displayed, generally uses sentinel values
@@ -143,31 +152,37 @@ export const uniUniversalRouter = (
               const { inputsDetails } = COMMANDS_DESCRIPTIONS.V2_SWAP_EXACT_IN
               const params = extractParams(inputsDetails, inputs[index])
               const path = params.path
+              const fullVisualization = [
+                getAction('Swap'),
+                getToken(path[0], params.amountIn),
+                getLabel('for at least'),
+                getToken(path[path.length - 1], params.amountOutMin)
+              ]
+              if (shouldShowDeadline) {
+                fullVisualization.push(getDeadline(deadline))
+              }
 
               parsed.push({
                 ...call,
-                fullVisualization: [
-                  getAction('Swap'),
-                  getToken(path[0], params.amountIn),
-                  getLabel('for at least'),
-                  getToken(path[path.length - 1], params.amountOutMin),
-                  getDeadline(deadline)
-                ]
+                fullVisualization
               })
             } else if (command === COMMANDS.V2_SWAP_EXACT_OUT) {
               const { inputsDetails } = COMMANDS_DESCRIPTIONS.V2_SWAP_EXACT_OUT
               const params = extractParams(inputsDetails, inputs[index])
               const path = params.path
+              const fullVisualization = [
+                getAction('Swap up  to'),
+                getToken(path[0], params.amountInMax),
+                getLabel('for'),
+                getToken(path[path.length - 1], params.amountOut)
+              ]
+              if (shouldShowDeadline) {
+                fullVisualization.push(getDeadline(deadline))
+              }
 
               parsed.push({
                 ...call,
-                fullVisualization: [
-                  getAction('Swap up  to'),
-                  getToken(path[0], params.amountInMax),
-                  getLabel('for'),
-                  getToken(path[path.length - 1], params.amountOut),
-                  getDeadline(deadline)
-                ]
+                fullVisualization
               })
             } else if (command === COMMANDS.PERMIT2_PERMIT) {
               parsed.push({

--- a/src/libs/humanizer/modules/Uniswap/uniV2.ts
+++ b/src/libs/humanizer/modules/Uniswap/uniV2.ts
@@ -1,13 +1,15 @@
 import { ethers } from 'ethers'
-import { getAction, getLabel, getToken, getRecipientText, getDeadline } from '../../utils'
 
 import { AccountOp } from '../../../accountOp/accountOp'
 import { IrCall } from '../../interfaces'
+import { getAction, getDeadline, getLabel, getRecipientText, getToken } from '../../utils'
 
 const uniV2Mapping = (
-  humanizerInfo: any
+  humanizerInfo: any,
+  options?: any
 ): { [key: string]: (a: AccountOp, c: IrCall) => IrCall[] } => {
   const iface = new ethers.Interface(humanizerInfo?.['abis:UniV2Router'])
+  const shouldShowDeadline = options?.uniswap?.showDeadline ?? true
 
   return {
     // ordered in the same order as the router
@@ -17,17 +19,20 @@ const uniV2Mapping = (
     ): IrCall[] => {
       const [amountIn, amountOutMin, path, to, deadline] = iface.parseTransaction(call)?.args || []
       const outputAsset = path[path.length - 1]
+      const fullVisualization = [
+        getAction('Swap'),
+        getToken(path[0], amountIn),
+        getLabel('for at least'),
+        getToken(outputAsset, amountOutMin),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Swap'),
-            getToken(path[0], amountIn),
-            getLabel('for at least'),
-            getToken(outputAsset, amountOutMin),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -37,18 +42,21 @@ const uniV2Mapping = (
     ): IrCall[] => {
       const [amountOut, amountInMax, path, to, deadline] = iface.parseTransaction(call)?.args || []
       const outputAsset = path[path.length - 1]
+      const fullVisualization = [
+        getAction('Swap'),
+        getLabel('up to'),
+        getToken(path[0], amountInMax),
+        getLabel('for at least'),
+        getToken(outputAsset, amountOut),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Swap'),
-            getLabel('up to'),
-            getToken(path[0], amountInMax),
-            getLabel('for at least'),
-            getToken(outputAsset, amountOut),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -59,17 +67,20 @@ const uniV2Mapping = (
       const { args, value } = iface.parseTransaction(call) || { value: BigInt(0) }
       const [amountOutMin, path, to, deadline] = args || []
       const outputAsset = path[path.length - 1]
+      const fullVisualization = [
+        getAction('Swap'),
+        getToken(ethers.ZeroAddress, value),
+        getLabel('for at least'),
+        getToken(outputAsset, amountOutMin),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Swap'),
-            getToken(ethers.ZeroAddress, value),
-            getLabel('for at least'),
-            getToken(outputAsset, amountOutMin),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -78,18 +89,21 @@ const uniV2Mapping = (
       call: IrCall
     ): IrCall[] => {
       const [amountOut, amountInMax, path, to, deadline] = iface.parseTransaction(call)?.args || []
+      const fullVisualization = [
+        getAction('Swap'),
+        getLabel('up to'),
+        getToken(path[0], amountInMax),
+        getLabel('for at least'),
+        getToken(ethers.ZeroAddress, amountOut),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Swap'),
-            getLabel('up to'),
-            getToken(path[0], amountInMax),
-            getLabel('for at least'),
-            getToken(ethers.ZeroAddress, amountOut),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -98,17 +112,20 @@ const uniV2Mapping = (
       call: IrCall
     ): IrCall[] => {
       const [amountIn, amountOutMin, path, to, deadline] = iface.parseTransaction(call)?.args || []
+      const fullVisualization = [
+        getAction('Swap'),
+        getToken(path[0], amountIn),
+        getLabel('for at least'),
+        getToken(ethers.ZeroAddress, amountOutMin),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Swap'),
-            getToken(path[0], amountIn),
-            getLabel('for at least'),
-            getToken(ethers.ZeroAddress, amountOutMin),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -119,18 +136,21 @@ const uniV2Mapping = (
       const { args, value } = iface.parseTransaction(call) || { value: BigInt(0) }
       const [amountOut, path, to, deadline] = args || []
       const outputAsset = path[path.length - 1]
+      const fullVisualization = [
+        getAction('Swap'),
+        getLabel('up to'),
+        getToken(ethers.ZeroAddress, value),
+        getLabel('for at least'),
+        getToken(outputAsset, amountOut),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Swap'),
-            getLabel('up to'),
-            getToken(ethers.ZeroAddress, value),
-            getLabel('for at least'),
-            getToken(outputAsset, amountOut),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -149,17 +169,20 @@ const uniV2Mapping = (
         to,
         deadline
       ] = iface.parseTransaction(call)?.args || []
+      const fullVisualization = [
+        getAction('Add liquidity'),
+        getToken(tokenA, amountADesired),
+        getLabel('and'),
+        getToken(tokenB, amountBDesired),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Add liquidity'),
-            getToken(tokenA, amountADesired),
-            getLabel('and'),
-            getToken(tokenB, amountBDesired),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -170,17 +193,20 @@ const uniV2Mapping = (
       const { args, value } = iface.parseTransaction(call) || { args: [], value: BigInt(0) }
       const [token, amountTokenDesired /* amountTokenMin */ /* amountETHMin */, , , to, deadline] =
         args
+      const fullVisualization = [
+        getAction('Add liquidity'),
+        getToken(token, amountTokenDesired),
+        getLabel('and'),
+        getToken(ethers.ZeroAddress, value),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Add liquidity'),
-            getToken(token, amountTokenDesired),
-            getLabel('and'),
-            getToken(ethers.ZeroAddress, value),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -190,18 +216,21 @@ const uniV2Mapping = (
     ): IrCall[] => {
       const [tokenA, tokenB /* liquidity */, , amountAMin, amountBMin, to, deadline] =
         iface.parseTransaction(call)?.args || []
+      const fullVisualization = [
+        getAction('Remove liquidity'),
+        getLabel('at least'),
+        getToken(tokenA, amountAMin),
+        getLabel('and'),
+        getToken(tokenB, amountBMin),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Remove liquidity'),
-            getLabel('at least'),
-            getToken(tokenA, amountAMin),
-            getLabel('and'),
-            getToken(tokenB, amountBMin),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     },
@@ -211,18 +240,21 @@ const uniV2Mapping = (
     ): IrCall[] => {
       const [token /* liquidity */, , amountTokenMin, amountETHMin, to, deadline] =
         iface.parseTransaction(call)?.args || []
+      const fullVisualization = [
+        getAction('Remove liquidity'),
+        getLabel('at least'),
+        getToken(token, amountTokenMin),
+        getLabel('and'),
+        getToken(ethers.ZeroAddress, amountETHMin),
+        ...getRecipientText(accountOp.accountAddr, to)
+      ]
+      if (shouldShowDeadline) {
+        fullVisualization.push(getDeadline(deadline))
+      }
       return [
         {
           ...call,
-          fullVisualization: [
-            getAction('Remove liquidity'),
-            getLabel('at least'),
-            getToken(token, amountTokenMin),
-            getLabel('and'),
-            getToken(ethers.ZeroAddress, amountETHMin),
-            ...getRecipientText(accountOp.accountAddr, to),
-            getDeadline(deadline)
-          ]
+          fullVisualization
         }
       ]
     }


### PR DESCRIPTION
In benzina, swap deadline started showing up for swaps from uniswap which is not correct as the transaction has already finished.  
This hides the deadline from the uniswap module if that is passed in options