### PR TITLE
Bug / Banner IDs should be unique, but not based on timestamps (because same error gets duplicated)

### DIFF
--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -188,7 +188,7 @@ export const getNetworksWithFailedRPCBanners = ({
       const networkData = networks.find((n: NetworkDescriptor) => n.id === network)!
 
       return {
-        id: `${networkData.id}-${new Date().getTime()}`,
+        id: `${networkData.id}-rpc-down`,
         topic: 'WARNING',
         title: `Failed to retrieve network data for ${networkData?.name} (RPC is down)`,
         text: 'Affected features: visible tokens, sign message/transaction, ENS/UD domain resolving, add account. Please try again later or contact support.',
@@ -229,7 +229,7 @@ export const getNetworksWithCriticalPortfolioErrorBanners = ({
 
       return [
         {
-          id: `${networkData.id}-${new Date().getTime()}`,
+          id: `${networkData.id}-portfolio-critical-error`,
           topic: 'WARNING',
           title: `Failed to retrieve the portfolio data for ${networkData.name}`,
           text: 'Affected features: account balances, assets. Please try again later or contact support.',


### PR DESCRIPTION
Solves the issue that happens when the main controller banners (getter method) gets executed multiple times. It returns duplicated banners (RPC error), where it should be only one error per network.