### PR TITLE
Fix: EOA simulation

### DIFF
--- a/src/libs/deployless/deployless.ts
+++ b/src/libs/deployless/deployless.ts
@@ -49,12 +49,17 @@ const defaultOptions: CallOptions = {
 
 export class Deployless {
   private iface: Interface
+
   // the contract deploy (constructor) code: this is the code that tjhe solidity compiler outputs
   private contractBytecode: string
+
   private provider: JsonRpcProvider | Provider
+
   // We need to detect whether the provider supports state override
   private detectionPromise?: Promise<void>
+
   private stateOverrideSupported?: boolean
+
   // the code of the contract after it's actually deployed (or in our case, simulate-deployed)
   // see this: https://medium.com/coinmonks/the-difference-between-bytecode-and-deployed-bytecode-64594db723df
   private contractRuntimeCode?: string

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -1,3 +1,5 @@
+import { toBeHex } from 'ethers'
+
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
 import { getAccountDeployParams, isSmartAccount } from '../account/account'
@@ -9,6 +11,10 @@ import { Collectible, CollectionResult, GetOptions, LimitsOptions, TokenResult }
 
 // 0x00..01 is the address from which simulation signatures are valid
 const DEPLOYLESS_SIMULATION_FROM = '0x0000000000000000000000000000000000000001'
+
+// fake nonce for EOA simulation
+export const EOA_SIMULATION_NONCE =
+  '0x1000000000000000000000000000000000000000000000000000000000000000'
 
 class SimulationError extends Error {
   public simulationErrorMsg: string
@@ -25,17 +31,34 @@ class SimulationError extends Error {
   }
 }
 
-function handleSimulationError(error: string, beforeNonce: bigint, afterNonce: bigint) {
+function handleSimulationError(
+  error: string,
+  beforeNonce: bigint,
+  afterNonce: bigint,
+  simulationOps: { nonce: bigint | null; calls: [string, string, string][] }[]
+) {
   if (error !== '0x') throw new SimulationError(parseErr(error) || error, beforeNonce, afterNonce)
+
   // If the afterNonce is 0, it means that we reverted, even if the error is empty
   // In both BalanceOracle and NFTOracle, afterSimulation and therefore afterNonce will be left empty
   if (afterNonce === 0n) throw new SimulationError('Simulation reverted', beforeNonce, afterNonce)
-  if (afterNonce < beforeNonce)
+  if (afterNonce <= beforeNonce)
     throw new SimulationError(
-      'lower "after" nonce, should not be possible',
+      'lower or equal "after" nonce, should not be possible',
       beforeNonce,
       afterNonce
     )
+
+  // make sure the final afterNonce (after all the accOps execution) is bigger
+  // than the last lastAccOpNonce
+  const lastAccOpNonce = simulationOps.length ? simulationOps[simulationOps.length - 1].nonce : null
+  if (lastAccOpNonce && afterNonce < lastAccOpNonce + 1n) {
+    throw new SimulationError(
+      'lower or equal "after" nonce, should not be possible',
+      beforeNonce,
+      afterNonce
+    )
+  }
 }
 
 function getDeploylessOpts(accountAddr: string, opts: Partial<GetOptions>) {
@@ -50,7 +73,9 @@ function getDeploylessOpts(accountAddr: string, opts: Partial<GetOptions>) {
             stateDiff: {
               // if we use 0x00...01 we get a geth bug: "invalid argument 2: hex number with leading zero digits\" - on some RPC providers
               [`0x${privSlot(0, 'address', accountAddr, 'bytes32')}`]:
-                '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+                '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+              // any number with leading zeros is not supported on some RPCs
+              [toBeHex(1, 32)]: EOA_SIMULATION_NONCE
             }
           }
         }
@@ -102,6 +127,11 @@ export async function getNFTs(
   const { accountOps, account } = opts.simulation
   const [factory, factoryCalldata] = getAccountDeployParams(account)
 
+  const simulationOps = accountOps.map(({ nonce, calls }) => ({
+    // EOA starts from a fake, specified nonce
+    nonce: isSmartAccount(account) ? nonce : BigInt(EOA_SIMULATION_NONCE),
+    calls: calls.map(callToTuple)
+  }))
   const [before, after, simulationErr] = await deployless.call(
     'simulateAndGetAllNFTs',
     [
@@ -112,14 +142,14 @@ export async function getNFTs(
       limits.erc721Tokens,
       factory,
       factoryCalldata,
-      accountOps.map(({ nonce, calls }) => [nonce, calls.map(callToTuple)])
+      simulationOps.map((op) => Object.values(op))
     ],
     deploylessOpts
   )
 
   const beforeNonce = before[1]
   const afterNonce = after[1]
-  handleSimulationError(simulationErr, beforeNonce, afterNonce)
+  handleSimulationError(simulationErr, beforeNonce, afterNonce, simulationOps)
 
   // no simulation was performed if the nonce is the same
   const postSimulationAmounts = (after[1] === before[1] ? before[0] : after[0]).map(mapToken)
@@ -160,6 +190,11 @@ export async function getTokens(
     return results.map((token: any, i: number) => [token.error, mapToken(token, tokenAddrs[i])])
   }
   const { accountOps, account } = opts.simulation
+  const simulationOps = accountOps.map(({ nonce, calls }) => ({
+    // EOA starts from a fake, specified nonce
+    nonce: isSmartAccount(account) ? nonce : BigInt(EOA_SIMULATION_NONCE),
+    calls: calls.map(callToTuple)
+  }))
   const [factory, factoryCalldata] = getAccountDeployParams(account)
   const [before, after, simulationErr] = await deployless.call(
     'simulateAndGetBalances',
@@ -169,17 +204,14 @@ export async function getTokens(
       tokenAddrs,
       factory,
       factoryCalldata,
-      accountOps.map(({ nonce, calls }, index) => [
-        isSmartAccount(account) ? nonce : BigInt(index), // EOA simulation always starts from 0
-        calls.map(callToTuple)
-      ])
+      simulationOps.map((op) => Object.values(op))
     ],
     deploylessOpts
   )
 
   const beforeNonce = before[1]
   const afterNonce = after[1]
-  handleSimulationError(simulationErr, beforeNonce, afterNonce)
+  handleSimulationError(simulationErr, beforeNonce, afterNonce, simulationOps)
 
   // no simulation was performed if the nonce is the same
   const postSimulationAmounts = afterNonce === beforeNonce ? before[0] : after[0]

--- a/src/libs/portfolio/portfolio.test.ts
+++ b/src/libs/portfolio/portfolio.test.ts
@@ -8,6 +8,7 @@ import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import { networks } from '../../consts/networks'
 import { AccountOp } from '../accountOp/accountOp'
 import { stringify } from '../bigintJson/bigintJson'
+import { EOA_SIMULATION_NONCE } from './getOnchainBalances'
 import { Portfolio } from './portfolio'
 
 describe('Portfolio', () => {
@@ -205,8 +206,8 @@ describe('Portfolio', () => {
       gasLimit: null,
       gasFeePayment: null,
       networkId: 'ethereum',
-      nonce: 0, // for EOA simulation it always has to be 0; @TODO should be handled in portfolio
-      signature: '0x0000000000000000000000007a15866aFfD2149189Aa52EB8B40a8F9166441D903',
+      nonce: BigInt(EOA_SIMULATION_NONCE),
+      signature: '0x',
       calls: [
         {
           to: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -238,6 +239,95 @@ describe('Portfolio', () => {
     expect(entry.amount - entry.amountPostSimulation).toBe(5259434n)
   })
 
+  test('simulation works for smart accounts imported as EOAs', async () => {
+    const acc = '0xba4d70875B99CAaBb90e558e46d3ea7164D80E4E'
+    const accountOp: any = {
+      accountAddr: acc,
+      signingKeyAddr: acc,
+      gasLimit: null,
+      gasFeePayment: null,
+      networkId: 'ethereum',
+      nonce: BigInt(EOA_SIMULATION_NONCE),
+      signature: '0x',
+      calls: [
+        {
+          to: '0x26d6a373397d553595cd6a7bbabd86debd60a1cc',
+          value: 10000000000000000n,
+          data: '0x'
+        }
+      ]
+    }
+    const account: Account = {
+      addr: acc,
+      associatedKeys: [acc],
+      creation: null,
+      initialPrivileges: []
+    }
+    const postSimulation = await portfolio.get(acc, {
+      simulation: { accountOps: [accountOp], account },
+      isEOA: true
+    })
+    const entry = postSimulation.tokens.find((x) => x.symbol === 'ETH')
+    if (!entry || entry.amountPostSimulation === undefined) {
+      throw new Error('Entry not found or `amountPostSimulation` is not calculated')
+    }
+    expect(entry.amount - entry.amountPostSimulation).toBe(10000000000000000n)
+  })
+
+  test('token simulation should throw a simulation error if the account op nonce is lower or higher', async () => {
+    const accountOp: any = {
+      accountAddr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
+      signingKeyAddr: '0xe5a4Dad2Ea987215460379Ab285DF87136E83BEA',
+      gasLimit: null,
+      gasFeePayment: null,
+      networkId: 'ethereum',
+      nonce: 0n,
+      signature: '0x',
+      calls: [
+        {
+          to: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+          value: BigInt(0),
+          data: '0xa9059cbb000000000000000000000000e5a4dad2ea987215460379ab285df87136e83bea00000000000000000000000000000000000000000000000000000000005040aa'
+        }
+      ]
+    }
+    const account = {
+      addr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
+      initialPrivileges: [],
+      associatedKeys: ['0xe5a4Dad2Ea987215460379Ab285DF87136E83BEA'],
+      creation: {
+        factoryAddr: '0xBf07a0Df119Ca234634588fbDb5625594E2a5BCA',
+        bytecode:
+          '0x7f00000000000000000000000000000000000000000000000000000000000000017f02c94ba85f2ea274a3869293a0a9bf447d073c83c617963b0be7c862ec2ee44e553d602d80604d3d3981f3363d3d373d3d3d363d732a2b85eb1054d6f0c6c2e37da05ed3e5fea684ef5af43d82803e903d91602b57fd5bf3',
+        salt: '0x2ee01d932ede47b0b2fb1b6af48868de9f86bfc9a5be2f0b42c0111cf261d04c'
+      }
+    }
+    try {
+      await portfolio.get('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', {
+        simulation: { accountOps: [accountOp], account }
+      })
+      // should throw an error and never come here
+      expect(true).toBe(false)
+    } catch (e: any) {
+      expect(e.message).toBe(
+        'simulation error: lower or equal "after" nonce, should not be possible'
+      )
+    }
+
+    accountOp.nonce = 99999999999999999999999999999999999999999n
+    try {
+      await portfolio.get('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', {
+        simulation: { accountOps: [accountOp], account }
+      })
+      // should throw an error and never come here
+      expect(true).toBe(false)
+    } catch (e: any) {
+      expect(e.message).toBe(
+        'simulation error: lower or equal "after" nonce, should not be possible'
+      )
+    }
+  })
+
   test('simulation should revert with SV_NO_KEYS for an account we do not posses the assoicated key for', async () => {
     const acc = '0x7a15866aFfD2149189Aa52EB8B40a8F9166441D9'
     const accountOp: any = {
@@ -246,8 +336,8 @@ describe('Portfolio', () => {
       gasLimit: null,
       gasFeePayment: null,
       networkId: 'ethereum',
-      nonce: 0, // for EOA simulation it always has to be 0; @TODO should be handled in portfolio
-      signature: '0x0000000000000000000000007a15866aFfD2149189Aa52EB8B40a8F9166441D903',
+      nonce: BigInt(EOA_SIMULATION_NONCE),
+      signature: '0x',
       calls: [
         {
           to: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -287,8 +377,8 @@ describe('Portfolio', () => {
       gasLimit: null,
       gasFeePayment: null,
       networkId: 'ethereum',
-      nonce: 0, // for EOA simulation it always has to be 0; @TODO should be handled in portfolio
-      signature: '0x0000000000000000000000007a15866aFfD2149189Aa52EB8B40a8F9166441D903',
+      nonce: BigInt(EOA_SIMULATION_NONCE),
+      signature: '0x',
       calls: [
         {
           to: '0xdAC17F958D2ee523a2206206994597C13D831ec7',


### PR DESCRIPTION
Change log:
* override the nonce for EOA during simulation;
* throw an error if the afterNonce is equal to or less to the beforeNonce;
* throw an error if the afterNonce is smaller or equal to the last account op nonce, if any set

Noticeable changes:
* instead of always setting the nonce to 0 for EOA during simulation, we set it to `0x1000000000000000000000000000000000000000000000000000000000000000`. This is because some RPCs complain when we try to do a state override with a number that has leading zeros.
* we throw an error if `afterNonce < simulatedAccountOpLastNonce + 1` for EOAs as well as the "fake" EOA nonce should have moved as well after simulation
