### PR TITLE
Fix: user op estimation

### DIFF
--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -359,8 +359,14 @@ export async function estimate(
         gasUsed: 0n
       }
     } else {
+      // set the callGasLimit buffer. We take 5% of the gasUsed
+      // and compare it with 10k. The bigger one gets added on as a buffer
+      const gasLimitBufferInPercentage = gasUsed / 20n // 5%
+      const gasLimitBuffer =
+        gasLimitBufferInPercentage > 10000n ? gasLimitBufferInPercentage : 10000n
+
       userOp.verificationGasLimit = toBeHex(BigInt(verificationGasLimit) + 5000n)
-      userOp.callGasLimit = toBeHex(BigInt(gasUsed) + 10000n)
+      userOp.callGasLimit = toBeHex(gasUsed + gasLimitBuffer)
       erc4337estimation = {
         userOp,
         gasUsed: BigInt(gasUsed) // the minimum for payments

--- a/src/libs/userOperation/userOperation.ts
+++ b/src/libs/userOperation/userOperation.ts
@@ -93,7 +93,7 @@ export function toUserOperation(
     initCode,
     callData: '0x',
     preVerificationGas: ethers.toBeHex(0),
-    callGasLimit: '0x',
+    callGasLimit: 20000000n,
     verificationGasLimit: '0x',
     maxFeePerGas: ethers.toBeHex(1),
     maxPriorityFeePerGas: ethers.toBeHex(1),
@@ -112,13 +112,11 @@ export function toUserOperation(
       [[getSignableCalls(localAccOp), spoofSig]]
     ])
     userOperation.verificationGasLimit = 250000n
-    userOperation.callGasLimit = 380000n
   } else {
     userOperation.callData = ambireAccount.interface.encodeFunctionData('executeBySender', [
       getSignableCalls(localAccOp)
     ])
     userOperation.verificationGasLimit = 150000n
-    userOperation.callGasLimit = 250000n
   }
 
   const abiCoder = new ethers.AbiCoder()


### PR DESCRIPTION
Change log:
* set the userOp callGasLimit to 20m during estimation so the estimation does not run out of gas
* add a buffer of 5% to the `callGasLimit` if the buffer is bigger than 10k. If it's smaller, add the 10k buffer