### PR TITLE
Fix: Account related pinned tokens

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -206,7 +206,7 @@ export class PortfolioController extends EventEmitter {
 
         const correspondingPinnedToken = this.#pinned.find(
           (pinnedToken) =>
-            pinnedToken.accountId === accountId &&
+            (!('accountId' in pinnedToken) || pinnedToken.accountId === accountId) &&
             pinnedToken.address === token.address &&
             pinnedToken.networkId === token.network
         )

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -148,10 +148,10 @@ export interface Limits {
 }
 
 export type PinnedTokens = {
-  accountId: AccountId
   networkId: NetworkDescriptor['id']
   address: string
   onGasTank: boolean
+  accountId?: AccountId
 }[]
 
 export interface GetOptions {

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -87,7 +87,9 @@ export class Portfolio {
     const localOpts = { ...defaultOptions, ...opts }
     const { baseCurrency } = localOpts
     const pinned = localOpts.pinned
-      ? localOpts.pinned.filter((pin) => pin.accountId === accountAddr)
+      ? localOpts.pinned.filter(
+          (pinnedToken) => !('accountId' in pinnedToken) || pinnedToken.accountId === accountAddr
+        )
       : []
     if (localOpts.simulation && localOpts.simulation.account.addr !== accountAddr)
       throw new Error('wrong account passed')


### PR DESCRIPTION
Until now, the pinned tokens that were added to the portfolio controller did not have an account relationship.  
This meant that once a pinned token got saved in the portfolio controller, that token was fetched for each account.  

This PR separates the tokens in two:
* without accountId, belonging to each account (the preset)
* with accountId, added on simulation

There's a test for this in the PR - once we add the pinned token to an account, it does not get fetched for another.  
Also, a discussion point that @PetromirDev found. Once a pinned token is added, it goes to hints.erc20 and gets cached. So even if the balance of the token is zero (the user makes a simulation but does not conclude his txn), it will continue to be fetched for this account in the future. This is also proven in the test in this PR.  
We should probably think how to handle this.