### PR TITLE
Revert / Manually updating the "dist" directory

### DIFF
--- a/dist/src/libs/account/account.js
+++ b/dist/src/libs/account/account.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isAmbireV1LinkedAccount = exports.getSmartAccount = exports.getBasicAccount = exports.getAccountDeployParams = void 0;
+exports.isAmbireV1LinkedAccount = exports.getSmartAccount = exports.getLegacyAccount = exports.getAccountDeployParams = void 0;
 const ethers_1 = require("ethers");
 const deploy_1 = require("../../consts/deploy");
 const networks_1 = require("../../consts/networks");
@@ -17,7 +17,7 @@ function getAccountDeployParams(account) {
     ];
 }
 exports.getAccountDeployParams = getAccountDeployParams;
-function getBasicAccount(key) {
+function getLegacyAccount(key) {
     return {
         addr: key,
         label: '',
@@ -26,7 +26,7 @@ function getBasicAccount(key) {
         creation: null
     };
 }
-exports.getBasicAccount = getBasicAccount;
+exports.getLegacyAccount = getLegacyAccount;
 async function getSmartAccount(address) {
     // Temporarily use the polygon network,
     // to be discussed which network we would use for


### PR DESCRIPTION
We discussed with Bobby that the Relayer uses the cached "dist" directory, so it's not a good idea to manually update it. And compiling it in general should be done only when needed.

This reverts commit e70a28df39d5acacb79250be09d07171fba0c3b9.