### PR TITLE
Fix: use our estimation for basic accs on optimism

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -408,7 +408,9 @@ export class MainController extends EventEmitter {
         try {
           this.gasPrices[network] = await getGasPriceRecommendations(
             this.settings.providers[network],
-            this.settings.networks.find((net) => net.id === network)!
+            this.settings.networks.find((net) => net.id === network)!,
+            -1,
+            this.selectedAccount ? this.accountStates[this.selectedAccount][network] : null
           )
         } catch (e: any) {
           this.emitError({

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -11,7 +11,8 @@ import { UserOperation } from '../userOperation/types'
 import {
   getCleanUserOp,
   getPaymasterSpoof,
-  getSigForCalculations
+  getSigForCalculations,
+  isErc4337Broadcast
 } from '../userOperation/userOperation'
 
 // https://eips.ethereum.org/EIPS/eip-1559
@@ -117,7 +118,8 @@ async function refetchBlock(
 export async function getGasPriceRecommendations(
   provider: Provider,
   network: NetworkDescriptor,
-  blockTag: string | number = -1
+  blockTag: string | number = -1,
+  selectedAccountState: AccountOnchainState | null = null
 ): Promise<GasRecommendation[]> {
   const lastBlock = await refetchBlock(provider, blockTag)
   // https://github.com/ethers-io/ethers.js/issues/3683#issuecomment-1436554995
@@ -128,7 +130,7 @@ export async function getGasPriceRecommendations(
   // on the bundler. But estimation is pretty difficult and each network
   // comes with its caveats. Also, the bundlers will start disallowing soon
   // user ops with low fees, making our estimation riskier
-  if (network.erc4337?.enabled) {
+  if (selectedAccountState && isErc4337Broadcast(network, selectedAccountState)) {
     return bundler.pollGetUserOpGasPrice(network)
   }
 


### PR DESCRIPTION
Add: use our estimation for basic accs on optimism

To do this, we need to understand whether the account is:
* basic
* v1

That's why we need the account state in gas prices. Therefore, the change in the code