### PR TITLE
Config / Rename "Legacy" to "Basic" account

### DIFF
--- a/dist/src/libs/account/account.js
+++ b/dist/src/libs/account/account.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isAmbireV1LinkedAccount = exports.getSmartAccount = exports.getLegacyAccount = exports.getAccountDeployParams = void 0;
+exports.isAmbireV1LinkedAccount = exports.getSmartAccount = exports.getBasicAccount = exports.getAccountDeployParams = void 0;
 const ethers_1 = require("ethers");
 const deploy_1 = require("../../consts/deploy");
 const networks_1 = require("../../consts/networks");
@@ -17,7 +17,7 @@ function getAccountDeployParams(account) {
     ];
 }
 exports.getAccountDeployParams = getAccountDeployParams;
-function getLegacyAccount(key) {
+function getBasicAccount(key) {
     return {
         addr: key,
         label: '',
@@ -26,7 +26,7 @@ function getLegacyAccount(key) {
         creation: null
     };
 }
-exports.getLegacyAccount = getLegacyAccount;
+exports.getBasicAccount = getBasicAccount;
 async function getSmartAccount(address) {
     // Temporarily use the polygon network,
     // to be discussed which network we would use for

--- a/glossary.md
+++ b/glossary.md
@@ -1,24 +1,24 @@
 ## Glossary
 
-*The purpose of this glossary is to create a consensus on the terminology we use internally within the company, but also publicly in our communications.* For the purpose of eliminating errors and misconceptions, we aim to eliminate differences between internal terminology and what we use publicly.
+_The purpose of this glossary is to create a consensus on the terminology we use internally within the company, but also publicly in our communications._ For the purpose of eliminating errors and misconceptions, we aim to eliminate differences between internal terminology and what we use publicly.
 
 **Smart account:** those include a number of security features such as account recovery and progressively upgradable security. In addition, you can pay for transactions in stablecoins, and do multiple actions in one transaction, therefore saving on fees. ✨ The cherry on top ✨ is that you're receiving $WALLET rewards for any funds you keep on them.
- 
-**Legacy account:** this is the account type used in Metamask and most other wallets. Only use this if you're importing an account.
 
-**Key:** a cryptographic key that is actually used to authorize interactions on accounts. A single smart account can have multiple keys authorized. A legacy account only has one key that cannot be changed.
+**Basic account:** this is the account type used in Metamask and most other wallets. Only use this if you're importing an account.
+
+**Key:** a cryptographic key that is actually used to authorize interactions on accounts. A single smart account can have multiple keys authorized. A basic account only has one key that cannot be changed.
 
 **Account authorization:** anything that the account does or authorizes - could be either a transaction or a signed message
 
-**Signed message:** a piece of data that is digitally signed via an account (legacy or smart) - this could be used for multiple purposes, including authorizing future actions (token permits/approvals), logging into apps, listing NFTs for sale, etc.
+**Signed message:** a piece of data that is digitally signed via an account (basic or smart) - this could be used for multiple purposes, including authorizing future actions (token permits/approvals), logging into apps, listing NFTs for sale, etc.
 
 **Call:** a single smart contract interaction or value transfer, as part of transaction. Previously wrongly named `txn` in the source code.
 
-**Transaction:** a set of instructions that are digitally signed via the account, meant to be executed right now. With smart accounts, those can contain multiple calls, while with legacy account, there can only be one. A transaction normally transfers value, although not always - for example, you might just be changing your ENS address. A transaction runs atomically - meaning that either the whole set of instructions succeeds, or it entirely fails, leaving behind no changes to your account or the blockchain state.
+**Transaction:** a set of instructions that are digitally signed via the account, meant to be executed right now. With smart accounts, those can contain multiple calls, while with basic account, there can only be one. A transaction normally transfers value, although not always - for example, you might just be changing your ENS address. A transaction runs atomically - meaning that either the whole set of instructions succeeds, or it entirely fails, leaving behind no changes to your account or the blockchain state.
 
 **Smart transaction:** the type of transaction that smart accounts send. Internal developer name is `accountOp`. Those are different in that 1) they can contain multiple calls or 2) the fee can be paid din ERC20 tokens.
 
-**Relayerless mode:** when you interact with a smart contract, but you pay the fee through a legacy account in the network's native currency.
+**Relayerless mode:** when you interact with a smart contract, but you pay the fee through a basic account in the network's native currency.
 
 **Email-based account recovery:** timelock-based on-chain recovery using a recovery key kept by the relayer, unlocked via email
 
@@ -41,4 +41,3 @@
 **Device Password:** this is the keystore password; "device password" is better because it's self-explanatory that this is a local device password and not an account password
 
 **V1 smart account:** an Ambire smart account that was originally created in Ambire v1. This account type will not have some features that are available in v2 (such as ERC-4337 support), but will generally include all the significant features.
-

--- a/src/consts/derivation.ts
+++ b/src/consts/derivation.ts
@@ -37,7 +37,7 @@ export const HD_PATHS: HDPath[] = [
 ]
 
 /**
- * For legacy (EOA) accounts that are Ambire smart account keys use the derived
+ * For basic (EOA) accounts that are Ambire smart account keys use the derived
  * address at index N + x, where N is this derivation offset (this constant),
  * and x is the given <account> index in the derivation (template) path.
  */

--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -24,7 +24,7 @@ const key1PublicAddress = '0x9188fdd757Df66B4F693D624Ed6A13a15Cf717D7'
 // const key2PublicAddress = '0xE4166d78C834367B186Ce6492993ac8D52De738F'
 // const key3PublicAddress = '0xcC48f0C6d79b6E79F90a3228E284324b5F2cC529'
 
-const legacyAccount: Account = {
+const basicAccount: Account = {
   addr: key1PublicAddress,
   associatedKeys: [key1PublicAddress],
   initialPrivileges: [
@@ -49,12 +49,12 @@ describe('AccountAdder', () => {
     const keyIterator = new KeyIterator(seedPhrase)
     accountAdder.init({
       keyIterator,
-      preselectedAccounts: [legacyAccount],
+      preselectedAccounts: [basicAccount],
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
 
     expect(accountAdder.isInitialized).toBeTruthy()
-    expect(accountAdder.preselectedAccounts).toContainEqual(legacyAccount)
+    expect(accountAdder.preselectedAccounts).toContainEqual(basicAccount)
     expect(accountAdder.selectedAccounts).toEqual([])
   })
 
@@ -76,7 +76,7 @@ describe('AccountAdder', () => {
     accountAdder.setPage({ page: 1, networks, providers })
   })
 
-  test('should set first page and retrieve one smart account for every legacy account', (done) => {
+  test('should set first page and retrieve one smart account for every basic account', (done) => {
     const keyIterator = new KeyIterator(seedPhrase)
     const PAGE_SIZE = 3
     accountAdder.init({
@@ -94,7 +94,7 @@ describe('AccountAdder', () => {
       if (emitCounter === 1) {
         // First emit is triggered when account derivation is done
         expect(accountAdder.accountsOnPage.length).toEqual(
-          // One smart account for every legacy account
+          // One smart account for every basic account
           PAGE_SIZE * 2
         )
         expect(accountAdder.accountsLoading).toBe(false)
@@ -167,13 +167,13 @@ describe('AccountAdder', () => {
     const keyIterator = new KeyIterator(seedPhrase)
     accountAdder.init({
       keyIterator,
-      preselectedAccounts: [legacyAccount],
+      preselectedAccounts: [basicAccount],
       pageSize: 1,
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
     accountAdder.selectedAccounts = [
       {
-        account: legacyAccount,
+        account: basicAccount,
         accountKeyAddr: key1PublicAddress,
         slot: 1,
         index: 0,
@@ -195,6 +195,6 @@ describe('AccountAdder', () => {
       }
     })
 
-    accountAdder.deselectAccount(legacyAccount)
+    accountAdder.deselectAccount(basicAccount)
   })
 })

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -6,7 +6,6 @@ import {
   HD_PATH_TEMPLATE_TYPE,
   SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
 } from '../../consts/derivation'
-
 import { Account, AccountOnchainState } from '../../interfaces/account'
 import { KeyIterator } from '../../interfaces/keyIterator'
 import { dedicatedToOneSAPriv, Key } from '../../interfaces/keystore'
@@ -14,17 +13,17 @@ import { NetworkDescriptor, NetworkId } from '../../interfaces/networkDescriptor
 import { AccountPreferences, KeyPreferences } from '../../interfaces/settings'
 import { Storage } from '../../interfaces/storage'
 import {
+  getBasicAccount,
   getEmailAccount,
-  getLegacyAccount,
   getSmartAccount,
   isAmbireV1LinkedAccount,
   isDerivedForSmartAccountKeyOnly,
   isSmartAccount
 } from '../../libs/account/account'
 import { getAccountState } from '../../libs/accountState/accountState'
-import EventEmitter from '../eventEmitter/eventEmitter'
 import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import wait from '../../utils/wait'
+import EventEmitter from '../eventEmitter/eventEmitter'
 
 const INITIAL_PAGE_INDEX = 1
 const PAGE_SIZE = 5
@@ -40,7 +39,7 @@ type AccountDerivationMeta = {
 /**
  * The account that the user has actively chosen (selected) via the app UI.
  * It's always one of the visible accounts returned by the accountsOnPage().
- * Could be either a legacy (EOA) account, a smart account or a linked account.
+ * Could be either a basic (EOA) account, a smart account or a linked account.
  */
 export type SelectedAccount = AccountDerivationMeta & {
   account: Account
@@ -49,8 +48,8 @@ export type SelectedAccount = AccountDerivationMeta & {
 
 /**
  * The account that is derived programmatically and internally by Ambire.
- * Could be either a legacy (EOA) account, a derived with custom derivation
- * legacy (EOA) account (used for smart account key only) or a smart account.
+ * Could be either a basic (EOA) account, a derived with custom derivation
+ * basic (EOA) account (used for smart account key only) or a smart account.
  */
 type DerivedAccount = AccountDerivationMeta & { account: AccountWithNetworkMeta }
 // Sub-type, used during intermediate step during the deriving accounts process
@@ -133,7 +132,7 @@ export class AccountAdderController extends EventEmitter {
   get accountsOnPage(): DerivedAccount[] {
     const processedAccounts = this.#derivedAccounts
       // The displayed (visible) accounts on page should not include the derived
-      // EOA (legacy) accounts only used as smart account keys, they should not
+      // EOA (basic) accounts only used as smart account keys, they should not
       // be visible nor importable (or selectable).
       .filter((x) => !isDerivedForSmartAccountKeyOnly(x.index))
       .flatMap((derivedAccount) => {
@@ -308,14 +307,14 @@ export class AccountAdderController extends EventEmitter {
     // eslint-disable-next-line no-nested-ternary
     const accountKey = isSmartAccount(accountOnPage.account)
       ? accountOnPage.isLinked
-        ? // The key of the linked account is the EOA (legacy) account on the same slot with the same index
+        ? // The key of the linked account is the EOA (basic) account on the same slot with the same index
           allAccountsOnThisSlot.find(
             ({ account, index }) => !isSmartAccount(account) && accountOnPage.index === index
           )
-        : // The key of the smart account is the EOA (legacy) account derived on the
+        : // The key of the smart account is the EOA (basic) account derived on the
           // same slot, but with the `SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET` offset.
           allAccountsOnThisSlot.find(({ index }) => isDerivedForSmartAccountKeyOnly(index))
-      : // The key of the legacy account is the legacy account itself.
+      : // The key of the basic account is the basic account itself.
         accountOnPage
 
     if (!accountKey)
@@ -323,7 +322,7 @@ export class AccountAdderController extends EventEmitter {
         level: 'major',
         message: `Selecting ${_account.addr} account failed because some of the details for this account are missing. Please try again or contact support if the problem persists.`,
         error: new Error(
-          `The legacy account for the ${_account.addr} account was not found on this slot.`
+          `The basic account for the ${_account.addr} account was not found on this slot.`
         )
       })
 
@@ -389,11 +388,11 @@ export class AccountAdderController extends EventEmitter {
       accounts: this.#derivedAccounts
         .filter(
           (acc) =>
-            // Search for linked accounts to the legacy (EOA) accounts only.
+            // Search for linked accounts to the basic (EOA) accounts only.
             // Searching for linked accounts to another Ambire smart accounts
             // is a feature that Ambire is yet to support.
             !isSmartAccount(acc.account) &&
-            // Skip searching for linked accounts to the derived EOA (legacy)
+            // Skip searching for linked accounts to the derived EOA (basic)
             // accounts that are used for smart account keys only. They are
             // solely purposed to manage 1 particular (smart) account,
             // not at all for linking.
@@ -589,9 +588,9 @@ export class AccountAdderController extends EventEmitter {
     // That's optimization primarily focused on hardware wallets, to reduce the
     // number of calls to the hardware device. This is important, especially
     // for Trezor, because it fires a confirmation popup for each call.
-    const combinedLegacyAndSmartAccKeys = await this.#keyIterator.retrieve(
+    const combinedBasicAndSmartAccKeys = await this.#keyIterator.retrieve(
       [
-        // Indices for the legacy (EOA) accounts
+        // Indices for the basic (EOA) accounts
         { from: startIdx, to: endIdx },
         // Indices for the smart accounts
         {
@@ -602,10 +601,10 @@ export class AccountAdderController extends EventEmitter {
       this.hdPathTemplate
     )
 
-    const legacyAccKeys = combinedLegacyAndSmartAccKeys.slice(0, this.pageSize)
-    const smartAccKeys = combinedLegacyAndSmartAccKeys.slice(
+    const basicAccKeys = combinedBasicAndSmartAccKeys.slice(0, this.pageSize)
+    const smartAccKeys = combinedBasicAndSmartAccKeys.slice(
       this.pageSize,
-      combinedLegacyAndSmartAccKeys.length
+      combinedBasicAndSmartAccKeys.length
     )
 
     const smartAccountsPromises: Promise<DerivedAccountWithoutNetworkMeta | null>[] = []
@@ -615,8 +614,8 @@ export class AccountAdderController extends EventEmitter {
     for (const [index, smartAccKey] of smartAccKeys.entries()) {
       const slot = startIdx + (index + 1)
 
-      // The derived EOA (legacy) account which is the key for the smart account
-      const account = getLegacyAccount(smartAccKey)
+      // The derived EOA (basic) account which is the key for the smart account
+      const account = getBasicAccount(smartAccKey)
       const indexWithOffset = slot - 1 + SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
       accounts.push({ account, isLinked: false, slot, index: indexWithOffset })
 
@@ -644,11 +643,11 @@ export class AccountAdderController extends EventEmitter {
     accounts.push(...smartAccounts)
 
     // eslint-disable-next-line no-restricted-syntax
-    for (const [index, legacyAccKey] of legacyAccKeys.entries()) {
+    for (const [index, basicAccKey] of basicAccKeys.entries()) {
       const slot = startIdx + (index + 1)
 
-      // The EOA (legacy) account on this slot
-      const account = getLegacyAccount(legacyAccKey)
+      // The EOA (basic) account on this slot
+      const account = getBasicAccount(basicAccKey)
       accounts.push({ account, isLinked: false, slot, index: slot - 1 })
     }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -773,7 +773,7 @@ export class MainController extends EventEmitter {
       throw new Error(`estimateAccountOp: ${localAccountOp.networkId}: network does not exist`)
 
     // start transforming the accountOp to userOp if the network is 4337
-    // and it's not a legacy account
+    // and it's not a basic account
     const is4337Broadcast = isErc4337Broadcast(
       network,
       this.accountStates[localAccountOp.accountAddr][localAccountOp.networkId]
@@ -873,7 +873,7 @@ export class MainController extends EventEmitter {
 
   /**
    * There are 4 ways to broadcast an AccountOp:
-   *   1. For legacy accounts (EOA), there is only one way to do that. After
+   *   1. For basic accounts (EOA), there is only one way to do that. After
    *   signing the transaction, the serialized signed transaction object gets
    *   send to the network.
    *   2. For smart accounts, when EOA pays the fee. Two signatures are needed
@@ -923,7 +923,7 @@ export class MainController extends EventEmitter {
         option.paidBy === accountOp.gasFeePayment?.paidBy
     )!
 
-    // Legacy account (EOA)
+    // Basic account (EOA)
     if (!isSmartAccount(account)) {
       try {
         const feePayerKeys = this.keystore.keys.filter(

--- a/src/libs/account/account.test.ts
+++ b/src/libs/account/account.test.ts
@@ -5,19 +5,19 @@ import { describe, expect, test } from '@jest/globals'
 
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { Account, AccountCreation } from '../../interfaces/account'
-import { dedicatedToOneSAPriv, standardSigningOnlyPriv } from '../../interfaces/keystore'
+import { dedicatedToOneSAPriv } from '../../interfaces/keystore'
 import { getBytecode } from '../proxyDeploy/bytecode'
 import { getAmbireAccountAddress } from '../proxyDeploy/getAmbireAddressTwo'
 import {
   getAccountDeployParams,
+  getBasicAccount,
   getEmailAccount,
-  getLegacyAccount,
   getSmartAccount
 } from './account'
 
 const keyPublicAddress = '0x9188fdd757Df66B4F693D624Ed6A13a15Cf717D7'
 
-const legacyAccount: Account = {
+const basicAccount: Account = {
   addr: keyPublicAddress,
   associatedKeys: [keyPublicAddress],
   initialPrivileges: [],
@@ -25,10 +25,10 @@ const legacyAccount: Account = {
 }
 
 describe('Account', () => {
-  test('should return legacyAccount', () => {
+  test('should return basic account', () => {
     expect.assertions(1)
-    const newLegacyAccount = getLegacyAccount(keyPublicAddress)
-    expect(newLegacyAccount as Account).toStrictEqual(legacyAccount)
+    const newBasicAccount = getBasicAccount(keyPublicAddress)
+    expect(newBasicAccount as Account).toStrictEqual(basicAccount)
   })
   test('should return smartAccount', async () => {
     expect.assertions(3)
@@ -52,9 +52,9 @@ describe('Account', () => {
     expect(newSmartAccount.creation as AccountCreation).not.toBe(null)
     expect(newSmartAccount.associatedKeys[0]).toBe(keyPublicAddress)
   })
-  test('should return zero address and 0x deploy data if legacy account is passed', async () => {
+  test('should return zero address and 0x deploy data if basic account is passed', async () => {
     expect.assertions(1)
-    const accountData = getAccountDeployParams(legacyAccount)
+    const accountData = getAccountDeployParams(basicAccount)
     expect(accountData as any).toEqual([ZeroAddress, '0x'])
   })
   test('should return account deploy params', async () => {

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -1,11 +1,11 @@
 import { ethers, Interface } from 'ethers'
 
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
-import { Account } from '../../interfaces/account'
-import { DKIM_VALIDATOR_ADDR, getSignerKey, RECOVERY_DEFAULTS } from '../dkim/recovery'
 import { SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET } from '../../consts/derivation'
+import { Account } from '../../interfaces/account'
 import { Key } from '../../interfaces/keystore'
 import { AccountPreferences, KeyPreferences } from '../../interfaces/settings'
+import { DKIM_VALIDATOR_ADDR, getSignerKey, RECOVERY_DEFAULTS } from '../dkim/recovery'
 import { KnownAddressLabels } from '../humanizer/interfaces'
 import { getBytecode } from '../proxyDeploy/bytecode'
 import { PrivLevels } from '../proxyDeploy/deploy'
@@ -48,7 +48,7 @@ export function getAccountDeployParams(account: Account): [string, string] {
   ]
 }
 
-export function getLegacyAccount(key: string): Account {
+export function getBasicAccount(key: string): Account {
   return {
     addr: key,
     associatedKeys: [key],
@@ -160,7 +160,7 @@ export const isAmbireV1LinkedAccount = (factoryAddr?: string) =>
 export const isSmartAccount = (account: Account) => !!account.creation
 
 /**
- * Checks if a (legacy) EOA account is a derived one,
+ * Checks if a (basic) EOA account is a derived one,
  * that is meant to be used as a smart account key only.
  */
 export const isDerivedForSmartAccountKeyOnly = (index: number) =>


### PR DESCRIPTION
The previously "Legacy" accounts are now called "Basic" accounts. Refactor all related parts.