### PR TITLE
Bug/ SignAccountOp can't estimate when the user doesn't have the native token in his portfolio

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -805,12 +805,12 @@ export class MainController extends EventEmitter {
 
     const isNativeInPortfolio = this.portfolio.latest?.[localAccountOp.accountAddr]?.[
       localAccountOp.networkId
-    ]?.result?.tokens.find((token) => token.address === `0x${'0'.repeat(40)}`)
+    ]?.result?.tokens.find((token) => token.address === ethers.ZeroAddress)
 
     // The native token is required for the estimation
     if (!isNativeInPortfolio) {
       pinned.push({
-        address: `0x${'0'.repeat(40)}`,
+        address: ethers.ZeroAddress,
         networkId: localAccountOp.networkId,
         accountId: localAccountOp.accountAddr,
         onGasTank: false

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -789,7 +789,7 @@ export class MainController extends EventEmitter {
       this.#fetch,
       this.emitError
     )
-    const addresses = humanization
+    const pinned = humanization
       .map((call) =>
         !call.fullVisualization
           ? []
@@ -802,6 +802,20 @@ export class MainController extends EventEmitter {
       )
       .flat()
       .filter(({ address }) => isAddress(address))
+
+    const isNativeInPortfolio = this.portfolio.latest?.[localAccountOp.accountAddr]?.[
+      localAccountOp.networkId
+    ]?.result?.tokens.find((token) => token.address === `0x${'0'.repeat(40)}`)
+
+    // The native token is required for the estimation
+    if (!isNativeInPortfolio) {
+      pinned.push({
+        address: `0x${'0'.repeat(40)}`,
+        networkId: localAccountOp.networkId,
+        accountId: localAccountOp.accountAddr,
+        onGasTank: false
+      })
+    }
 
     const [, , estimation] = await Promise.all([
       // NOTE: we are not emitting an update here because the portfolio controller will do that
@@ -816,7 +830,10 @@ export class MainController extends EventEmitter {
             .filter(([, accOp]) => accOp)
             .map(([networkId, x]) => [networkId, [x!.accountOp]])
         ),
-        { forceUpdate: true, pinned: addresses }
+        {
+          forceUpdate: true,
+          pinned
+        }
       ),
       shouldGetAdditionalPortfolio(account) &&
         this.portfolio.getAdditionalPortfolio(localAccountOp.accountAddr),


### PR DESCRIPTION
## Changes:

- Added the native token to pinned if it's missing in portfolio

## Before:
![image](https://github.com/AmbireTech/ambire-common/assets/68795596/b85a4feb-b803-4c7d-920d-41eabff71565)
## After:
![image](https://github.com/AmbireTech/ambire-common/assets/68795596/4c0f73b6-47cc-4859-9021-262f20ffa4bf)
