### PR TITLE
Bug / Account Adder - should NOT be able to select the same account more than once

### DIFF
--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -305,24 +305,43 @@ describe('AccountAdder', () => {
     accountAdder.setPage({ page: 1, networks, providers })
   })
 
-  test('should NOT be able to select the same account more than once', (done) => {
-    // Subscription to select an account and trigger a deselect
+  test.only('should NOT be able to select the same account more than once', (done) => {
+    // 3 subscriptions to select the same account account again and again
     let emitCounter1 = 0
     const unsubscribe1 = accountAdder.onUpdate(() => {
       emitCounter1++
 
-      if (emitCounter1 === 3) {
-        accountAdder.selectAccount(basicAccount)
-        accountAdder.selectAccount(basicAccount)
-        accountAdder.selectAccount(basicAccount)
-      }
+      if (emitCounter1 === 3) accountAdder.selectAccount(basicAccount)
+    })
 
-      if (emitCounter1 === 6) {
+    let emitCounter2 = 0
+    const unsubscribe2 = accountAdder.onUpdate(() => {
+      emitCounter2++
+
+      if (emitCounter2 === 4) accountAdder.selectAccount(basicAccount)
+    })
+
+    let emitCounter3 = 0
+    const unsubscribe3 = accountAdder.onUpdate(() => {
+      emitCounter3++
+
+      if (emitCounter3 === 5) accountAdder.selectAccount(basicAccount)
+    })
+
+    // A separate subscription to check if the account got selected only once
+    let emitCounter4 = 0
+    const unsubscribe4 = accountAdder.onUpdate(() => {
+      emitCounter4++
+
+      if (emitCounter4 === 6) {
         expect(accountAdder.selectedAccounts).toHaveLength(1)
         const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
         expect(selectedAccountAddr).toContain(basicAccount.addr)
 
         unsubscribe1()
+        unsubscribe2()
+        unsubscribe3()
+        unsubscribe4()
         done()
       }
     })

--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -305,7 +305,7 @@ describe('AccountAdder', () => {
     accountAdder.setPage({ page: 1, networks, providers })
   })
 
-  test.only('should NOT be able to select the same account more than once', (done) => {
+  test('should NOT be able to select the same account more than once', (done) => {
     // 3 subscriptions to select the same account account again and again
     let emitCounter1 = 0
     const unsubscribe1 = accountAdder.onUpdate(() => {

--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -305,6 +305,37 @@ describe('AccountAdder', () => {
     accountAdder.setPage({ page: 1, networks, providers })
   })
 
+  test('should NOT be able to select the same account more than once', (done) => {
+    // Subscription to select an account and trigger a deselect
+    let emitCounter1 = 0
+    const unsubscribe1 = accountAdder.onUpdate(() => {
+      emitCounter1++
+
+      if (emitCounter1 === 3) {
+        accountAdder.selectAccount(basicAccount)
+        accountAdder.selectAccount(basicAccount)
+        accountAdder.selectAccount(basicAccount)
+      }
+
+      if (emitCounter1 === 6) {
+        expect(accountAdder.selectedAccounts).toHaveLength(1)
+        const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
+        expect(selectedAccountAddr).toContain(basicAccount.addr)
+
+        unsubscribe1()
+        done()
+      }
+    })
+
+    const keyIterator = new KeyIterator(process.env.SEED)
+    accountAdder.init({
+      keyIterator,
+      pageSize: 1,
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+    })
+    accountAdder.setPage({ page: 1, networks, providers })
+  })
+
   test('should be able to select all the keys of a selected basic account (always one key)', (done) => {
     // Subscription to select an account
     let emitCounter1 = 0

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -349,7 +349,7 @@ export class AccountAdderController extends EventEmitter {
         )
       })
 
-    this.selectedAccounts.push({
+    const nextSelectedAccount = {
       account: _account,
       // If the account has more than 1 key, it is for sure linked account,
       // since Basic accounts have only 1 key and smart accounts with more than
@@ -360,7 +360,22 @@ export class AccountAdderController extends EventEmitter {
         slot: a.slot,
         index: a.index
       }))
-    })
+    }
+
+    const accountExists = this.selectedAccounts.some(
+      (x) => x.account.addr === nextSelectedAccount.account.addr
+    )
+    if (accountExists) {
+      // If the account exists, replace it with the new one, to make sure
+      // the latest data is used. We could add one more sub-step to skip this,
+      // if we do a deep comparison, but that would probably be an overkill.
+      this.selectedAccounts = this.selectedAccounts.map((x) =>
+        x.account.addr === nextSelectedAccount.account.addr ? nextSelectedAccount : x
+      )
+    } else {
+      this.selectedAccounts.push(nextSelectedAccount)
+    }
+
     this.emitUpdate()
   }
 


### PR DESCRIPTION
Should never happen, but if for some reason the extension front-end triggers selecting the same account more than once - the same instance should be added only once in the Account Adder selected (for import) accounts.