### PR TITLE
gas tank call: ignore calls to address(0)

### DIFF
--- a/contracts/AmbireAccount.sol
+++ b/contracts/AmbireAccount.sol
@@ -198,11 +198,22 @@ contract AmbireAccount {
 	/**
 	 * @notice  allows the contract itself to execute a batch of calls
 	 * self-calling is useful in cases like wanting to do multiple things in a tryCatchLimit
-	 * @param   calls  the transaction we're executing
+	 * @param   calls  the calls we're executing
 	 */
 	function executeBySelf(Transaction[] calldata calls) external payable {
 		require(msg.sender == address(this), 'ONLY_ACCOUNT_CAN_CALL');
 		executeBatch(calls);
+	}
+
+	/**
+	 * @notice  allows the contract itself to execute a single calls
+	 * self-calling is useful when you want to workaround the executeBatch()
+	 * protection of not being able to call address(0)
+	 * @param   call  the call we're executing
+	 */
+	function executeBySelfSingle(Transaction calldata call) external payable {
+		require(msg.sender == address(this), 'ONLY_ACCOUNT_CAN_CALL');
+		executeCall(call.to, call.value, call.data);
 	}
 
 	/**

--- a/contracts/AmbireAccount.sol
+++ b/contracts/AmbireAccount.sol
@@ -224,7 +224,7 @@ contract AmbireAccount {
 		uint256 len = calls.length;
 		for (uint256 i = 0; i < len; i++) {
 			Transaction memory call = calls[i];
-			executeCall(call.to, call.value, call.data);
+			if (call.to != address(0)) executeCall(call.to, call.value, call.data);
 		}
 	}
 


### PR DESCRIPTION
## Summary
Ignores all calls to address(0), allowing to use them as "notes" or "inscriptions"