### PR TITLE
Fix: remove view only acc as payment options for other accounts

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -842,7 +842,7 @@ export class MainController extends EventEmitter {
         account,
         localAccountOp,
         this.accountStates[localAccountOp.accountAddr][localAccountOp.networkId],
-        EOAaccounts.map((acc) => acc.addr),
+        EOAaccounts,
         // @TODO - first time calling this, portfolio is still not loaded.
         feeTokens,
         {

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -58,7 +58,7 @@ const createAccountOp = (
   networkId: NetworkId = 'ethereum'
 ): {
   op: AccountOp
-  nativeToCheck: string[]
+  nativeToCheck: Account[]
   feeTokens: FeeToken[]
 } => {
   const to = '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45'
@@ -72,7 +72,14 @@ const createAccountOp = (
   // Fee tokens: USDT, USDC
   const data = `0x5ae401dc${expire}00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e404e45aaf000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000000000000000000000000000000001f4000000000000000000000000a07d75aacefd11b425af7181958f0f85c312f14300000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000c33d9000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
 
-  const nativeToCheck = ['0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0']
+  const nativeToCheck: Account[] = [
+    {
+      addr: '0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0',
+      associatedKeys: ['0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0'],
+      initialPrivileges: [],
+      creation: null
+    }
+  ]
   const feeTokens = [
     {
       address: '0x0000000000000000000000000000000000000000',
@@ -102,7 +109,14 @@ const createEOAAccountOp = (account: Account) => {
 
   const data = '0x'
 
-  const nativeToCheck = [account.addr]
+  const nativeToCheck: Account[] = [
+    {
+      addr: account.addr,
+      associatedKeys: [account.addr],
+      initialPrivileges: [],
+      creation: null
+    }
+  ]
   const feeTokens = [
     {
       address: '0x0000000000000000000000000000000000000000',
@@ -253,7 +267,7 @@ const init = async (
   account: Account,
   accountOp: {
     op: AccountOp
-    nativeToCheck: string[]
+    nativeToCheck: Account[]
     feeTokens: FeeToken[]
   },
   signer: any,

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -108,7 +108,7 @@ export async function estimate(
   account: Account,
   op: AccountOp,
   accountState: AccountOnchainState,
-  nativeToCheck: string[],
+  EOAaccounts: Account[],
   feeTokens: FeeToken[],
   opts?: {
     calculateRefund?: boolean
@@ -117,6 +117,14 @@ export async function estimate(
   blockFrom: string = '0x0000000000000000000000000000000000000001',
   blockTag: string | number = 'latest'
 ): Promise<EstimateResult> {
+  // we're excluding the view only accounts from the natives to check
+  // in all cases EXCEPT the case where we're making an estimation for
+  // the view only account itself. In all other, view only accounts options
+  // should not be present as the user cannot pay the fee with them (no key)
+  const nativeToCheck = EOAaccounts.filter(
+    (acc) => acc.addr === op.accountAddr || acc.associatedKeys.length
+  ).map((acc) => acc.addr)
+
   const nativeAddr = '0x0000000000000000000000000000000000000000'
   const deploylessEstimator = fromDescriptor(provider, Estimation, !network.rpcNoStateOverride)
   const abiCoder = new AbiCoder()


### PR DESCRIPTION
Fix: hide view only accounts as fee payment options for other accounts as they are invalid; But continue displaying them if the estimation is for the view only account itself

Refactor:
* instead of EOA addresses, we pass EOA accounts to estimate
* on estimate, we filter the EOAs so only the valid ones proceed to get estimated