### PR TITLE
Bug/ Zero-balance tokens are preselected, amount/maxAmount comparsion doesn't work properly, can select a token with amount 0 `Transfer ctrl`

### DIFF
--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -69,6 +69,13 @@ export class TransferController extends EventEmitter {
 
   // every time when updating selectedToken update the amount and maxAmount of the form
   set selectedToken(token: TokenResult | null) {
+    if (token?.amount && Number(token?.amount) === 0) {
+      this.#selectedToken = null
+      this.amount = ''
+      this.maxAmount = '0'
+      return
+    }
+
     if (
       this.selectedToken?.address !== token?.address ||
       this.selectedToken?.networkId !== token?.networkId
@@ -88,7 +95,7 @@ export class TransferController extends EventEmitter {
 
   set tokens(tokenResults: TokenResult[]) {
     const filteredTokens = tokenResults.filter(
-      (token) => token.amount !== 0n && !token.flags.onGasTank
+      (token) => Number(token.amount) > 0 && !token.flags.onGasTank
     )
     this.#tokens = filteredTokens
     this.#updateSelectedTokenIfNeeded(filteredTokens)

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -130,7 +130,7 @@ const validateSendTransferAmount = (amount: string, selectedAsset: TokenResult) 
       )
       const currentAmount = Number(amount)
 
-      if (currentAmount && selectedAssetMaxAmount && Number(amount) > selectedAssetMaxAmount) {
+      if (currentAmount > selectedAssetMaxAmount) {
         return {
           success: false,
           message: `The amount is greater than the asset's balance: ${selectedAssetMaxAmount} ${selectedAsset?.symbol}.`


### PR DESCRIPTION
## Fixes:
- XWALLET was preselected in smart accounts even when its balance was zero. 
- Amount/maxAmount wasn't validated properly

## Screenshot of the bug
![Screenshot from 2024-02-20 12-17-10](https://github.com/AmbireTech/ambire-common/assets/68795596/19e2bc0d-6ade-487a-9d88-488449d2f452)
