### PR TITLE
Enhancement/ Handle portfolio malfunctions

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -604,7 +604,7 @@ export class MainController extends EventEmitter {
   async updateSelectedAccount(selectedAccount: string | null = null, forceUpdate: boolean = false) {
     if (!selectedAccount) return
 
-    await this.portfolio.updateSelectedAccount(
+    this.portfolio.updateSelectedAccount(
       this.accounts,
       this.settings.networks,
       selectedAccount,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1178,12 +1178,11 @@ export class MainController extends EventEmitter {
     }
   }
 
-  /*
-    Banners that depend on async data from sub-controllers should be implemented
-    in the sub-controllers themselves. This is because updates in the sub-controllers
-    will not trigger emitUpdate in the MainController, therefore the banners will
-    remain the same until a subsequent update in the MainController.
-  */
+  // ! IMPORTANT !
+  // Banners that depend on async data from sub-controllers should be implemented
+  // in the sub-controllers themselves. This is because updates in the sub-controllers
+  // will not trigger emitUpdate in the MainController, therefore the banners will
+  // remain the same until a subsequent update in the MainController.
   get banners(): Banner[] {
     const userRequests =
       this.userRequests.filter((req) => req.accountAddr === this.selectedAccount) || []

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1174,6 +1174,12 @@ export class MainController extends EventEmitter {
     }
   }
 
+  /*
+    Banners that depend on async data from sub-controllers should be implemented
+    in the sub-controllers themselves. This is because updates in the sub-controllers
+    will not trigger emitUpdate in the MainController, therefore the banners will
+    remain the same until a subsequent update in the MainController.
+  */
   get banners(): Banner[] {
     const userRequests =
       this.userRequests.filter((req) => req.accountAddr === this.selectedAccount) || []
@@ -1191,18 +1197,12 @@ export class MainController extends EventEmitter {
       networks: this.settings.networks
     })
     const messageBanners = getMessageBanners({ userRequests })
-    const networksWithFailedRPCBanners = getNetworksWithFailedRPCBanners({
-      providers: this.settings.providers,
-      networks: this.settings.networks,
-      networksWithAssets: this.portfolio.networksWithAssets
-    })
 
     return [
       ...accountOpSmartAccountBanners,
       ...accountOpEOABanners,
       ...pendingAccountOpEOABanners,
-      ...messageBanners,
-      ...networksWithFailedRPCBanners
+      ...messageBanners
     ]
   }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -23,8 +23,8 @@ import {
   getAccountOpBannersForEOA,
   getAccountOpBannersForSmartAccount,
   getMessageBanners,
-  getNetworksWithCriticalPortfolioErrorBanners,
   getNetworksWithFailedRPCBanners,
+  getNetworksWithPortfolioErrorBanners,
   getPendingAccountOpBannersForEOA
 } from '../../libs/banners/banners'
 import { estimate, EstimateResult } from '../../libs/estimate/estimate'
@@ -1204,7 +1204,7 @@ export class MainController extends EventEmitter {
       networks: this.settings.networks,
       networksWithAssets: this.portfolio.networksWithAssets
     })
-    const networksWithCriticalPortfolioErrorBanners = getNetworksWithCriticalPortfolioErrorBanners({
+    const networksWithPortfolioErrorBanners = getNetworksWithPortfolioErrorBanners({
       selectedAccount: this.selectedAccount,
       networks: this.settings.networks,
       portfolio: this.portfolio
@@ -1218,7 +1218,7 @@ export class MainController extends EventEmitter {
       ...messageBanners,
       ...this.activity.banners,
       ...networksWithFailedRPCBanners,
-      ...networksWithCriticalPortfolioErrorBanners
+      ...networksWithPortfolioErrorBanners
     ]
   }
 

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -77,7 +77,7 @@ describe('Portfolio Controller ', () => {
       }
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
       await controller.updateSelectedAccount([account2], networks, account2.addr)
 
       const storagePreviousHints = await storage.get('previousHints', {})
@@ -95,7 +95,7 @@ describe('Portfolio Controller ', () => {
   describe('Latest tokens', () => {
     test('Latest tokens are fetched and kept in the controller, while the pending should not be fetched (no AccountOp passed)', (done) => {
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
 
       controller.onUpdate(() => {
         const latestState =
@@ -121,7 +121,7 @@ describe('Portfolio Controller ', () => {
       const done = jest.fn(() => null)
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
       let pendingState1: any
       controller.onUpdate(() => {
         if (!pendingState1?.isReady) {
@@ -143,7 +143,7 @@ describe('Portfolio Controller ', () => {
 
     test('Latest and Pending are fetched, because `forceUpdate` flag is set', (done) => {
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
 
       controller.onUpdate(() => {
         const latestState =
@@ -177,7 +177,7 @@ describe('Portfolio Controller ', () => {
       const accountOp = await getAccountOp()
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
 
       await controller.updateSelectedAccount([account], networks, account.addr, accountOp)
 
@@ -231,7 +231,7 @@ describe('Portfolio Controller ', () => {
       const accountOp = await getAccountOp()
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
       let pendingState1: any
       let pendingState2: any
       controller.onUpdate(() => {
@@ -258,7 +258,7 @@ describe('Portfolio Controller ', () => {
       const accountOp = await getAccountOp()
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
 
       await controller.updateSelectedAccount([account], networks, account.addr, accountOp)
       const pendingState1 =
@@ -279,7 +279,7 @@ describe('Portfolio Controller ', () => {
       const accountOp = await getAccountOp()
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
 
       await controller.updateSelectedAccount([account], networks, account.addr, accountOp)
       const pendingState1 =
@@ -308,6 +308,7 @@ describe('Portfolio Controller ', () => {
       const controller = new PortfolioController(
         storage,
         { avalanche: avalancheProvider },
+        networks,
         relayerUrl,
         []
       )

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -13,7 +13,10 @@ import { isSmartAccount } from '../../libs/account/account'
 import { AccountOp, isAccountOpsIntentEqual } from '../../libs/accountOp/accountOp'
 /* eslint-disable no-restricted-syntax */
 // eslint-disable-next-line import/no-cycle
-import { getNetworksWithPortfolioErrorBanners } from '../../libs/banners/banners'
+import {
+  getNetworksWithFailedRPCBanners,
+  getNetworksWithPortfolioErrorBanners
+} from '../../libs/banners/banners'
 import getAccountNetworksWithAssets from '../../libs/portfolio/getNetworksWithAssets'
 import { getFlags } from '../../libs/portfolio/helpers'
 import {
@@ -458,10 +461,17 @@ export class PortfolioController extends EventEmitter {
   }
 
   get banners() {
-    return getNetworksWithPortfolioErrorBanners({
+    const networksWithFailedRPCBanners = getNetworksWithFailedRPCBanners({
+      providers: this.#providers,
+      networks: this.#networks,
+      networksWithAssets: this.networksWithAssets
+    })
+    const networksWithPortfolioErrorBanners = getNetworksWithPortfolioErrorBanners({
       networks: this.#networks,
       portfolioLatest: this.latest
     })
+
+    return [...networksWithFailedRPCBanners, ...networksWithPortfolioErrorBanners]
   }
 
   toJSON() {

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -292,6 +292,7 @@ const init = async (
   const portfolio = new PortfolioController(
     storage,
     providers,
+    networks,
     'https://staging-relayer.ambire.com',
     []
   )

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -419,7 +419,8 @@ export class SignAccountOpController extends EventEmitter {
     if (!native) return null
 
     // In case the fee token is the native token we don't want to depend to priceIn, as it might not be available.
-    if (native.address === feeToken.address) return BigInt(1 * 1e18)
+    if (native.address === feeToken.address && native.networkId === feeToken.networkId)
+      return BigInt(1 * 1e18)
 
     const isUsd = (price: Price) => price.baseCurrency === 'usd'
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -67,12 +67,20 @@ type FanSpeed = {
 // declare the statuses we don't want state updates on
 const noStateUpdateStatuses = [SigningStatus.InProgress, SigningStatus.Done]
 
-function getTokenUsdAmount(token: TokenResult, gasAmount: bigint): string {
+function getTokenUsdAmount(token: TokenResult, gasAmount: bigint): string | null {
   const isUsd = (price: Price) => price.baseCurrency === 'usd'
-  const usdPrice = BigInt(token.priceIn.find(isUsd)!.price * 1e18)
+  const usdPrice = token.priceIn.find(isUsd)?.price
+
+  if (!usdPrice) return null
+
+  const usdPriceFormatted = BigInt(usdPrice * 1e18)
 
   // 18 it's because we multiply usdPrice * 1e18 and here we need to deduct it
-  return ethers.formatUnits(gasAmount * usdPrice, 18 + token.decimals)
+  return ethers.formatUnits(gasAmount * usdPriceFormatted, 18 + token.decimals)
+}
+
+const NON_CRITICAL_ERRORS = {
+  feeUsdEstimation: 'Unable to estimate the transaction fee in USD.'
 }
 
 export class SignAccountOpController extends EventEmitter {
@@ -261,6 +269,14 @@ export class SignAccountOpController extends EventEmitter {
       errors.push(this.status.error)
     }
 
+    if (!this.feeSpeeds.length) {
+      errors.push('Unable to estimate transaction fee speeds. Try changing the fee token.')
+    }
+
+    if (this.feeSpeeds.some((speed) => speed.amountUsd === null)) {
+      errors.push(NON_CRITICAL_ERRORS.feeUsdEstimation)
+    }
+
     return errors
   }
 
@@ -346,13 +362,17 @@ export class SignAccountOpController extends EventEmitter {
   updateStatusToReadyToSign() {
     const isInTheMiddleOfSigning = this.status?.type === SigningStatus.InProgress
 
+    const criticalErrors = this.errors.filter(
+      (error) => !Object.values(NON_CRITICAL_ERRORS).includes(error)
+    )
+
     if (
       this.isInitialized &&
       this.#estimation &&
       this.accountOp?.signingKeyAddr &&
       this.accountOp?.signingKeyType &&
       this.accountOp?.gasFeePayment &&
-      !this.errors.length &&
+      !criticalErrors.length &&
       // Update if status is NOT already set (that's the initial state update)
       // or in general if the user is not in the middle of signing (otherwise
       // it resets the loading state back to ready to sign)
@@ -398,8 +418,17 @@ export class SignAccountOpController extends EventEmitter {
     )
     if (!native) return null
 
+    // In case the fee token is the native token we don't want to depend to priceIn, as it might not be available.
+    if (native.address === feeToken.address) return BigInt(1 * 1e18)
+
     const isUsd = (price: Price) => price.baseCurrency === 'usd'
-    const ratio = native!.priceIn.find(isUsd)!.price / feeToken!.priceIn.find(isUsd)!.price
+
+    const nativePrice = native.priceIn.find(isUsd)?.price
+    const feeTokenPrice = feeToken.priceIn.find(isUsd)?.price
+
+    if (!nativePrice || !feeTokenPrice) return null
+
+    const ratio = nativePrice / feeTokenPrice
 
     // Here we multiply it by 1e18, in order to keep the decimal precision.
     // Otherwise, passing the ratio to the BigInt constructor, we will lose the numbers after the decimal point.

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -238,15 +238,13 @@ export const getNetworksWithPortfolioErrorBanners = ({
       return []
     }
 
-    if (!criticalError) {
-      const priceMissingForAllTokens =
-        !portfolioForNetwork?.result ||
-        portfolioForNetwork?.result.tokens
-          // WALLET prices are not retrieved from coingecko
-          .filter((t) => !t.symbol.includes('WALLET'))
-          .every((token) => !token.priceIn.length)
+    if (!criticalError && portfolioForNetwork?.result) {
+      const priceMissingForAllTokens = portfolioForNetwork?.result.tokens
+        // WALLET prices are not retrieved from coingecko
+        .filter((t) => !t.symbol.includes('WALLET'))
+        .every((token) => !token.priceIn.length)
 
-      if (priceMissingForAllTokens)
+      if (priceMissingForAllTokens && portfolioForNetwork?.result.tokens.length > 0)
         return [
           {
             id: `${networkData.id}-portfolio-prices-error`,

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -222,6 +222,7 @@ export const getNetworksWithPortfolioErrorBanners = ({
 
     if (!accPortfolio) return
 
+    // @ts-expect-error
     Object.keys(accPortfolio).forEach((network) => {
       if (['rewards', 'gasTank'].includes(network)) return []
 

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -214,20 +214,26 @@ export class Portfolio {
           token.priceIn = cachedPriceIn
           return
         }
-        const priceData = await this.batchedGecko({
-          ...token,
-          networkId,
-          baseCurrency,
-          // this is what to look for in the coingecko response object
-          responseIdentifier: geckoResponseIdentifier(token.address, networkId)
-        })
-        const priceIn: Price[] = Object.entries(priceData || {}).map(([baseCurr, price]) => ({
-          baseCurrency: baseCurr,
-          price: price as number
-        }))
-        if (priceIn.length) priceCache.set(token.address, [Date.now(), priceIn])
-        /* eslint-disable-next-line no-param-reassign */
-        token.priceIn = priceIn
+
+        try {
+          const priceData = await this.batchedGecko({
+            ...token,
+            networkId,
+            baseCurrency,
+            // this is what to look for in the coingecko response object
+            responseIdentifier: geckoResponseIdentifier(token.address, networkId)
+          })
+          const priceIn: Price[] = Object.entries(priceData || {}).map(([baseCurr, price]) => ({
+            baseCurrency: baseCurr,
+            price: price as number
+          }))
+          if (priceIn.length) priceCache.set(token.address, [Date.now(), priceIn])
+          /* eslint-disable-next-line no-param-reassign */
+          token.priceIn = priceIn
+        } catch {
+          /* eslint-disable-next-line no-param-reassign */
+          token.priceIn = []
+        }
       })
     )
     const priceUpdateDone = Date.now()


### PR DESCRIPTION
The extension wasn't working at all when Coingecko is down- tokens weren't visible and signing a transaction wasn't possible. This PR aims to enable users to continue using the extension with slight drawbacks:
- Tokens will be visible, together with banners indicating that there is a problem. Token sorting changes from balance descending to amount descending
### Before:
![image](https://github.com/AmbireTech/ambire-common/assets/68795596/190bfa10-44b0-43d8-bc7f-ea76a0f7d4e8)
### After:
![image](https://github.com/AmbireTech/ambire-common/assets/68795596/2c17853d-1a4c-4452-9a01-1c5b1af0566e)
- The user can sign transactions, with the caveat that fees can only be paid with the native token of the network/gas tank tokens(prices come from our api and not coingecko), because `#getNativeToFeeTokenRatio` can't calculate the ratio without the price of the tokens. I could use some help here @borislav-itskov 

## Other fixes:
- If `feeSpeeds` is an empty array no speeds are shown and the user isn't notified that there is an error- an error is displayed in this case now.
- Portfolio dependent banners are displayed immediately after changing the account

## What can we do to prevent such PRs in the future:

- Avoid the bang operator(`!`) as much as possible
- Wrap promises in try catch

## Linked with:
https://github.com/AmbireTech/ambire-app/pull/1751