### PR TITLE
Fix/double email

### DIFF
--- a/src/controllers/emailVault/emailVault.ts
+++ b/src/controllers/emailVault/emailVault.ts
@@ -216,9 +216,9 @@ export class EmailVaultController extends EventEmitter {
       this.#requestSessionKey(email)
     } else if (this.#shouldStopConfirmationPolling)
       this.emitError({
-        message: `Unexpected error getting email vault for ${email} ${ev?.error}`,
+        message: `Unexpected error getting email vault for ${email}`,
         level: 'major',
-        error: new Error(`Unexpected error getting email vault for ${email} ${ev?.error}`)
+        error: new Error(`Unexpected error getting email vault for ${email}`)
       })
     this.emitUpdate()
   }

--- a/src/libs/polling/polling.ts
+++ b/src/libs/polling/polling.ts
@@ -61,7 +61,7 @@ export class Polling extends EventEmitter {
           await this.exec(
             fn,
             params,
-            cleanup,
+            () => null,
             shouldStop,
             timeout || DEFAULT_TIMEOUT,
             this.defaultTimeout


### PR DESCRIPTION
We used to send two emails, making the key from the first one unuseable. 
The two causes for this were:
- short polling time (this is a problem on its own)
- second email and second polling (this was the reason it was hard to find, this is the confusion factor)

Also updated emitted errors
Made polling time longer (15s => 3m)