### PR TITLE
Refactoring / AccountAdder Controller types and import status method

### DIFF
--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -14,7 +14,7 @@ import {
   DerivedAccount,
   DerivedAccountWithoutNetworkMeta,
   ImportStatus,
-  SelectedAccount
+  SelectedAccountForImport
 } from '../../interfaces/account'
 import { KeyIterator } from '../../interfaces/keyIterator'
 import { dedicatedToOneSAPriv, ReadyToAddKeys } from '../../interfaces/keystore'
@@ -62,7 +62,7 @@ export class AccountAdderController extends EventEmitter {
 
   pageSize: number = DEFAULT_PAGE_SIZE
 
-  selectedAccounts: SelectedAccount[] = []
+  selectedAccounts: SelectedAccountForImport[] = []
 
   // Accounts which identity is created on the Relayer (if needed), and are ready
   // to be added to the user's account list by the Main Controller
@@ -467,7 +467,7 @@ export class AccountAdderController extends EventEmitter {
    * the newly added accounts data (like preferences, keys and others)
    */
   async addAccounts(
-    accounts: SelectedAccount[] = [],
+    accounts: SelectedAccountForImport[] = [],
     readyToAddAccountPreferences: AccountPreferences = {},
     readyToAddKeys: ReadyToAddKeys = { internal: [], external: [] },
     readyToAddKeyPreferences: KeyPreferences = []
@@ -490,14 +490,14 @@ export class AccountAdderController extends EventEmitter {
     this.emitUpdate()
 
     let newlyCreatedAccounts: Account['addr'][] = []
-    const accountsToAddOnRelayer: SelectedAccount[] = accounts
+    const accountsToAddOnRelayer: SelectedAccountForImport[] = accounts
       // Identity only for the smart accounts must be created on the Relayer
       .filter((x) => isSmartAccount(x.account))
       // Skip creating identity for Ambire v1 smart accounts
       .filter((x) => !isAmbireV1LinkedAccount(x.account.creation?.factoryAddr))
 
     if (accountsToAddOnRelayer.length) {
-      const body = accountsToAddOnRelayer.map(({ account }: SelectedAccount) => ({
+      const body = accountsToAddOnRelayer.map(({ account }: SelectedAccountForImport) => ({
         addr: account.addr,
         ...(account.email ? { email: account.email } : {}),
         associatedKeys: account.initialPrivileges,
@@ -564,7 +564,7 @@ export class AccountAdderController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async createAndAddEmailAccount(selectedAccount: SelectedAccount) {
+  async createAndAddEmailAccount(selectedAccount: SelectedAccountForImport) {
     const {
       account: { email },
       accountKeys: [recoveryKey]

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -20,7 +20,7 @@ import { dedicatedToOneSAPriv, ReadyToAddKeys } from '../../interfaces/keystore'
 import { NetworkDescriptor, NetworkId } from '../../interfaces/networkDescriptor'
 import { AccountPreferences, KeyPreferences } from '../../interfaces/settings'
 import {
-  getAccountOnPageImportStatus,
+  getAccountImportStatus,
   getBasicAccount,
   getEmailAccount,
   getSmartAccount,
@@ -201,7 +201,7 @@ export class AccountAdderController extends EventEmitter {
 
     return mergedAccounts.map((acc) => ({
       ...acc,
-      ...getAccountOnPageImportStatus({
+      importStatus: getAccountImportStatus({
         account: acc.account,
         alreadyImportedAccounts: this.#alreadyImportedAccounts,
         keys: this.#keystore.keys,

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -6,9 +6,18 @@ import {
   HD_PATH_TEMPLATE_TYPE,
   SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
 } from '../../consts/derivation'
-import { Account, AccountOnchainState } from '../../interfaces/account'
+import {
+  Account,
+  AccountOnchainState,
+  AccountOnPage,
+  AccountWithNetworkMeta,
+  DerivedAccount,
+  DerivedAccountWithoutNetworkMeta,
+  ImportStatus,
+  SelectedAccount
+} from '../../interfaces/account'
 import { KeyIterator } from '../../interfaces/keyIterator'
-import { dedicatedToOneSAPriv, ExternalKey, Key } from '../../interfaces/keystore'
+import { dedicatedToOneSAPriv, ReadyToAddKeys } from '../../interfaces/keystore'
 import { NetworkDescriptor, NetworkId } from '../../interfaces/networkDescriptor'
 import { AccountPreferences, KeyPreferences } from '../../interfaces/settings'
 import {
@@ -27,62 +36,6 @@ import { KeystoreController } from '../keystore/keystore'
 
 export const DEFAULT_PAGE = 1
 export const DEFAULT_PAGE_SIZE = 5
-
-type AccountWithNetworkMeta = Account & { usedOnNetworks: NetworkDescriptor[] }
-
-type AccountDerivationMeta = {
-  slot: number // the iteration on which the account is derived, starting from 1
-  index: number // the derivation index of the <account> in the slot, starting from 0
-  isLinked: boolean // linked accounts are also smart accounts, so use a flag to differentiate
-}
-
-/**
- * The account that the user has actively chosen (selected) via the app UI.
- * It's always one of the visible accounts returned by the accountsOnPage().
- * Could be either a basic (EOA) account, a smart account or a linked account.
- */
-export type SelectedAccount = {
-  account: Account
-  isLinked: AccountDerivationMeta['isLinked']
-  accountKeys: (Omit<AccountDerivationMeta, 'isLinked'> & { addr: Account['addr'] })[]
-}
-
-/**
- * The account that is derived programmatically and internally by Ambire.
- * Could be either a basic (EOA) account, a derived with custom derivation
- * basic (EOA) account (used for smart account key only) or a smart account.
- */
-type DerivedAccount = AccountDerivationMeta & { account: AccountWithNetworkMeta }
-// Sub-type, used during intermediate step during the deriving accounts process
-type DerivedAccountWithoutNetworkMeta = Omit<DerivedAccount, 'account'> & { account: Account }
-
-export enum ImportStatus {
-  NotImported = 'not-imported',
-  ImportedWithoutKey = 'imported-without-key', // as a view only account
-  ImportedWithSomeOfTheKeys = 'imported-with-some-of-the-keys', // imported with
-  // some of the keys (having the same key type), but not all found on the current page
-  ImportedWithTheSameKeys = 'imported-with-the-same-keys', // imported with all
-  // keys (having the same key type) found on the current page
-  ImportedWithDifferentKeys = 'imported-with-different-keys' // different key
-  // meaning that could be a key with the same address but different type,
-  // or a key with different address altogether.
-}
-/**
- * All the accounts that should be visible on the current page - the Basic
- * Accounts, Smart Accounts and the linked accounts. Excludes the derived
- * EOA (basic) accounts used for smart account keys only.
- */
-export type AccountOnPage = DerivedAccount & { importStatus: ImportStatus }
-
-export type ReadyToAddKeys = {
-  internal: { privateKey: string; dedicatedToOneSA: boolean }[]
-  external: {
-    addr: Key['addr']
-    type: Key['type']
-    dedicatedToOneSA: boolean
-    meta: ExternalKey['meta']
-  }[]
-}
 
 /**
  * Account Adder Controller

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from '@jest/globals'
 import { produceMemoryStore } from '../../../test/helpers'
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { BIP44_STANDARD_DERIVATION_TEMPLATE } from '../../consts/derivation'
-import { SelectedAccount } from '../../interfaces/account'
+import { SelectedAccountForImport } from '../../interfaces/account'
 import { UserRequest } from '../../interfaces/userRequest'
 import { KeyIterator } from '../../libs/keyIterator/keyIterator'
 import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
@@ -177,7 +177,7 @@ describe('Main Controller ', () => {
 
     // Same mechanism to generating this one as used for the
     // `accountNotDeployed` in accountState.test.ts
-    const accountPendingCreation: SelectedAccount = {
+    const accountPendingCreation: SelectedAccountForImport = {
       account: {
         addr: getAmbireAccountAddress(AMBIRE_ACCOUNT_FACTORY, bytecode),
         associatedKeys: [signerAddr],

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -1,4 +1,3 @@
-import { SelectedAccount } from 'controllers/accountAdder/accountAdder'
 import { ethers } from 'ethers'
 import fetch from 'node-fetch'
 
@@ -7,6 +6,7 @@ import { describe, expect, test } from '@jest/globals'
 import { produceMemoryStore } from '../../../test/helpers'
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { BIP44_STANDARD_DERIVATION_TEMPLATE } from '../../consts/derivation'
+import { SelectedAccount } from '../../interfaces/account'
 import { UserRequest } from '../../interfaces/userRequest'
 import { KeyIterator } from '../../libs/keyIterator/keyIterator'
 import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'

--- a/src/interfaces/account.ts
+++ b/src/interfaces/account.ts
@@ -89,9 +89,8 @@ export type AccountOnPage = DerivedAccount & { importStatus: ImportStatus }
  * It's always one of the visible accounts returned by the accountsOnPage().
  * Could be either a basic (EOA) account, a smart account or a linked account.
  */
-export type SelectedAccount = {
+export type SelectedAccountForImport = {
   account: Account
   isLinked: AccountDerivationMeta['isLinked']
-  importStatus: ImportStatus
   accountKeys: (Omit<AccountDerivationMeta, 'isLinked'> & { addr: Account['addr'] })[]
 }

--- a/src/interfaces/account.ts
+++ b/src/interfaces/account.ts
@@ -1,3 +1,5 @@
+import { NetworkDescriptor } from './networkDescriptor'
+
 export type AccountId = string
 
 export interface Account {
@@ -39,4 +41,57 @@ export type AccountStates = {
   [accountId: string]: {
     [networkId: string]: AccountOnchainState
   }
+}
+
+type AccountDerivationMeta = {
+  slot: number // the iteration on which the account is derived, starting from 1
+  index: number // the derivation index of the <account> in the slot, starting from 0
+  isLinked: boolean // linked accounts are also smart accounts, so use a flag to differentiate
+}
+
+export type AccountWithNetworkMeta = Account & { usedOnNetworks: NetworkDescriptor[] }
+
+/**
+ * The account that is derived programmatically and internally by Ambire.
+ * Could be either a basic (EOA) account, a derived with custom derivation
+ * basic (EOA) account (used for smart account key only) or a smart account.
+ */
+export type DerivedAccount = AccountDerivationMeta & { account: AccountWithNetworkMeta }
+// Sub-type, used during intermediate step during the deriving accounts process
+export type DerivedAccountWithoutNetworkMeta = Omit<DerivedAccount, 'account'> & {
+  account: Account
+}
+
+/**
+ * Enum for tracking the import status of an account during the import process.
+ */
+export enum ImportStatus {
+  NotImported = 'not-imported',
+  ImportedWithoutKey = 'imported-without-key', // as a view only account
+  ImportedWithSomeOfTheKeys = 'imported-with-some-of-the-keys', // imported with
+  // some of the keys (having the same key type), but not all found on the current page
+  ImportedWithTheSameKeys = 'imported-with-the-same-keys', // imported with all
+  // keys (having the same key type) found on the current page
+  ImportedWithDifferentKeys = 'imported-with-different-keys' // different key
+  // meaning that could be a key with the same address but different type,
+  // or a key with different address altogether.
+}
+
+/**
+ * All the accounts that should be visible on the current page - the Basic
+ * Accounts, Smart Accounts and the linked accounts. Excludes the derived
+ * EOA (basic) accounts used for smart account keys only.
+ */
+export type AccountOnPage = DerivedAccount & { importStatus: ImportStatus }
+
+/**
+ * The account that the user has actively chosen (selected) via the app UI.
+ * It's always one of the visible accounts returned by the accountsOnPage().
+ * Could be either a basic (EOA) account, a smart account or a linked account.
+ */
+export type SelectedAccount = {
+  account: Account
+  isLinked: AccountDerivationMeta['isLinked']
+  importStatus: ImportStatus
+  accountKeys: (Omit<AccountDerivationMeta, 'isLinked'> & { addr: Account['addr'] })[]
 }

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -116,3 +116,18 @@ export type StoredKey = (InternalKey & { privKey: string }) | (ExternalKey & { p
 export type KeystoreSignerType = {
   new (key: Key, privateKey?: string): KeystoreSigner
 }
+
+/**
+ * The keys that are ready to be added to the user's keystore (by the Main Controller).
+ * They are needed as an intermediate step during the accounts import flow
+ * (for the accounts that were just imported by the AccountAdder Controller).
+ */
+export type ReadyToAddKeys = {
+  internal: { privateKey: string; dedicatedToOneSA: boolean }[]
+  external: {
+    addr: Key['addr']
+    type: Key['type']
+    dedicatedToOneSA: boolean
+    meta: ExternalKey['meta']
+  }[]
+}

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -174,25 +174,25 @@ export const getDefaultSelectedAccount = (accounts: Account[]) => {
   return accounts[0]
 }
 
-export const getAccountOnPageImportStatus = ({
+export const getAccountImportStatus = ({
   account,
   alreadyImportedAccounts,
   keys,
-  accountsOnPage,
+  accountsOnPage = [],
   keyIteratorType
 }: {
   account: Account
   alreadyImportedAccounts: Account[]
   keys: Key[]
-  accountsOnPage: Omit<AccountOnPage, 'importStatus'>[]
+  accountsOnPage?: Omit<AccountOnPage, 'importStatus'>[]
   keyIteratorType?: KeyIterator['type']
-}): { importStatus: ImportStatus } => {
+}): ImportStatus => {
   const isAlreadyImported = alreadyImportedAccounts.some(({ addr }) => addr === account.addr)
-  if (!isAlreadyImported) return { importStatus: ImportStatus.NotImported }
+  if (!isAlreadyImported) return ImportStatus.NotImported
 
   const importedKeysForThisAcc = keys.filter((key) => account.associatedKeys.includes(key.addr))
   // Could be imported as a view only account (and therefore, without a key)
-  if (!importedKeysForThisAcc.length) return { importStatus: ImportStatus.ImportedWithoutKey }
+  if (!importedKeysForThisAcc.length) return ImportStatus.ImportedWithoutKey
 
   // Same key in this context means not only the same key address, but the
   // same type too. Because user can opt in to import same key address with
@@ -210,12 +210,10 @@ export const getAccountOnPageImportStatus = ({
       associatedKeysNotImportedYet.includes(x.account.addr)
     )
 
-    return {
-      importStatus: notImportedYetKeysExistInPage
-        ? ImportStatus.ImportedWithSomeOfTheKeys
-        : ImportStatus.ImportedWithTheSameKeys
-    }
+    return notImportedYetKeysExistInPage
+      ? ImportStatus.ImportedWithSomeOfTheKeys
+      : ImportStatus.ImportedWithTheSameKeys
   }
 
-  return { importStatus: ImportStatus.NotImported }
+  return ImportStatus.NotImported
 }


### PR DESCRIPTION
Move the AccountAdder controller types in the account and the keystore interfaces.

Extract the logic for getting the import status of an account in a separate method, so it is easily reusable on the extension when checking this for the view-only accounts.