### PR TITLE
Fix / Transfer Amount Validation Bug

### DIFF
--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -143,7 +143,7 @@ export class TransferController extends EventEmitter {
     }
 
     // Validate the amount
-    if (this.selectedToken && (this.amount !== '' || this.addressState.fieldValue !== '')) {
+    if (this.selectedToken) {
       validationFormMsgsNew.amount = validateSendTransferAmount(this.amount, this.selectedToken)
     }
 


### PR DESCRIPTION
Fix: Transfer amount validation bug 

ISSUE EXPLAINED:
When there is an insufficient amount validation message for the selected token and a new token is chosen, the message from the previous token remains visible until the user updates the token amount in the field.

