### PR TITLE
Config / AccountAdder Controller - expose (key iterator) `type` and `subType`

### DIFF
--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -315,6 +315,10 @@ export class AccountAdderController extends EventEmitter {
     return this.#keyIterator?.type
   }
 
+  get subType() {
+    return this.#keyIterator?.subType
+  }
+
   reset() {
     this.#keyIterator = null
     this.selectedAccounts = []
@@ -956,7 +960,8 @@ export class AccountAdderController extends EventEmitter {
       ...super.toJSON(),
       // includes the getter in the stringified instance
       accountsOnPage: this.accountsOnPage,
-      type: this.type
+      type: this.type,
+      subType: this.subType
     }
   }
 }

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -311,6 +311,10 @@ export class AccountAdderController extends EventEmitter {
     this.emitUpdate()
   }
 
+  get type() {
+    return this.#keyIterator?.type
+  }
+
   reset() {
     this.#keyIterator = null
     this.selectedAccounts = []
@@ -950,7 +954,9 @@ export class AccountAdderController extends EventEmitter {
     return {
       ...this,
       ...super.toJSON(),
-      accountsOnPage: this.accountsOnPage // includes the getter in the stringified instance
+      // includes the getter in the stringified instance
+      accountsOnPage: this.accountsOnPage,
+      type: this.type
     }
   }
 }

--- a/src/interfaces/keyIterator.ts
+++ b/src/interfaces/keyIterator.ts
@@ -3,6 +3,7 @@ import { Key } from './keystore'
 
 export interface KeyIterator {
   type: Key['type']
+  subType?: 'seed' | 'private-key'
   /** The wallet native SDK instance, if any exists */
   walletSDK?: any
   retrieve: (

--- a/src/libs/keyIterator/keyIterator.ts
+++ b/src/libs/keyIterator/keyIterator.ts
@@ -55,6 +55,8 @@ export function derivePrivateKeyFromAnotherPrivateKey(privateKey: string) {
 export class KeyIterator implements KeyIteratorInterface {
   type = 'internal'
 
+  subType: 'seed' | 'private-key'
+
   #privateKey: string | null = null
 
   #seedPhrase: string | null = null
@@ -64,11 +66,13 @@ export class KeyIterator implements KeyIteratorInterface {
 
     if (isValidPrivateKey(_privKeyOrSeed)) {
       this.#privateKey = _privKeyOrSeed
+      this.subType = 'private-key'
       return
     }
 
     if (Mnemonic.isValidMnemonic(_privKeyOrSeed)) {
       this.#seedPhrase = _privKeyOrSeed
+      this.subType = 'seed'
       return
     }
 


### PR DESCRIPTION
Previously they got determined on the extension front-end. Which was not scaling very well - we had to know the types in many places (including in the background process) and we were passing these types via the router or via params in dispatches.