### PR TITLE
Fix: erc 4337 estimation on optimism

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -50,7 +50,7 @@ const networks: NetworkDescriptor[] = [
       is1559: true,
       elasticityMultiplier: 6n,
       baseFeeMaxChangeDenominator: 50n,
-      maxPriorityFeePerGasCalc: 'baseFeePercentange'
+      maxPriorityFee: 100n
     },
     reestimateOn: 6000
   },
@@ -88,7 +88,8 @@ const networks: NetworkDescriptor[] = [
     unstoppableDomainsChain: 'ERC20',
     feeOptions: {
       is1559: true,
-      minBaseFee: 100000000n // 1 gwei
+      minBaseFee: 100000000n, // 1 gwei
+      maxPriorityFee: 100n
     },
     reestimateOn: 6000
   }

--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -50,7 +50,8 @@ const networks: NetworkDescriptor[] = [
       is1559: true,
       elasticityMultiplier: 6n,
       baseFeeMaxChangeDenominator: 50n,
-      maxPriorityFee: 100n
+      maxPriorityFee: 100n,
+      feeIncrease: 2n // %
     },
     reestimateOn: 6000
   },

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -409,22 +409,26 @@ describe('SignAccountOp Controller ', () => {
         {
           name: 'slow',
           baseFeePerGas: 100n,
-          maxPriorityFeePerGas: 100n
+          maxPriorityFeePerGas: 100n,
+          baseFeeToDivide: 100n
         },
         {
           name: 'medium',
           baseFeePerGas: 200n,
-          maxPriorityFeePerGas: 200n
+          maxPriorityFeePerGas: 200n,
+          baseFeeToDivide: 200n
         },
         {
           name: 'fast',
           baseFeePerGas: 300n,
-          maxPriorityFeePerGas: 300n
+          maxPriorityFeePerGas: 300n,
+          baseFeeToDivide: 300n
         },
         {
           name: 'ape',
           baseFeePerGas: 400n,
-          maxPriorityFeePerGas: 400n
+          maxPriorityFeePerGas: 400n,
+          baseFeeToDivide: 400n
         }
       ]
     )
@@ -453,7 +457,7 @@ describe('SignAccountOp Controller ', () => {
       amount: 6005000n, // ((300 + 300) × 10000) + 10000, i.e. ((baseFee + priorityFee) * gasUsed) + addedNative
       simulatedGasLimit: 10000n, // 10000, i.e. gasUsed,
       maxPriorityFeePerGas: 300n,
-      baseFeePerGas: 300n
+      baseFeeToDivide: 300n
     })
 
     expect(controller.accountOp.signature).toEqual('0x') // broadcasting and signRawTransaction is handled in main controller
@@ -504,22 +508,26 @@ describe('SignAccountOp Controller ', () => {
         {
           name: 'slow',
           baseFeePerGas: 1000000000n,
-          maxPriorityFeePerGas: 1000000000n
+          maxPriorityFeePerGas: 1000000000n,
+          baseFeeToDivide: 1000000000n
         },
         {
           name: 'medium',
           baseFeePerGas: 2000000000n,
-          maxPriorityFeePerGas: 2000000000n
+          maxPriorityFeePerGas: 2000000000n,
+          baseFeeToDivide: 2000000000n
         },
         {
           name: 'fast',
           baseFeePerGas: 5000000000n,
-          maxPriorityFeePerGas: 5000000000n
+          maxPriorityFeePerGas: 5000000000n,
+          baseFeeToDivide: 5000000000n
         },
         {
           name: 'ape',
           baseFeePerGas: 7000000000n,
-          maxPriorityFeePerGas: 7000000000n
+          maxPriorityFeePerGas: 7000000000n,
+          baseFeeToDivide: 7000000000n
         }
       ]
     )
@@ -627,22 +635,26 @@ describe('SignAccountOp Controller ', () => {
         {
           name: 'slow',
           baseFeePerGas: 1000000000n,
-          maxPriorityFeePerGas: 1000000000n
+          maxPriorityFeePerGas: 1000000000n,
+          baseFeeToDivide: 1000000000n
         },
         {
           name: 'medium',
           baseFeePerGas: 2000000000n,
-          maxPriorityFeePerGas: 2000000000n
+          maxPriorityFeePerGas: 2000000000n,
+          baseFeeToDivide: 2000000000n
         },
         {
           name: 'fast',
           baseFeePerGas: 5000000000n,
-          maxPriorityFeePerGas: 5000000000n
+          maxPriorityFeePerGas: 5000000000n,
+          baseFeeToDivide: 5000000000n
         },
         {
           name: 'ape',
           baseFeePerGas: 7000000000n,
-          maxPriorityFeePerGas: 7000000000n
+          maxPriorityFeePerGas: 7000000000n,
+          baseFeeToDivide: 7000000000n
         }
       ]
     )
@@ -731,22 +743,26 @@ describe('SignAccountOp Controller ', () => {
         {
           name: 'slow',
           baseFeePerGas: 100n,
-          maxPriorityFeePerGas: 100n
+          maxPriorityFeePerGas: 100n,
+          baseFeeToDivide: 100n
         },
         {
           name: 'medium',
           baseFeePerGas: 200n,
-          maxPriorityFeePerGas: 200n
+          maxPriorityFeePerGas: 200n,
+          baseFeeToDivide: 200n
         },
         {
           name: 'fast',
           baseFeePerGas: 300n,
-          maxPriorityFeePerGas: 300n
+          maxPriorityFeePerGas: 300n,
+          baseFeeToDivide: 300n
         },
         {
           name: 'ape',
           baseFeePerGas: 400n,
-          maxPriorityFeePerGas: 400n
+          maxPriorityFeePerGas: 400n,
+          baseFeeToDivide: 400n
         }
       ]
     )
@@ -779,7 +795,7 @@ describe('SignAccountOp Controller ', () => {
       amount: 9005000n, // (300 + 300) × (10000+5000) + 10000, i.e. (baseFee + priorityFee) * (gasUsed + additionalCall) + addedNative
       simulatedGasLimit: 15000n, // 10000 + 5000, i.e. gasUsed + additionalCall
       maxPriorityFeePerGas: 300n,
-      baseFeePerGas: 300n
+      baseFeeToDivide: 300n
     })
 
     const typedData = getTypedData(
@@ -832,22 +848,26 @@ describe('SignAccountOp Controller ', () => {
         {
           name: 'slow',
           baseFeePerGas: 100n,
-          maxPriorityFeePerGas: 100n
+          maxPriorityFeePerGas: 100n,
+          baseFeeToDivide: 100n
         },
         {
           name: 'medium',
           baseFeePerGas: 200n,
-          maxPriorityFeePerGas: 200n
+          maxPriorityFeePerGas: 200n,
+          baseFeeToDivide: 200n
         },
         {
           name: 'fast',
           baseFeePerGas: 300n,
-          maxPriorityFeePerGas: 300n
+          maxPriorityFeePerGas: 300n,
+          baseFeeToDivide: 300n
         },
         {
           name: 'ape',
           baseFeePerGas: 400n,
-          maxPriorityFeePerGas: 400n
+          maxPriorityFeePerGas: 400n,
+          baseFeeToDivide: 400n
         }
       ]
     )

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -62,7 +62,7 @@ type FanSpeed = {
   amountFormatted: string
   amountUsd: string
   maxPriorityFeePerGas?: bigint
-  baseFeePerGas?: bigint
+  baseFeeToDivide: bigint
 }
 
 // declare the statuses we don't want state updates on
@@ -535,6 +535,9 @@ export class SignAccountOpController extends EventEmitter {
       if ('baseFeePerGas' in gasRecommendation)
         gasPrice = gasRecommendation.baseFeePerGas + gasRecommendation.maxPriorityFeePerGas
 
+      const baseFeeToDivide =
+        'baseFeeToDivide' in gasRecommendation ? gasRecommendation.baseFeeToDivide : gasPrice
+
       // EOA
       if (!this.#account || !this.#account?.creation) {
         simulatedGasLimit = gasUsed
@@ -547,12 +550,23 @@ export class SignAccountOpController extends EventEmitter {
         simulatedGasLimit += usesPaymaster
           ? this.#estimation!.arbitrumL1FeeIfArbitrum.withFee
           : this.#estimation!.arbitrumL1FeeIfArbitrum.noFee
+
+        // add preVerificationGas to simulated gas so we could get the correct
+        // fee the user should pay
+        const l1FeeAsL2Gas = feeTokenEstimation.addedNative / baseFeeToDivide
+        const preVerificationGas = getPreVerificationGas(
+          this.#userOperation,
+          usesPaymaster,
+          l1FeeAsL2Gas
+        )
+        simulatedGasLimit += BigInt(preVerificationGas)
+
         amount = SignAccountOpController.getAmountAfterFeeTokenConvert(
           simulatedGasLimit,
           gasPrice,
           nativeRatio,
           this.feeTokenResult!.decimals,
-          feeTokenEstimation.addedNative
+          0n
         )
         if (usesPaymaster) {
           amount = this.#increaseFee(amount)
@@ -593,12 +607,12 @@ export class SignAccountOpController extends EventEmitter {
         simulatedGasLimit,
         amount,
         amountFormatted: ethers.formatUnits(amount, Number(this.feeTokenResult!.decimals)),
-        amountUsd: getTokenUsdAmount(this.feeTokenResult!, amount)
+        amountUsd: getTokenUsdAmount(this.feeTokenResult!, amount),
+        baseFeeToDivide
       }
 
       if ('maxPriorityFeePerGas' in gasRecommendation) {
         fee.maxPriorityFeePerGas = gasRecommendation.maxPriorityFeePerGas
-        fee.baseFeePerGas = gasRecommendation.baseFeePerGas
       }
 
       return fee
@@ -665,12 +679,12 @@ export class SignAccountOpController extends EventEmitter {
       isGasTank: this.feeTokenResult.flags.onGasTank,
       inToken: this.feeTokenResult.address,
       amount: chosenSpeed.amount,
-      simulatedGasLimit: chosenSpeed.simulatedGasLimit
+      simulatedGasLimit: chosenSpeed.simulatedGasLimit,
+      baseFeeToDivide: chosenSpeed.baseFeeToDivide
     }
 
     if ('maxPriorityFeePerGas' in chosenSpeed) {
       gasFeePayment.maxPriorityFeePerGas = chosenSpeed.maxPriorityFeePerGas
-      gasFeePayment.baseFeePerGas = chosenSpeed.baseFeePerGas
     }
 
     return gasFeePayment
@@ -829,10 +843,13 @@ export class SignAccountOpController extends EventEmitter {
             (gasFeePayment.amount * BigInt(10 ** (18 + 18 - this.feeTokenResult!.decimals))) /
             nativeRatio
         }
-        const gasPrice =
-          (amountInWei - feeTokenEstimation.addedNative) / gasFeePayment.simulatedGasLimit
+        // NOTE: we do not subtract the addedNative from here as we put it
+        // in preVerificationGas
+        const gasPrice = amountInWei / gasFeePayment.simulatedGasLimit
         userOperation.maxFeePerGas = ethers.toBeHex(gasPrice)
-        userOperation.maxPriorityFeePerGas = ethers.toBeHex(gasFeePayment.maxPriorityFeePerGas!)
+        userOperation.maxPriorityFeePerGas = ethers.toBeHex(
+          gasFeePayment.maxPriorityFeePerGas ?? userOperation.maxFeePerGas
+        )
 
         const usesOneTimeNonce = shouldUseOneTimeNonce(userOperation)
         const usesPaymaster = shouldUsePaymaster(this.#network)
@@ -859,11 +876,8 @@ export class SignAccountOpController extends EventEmitter {
           ])
         }
 
-        // TODO: ARBITRUM 4337 IMPLEMENTATION
-        // TODO: Not working for networks that do not support EIP-1559 and demand a L1 fee
-        // Set the real preVerificationGas
-        if (feeTokenEstimation.addedNative > 0n && gasFeePayment.baseFeePerGas) {
-          const l1FeeAsL2Gas = feeTokenEstimation.addedNative / gasFeePayment.baseFeePerGas
+        if (feeTokenEstimation.addedNative > 0n) {
+          const l1FeeAsL2Gas = feeTokenEstimation.addedNative / gasFeePayment.baseFeeToDivide
 
           userOperation.preVerificationGas = getPreVerificationGas(
             userOperation,

--- a/src/interfaces/networkDescriptor.ts
+++ b/src/interfaces/networkDescriptor.ts
@@ -12,7 +12,7 @@ interface FeeOptions {
   baseFeeMaxChangeDenominator?: bigint
   // should we increase the relayer fee in %
   feeIncrease?: bigint
-  maxPriorityFeePerGasCalc?: string
+  maxPriorityFee?: bigint
 }
 
 // NetworkId is a string: this is our internal identifier for the network

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -22,7 +22,10 @@ export interface GasFeePayment {
   amount: bigint
   simulatedGasLimit: bigint
   maxPriorityFeePerGas?: bigint
-  baseFeePerGas?: bigint
+  // in l2s, to calculate correctly the preVerificationGas,
+  // we use the baseFee for each speed in reverse order as dividing
+  // by a greater baseFee gives smaller gas fee. That's why we need this
+  baseFeeToDivide: bigint
 }
 
 export enum AccountOpStatus {

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -34,6 +34,10 @@ export interface GasPriceRecommendation {
 export interface Gas1559Recommendation {
   name: string
   baseFeePerGas: bigint
+  // in l2s, to calculate correctly the preVerificationGas,
+  // we use the baseFee for each speed in reverse order as dividing
+  // by a greater baseFee gives smaller gas fee. That's why we need this
+  baseFeeToDivide: bigint
   maxPriorityFeePerGas: bigint
 }
 export type GasRecommendation = GasPriceRecommendation | Gas1559Recommendation
@@ -151,24 +155,20 @@ export async function getGasPriceRecommendations(
     const tips = filterOutliers(txns.map((x) => x.maxPriorityFeePerGas!).filter((x) => x > 0))
     return speeds.map(({ name, baseFeeAddBps }, i) => {
       const baseFee = expectedBaseFee + (expectedBaseFee * baseFeeAddBps) / 10000n
+      const baseFeeToDivide =
+        expectedBaseFee + (expectedBaseFee * speeds[speeds.length - (i + 1)].baseFeeAddBps) / 10000n
 
-      // instead of an average, calculate the maxPriorityFeePerGas in
-      // base fee percentage if so specified in the network fee options.
-      // This is for networks like optimism that have block transactions with
-      // too random maxPriorityFeePerGas fees included in a block. The average
-      // can differ greatly, causing a large gap between what we expect at the
-      // end. Additionally, we may set this as the userOp maxPriorityFee, making
-      // it even worse as it may radically change what the bundle receives in the end.
-      // A small percentage (<1%) is enough for the transaction to pass
+      // maxPriorityFeePerGas is important for networks with longer block time
+      // like Ethereum (12s) but not at all for L2s with instant block creation.
+      // For L2s we hardcode the maxPriorityFee to 100n
       const maxPriorityFeePerGas =
-        network.feeOptions.maxPriorityFeePerGasCalc === 'baseFeePercentage'
-          ? baseFee / (160n - BigInt(i) * 35n)
-          : average(nthGroup(tips, i, speeds.length))
+        network.feeOptions.maxPriorityFee ?? average(nthGroup(tips, i, speeds.length))
 
       return {
         name,
         baseFeePerGas: baseFee,
-        maxPriorityFeePerGas: network.id === 'arbitrum' ? 0n : maxPriorityFeePerGas
+        baseFeeToDivide,
+        maxPriorityFeePerGas
       }
     })
   }

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -104,9 +104,12 @@ export class Bundler {
     // transfrom to bigint
     const gasPrices = []
     for (const [key] of Object.entries(prices)) {
+      const baseFeePerGas =
+        BigInt(prices[key].maxFeePerGas) - BigInt(prices[key].maxPriorityFeePerGas)
       gasPrices.push({
         name: key,
-        baseFeePerGas: BigInt(prices[key].maxFeePerGas) - BigInt(prices[key].maxPriorityFeePerGas),
+        baseFeePerGas,
+        baseFeeToDivide: baseFeePerGas,
         maxPriorityFeePerGas: BigInt(prices[key].maxPriorityFeePerGas)
       })
     }


### PR DESCRIPTION
Changes:
* place the L1 gas for optimistic rollups in simulatedGasLimit to get better estimation
* hardcode the priority fee for optimistic networks as it's really not needed