### PR TITLE
Add: userOpHash to SubmittedAccountOp

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1089,13 +1089,17 @@ export class MainController extends EventEmitter {
     }
 
     if (transactionRes) {
-      await this.activity.addAccountOp({
+      const submittedAccountOp: SubmittedAccountOp = {
         ...accountOp,
         status: AccountOpStatus.BroadcastedButNotConfirmed,
         txnId: transactionRes.hash,
         nonce: BigInt(transactionRes.nonce),
         timestamp: new Date().getTime()
-      } as SubmittedAccountOp)
+      }
+      if (accountOp.gasFeePayment?.isERC4337) {
+        submittedAccountOp.userOpHash = transactionRes.hash
+      }
+      await this.activity.addAccountOp(submittedAccountOp)
       accountOp.calls.forEach((call) => {
         if (call.fromUserRequestId) {
           this.removeUserRequest(call.fromUserRequestId)


### PR DESCRIPTION
Change log:
* add an `userOpHash` property to `SubmittedAccountOp` which records the user op hash
* in the activity controller, after successfully fetching the txn from the bundler, override the SubmittedAccountOp txnId with the real one from the bundler receipt in the case of a 4337 transaction