### PR TITLE
Delete/ `CachedResolvedDomain` typescript type

### DIFF
--- a/src/interfaces/domains.ts
+++ b/src/interfaces/domains.ts
@@ -12,10 +12,4 @@ type AddressStateOptional = {
   isDomainResolving?: AddressState['isDomainResolving']
 }
 
-type CachedResolvedDomain = {
-  name: string
-  address: string
-  type: 'ens' | 'ud'
-}
-
-export type { AddressState, AddressStateOptional, CachedResolvedDomain }
+export type { AddressState, AddressStateOptional }


### PR DESCRIPTION
## Changes

- We are no longer caching ENS/UD domains so that type is not needed

## Linked with:
https://github.com/AmbireTech/ambire-app/pull/1763