### PR TITLE
Enable 4337/optimism

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -42,7 +42,7 @@ const networks: NetworkDescriptor[] = [
     chainId: 10n,
     explorerUrl: 'https://optimistic.etherscan.io',
     erc4337: {
-      enabled: false,
+      enabled: true,
       hasPaymaster: true
     },
     unstoppableDomainsChain: 'ERC20',

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -326,10 +326,13 @@ export class SignAccountOpController extends EventEmitter {
     if (gasPrices) this.gasPrices = gasPrices
 
     if (estimation) {
-      // set a new copy of the user op if 4337
-      this.#userOperation = estimation.erc4337estimation
-        ? { ...estimation.erc4337estimation.userOp }
-        : null
+      if (estimation.erc4337estimation) {
+        // set a new copy of the user op if 4337
+        this.#userOperation = structuredClone(estimation.erc4337estimation.userOp)
+        // set the accountOp user op as a reference to this.#userOperation
+        // it's overriden during sign() to it's safe
+        this.accountOp.asUserOperation = this.#userOperation
+      }
 
       this.#estimation = estimation
     }

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -197,6 +197,10 @@ export async function estimate(
     }
   }
 
+  // is the estimation a 4337 one
+  const is4337Broadcast = opts && opts.is4337Broadcast
+  const userOp = is4337Broadcast ? toUserOperation(account, accountState, op) : null
+
   // @L2s
   // craft the probableTxn that's going to be saved on the L1
   // so we could do proper estimation
@@ -211,7 +215,7 @@ export async function estimate(
       'uint256' // gasLimit
     ],
     [
-      getProbableCallData(op, network, accountState),
+      getProbableCallData(op, accountState, userOp),
       op.accountAddr,
       FEE_COLLECTOR,
       100000000,
@@ -239,8 +243,6 @@ export async function estimate(
   ]
 
   // estimate 4337
-  const is4337Broadcast = opts && opts.is4337Broadcast
-  const userOp = is4337Broadcast ? toUserOperation(account, accountState, op) : null
   const IAmbireAccount = new Interface(AmbireAccount.abi)
   let deployless4337Estimator: any = null
   let functionArgs: any = null


### PR DESCRIPTION
Changes:
* enable 4337 for optimism 
* better L1 estimation for user operations on optimism
* fix a bug where the activator call was not added to signable calls