### PR TITLE
Fix / Slow to Open Notification Window for SignAccountOp and SignMessage screens

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -649,13 +649,7 @@ export class MainController extends EventEmitter {
         this.accountOpsToBeSigned[accountAddr] ||= {}
         this.accountOpsToBeSigned[accountAddr][networkId] = { accountOp, estimation: null }
         if (this.signAccountOp) this.signAccountOp.update({ accountOp })
-
-        try {
-          await this.#estimateAccountOp(accountOp)
-        } catch (e) {
-          // @TODO: unified wrapper for controller errors
-          console.error(e)
-        }
+        this.#estimateAccountOp(accountOp)
       }
     } else {
       if (!this.messagesToBeSigned[accountAddr]) this.messagesToBeSigned[accountAddr] = []


### PR DESCRIPTION
fix: slow to open sign message or sign account op notification window because if awaiting the estimation to complete before proceeding with the notification logic which is wrong because on a slow network the notif window will not appear probably for minutes. By removing the estimation await when making a new user request the window opens instantly