### PR TITLE
Fix: silent errors in portfolio tests because of missing providers

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -77,8 +77,8 @@ describe('Portfolio Controller ', () => {
       }
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
-      await controller.updateSelectedAccount([account2], networks, account2.addr)
+      const controller = new PortfolioController(storage, providers, [ethereum], relayerUrl, [])
+      await controller.updateSelectedAccount([account2], [ethereum], account2.addr)
 
       const storagePreviousHints = await storage.get('previousHints', {})
       const storageErc20s = storagePreviousHints[`ethereum:${account2.addr}`].erc20s
@@ -95,7 +95,7 @@ describe('Portfolio Controller ', () => {
   describe('Latest tokens', () => {
     test('Latest tokens are fetched and kept in the controller, while the pending should not be fetched (no AccountOp passed)', (done) => {
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, [ethereum], relayerUrl, [])
 
       controller.onUpdate(() => {
         const latestState =
@@ -113,7 +113,7 @@ describe('Portfolio Controller ', () => {
         }
       })
 
-      controller.updateSelectedAccount([account], networks, account.addr)
+      controller.updateSelectedAccount([account], [ethereum], account.addr)
     })
 
     // @TODO redo this test
@@ -121,7 +121,7 @@ describe('Portfolio Controller ', () => {
       const done = jest.fn(() => null)
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, [ethereum], relayerUrl, [])
       let pendingState1: any
       controller.onUpdate(() => {
         if (!pendingState1?.isReady) {
@@ -135,15 +135,15 @@ describe('Portfolio Controller ', () => {
             done()
         }
       })
-      await controller.updateSelectedAccount([account], networks, account.addr)
-      await controller.updateSelectedAccount([account], networks, account.addr)
+      await controller.updateSelectedAccount([account], [ethereum], account.addr)
+      await controller.updateSelectedAccount([account], [ethereum], account.addr)
 
       expect(done).not.toHaveBeenCalled()
     })
 
     test('Latest and Pending are fetched, because `forceUpdate` flag is set', (done) => {
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, [ethereum], relayerUrl, [])
 
       controller.onUpdate(() => {
         const latestState =
@@ -166,7 +166,7 @@ describe('Portfolio Controller ', () => {
         }
       })
 
-      controller.updateSelectedAccount([account], networks, account.addr, undefined, {
+      controller.updateSelectedAccount([account], [ethereum], account.addr, undefined, {
         forceUpdate: true
       })
     })
@@ -177,9 +177,8 @@ describe('Portfolio Controller ', () => {
       const accountOp = await getAccountOp()
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
-
-      await controller.updateSelectedAccount([account], networks, account.addr, accountOp)
+      const controller = new PortfolioController(storage, providers, [ethereum], relayerUrl, [])
+      await controller.updateSelectedAccount([account], [ethereum], account.addr, accountOp)
 
       controller.onUpdate(() => {
         const pendingState =
@@ -198,7 +197,7 @@ describe('Portfolio Controller ', () => {
       })
     })
 
-    // TODO: currently we disable this optimization in portfolio controller, as in the application it doesn't work at all
+    // TODO: currently we disable this optimizatin in portfolio controller, as in the application it doesn't work at all
     //   Under the tests, the caching works as expected, but once ran in the extension - it doesn't fetch the pending state.
     // test('Pending tokens are fetched only once if AccountOp is the same during the calls', async () => {
     //   const done = jest.fn(() => null)
@@ -231,7 +230,7 @@ describe('Portfolio Controller ', () => {
       const accountOp = await getAccountOp()
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, [ethereum], relayerUrl, [])
       let pendingState1: any
       let pendingState2: any
       controller.onUpdate(() => {
@@ -246,8 +245,8 @@ describe('Portfolio Controller ', () => {
           done()
         }
       })
-      await controller.updateSelectedAccount([account], networks, account.addr, accountOp)
-      await controller.updateSelectedAccount([account], networks, account.addr, accountOp, {
+      await controller.updateSelectedAccount([account], [ethereum], account.addr, accountOp)
+      await controller.updateSelectedAccount([account], [ethereum], account.addr, accountOp, {
         forceUpdate: true
       })
 
@@ -258,13 +257,13 @@ describe('Portfolio Controller ', () => {
       const accountOp = await getAccountOp()
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, [ethereum], relayerUrl, [])
 
-      await controller.updateSelectedAccount([account], networks, account.addr, accountOp)
+      await controller.updateSelectedAccount([account], [ethereum], account.addr, accountOp)
       const pendingState1 =
         controller.pending['0xB674F3fd5F43464dB0448a57529eAF37F04cceA5'].ethereum!
 
-      await controller.updateSelectedAccount([account], networks, account.addr, accountOp, {
+      await controller.updateSelectedAccount([account], [ethereum], account.addr, accountOp, {
         forceUpdate: true
       })
       const pendingState2 =
@@ -279,9 +278,9 @@ describe('Portfolio Controller ', () => {
       const accountOp = await getAccountOp()
 
       const storage = produceMemoryStore()
-      const controller = new PortfolioController(storage, providers, networks, relayerUrl, [])
+      const controller = new PortfolioController(storage, providers, [ethereum], relayerUrl, [])
 
-      await controller.updateSelectedAccount([account], networks, account.addr, accountOp)
+      await controller.updateSelectedAccount([account], [ethereum], account.addr, accountOp)
       const pendingState1 =
         controller.pending['0xB674F3fd5F43464dB0448a57529eAF37F04cceA5'].ethereum!
 
@@ -289,7 +288,7 @@ describe('Portfolio Controller ', () => {
       // Change the address
       accountOp2.ethereum[0].accountAddr = '0xB674F3fd5F43464dB0448a57529eAF37F04cceA4'
 
-      await controller.updateSelectedAccount([account], networks, account.addr, accountOp2)
+      await controller.updateSelectedAccount([account], [ethereum], account.addr, accountOp2)
       const pendingState2 =
         controller.pending['0xB674F3fd5F43464dB0448a57529eAF37F04cceA5'].ethereum!
 
@@ -308,7 +307,7 @@ describe('Portfolio Controller ', () => {
       const controller = new PortfolioController(
         storage,
         { avalanche: avalancheProvider },
-        networks,
+        [avalanche],
         relayerUrl,
         []
       )
@@ -316,7 +315,7 @@ describe('Portfolio Controller ', () => {
       const joeAddress = '0x6e84a6216eA6dACC71eE8E6b0a5B7322EEbC0fDd'
       await controller.updateSelectedAccount(
         [account],
-        networks,
+        [avalanche],
         account.addr,
         {},
         {
@@ -341,7 +340,13 @@ describe('Portfolio Controller ', () => {
       expect(joe?.address).toBe(joeAddress)
 
       // switch account and confirm joe is not there
-      await controller.updateSelectedAccount([EOA], networks, EOA.addr, {}, { forceUpdate: true })
+      await controller.updateSelectedAccount(
+        [EOA],
+        [avalanche],
+        EOA.addr,
+        {},
+        { forceUpdate: true }
+      )
       const latestStateEOA = controller.latest[EOA.addr].avalanche!
       expect(latestStateEOA.isLoading).toBe(false)
       expect(latestStateEOA.isReady).toBe(true)
@@ -351,7 +356,7 @@ describe('Portfolio Controller ', () => {
       // call the original update without pinned - JOE should be there
       await controller.updateSelectedAccount(
         [account],
-        networks,
+        [avalanche],
         account.addr,
         {},
         { forceUpdate: true }


### PR DESCRIPTION
As per the title, missing providers were causing silent errors in the portfolio in the tests.