### PR TITLE
Feature / Add NewlyCreated Prop to Each Added Account

### DIFF
--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -1,9 +1,9 @@
+import { SelectedAccount } from 'controllers/accountAdder/accountAdder'
 import { ethers } from 'ethers'
 import fetch from 'node-fetch'
 
 import { describe, expect, test } from '@jest/globals'
 
-import { SelectedAccount } from 'controllers/accountAdder/accountAdder'
 import { produceMemoryStore } from '../../../test/helpers'
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { BIP44_STANDARD_DERIVATION_TEMPLATE } from '../../consts/derivation'
@@ -230,7 +230,10 @@ describe('Main Controller ', () => {
           controller.status === 'SUCCESS' &&
           controller.latestMethodCall === 'onAccountAdderSuccess'
         ) {
-          expect(controller.accounts).toContainEqual(accountPendingCreation.account)
+          expect(controller.accounts).toContainEqual({
+            ...accountPendingCreation.account,
+            newlyCreated: false
+          })
           unsubscribe()
           resolve(true)
         }


### PR DESCRIPTION
relayer returns whether a smart account is newly created and then we store that in the storage for each account. For the next onboarding iterations, we make sure to reset the newlyCreated prop for the previously added accounts