### PR TITLE
Sign account op local user op

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -33,7 +33,7 @@ import { humanizeAccountOp } from '../../libs/humanizer'
 import { shouldGetAdditionalPortfolio } from '../../libs/portfolio/helpers'
 import { PinnedTokens } from '../../libs/portfolio/interfaces'
 import { relayerCall } from '../../libs/relayerCall/relayerCall'
-import { isErc4337Broadcast, toUserOperation } from '../../libs/userOperation/userOperation'
+import { isErc4337Broadcast } from '../../libs/userOperation/userOperation'
 import bundler from '../../services/bundlers'
 import generateSpoofSig from '../../utils/generateSpoofSig'
 import wait from '../../utils/wait'
@@ -772,19 +772,6 @@ export class MainController extends EventEmitter {
     if (!network)
       throw new Error(`estimateAccountOp: ${localAccountOp.networkId}: network does not exist`)
 
-    // start transforming the accountOp to userOp if the network is 4337
-    // and it's not a legacy account
-    const is4337Broadcast = isErc4337Broadcast(
-      network,
-      this.accountStates[localAccountOp.accountAddr][localAccountOp.networkId]
-    )
-    if (is4337Broadcast) {
-      localAccountOp.asUserOperation = toUserOperation(
-        account,
-        this.accountStates[localAccountOp.accountAddr][localAccountOp.networkId],
-        localAccountOp
-      )
-    }
     const humanization = await humanizeAccountOp(
       this.#storage,
       localAccountOp,
@@ -830,7 +817,12 @@ export class MainController extends EventEmitter {
         EOAaccounts.map((acc) => acc.addr),
         // @TODO - first time calling this, portfolio is still not loaded.
         feeTokens,
-        { is4337Broadcast }
+        {
+          is4337Broadcast: isErc4337Broadcast(
+            network,
+            this.accountStates[localAccountOp.accountAddr][localAccountOp.networkId]
+          )
+        }
       ).catch((e) => {
         this.emitError({
           level: 'major',
@@ -850,24 +842,10 @@ export class MainController extends EventEmitter {
     this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!.estimation =
       estimation
 
-    // add the estimation to the user operation
-    if (is4337Broadcast && estimation) {
-      localAccountOp.asUserOperation!.verificationGasLimit = ethers.toBeHex(
-        estimation.erc4337estimation!.verificationGasLimit
-      )
-      localAccountOp.asUserOperation!.callGasLimit = ethers.toBeHex(
-        estimation.erc4337estimation!.callGasLimit
-      )
-      this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!.accountOp =
-        localAccountOp
-    }
-
     // update the signAccountOp controller once estimation finishes;
     // this eliminates the infinite loading bug if the estimation comes slower
-    if (this.signAccountOp) {
-      estimation
-        ? this.signAccountOp.update({ estimation, accountOp: localAccountOp })
-        : this.signAccountOp.update({ accountOp: localAccountOp })
+    if (this.signAccountOp && estimation) {
+      this.signAccountOp.update({ estimation })
     }
   }
 
@@ -1069,7 +1047,7 @@ export class MainController extends EventEmitter {
       // broadcast through bundler's service
       let userOperationHash
       try {
-        userOperationHash = await bundler.broadcast(userOperation!, network!)
+        userOperationHash = await bundler.broadcast(userOperation, network!)
       } catch (e) {
         return this.#throwAccountOpBroadcastError(new Error('bundler broadcast failed'))
       }
@@ -1080,7 +1058,7 @@ export class MainController extends EventEmitter {
       // broadcast the userOperationHash
       transactionRes = {
         hash: userOperationHash,
-        nonce: Number(userOperation!.nonce)
+        nonce: Number(userOperation.nonce)
       }
     }
     // Smart account, the Relayer way

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -1,6 +1,6 @@
 /* eslint no-console: "off" */
 
-import { ethers, JsonRpcProvider } from 'ethers'
+import { ethers, JsonRpcProvider, toBeHex } from 'ethers'
 import fetch from 'node-fetch'
 
 import { describe, expect, jest, test } from '@jest/globals'
@@ -255,8 +255,7 @@ const init = async (
   },
   signer: any,
   estimationMock?: EstimateResult,
-  gasPricesMock?: gasPricesLib.GasRecommendation[],
-  isErc4337?: boolean
+  gasPricesMock?: gasPricesLib.GasRecommendation[]
 ) => {
   const storage: Storage = produceMemoryStore()
   await storage.set('HumanizerMeta', humanizerMeta)
@@ -275,11 +274,6 @@ const init = async (
 
   const prices = gasPricesMock || (await gasPricesLib.getGasPriceRecommendations(provider, network))
 
-  // if the request is a 4337 one, set the user op before the estimation
-  if (isErc4337) {
-    op.asUserOperation = toUserOperation(account, accountStates[op.accountAddr][op.networkId], op)
-  }
-
   const estimation =
     estimationMock ||
     (await estimate(
@@ -291,14 +285,6 @@ const init = async (
       nativeToCheck,
       feeTokens
     ))
-
-  // if the request is a 4337 one, set the final estimation properties
-  if (estimation.erc4337estimation) {
-    op.asUserOperation!.verificationGasLimit = ethers.toBeHex(
-      estimation.erc4337estimation.verificationGasLimit
-    )
-    op.asUserOperation!.callGasLimit = ethers.toBeHex(estimation.erc4337estimation.callGasLimit)
-  }
 
   const portfolio = new PortfolioController(
     storage,
@@ -880,14 +866,24 @@ describe('SignAccountOp Controller ', () => {
   })
 
   test('Signing [ERC-4337]: Smart account paying in native', async () => {
+    const accOpInfo = createAccountOp(trezorSlot7v24337Deployed, 'avalanche')
+    const accOp = accOpInfo.op
+    const accountStates = await getAccountsInfo([trezorSlot7v24337Deployed])
+    const userOp = toUserOperation(
+      trezorSlot7v24337Deployed,
+      accountStates[accOp.accountAddr][accOp.networkId],
+      accOp
+    )
+    userOp.verificationGasLimit = toBeHex(6000n)
+    userOp.callGasLimit = toBeHex(12000n)
     const { controller, estimation, prices } = await init(
       trezorSlot7v24337Deployed,
-      createAccountOp(trezorSlot7v24337Deployed, 'avalanche'),
+      accOpInfo,
       eoaSigner,
       {
         gasUsed: 200000n,
         nonce: 0,
-        erc4337estimation: { verificationGasLimit: 6000n, callGasLimit: 12000n, gasUsed: 200000n },
+        erc4337estimation: { userOp, gasUsed: 200000n },
         feePaymentOptions: [
           {
             address: '0x0000000000000000000000000000000000000000',
@@ -922,13 +918,10 @@ describe('SignAccountOp Controller ', () => {
           baseFeePerGas: 7000000000n,
           maxPriorityFeePerGas: 7000000000n
         }
-      ],
-      true
+      ]
     )
 
-    expect(controller.accountOp.asUserOperation).not.toBe(null)
-    expect(controller.accountOp.asUserOperation!.verificationGasLimit).toBe(ethers.toBeHex(6000n))
-    expect(controller.accountOp.asUserOperation!.callGasLimit).toBe(ethers.toBeHex(12000))
+    expect(controller.accountOp.asUserOperation).toBe(undefined)
 
     // We are mocking estimation and prices values, in order to validate the gas prices calculation in the test.
     // Knowing the exact amount of estimation and gas prices, we can predict GasFeePayment values.

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -17,6 +17,7 @@ import { callsHumanizer } from '../../libs/humanizer'
 import { IrCall } from '../../libs/humanizer/interfaces'
 import { Price, TokenResult } from '../../libs/portfolio'
 import { getExecuteSignature, getTypedData, wrapStandard } from '../../libs/signMessage/signMessage'
+import { UserOperation } from '../../libs/userOperation/types'
 import {
   getOneTimeNonce,
   isErc4337Broadcast,
@@ -97,6 +98,8 @@ export class SignAccountOpController extends EventEmitter {
 
   accountOp: AccountOp
 
+  #userOperation: UserOperation | null
+
   gasPrices: GasRecommendation[] | null = null
 
   #estimation: EstimateResult | null = null
@@ -140,6 +143,8 @@ export class SignAccountOpController extends EventEmitter {
     this.#storage = storage
     this.#fetch = fetch
     this.#callRelayer = callRelayer
+    // it's real value is set on update()
+    this.#userOperation = null
 
     this.#humanizeAccountOp()
   }
@@ -268,7 +273,6 @@ export class SignAccountOpController extends EventEmitter {
   }
 
   update({
-    accountOp,
     gasPrices,
     estimation,
     feeToken,
@@ -277,7 +281,6 @@ export class SignAccountOpController extends EventEmitter {
     signingKeyAddr,
     signingKeyType
   }: {
-    accountOp?: AccountOp
     gasPrices?: GasRecommendation[]
     estimation?: EstimateResult
     feeToken?: TokenResult
@@ -299,9 +302,14 @@ export class SignAccountOpController extends EventEmitter {
 
     if (gasPrices) this.gasPrices = gasPrices
 
-    if (estimation) this.#estimation = estimation
+    if (estimation) {
+      // set a new copy of the user op if 4337
+      this.#userOperation = estimation.erc4337estimation
+        ? { ...estimation.erc4337estimation.userOp }
+        : null
 
-    if (accountOp) this.accountOp = accountOp
+      this.#estimation = estimation
+    }
 
     if (this.#estimation?.error) {
       this.status = { type: SigningStatus.EstimationError }
@@ -465,14 +473,11 @@ export class SignAccountOpController extends EventEmitter {
       if (!this.#account || !this.#account?.creation) {
         simulatedGasLimit = gasUsed
         amount = simulatedGasLimit * gasPrice + feeTokenEstimation.addedNative
-      } else if (this.#estimation!.erc4337estimation) {
+      } else if (this.#userOperation) {
         // ERC 4337
-        const usesPaymaster = shouldUsePaymaster(
-          this.accountOp.asUserOperation!,
-          this.feeTokenResult!.address
-        )
+        const usesPaymaster = shouldUsePaymaster(this.#userOperation, this.feeTokenResult!.address)
         simulatedGasLimit =
-          this.#estimation!.erc4337estimation.gasUsed + feeTokenEstimation.gasUsed!
+          this.#estimation!.erc4337estimation!.gasUsed + feeTokenEstimation.gasUsed!
         simulatedGasLimit += usesPaymaster
           ? this.#estimation!.arbitrumL1FeeIfArbitrum.withFee
           : this.#estimation!.arbitrumL1FeeIfArbitrum.noFee
@@ -720,10 +725,10 @@ export class SignAccountOpController extends EventEmitter {
           signer
         )
       } else if (this.accountOp.gasFeePayment.isERC4337) {
-        const userOperation = this.accountOp.asUserOperation
+        const userOperation = this.#userOperation
         if (!userOperation) {
           return this.#setSigningError(
-            `Cannot sign as no user operation is present foxr account op ${this.accountOp.accountAddr}`
+            `Cannot sign as no user operation is present for account op ${this.accountOp.accountAddr}`
           )
         }
 

--- a/src/libs/estimate/estimate.test.ts
+++ b/src/libs/estimate/estimate.test.ts
@@ -15,7 +15,6 @@ import { Account, AccountStates } from '../../interfaces/account'
 import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
 import { getAccountState } from '../accountState/accountState'
 import { Portfolio } from '../portfolio/portfolio'
-import { toUserOperation } from '../userOperation/userOperation'
 import { estimate, EstimateResult } from './estimate'
 
 const ethereum = networks.find((x) => x.id === 'ethereum')
@@ -393,9 +392,6 @@ describe('estimate', () => {
       accountOpToExecuteBefore: null
     }
     const accountStates = await getAccountsInfo([trezorSlot6v2NotDeployed])
-    const accountState = accountStates[trezorSlot6v2NotDeployed.addr][arbitrum.id]
-    opArbitrum.asUserOperation = toUserOperation(trezorSlot6v2NotDeployed, accountState, opArbitrum)
-
     const response = await estimate(
       providerArbitrum,
       arbitrum,
@@ -427,13 +423,6 @@ describe('estimate', () => {
     }
     const accountStates = await getAccountsInfo([trezorSlot6v2NotDeployed])
     const accountState = accountStates[trezorSlot6v2NotDeployed.addr][avalanche.id]
-    opAvalanche.asUserOperation = toUserOperation(
-      trezorSlot6v2NotDeployed,
-      accountState,
-      opAvalanche
-    )
-
-    expect(opAvalanche.asUserOperation!.paymasterAndData).toEqual('0x')
 
     const response = await estimate(
       providerAvalanche,
@@ -446,15 +435,14 @@ describe('estimate', () => {
       { is4337Broadcast: true }
     )
 
-    expect(opAvalanche.asUserOperation!.paymasterAndData).toEqual('0x')
-
     expect(response.arbitrumL1FeeIfArbitrum.noFee).toEqual(0n)
     expect(response.arbitrumL1FeeIfArbitrum.withFee).toEqual(0n)
 
     expect(response.erc4337estimation).not.toBe(null)
     expect(response.erc4337estimation?.gasUsed).toBeGreaterThan(0n)
-    expect(response.erc4337estimation?.verificationGasLimit).toBeGreaterThan(5000n)
-    expect(response.erc4337estimation?.callGasLimit).toBeGreaterThan(10000n)
+    expect(response.erc4337estimation!.userOp.paymasterAndData).toEqual('0x')
+    expect(BigInt(response.erc4337estimation!.userOp.verificationGasLimit)).toBeGreaterThan(5000n)
+    expect(BigInt(response.erc4337estimation!.userOp.callGasLimit)).toBeGreaterThan(10000n)
 
     expect(response.feePaymentOptions.length).toBeGreaterThan(0)
     response.feePaymentOptions.forEach((opt) => {
@@ -486,13 +474,6 @@ describe('estimate', () => {
     }
     const accountStates = await getAccountsInfo([trezorSlot7v24337Deployed])
     const accountState = accountStates[trezorSlot7v24337Deployed.addr][avalanche.id]
-    opAvalanche.asUserOperation = toUserOperation(
-      trezorSlot7v24337Deployed,
-      accountState,
-      opAvalanche
-    )
-
-    expect(opAvalanche.asUserOperation!.paymasterAndData).toEqual('0x')
 
     const response = await estimate(
       providerAvalanche,
@@ -505,15 +486,14 @@ describe('estimate', () => {
       { is4337Broadcast: true }
     )
 
-    expect(opAvalanche.asUserOperation!.paymasterAndData).toEqual('0x')
-
     expect(response.arbitrumL1FeeIfArbitrum.noFee).toEqual(0n)
     expect(response.arbitrumL1FeeIfArbitrum.withFee).toEqual(0n)
 
     expect(response.erc4337estimation).not.toBe(null)
     expect(response.erc4337estimation?.gasUsed).toBeGreaterThan(0n)
-    expect(response.erc4337estimation?.verificationGasLimit).toBeGreaterThan(5000n)
-    expect(response.erc4337estimation?.callGasLimit).toBeGreaterThan(10000n)
+    expect(response.erc4337estimation!.userOp.paymasterAndData).toEqual('0x')
+    expect(BigInt(response.erc4337estimation!.userOp.verificationGasLimit)).toBeGreaterThan(5000n)
+    expect(BigInt(response.erc4337estimation!.userOp.callGasLimit)).toBeGreaterThan(10000n)
 
     expect(response.feePaymentOptions.length).toBeGreaterThan(0)
     response.feePaymentOptions.forEach((opt) => {

--- a/src/libs/estimate/estimateArbitrum.ts
+++ b/src/libs/estimate/estimateArbitrum.ts
@@ -14,10 +14,9 @@ function getTxnData(
   accountState: AccountOnchainState,
   account: Account,
   calls: [string, string, string][],
-  userOp: UserOperation,
-  is4337Broadcast: boolean
+  userOp: UserOperation | null
 ) {
-  if (is4337Broadcast) {
+  if (userOp) {
     const EntryPoint = new Interface(EntryPointAbi)
     return EntryPoint.encodeFunctionData('handleOps', [getCleanUserOp(userOp), account.addr])
   }
@@ -54,8 +53,7 @@ export async function estimateArbitrumL1GasUsed(
   account: Account,
   accountState: AccountOnchainState,
   provider: Provider | JsonRpcProvider,
-  userOp: UserOperation,
-  is4337Broadcast: boolean
+  userOp: UserOperation | null
 ): Promise<{ noFee: bigint; withFee: bigint }> {
   // if network is not arbitrum, just return a 0n
   // additional l1 gas estimation is only needed when the account is a smart one
@@ -83,12 +81,12 @@ export async function estimateArbitrumL1GasUsed(
     nodeInterface.gasEstimateL1Component.staticCall(
       op.accountAddr,
       accountState.isDeployed,
-      getTxnData(accountState, account, callsWithoutFee, userOp, is4337Broadcast)
+      getTxnData(accountState, account, callsWithoutFee, userOp)
     ),
     nodeInterface.gasEstimateL1Component.staticCall(
       op.accountAddr,
       accountState.isDeployed,
-      getTxnData(accountState, account, callsWithFee, userOp, is4337Broadcast)
+      getTxnData(accountState, account, callsWithFee, userOp)
     )
   ])
   return {


### PR DESCRIPTION
Main changes:
* do not set user op in the accountOp until it's ready for broadcast
* create the inital userOp in the estimation and pass it to sing account op
* sing account op receives the user op with it's estimation on `update()` and sets a local copy
* during signing, update the local copy, set it to accountOp and broadcast it