### PR TITLE
Feature/ Reusable ENS and UD resolution

### DIFF
--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -45,8 +45,6 @@ describe('Transfer Controller', () => {
   test('should emit not initialized error', () => {
     transferController = new TransferController()
 
-    transferController.onRecipientAddressChange()
-    errorCount++
     transferController.buildUserRequest()
     errorCount++
 
@@ -73,48 +71,30 @@ describe('Transfer Controller', () => {
     })
     expect(transferController.isInitialized).toBe(true)
   })
-  test('should set recipient address', () => {
+  test('should set address state', () => {
     transferController.update({
-      recipientAddress: PLACEHOLDER_RECIPIENT
+      addressState: {
+        fieldValue: PLACEHOLDER_RECIPIENT,
+        ensAddress: '',
+        udAddress: '',
+        isDomainResolving: false
+      }
     })
-    expect(transferController.recipientAddress).toBe(PLACEHOLDER_RECIPIENT)
-  })
-  test('should resolve ENS', async () => {
-    transferController.update({
-      recipientAddress: 'elmoto.eth'
-    })
-    await transferController.onRecipientAddressChange()
-
-    expect(transferController.recipientEnsAddress).toBe(PLACEHOLDER_RECIPIENT)
+    expect(transferController.addressState.fieldValue).toBe(PLACEHOLDER_RECIPIENT)
   })
   test('should set recipient address unknown', () => {
     expect(transferController.isRecipientAddressUnknown).toBe(true)
   })
   test('should flag recipient address as a smart contract', async () => {
     transferController.update({
-      recipientAddress: '0x7a250d5630b4cf539739df2c5dacb4c659f2488d'
+      addressState: {
+        fieldValue: XWALLET_ADDRESS,
+        ensAddress: '',
+        udAddress: '',
+        isDomainResolving: false
+      }
     })
-    await transferController.onRecipientAddressChange()
     expect(transferController.isRecipientHumanizerKnownTokenOrSmartContract).toBe(true)
-  })
-  test('should resolve UnstoppableDomains', async () => {
-    transferController.update({
-      recipientAddress: '0xyakmotoru.wallet'
-    })
-    await transferController.onRecipientAddressChange()
-
-    expect(transferController.recipientUDAddress?.toLowerCase()).toBe(
-      PLACEHOLDER_RECIPIENT_LOWERCASE
-    )
-  })
-  test('should reset recipientUDAddress and recipientEnsAddress when recipientAddress is set to a normal address', () => {
-    transferController.update({
-      recipientAddress: PLACEHOLDER_RECIPIENT
-    })
-    transferController.onRecipientAddressChange()
-
-    expect(transferController.recipientUDAddress).toBe('')
-    expect(transferController.recipientEnsAddress).toBe('')
   })
   test('should show SW warning', async () => {
     const tokens = await getTokens()
@@ -149,6 +129,15 @@ describe('Transfer Controller', () => {
     expect(transferController.isSWWarningAgreed).toBe(true)
   })
   test('should set validation form messages', async () => {
+    transferController.update({
+      addressState: {
+        fieldValue: PLACEHOLDER_RECIPIENT,
+        ensAddress: '',
+        udAddress: '',
+        isDomainResolving: false
+      }
+    })
+
     expect(transferController.validationFormMsgs.amount.success).toBe(true)
     expect(transferController.validationFormMsgs.recipientAddress.success).toBe(false)
 
@@ -218,9 +207,14 @@ describe('Transfer Controller', () => {
   })
 
   test('should detect that the recipient is the fee collector', async () => {
-    transferController.update({ recipientAddress: FEE_COLLECTOR })
-    await transferController.onRecipientAddressChange()
-
+    transferController.update({
+      addressState: {
+        fieldValue: FEE_COLLECTOR,
+        ensAddress: '',
+        udAddress: '',
+        isDomainResolving: false
+      }
+    })
     expect(transferController.isRecipientHumanizerKnownTokenOrSmartContract).toBeFalsy()
     expect(transferController.isRecipientAddressUnknown).toBeFalsy()
   })
@@ -229,11 +223,14 @@ describe('Transfer Controller', () => {
     expect(transferController.amount).toBe('')
     expect(transferController.maxAmount).toBe('0')
     expect(transferController.recipientAddress).toBe('')
-    expect(transferController.recipientEnsAddress).toBe('')
-    expect(transferController.recipientUDAddress).toBe('')
     expect(transferController.selectedToken).toBe(null)
     expect(transferController.isRecipientAddressUnknown).toBe(false)
-    expect(transferController.isRecipientDomainResolving).toBe(false)
+    expect(transferController.addressState).toEqual({
+      fieldValue: '',
+      ensAddress: '',
+      udAddress: '',
+      isDomainResolving: false
+    })
     expect(transferController.userRequest).toBe(null)
     expect(transferController.isRecipientAddressUnknownAgreed).toBe(false)
     expect(transferController.isRecipientHumanizerKnownTokenOrSmartContract).toBe(false)

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -217,6 +217,8 @@ export class TransferController extends EventEmitter {
         ...this.addressState,
         ...addressState
       }
+      if (!this.isInitialized) return
+
       this.#onRecipientAddressChange()
     }
     // We can do a regular check here, because the property defines if it should be updated

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -217,6 +217,7 @@ export class TransferController extends EventEmitter {
         ...this.addressState,
         ...addressState
       }
+      this.#onRecipientAddressChange()
     }
     // We can do a regular check here, because the property defines if it should be updated
     // and not the actual value
@@ -280,7 +281,7 @@ export class TransferController extends EventEmitter {
   }
 
   // Allows for debounce implementation in the UI
-  async onRecipientAddressChange() {
+  #onRecipientAddressChange() {
     if (!this.isInitialized) {
       this.#throwNotInitialized()
       return

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -1,18 +1,25 @@
 import erc20Abi from 'adex-protocol-eth/abi/ERC20.json'
-import { ethers, formatUnits, getAddress, Interface, parseUnits } from 'ethers'
+import { formatUnits, Interface, parseUnits } from 'ethers'
 
 import { HumanizerInfoType } from '../../../v1/hooks/useConstants'
 import { FEE_COLLECTOR } from '../../consts/addresses'
 import { networks } from '../../consts/networks'
+import { AddressState } from '../../interfaces/domains'
+import { TransferUpdate } from '../../interfaces/transfer'
 import { UserRequest } from '../../interfaces/userRequest'
 import { TokenResult } from '../../libs/portfolio'
 import { isHumanizerKnownTokenOrSmartContract } from '../../services/address'
-import { getBip44Items, resolveENSDomain } from '../../services/ensDomains'
-import { resolveUDomain } from '../../services/unstoppableDomains'
 import { validateSendTransferAddress, validateSendTransferAmount } from '../../services/validations'
 import EventEmitter from '../eventEmitter/eventEmitter'
 
 const ERC20 = new Interface(erc20Abi)
+
+const DEFAULT_ADDRESS_STATE = {
+  fieldValue: '',
+  ensAddress: '',
+  udAddress: '',
+  isDomainResolving: false
+}
 
 const DEFAULT_VALIDATION_FORM_MSGS = {
   amount: {
@@ -39,13 +46,7 @@ export class TransferController extends EventEmitter {
 
   maxAmount = '0'
 
-  recipientAddress = ''
-
-  recipientEnsAddress = ''
-
-  recipientUDAddress = ''
-
-  isRecipientDomainResolving = false
+  addressState: AddressState = { ...DEFAULT_ADDRESS_STATE }
 
   isRecipientAddressUnknown = false
 
@@ -100,13 +101,10 @@ export class TransferController extends EventEmitter {
   resetForm() {
     this.amount = ''
     this.maxAmount = '0'
-    this.recipientAddress = ''
-    this.recipientEnsAddress = ''
-    this.recipientUDAddress = ''
+    this.addressState = { ...DEFAULT_ADDRESS_STATE }
     this.selectedToken = null
     this.#selectedTokenNetworkData = null
     this.isRecipientAddressUnknown = false
-    this.isRecipientDomainResolving = false
     this.userRequest = null
     this.isRecipientAddressUnknownAgreed = false
     this.isRecipientHumanizerKnownTokenOrSmartContract = false
@@ -129,23 +127,23 @@ export class TransferController extends EventEmitter {
     const validationFormMsgsNew = DEFAULT_VALIDATION_FORM_MSGS
 
     if (this.#humanizerInfo && this.#selectedAccount) {
-      const isUDAddress = !!this.recipientUDAddress
-      const isEnsAddress = !!this.recipientEnsAddress
+      const isUDAddress = !!this.addressState.udAddress
+      const isEnsAddress = !!this.addressState.ensAddress
 
       validationFormMsgsNew.recipientAddress = validateSendTransferAddress(
-        this.recipientUDAddress || this.recipientEnsAddress || this.recipientAddress,
+        this.recipientAddress,
         this.#selectedAccount,
         this.isRecipientAddressUnknownAgreed,
         this.isRecipientAddressUnknown,
         this.isRecipientHumanizerKnownTokenOrSmartContract,
         isUDAddress,
         isEnsAddress,
-        this.isRecipientDomainResolving
+        this.addressState.isDomainResolving
       )
     }
 
     // Validate the amount
-    if (this.selectedToken && (this.amount !== '' || this.recipientAddress !== '')) {
+    if (this.selectedToken && (this.amount !== '' || this.addressState.fieldValue !== '')) {
       validationFormMsgsNew.amount = validateSendTransferAmount(this.amount, this.selectedToken)
     }
 
@@ -172,12 +170,18 @@ export class TransferController extends EventEmitter {
       areFormFieldsValid &&
       isSWWarningMissingOrAccepted &&
       isRecipientAddressUnknownMissingOrAccepted &&
-      !this.isRecipientDomainResolving
+      !this.addressState.isDomainResolving
     )
   }
 
   get isInitialized() {
     return !!this.#humanizerInfo && !!this.#selectedAccount && !!this.tokens
+  }
+
+  get recipientAddress() {
+    return (
+      this.addressState.ensAddress || this.addressState.udAddress || this.addressState.fieldValue
+    )
   }
 
   update({
@@ -186,22 +190,11 @@ export class TransferController extends EventEmitter {
     tokens,
     selectedToken,
     amount,
-    recipientAddress,
+    addressState,
     isSWWarningAgreed,
     isRecipientAddressUnknownAgreed,
     isTopUp
-  }: {
-    selectedAccount?: string
-    preSelectedToken?: string
-    humanizerInfo?: HumanizerInfoType
-    tokens?: TokenResult[]
-    selectedToken?: TokenResult
-    amount?: string
-    recipientAddress?: string
-    isSWWarningAgreed?: boolean
-    isRecipientAddressUnknownAgreed?: boolean
-    isTopUp?: boolean
-  }) {
+  }: TransferUpdate) {
     if (humanizerInfo) {
       this.#humanizerInfo = humanizerInfo
     }
@@ -219,12 +212,11 @@ export class TransferController extends EventEmitter {
     if (typeof amount === 'string') {
       this.amount = amount
     }
-    // If we do a regular check the value won't update if it's '' or '0'
-    if (typeof recipientAddress === 'string') {
-      const canBeEnsOrUd = recipientAddress.indexOf('.') !== -1
-      this.isRecipientDomainResolving = canBeEnsOrUd
-
-      this.recipientAddress = recipientAddress.trim()
+    if (addressState) {
+      this.addressState = {
+        ...this.addressState,
+        ...addressState
+      }
     }
     // We can do a regular check here, because the property defines if it should be updated
     // and not the actual value
@@ -255,8 +247,8 @@ export class TransferController extends EventEmitter {
 
     // if the request is a top up, the recipient is the relayer
     const recipientAddress = this.isTopUp
-      ? FEE_COLLECTOR
-      : getAddress(this.recipientUDAddress || this.recipientEnsAddress || this.recipientAddress)
+      ? FEE_COLLECTOR.toLowerCase()
+      : this.recipientAddress.toLowerCase()
 
     const bigNumberHexAmount = `0x${parseUnits(
       this.amount,
@@ -293,64 +285,18 @@ export class TransferController extends EventEmitter {
       this.#throwNotInitialized()
       return
     }
-    const address = this.recipientAddress.trim()
-    const canBeEnsOrUd = address.indexOf('.') !== -1
 
-    if (!canBeEnsOrUd) {
-      if (this.recipientUDAddress) this.recipientUDAddress = ''
-      if (this.recipientEnsAddress) this.recipientEnsAddress = ''
-    }
-
-    if (this.selectedToken?.networkId && this.#selectedTokenNetworkData && canBeEnsOrUd) {
-      try {
-        this.recipientUDAddress = await resolveUDomain(
-          address,
-          this.selectedToken.symbol,
-          this.#selectedTokenNetworkData.unstoppableDomainsChain
-        )
-      } catch {
-        this.emitError({
-          level: 'major',
-          message:
-            'We encountered an internal error during UD resolving. Retry, or contact support if the issue persists.',
-          error: new Error('transfer: UD resolving failed')
-        })
-      }
-
-      const bip44Item = getBip44Items(this.selectedToken.symbol)
-
-      try {
-        this.recipientEnsAddress = await resolveENSDomain(address, bip44Item)
-      } catch {
-        // Don't throw an error if the address is already resolved as UD
-        if (!this.recipientUDAddress) {
-          this.emitError({
-            level: 'major',
-            message:
-              'We encountered an internal error during ENS resolving. Retry, or contact support if the issue persists.',
-            error: new Error('transfer: ENS resolving failed')
-          })
-        }
-      }
-    }
     if (this.#humanizerInfo) {
       // @TODO: could fetch address code
       this.isRecipientHumanizerKnownTokenOrSmartContract = isHumanizerKnownTokenOrSmartContract(
         this.#humanizerInfo,
-        address
+        this.recipientAddress
       )
-    }
-
-    if (this.recipientUDAddress || this.recipientEnsAddress) {
-      this.isRecipientAddressUnknown = true // @TODO: check from the address book
     }
 
     // @TODO: isValidAddress & check from the address book
     this.isRecipientAddressUnknown =
-      (!this.recipientUDAddress && !this.recipientEnsAddress
-        ? ethers.getAddress(address)
-        : address) !== FEE_COLLECTOR
-    this.isRecipientDomainResolving = false
+      this.recipientAddress.toLowerCase() !== FEE_COLLECTOR.toLowerCase()
 
     this.emitUpdate()
   }

--- a/src/interfaces/domains.ts
+++ b/src/interfaces/domains.ts
@@ -12,4 +12,10 @@ type AddressStateOptional = {
   isDomainResolving?: AddressState['isDomainResolving']
 }
 
-export type { AddressState, AddressStateOptional }
+type CachedResolvedDomain = {
+  name: string
+  address: string
+  type: 'ens' | 'ud'
+}
+
+export type { AddressState, AddressStateOptional, CachedResolvedDomain }

--- a/src/interfaces/domains.ts
+++ b/src/interfaces/domains.ts
@@ -1,0 +1,15 @@
+type AddressState = {
+  fieldValue: string
+  udAddress: string
+  ensAddress: string
+  isDomainResolving: boolean
+}
+
+type AddressStateOptional = {
+  fieldValue?: AddressState['fieldValue']
+  ensAddress?: AddressState['ensAddress']
+  udAddress?: AddressState['udAddress']
+  isDomainResolving?: AddressState['isDomainResolving']
+}
+
+export type { AddressState, AddressStateOptional }

--- a/src/interfaces/transfer.ts
+++ b/src/interfaces/transfer.ts
@@ -1,4 +1,6 @@
+import { HumanizerInfoType } from '../../v1/hooks/useConstants'
 import { TokenResult } from '../libs/portfolio'
+import { AddressState, AddressStateOptional } from './domains'
 import { UserRequest } from './userRequest'
 
 export interface TransferControllerState {
@@ -16,13 +18,7 @@ export interface TransferControllerState {
 
   maxAmount: string
 
-  recipientAddress: string
-
-  recipientEnsAddress: string
-
-  recipientUDAddress: string
-
-  isRecipientDomainResolving: boolean
+  addressState: AddressState
 
   isRecipientAddressUnknown: boolean
 
@@ -46,4 +42,17 @@ export interface TransferControllerState {
   isFormValid: boolean
 
   isTopUp: boolean
+}
+
+export interface TransferUpdate {
+  selectedAccount?: string
+  preSelectedToken?: string
+  humanizerInfo?: HumanizerInfoType
+  tokens?: TokenResult[]
+  selectedToken?: TokenResult
+  amount?: string
+  addressState?: AddressStateOptional
+  isSWWarningAgreed?: boolean
+  isRecipientAddressUnknownAgreed?: boolean
+  isTopUp?: boolean
 }

--- a/src/services/ensDomains/ensDomains.ts
+++ b/src/services/ensDomains/ensDomains.ts
@@ -42,9 +42,19 @@ async function resolveENSDomain(domain, bip44Item?: any): Promise<string> {
   const provider = getProvider(ETH_ID)
   const resolver = await provider.getResolver(normalizedDomainName)
   if (!resolver) return ''
-  const ethAddress = await resolver.getAddress()
-  const addressForCoin = await resolveForCoin(resolver, bip44Item).catch(() => null)
-  return isCorrectAddress(addressForCoin) ? addressForCoin : ethAddress
+  try {
+    const ethAddress = await resolver.getAddress()
+    const addressForCoin = await resolveForCoin(resolver, bip44Item).catch(() => null)
+    return isCorrectAddress(addressForCoin) ? addressForCoin : ethAddress
+  } catch (e) {
+    // If the error comes from an internal server error don't
+    // show it to the user, because it happens when a domain
+    // doesn't exist and we already show a message for that.
+    // https://dnssec-oracle.ens.domains/ 500 (ISE)
+    if (e.message?.includes('500_SERVER_ERROR')) return ''
+
+    throw e
+  }
 }
 
 function getBip44Items(coinTicker) {

--- a/src/services/ensDomains/ensDomains.ts
+++ b/src/services/ensDomains/ensDomains.ts
@@ -36,7 +36,7 @@ export function isCorrectAddress(address) {
 }
 
 // @TODO: Get RPC provider url from settings controller
-async function resolveENSDomain(domain, bip44Item): string {
+async function resolveENSDomain(domain, bip44Item?: any): Promise<string> {
   const normalizedDomainName = normalizeDomain(domain)
   if (!normalizedDomainName) return ''
   const provider = getProvider(ETH_ID)

--- a/src/services/unstoppableDomains/unstoppableDomains.ts
+++ b/src/services/unstoppableDomains/unstoppableDomains.ts
@@ -44,7 +44,7 @@ async function resolveAddressMultiChain(domain, currency, chain) {
     .catch((e) => ({ success: false, code: e.code, message: getMessage(e.code) }))
 }
 
-async function resolveUDomain(domain, currency, chain): string {
+async function resolveUDomain(domain, currency?: any, chain?: any): Promise<string> {
   const [nativeUDAddress, customUDAddress] = await Promise.all([
     resolveAddress(domain),
     resolveAddressMultiChain(domain, currency, chain)

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -64,16 +64,6 @@ const validateSendTransferAddress = (
     }
   }
 
-  // Validate checksum
-  try {
-    getAddress(address)
-  } catch {
-    return {
-      success: false,
-      message: 'Invalid checksum. Verify the address and try again.'
-    }
-  }
-
   if (selectedAcc && address === selectedAcc) {
     return {
       success: false,

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -56,17 +56,32 @@ const validateSendTransferAddress = (
   isEnsAddress: boolean,
   isRecipientDomainResolving: boolean
 ) => {
-  const isValidAddr = validateAddress(address)
-  if (!isValidAddr.success && !isRecipientDomainResolving) return isValidAddr
+  // Basic validation is handled in the AddressInput component and we don't want to overwrite it.
+  if (!isValidAddress(address) || isRecipientDomainResolving) {
+    return {
+      success: true,
+      message: ''
+    }
+  }
 
-  if (address && selectedAcc && address === selectedAcc) {
+  // Validate checksum
+  try {
+    getAddress(address)
+  } catch {
+    return {
+      success: false,
+      message: 'Invalid checksum. Verify the address and try again.'
+    }
+  }
+
+  if (selectedAcc && address === selectedAcc) {
     return {
       success: false,
       message: 'The entered address should be different than the your own account address.'
     }
   }
 
-  if (address && isRecipientHumanizerKnownTokenOrSmartContract) {
+  if (isRecipientHumanizerKnownTokenOrSmartContract) {
     return {
       success: false,
       message: 'You are trying to send tokens to a smart contract. Doing so would burn them.'
@@ -74,7 +89,6 @@ const validateSendTransferAddress = (
   }
 
   if (
-    address &&
     isRecipientAddressUnknown &&
     !addressConfirmed &&
     !isUDAddress &&
@@ -89,7 +103,6 @@ const validateSendTransferAddress = (
   }
 
   if (
-    address &&
     isRecipientAddressUnknown &&
     !addressConfirmed &&
     (isUDAddress || isEnsAddress) &&


### PR DESCRIPTION
## Changes:

- Moved ENS/UD resolution out of transfer ctrl
- Changed recipient data structure
- Added `interfaces/domains`
- Made slight changes to ensDomains.ts and unstoppableDomains.ts
- Deleted redundant validation in `validateSendTransferAddress`(it moved to `useAddressInput`)
- Updated transfer ctrl tests

## Linked with
https://github.com/AmbireTech/ambire-app/pull/1676