### PR TITLE
Config / Skip showing the actual critical portfolio error in the Dashboard banner

### DIFF
--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -232,9 +232,7 @@ export const getNetworksWithCriticalPortfolioErrorBanners = ({
           id: `${networkData.id}-${new Date().getTime()}`,
           topic: 'WARNING',
           title: `Failed to retrieve the portfolio data for ${networkData.name}`,
-          text: `Affected features: account balances, assets. Please try again later or contact support.${
-            criticalError?.message ? `\nError: ${criticalError.message}` : ''
-          }`,
+          text: 'Affected features: account balances, assets. Please try again later or contact support.',
           actions: []
         }
       ]


### PR DESCRIPTION
Showing it sometimes results very hairy Dashboard banners like the one below:

![image](https://github.com/AmbireTech/ambire-common/assets/2548061/6c0eafc8-7b05-4d54-a5e0-cb402e5891ed)
