### PR TITLE
Fix/handle estimation deployless errors

### DIFF
--- a/src/libs/deployless/deployless.ts
+++ b/src/libs/deployless/deployless.ts
@@ -207,7 +207,7 @@ export function parseErr(data: string): string | null {
       return abiCoder.decode(['string'], `0x${dataNoPrefix}`)[0]
     } catch (e: any) {
       if (e.code === 'BUFFER_OVERRUN' || e.code === 'NUMERIC_FAULT') return dataNoPrefix
-      else throw e
+      return e
     }
   }
   // uniswap expired error

--- a/src/libs/estimate/errors.ts
+++ b/src/libs/estimate/errors.ts
@@ -2,8 +2,6 @@
 
 import { AbiCoder } from 'ethers'
 
-import { AccountOp } from '../accountOp/accountOp'
-
 const contractErrors = [
   'caller is a contract',
   'contract not allowed',
@@ -18,7 +16,7 @@ const errorSig = '0x08c379a0'
 // Signature of TransactionDeadlinePassed
 const expiredSig = '0x5bf6f916'
 
-export function mapTxnErrMsg(contractError: string, op: AccountOp) {
+export function mapTxnErrMsg(contractError: string): string | null {
   let msg = ''
   if (contractError.startsWith(errorSig)) {
     try {
@@ -32,7 +30,7 @@ export function mapTxnErrMsg(contractError: string, op: AccountOp) {
     msg = Buffer.from(contractError.substring(2), 'hex').toString()
   }
 
-  if (!msg || msg === '0x') return `Estimation failed for ${op.accountAddr} on ${op.networkId}`
+  if (!msg || msg === '0x') return null
 
   if (msg.includes('Router: EXPIRED') || msg.includes('Transaction too old') || msg === expiredSig)
     return 'Swap expired'
@@ -42,5 +40,6 @@ export function mapTxnErrMsg(contractError: string, op: AccountOp) {
     return 'Your signer address is not authorized'
   if (contractErrors.find((contractMsg) => msg.includes(contractMsg)))
     return 'This dApp does not support smart wallets'
-  return msg
+
+  return null
 }

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -91,9 +91,7 @@ async function reestimate(fetchRequests: Function, counter: number = 0): Promise
   // if one of the calls returns an error, return it
   if (Array.isArray(result)) {
     const error = result.find((res) => res instanceof Error)
-    if (error) {
-      return new Error(error)
-    }
+    if (error) throw error
   }
 
   return result

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -51,6 +51,20 @@ export interface EstimateResult {
   error: Error | null
 }
 
+function catchEstimationFailure(e: Error | string | null) {
+  if (e instanceof Error) {
+    return e
+  }
+
+  if (typeof e === 'string') {
+    return new Error(e)
+  }
+
+  return new Error(
+    'Estimation failed with unknown reason. Please try again to initialize your request or contact Ambire support'
+  )
+}
+
 async function reestimate(fetchRequests: Function, counter: number = 0): Promise<any> {
   // stop the execution on 5 fails;
   // the below error message is not shown to the user so we are safe
@@ -74,13 +88,11 @@ async function reestimate(fetchRequests: Function, counter: number = 0): Promise
     result = await reestimate(fetchRequests, incremented)
   }
 
-  // if the requests do not reach the timeout but any of them
-  // results in a failure, we should try them again. That's what we do here
+  // if one of the calls returns an error, return it
   if (Array.isArray(result)) {
-    const hasError = result.find((res) => res instanceof Error)
-    if (hasError) {
-      const incremented = counter + 1
-      result = await reestimate(fetchRequests, incremented)
+    const error = result.find((res) => res instanceof Error)
+    if (error) {
+      return new Error(error)
     }
   }
 
@@ -143,14 +155,14 @@ export async function estimate(
           data: call.data,
           nonce
         })
-        .catch((e) => e),
-      provider.getBalance(account.addr).catch((e) => e),
+        .catch(catchEstimationFailure),
+      provider.getBalance(account.addr).catch(catchEstimationFailure),
       deploylessEstimator
         .call('getL1GasEstimation', [encodeRlp(encodedCallData), '0x'], {
           from: blockFrom,
           blockTag
         })
-        .catch((e) => e)
+        .catch(catchEstimationFailure)
     ]
     const result = await reestimate(initializeRequests)
     const [gasUsed, balance, [l1GasEstimation]] = result instanceof Error ? [0n, 0n, [0n]] : result
@@ -252,7 +264,7 @@ export async function estimate(
         from: blockFrom,
         blockTag
       })
-      .catch((e) => e),
+      .catch(catchEstimationFailure),
     is4337Broadcast
       ? deployless4337Estimator
           .call('estimate', functionArgs, {
@@ -263,7 +275,9 @@ export async function estimate(
       : new Promise((resolve) => {
           resolve(null)
         }),
-    estimateArbitrumL1GasUsed(op, account, accountState, provider, estimateUserOp).catch((e) => e)
+    estimateArbitrumL1GasUsed(op, account, accountState, provider, estimateUserOp).catch(
+      catchEstimationFailure
+    )
   ]
   const estimations = await reestimate(initializeRequests)
 
@@ -303,7 +317,9 @@ export async function estimate(
   // the re-estimation for this accountOp
   let estimationError = null
   if (!accountOp.success) {
-    estimationError = new Error(mapTxnErrMsg(accountOp.err, op), {
+    let error = mapTxnErrMsg(accountOp.err)
+    if (!error) error = `Estimation failed for ${op.accountAddr} on ${op.networkId}`
+    estimationError = new Error(error, {
       cause: 'CALLS_FAILURE'
     })
   }


### PR DESCRIPTION
Fix:
* if an estimation call failed, the error got caught in a `catch` and was not properly returned. This fixes that
* eslint deployless.test.ts