### PR TITLE
Fix: hide tokens from portfolio without balance (and not preset)

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -791,7 +791,7 @@ export class MainController extends EventEmitter {
           ? []
           : call.fullVisualization.map((vis) => ({
               address: vis.address || '',
-              networkId: null,
+              networkId: localAccountOp.networkId,
               onGasTank: false
             }))
       )

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -792,6 +792,7 @@ export class MainController extends EventEmitter {
           : call.fullVisualization.map((vis) => ({
               address: vis.address || '',
               networkId: localAccountOp.networkId,
+              accountId: localAccountOp.accountAddr,
               onGasTank: false
             }))
       )

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -206,7 +206,9 @@ export class PortfolioController extends EventEmitter {
 
         const correspondingPinnedToken = this.#pinned.find(
           (pinnedToken) =>
-            pinnedToken.address === token.address && pinnedToken.networkId === token.network
+            pinnedToken.accountId === accountId &&
+            pinnedToken.address === token.address &&
+            pinnedToken.networkId === token.network
         )
 
         if (correspondingPinnedToken && correspondingPinnedToken.onGasTank) {

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -209,11 +209,7 @@ export class PortfolioController extends EventEmitter {
             pinnedToken.address === token.address && pinnedToken.networkId === token.network
         )
 
-        if (
-          correspondingPinnedToken &&
-          correspondingPinnedToken.networkId !== null &&
-          correspondingPinnedToken.onGasTank
-        ) {
+        if (correspondingPinnedToken && correspondingPinnedToken.onGasTank) {
           acc.push({
             address: token.address,
             symbol: token.symbol.toUpperCase(),

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -148,7 +148,7 @@ export interface Limits {
 }
 
 export type PinnedTokens = {
-  networkId: NetworkDescriptor['id'] | null
+  networkId: NetworkDescriptor['id']
   address: string
   onGasTank: boolean
 }[]

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -1,4 +1,4 @@
-import { Account } from '../../interfaces/account'
+import { Account, AccountId } from '../../interfaces/account'
 import { NetworkDescriptor, NetworkId } from '../../interfaces/networkDescriptor'
 import { AccountOp } from '../accountOp/accountOp'
 
@@ -148,6 +148,7 @@ export interface Limits {
 }
 
 export type PinnedTokens = {
+  accountId: AccountId
   networkId: NetworkDescriptor['id']
   address: string
   onGasTank: boolean

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -168,9 +168,6 @@ export class Portfolio {
     const tokenFilter = ([error, result]: [string, TokenResult]): boolean =>
       (result.amount > 0 ||
         !!pinned.find((pinnedToken) => {
-          // Pinned tokens from the humanizer don't have a networkId
-          if (pinnedToken.networkId === null) return pinnedToken.address === result.address
-
           return pinnedToken.networkId === networkId && pinnedToken.address === result.address
         })) &&
       error === '0x' &&

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -85,7 +85,10 @@ export class Portfolio {
 
   async get(accountAddr: string, opts: Partial<GetOptions> = {}): Promise<PortfolioGetResult> {
     const localOpts = { ...defaultOptions, ...opts }
-    const { baseCurrency, pinned = [] } = localOpts
+    const { baseCurrency } = localOpts
+    const pinned = localOpts.pinned
+      ? localOpts.pinned.filter((pin) => pin.accountId === accountAddr)
+      : []
     if (localOpts.simulation && localOpts.simulation.account.addr !== accountAddr)
       throw new Error('wrong account passed')
 


### PR DESCRIPTION
Add a `networkId` to tokens that are simulated and hide from the portfolio all the tokens from the simulation without a balance that are not predefined