### PR TITLE
Enhancement: clear the estimation on remove user request

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -677,7 +677,7 @@ export class MainController extends EventEmitter {
       if (accountOp) {
         this.accountOpsToBeSigned[accountAddr] ||= {}
         this.accountOpsToBeSigned[accountAddr][networkId] = { accountOp, estimation: null }
-        if (this.signAccountOp) this.signAccountOp.update({ accountOp })
+        if (this.signAccountOp) this.signAccountOp.update({ accountOp, clearEstimation: true })
 
         try {
           await this.#estimateAccountOp(accountOp)

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -677,7 +677,7 @@ export class MainController extends EventEmitter {
       if (accountOp) {
         this.accountOpsToBeSigned[accountAddr] ||= {}
         this.accountOpsToBeSigned[accountAddr][networkId] = { accountOp, estimation: null }
-        if (this.signAccountOp) this.signAccountOp.update({ accountOp, clearEstimation: true })
+        if (this.signAccountOp) this.signAccountOp.update({ accountOp, estimation: null })
 
         try {
           await this.#estimateAccountOp(accountOp)

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -296,7 +296,8 @@ export class SignAccountOpController extends EventEmitter {
     speed,
     signingKeyAddr,
     signingKeyType,
-    accountOp
+    accountOp,
+    clearEstimation
   }: {
     accountOp?: AccountOp
     gasPrices?: GasRecommendation[]
@@ -306,6 +307,7 @@ export class SignAccountOpController extends EventEmitter {
     speed?: FeeSpeed
     signingKeyAddr?: Key['addr']
     signingKeyType?: Key['type']
+    clearEstimation?: boolean
   }) {
     // once the user commits to the things he sees on his screen,
     // we need to be sure nothing changes afterwards.
@@ -336,6 +338,8 @@ export class SignAccountOpController extends EventEmitter {
 
       this.#estimation = estimation
     }
+
+    if (clearEstimation) this.#estimation = null
 
     if (this.#estimation?.error) {
       this.status = { type: SigningStatus.EstimationError }

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -296,18 +296,16 @@ export class SignAccountOpController extends EventEmitter {
     speed,
     signingKeyAddr,
     signingKeyType,
-    accountOp,
-    clearEstimation
+    accountOp
   }: {
     accountOp?: AccountOp
     gasPrices?: GasRecommendation[]
-    estimation?: EstimateResult
+    estimation?: EstimateResult | null
     feeToken?: TokenResult
     paidBy?: string
     speed?: FeeSpeed
     signingKeyAddr?: Key['addr']
     signingKeyType?: Key['type']
-    clearEstimation?: boolean
   }) {
     // once the user commits to the things he sees on his screen,
     // we need to be sure nothing changes afterwards.
@@ -339,7 +337,9 @@ export class SignAccountOpController extends EventEmitter {
       this.#estimation = estimation
     }
 
-    if (clearEstimation) this.#estimation = null
+    // if estimation is undefined, do not clear the estimation.
+    // We do this only if strictly specified as null
+    if (estimation === null) this.#estimation = null
 
     if (this.#estimation?.error) {
       this.status = { type: SigningStatus.EstimationError }


### PR DESCRIPTION
When removing a user request, the sign account op starts reestimation the new account op calls. During that time, the old estimation is displayed to the user. There's this slight risk that the user might go on with that estimation until waiting for the new one. That's why we clear the estimation from sign account op and wait for the latest one