### PR TITLE
Feature: should not happen estimation errors handling

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -833,12 +833,14 @@ export class MainController extends EventEmitter {
       })
     ])
 
-    if (estimation) {
-      this.accountOpsToBeSigned[localAccountOp.accountAddr] ||= {}
-      // @TODO compare intent between accountOp and this.accountOpsToBeSigned[accountOp.accountAddr][accountOp.networkId].accountOp
-      this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!.estimation =
-        estimation
+    this.accountOpsToBeSigned[localAccountOp.accountAddr] ||= {}
+    this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId] ||= {
+      accountOp: localAccountOp,
+      estimation
     }
+    // @TODO compare intent between accountOp and this.accountOpsToBeSigned[accountOp.accountAddr][accountOp.networkId].accountOp
+    this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!.estimation =
+      estimation
 
     // add the estimation to the user operation
     if (is4337Broadcast && estimation) {


### PR DESCRIPTION
Instead of throwing Errors, return an error with a message to the user if strange estimations occur like:
* EOA receives more than one call for estimation (should not happen)
* RPC fails more than 5 times to estimate the request. Instead of a slow request, tell the user that there really is an RPC issue but we will continue re-estimating after a couple of seconds