### PR TITLE
Config / Migrate from the `ethers` named import to module specific imports

### DIFF
--- a/scripts/4337/secondTxn.ts
+++ b/scripts/4337/secondTxn.ts
@@ -1,9 +1,11 @@
-import { Wallet, Contract, getBytes, JsonRpcProvider, ethers } from 'ethers'
+import { Contract, getBytes, JsonRpcProvider, toBeHex, Wallet } from 'ethers'
 import fetch from 'node-fetch'
-import { wrapEthSign } from '../../test/ambireSign'
-import AMBIRE_ACCOUNT from '../../contracts/compiled/AmbireAccount.json'
-import ENTRY_POINT_ABI from './ENTRY_POINT.json'
+
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
+
+import AMBIRE_ACCOUNT from '../../contracts/compiled/AmbireAccount.json'
+import { wrapEthSign } from '../../test/ambireSign'
+import ENTRY_POINT_ABI from './ENTRY_POINT.json'
 
 // const AMBIRE_ACCOUNT_ADDR = '0xD1cE5E6AE56693D2D3D52b2EBDf969C1D7901971'
 const SIGNER_PRIV_KEY = '0x574f261b776b26b1ad75a991173d0e8ca2ca1d481bd7822b2b58b2ef8a969f12'
@@ -30,12 +32,12 @@ async function test() {
 
   const userOperation = {
     sender: SENDER_ADDR,
-    nonce: ethers.toBeHex(newNonce, 1),
+    nonce: toBeHex(newNonce, 1),
     initCode: '0x',
     callData,
-    callGasLimit: ethers.toBeHex(100000), // hardcode it for now at a high value
-    verificationGasLimit: ethers.toBeHex(500000), // hardcode it for now at a high value
-    preVerificationGas: ethers.toBeHex(50000), // hardcode it for now at a high value
+    callGasLimit: toBeHex(100000), // hardcode it for now at a high value
+    verificationGasLimit: toBeHex(500000), // hardcode it for now at a high value
+    preVerificationGas: toBeHex(50000), // hardcode it for now at a high value
     maxFeePerGas: gasPrice,
     maxPriorityFeePerGas: gasPrice,
     paymasterAndData: '0x',
@@ -59,26 +61,29 @@ async function test() {
 
   userOperation.paymasterAndData = paymasterAndData
 
-  const signature = wrapEthSign(await signer.signMessage(
-    getBytes(await entryPoint.getUserOpHash(userOperation))
-  ))
+  const signature = wrapEthSign(
+    await signer.signMessage(getBytes(await entryPoint.getUserOpHash(userOperation)))
+  )
   userOperation.signature = signature
 
-  const userOperationHash = await pimlicoProvider.send("eth_sendUserOperation", [userOperation, ENTRY_POINT_ADDR])
-  console.log("UserOperation hash:", userOperationHash)
+  const userOperationHash = await pimlicoProvider.send('eth_sendUserOperation', [
+    userOperation,
+    ENTRY_POINT_ADDR
+  ])
+  console.log('UserOperation hash:', userOperationHash)
 
   // let's also wait for the userOperation to be included, by continually querying for the receipts
-  console.log("Querying for receipts...")
+  console.log('Querying for receipts...')
   let receipt = null
   let counter = 0
   while (receipt === null) {
     try {
-      await new Promise((r) => setTimeout(r, 1000)) //sleep
+      await new Promise((r) => setTimeout(r, 1000)) // sleep
       counter++
-      receipt = await pimlicoProvider.send("eth_getUserOperationReceipt", [userOperationHash])
+      receipt = await pimlicoProvider.send('eth_getUserOperationReceipt', [userOperationHash])
       console.log(receipt)
     } catch (e) {
-      console.log('error throwed, retry counter ' + counter)
+      console.log(`error throwed, retry counter ${counter}`)
     }
   }
 }

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { ethers, JsonRpcProvider } from 'ethers'
+import { getCreate2Address, JsonRpcProvider, keccak256 } from 'ethers'
 
 import { PROXY_AMBIRE_ACCOUNT } from '../../consts/deploy'
 import {
@@ -830,7 +830,7 @@ export class AccountAdderController extends EventEmitter {
       // Checks whether the account.addr matches the addr generated from the
       // factory. Should never happen, but could be a possible attack vector.
       const isInvalidAddress =
-        ethers.getCreate2Address(factoryAddr, salt, ethers.keccak256(bytecode)).toLowerCase() !==
+        getCreate2Address(factoryAddr, salt, keccak256(bytecode)).toLowerCase() !==
         addr.toLowerCase()
       if (isInvalidAddress) {
         const message = `The address ${addr} can't be verified to be a smart account address.`

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/brace-style */
-import { ethers, getAddress, isAddress, TransactionResponse } from 'ethers'
+import { getAddress, Interface, isAddress, TransactionResponse } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireAccountFactory from '../../../contracts/compiled/AmbireAccountFactory.json'
@@ -996,14 +996,14 @@ export class MainController extends EventEmitter {
       let data
       let to
       if (accountState.isDeployed) {
-        const ambireAccount = new ethers.Interface(AmbireAccount.abi)
+        const ambireAccount = new Interface(AmbireAccount.abi)
         to = accountOp.accountAddr
         data = ambireAccount.encodeFunctionData('execute', [
           getSignableCalls(accountOp),
           accountOp.signature
         ])
       } else {
-        const ambireFactory = new ethers.Interface(AmbireAccountFactory.abi)
+        const ambireFactory = new Interface(AmbireAccountFactory.abi)
         to = account.creation.factoryAddr
         data = ambireFactory.encodeFunctionData('deployAndExecute', [
           account.creation.bytecode,

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -1,4 +1,4 @@
-import { ethers, Interface } from 'ethers'
+import { AbiCoder, hexlify, Interface, toBeHex, toUtf8Bytes, ZeroAddress } from 'ethers'
 
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET } from '../../consts/derivation'
@@ -38,7 +38,7 @@ interface DKIMRecoveryAccInfo {
 export function getAccountDeployParams(account: Account): [string, string] {
   // for EOAs, we do not throw an error anymore as we need fake
   // values for the simulation
-  if (account.creation === null) return [ethers.ZeroAddress, '0x']
+  if (account.creation === null) return [ZeroAddress, '0x']
 
   const factory = new Interface(['function deploy(bytes calldata code, uint256 salt) external'])
   return [
@@ -66,7 +66,7 @@ export async function getSmartAccount(privileges: PrivLevels[]): Promise<Account
     creation: {
       factoryAddr: AMBIRE_ACCOUNT_FACTORY,
       bytecode,
-      salt: ethers.toBeHex(0, 32)
+      salt: toBeHex(0, 32)
     }
   }
 }
@@ -106,13 +106,13 @@ export async function getEmailAccount(
   // if there's no dkimKey, standard DKIM recovery is not possible
   // we leave the defaults empty and the user will have to rely on
   // keys added through DNSSEC
-  const selector = ethers.hexlify(ethers.toUtf8Bytes(''))
-  const modulus = ethers.hexlify(ethers.toUtf8Bytes(''))
-  const exponent = ethers.hexlify(ethers.toUtf8Bytes(''))
+  const selector = hexlify(toUtf8Bytes(''))
+  const modulus = hexlify(toUtf8Bytes(''))
+  const exponent = hexlify(toUtf8Bytes(''))
   // if (dkimKey) {
   //   const key = publicKeyToComponents(dkimKey.publicKey)
-  //   modulus = ethers.hexlify(key.modulus)
-  //   exponent = ethers.hexlify(ethers.toBeHex(key.exponent))
+  //   modulus = hexlify(key.modulus)
+  //   exponent = hexlify(toBeHex(key.exponent))
   // }
 
   // acceptUnknownSelectors should be always true
@@ -127,7 +127,7 @@ export async function getEmailAccount(
     recoveryInfo.acceptEmptySecondSig ?? RECOVERY_DEFAULTS.acceptEmptySecondSig
   const onlyOneSigTimelock = recoveryInfo.onlyOneSigTimelock ?? RECOVERY_DEFAULTS.onlyOneSigTimelock
 
-  const abiCoder = new ethers.AbiCoder()
+  const abiCoder = new AbiCoder()
   const validatorAddr = DKIM_VALIDATOR_ADDR
   const validatorData = abiCoder.encode(
     ['tuple(string,string,string,bytes,bytes,address,bool,uint32,uint32,bool,bool,uint32)'],

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers'
+import { AbiCoder, getBytes, keccak256 } from 'ethers'
 import { Key } from 'interfaces/keystore'
 import { HumanizerMeta } from 'libs/humanizer/interfaces'
 
@@ -152,9 +152,9 @@ export function accountOpSignableHash(op: AccountOp): Uint8Array {
   const opNetworks = networks.filter((network: NetworkDescriptor) => op.networkId === network.id)
   if (!opNetworks.length) throw new Error('unsupported network')
 
-  const abiCoder = new ethers.AbiCoder()
-  return ethers.getBytes(
-    ethers.keccak256(
+  const abiCoder = new AbiCoder()
+  return getBytes(
+    keccak256(
       abiCoder.encode(
         ['address', 'uint', 'uint', 'tuple(address, uint, bytes)[]'],
         [op.accountAddr, opNetworks[0].chainId, op.nonce ?? 0n, getSignableCalls(op)]

--- a/src/libs/deploy/singleton.ts
+++ b/src/libs/deploy/singleton.ts
@@ -1,7 +1,14 @@
 // this script is used to deploy the proxy, factory and paymaster
 // contract via EIP-2470, singleton pattern:
 // https://eips.ethereum.org/EIPS/eip-2470
-import { ethers, JsonRpcProvider } from 'ethers'
+import {
+  BaseContract,
+  getAddress,
+  getCreate2Address,
+  JsonRpcProvider,
+  keccak256,
+  Wallet
+} from 'ethers'
 
 import DeployHelper from '../../../contracts/compiled/DeployHelper.json'
 import { networks } from '../../consts/networks'
@@ -28,11 +35,8 @@ export async function deploy(network: NetworkDescriptor) {
   const singletonAddr = '0xce0042B868300000d44A59004Da54A005ffdcf9f'
 
   // run a simulation, take the contract addresses and verify there's no code there
-  const helperAddr = ethers.getCreate2Address(singletonAddr, salt, ethers.keccak256(bytecode))
-  if (
-    ethers.getAddress(helperAddr) !==
-    ethers.getAddress('0x1F8D50d09C019C26518AA859b07C8888d0eB9576')
-  ) {
+  const helperAddr = getCreate2Address(singletonAddr, salt, keccak256(bytecode))
+  if (getAddress(helperAddr) !== getAddress('0x1F8D50d09C019C26518AA859b07C8888d0eB9576')) {
     throw new Error('Helper address different. Comment out this error if you think it is correct')
   }
 
@@ -43,8 +47,8 @@ export async function deploy(network: NetworkDescriptor) {
   }
 
   const pk = process.env.DEPLOY_PRIVATE_KEY!
-  const wallet = new ethers.Wallet(pk, provider)
-  const singletonContract: any = new ethers.BaseContract(singletonAddr, singletonABI, wallet)
+  const wallet = new Wallet(pk, provider)
+  const singletonContract: any = new BaseContract(singletonAddr, singletonABI, wallet)
   const result = await singletonContract.deploy(bytecode, salt)
   console.log(result)
 }

--- a/src/libs/dkim/recovery.ts
+++ b/src/libs/dkim/recovery.ts
@@ -1,4 +1,4 @@
-import { ethers, getAddress } from 'ethers'
+import { AbiCoder, getAddress, keccak256 } from 'ethers'
 
 // TODO: change to original address once deployed
 export const DKIM_VALIDATOR_ADDR = '0x0000000000000000000000000000000000000000'
@@ -38,10 +38,8 @@ export const frequentlyUsedSelectors = [
  * @returns {Address, bytes32}
  */
 export function getSignerKey(validatorAddr: string, validatorData: any) {
-  const abiCoder = new ethers.AbiCoder()
-  const hash = ethers.keccak256(
-    abiCoder.encode(['address', 'bytes'], [validatorAddr, validatorData])
-  )
+  const abiCoder = new AbiCoder()
+  const hash = keccak256(abiCoder.encode(['address', 'bytes'], [validatorAddr, validatorData]))
   const signerKey = getAddress(`0x${hash.slice(hash.length - 40, hash.length)}`)
   return { signerKey, hash }
 }

--- a/src/libs/gasPrice/tests/MockProvider.ts
+++ b/src/libs/gasPrice/tests/MockProvider.ts
@@ -4,10 +4,13 @@ import {
   FetchRequest,
   JsonRpcApiProviderOptions,
   JsonRpcProvider,
+  keccak256,
   Networkish,
-  ethers
+  parseUnits
 } from 'ethers'
+
 import { abiCoder, addressOne, localhost } from '../../../../test/config'
+
 const ELASTICITY_MULTIPLIER = 2n
 const gasLimit = 30000000n
 const gasTarget = gasLimit / ELASTICITY_MULTIPLIER
@@ -35,8 +38,7 @@ export default class MockProvider extends JsonRpcProvider {
       number: this.blockParams.number ?? 0,
       timestamp: this.blockParams.timestamp ?? 30000000,
       parentHash:
-        this.blockParams.parentHash ??
-        ethers.keccak256(abiCoder.encode(['string'], ['random hash'])),
+        this.blockParams.parentHash ?? keccak256(abiCoder.encode(['string'], ['random hash'])),
       nonce: this.blockParams.nonce ?? '0',
       difficulty: this.blockParams.difficulty ?? 1n,
       gasLimit: this.blockParams.gasLimit ?? gasLimit,
@@ -45,7 +47,7 @@ export default class MockProvider extends JsonRpcProvider {
       extraData: this.blockParams.extraData ?? 'extra data',
       baseFeePerGas: this.blockParams.hasOwnProperty('baseFeePerGas')
         ? this.blockParams.baseFeePerGas
-        : ethers.parseUnits('1', 'gwei'),
+        : parseUnits('1', 'gwei'),
       transactions: this.blockParams.transactions ?? []
     }
     return new Block(params, this)

--- a/src/libs/humanizer/humanizerFuncs.ts
+++ b/src/libs/humanizer/humanizerFuncs.ts
@@ -1,7 +1,7 @@
-import { ethers } from 'ethers'
+import { formatUnits } from 'ethers'
+
 import { MAX_UINT256 } from '../../consts/deploy'
 import { ErrorRef } from '../../controllers/eventEmitter/eventEmitter'
-
 import { Message, PlainTextMessage, TypedMessage } from '../../interfaces/userRequest'
 import { AccountOp } from '../accountOp/accountOp'
 import {
@@ -12,7 +12,7 @@ import {
   IrCall,
   IrMessage
 } from './interfaces'
-import { getAction, getLabel, getDeadlineText } from './utils'
+import { getAction, getDeadlineText, getLabel } from './utils'
 
 export function humanizeCalls(
   _accountOp: AccountOp,
@@ -58,7 +58,7 @@ export const visualizationToText = (call: IrCall, options: any): string => {
             v.humanizerMeta.token?.symbol ? v.humanizerMeta.token?.symbol : `${v.address} token`
           }`
         } else {
-          text += `${ethers.formatUnits(v.amount!, v.humanizerMeta.token.decimals)} ${
+          text += `${formatUnits(v.amount!, v.humanizerMeta.token.decimals)} ${
             v.humanizerMeta.token?.symbol ? v.humanizerMeta.token?.symbol : `${v.address} token`
           }`
         }

--- a/src/libs/humanizer/modules/Aave/aaveLendingPoolV2.ts
+++ b/src/libs/humanizer/modules/Aave/aaveLendingPoolV2.ts
@@ -1,10 +1,11 @@
-import { ethers } from 'ethers'
-import { getAction, getLabel, getToken, getOnBehalfOf, getKnownAbi } from '../../utils'
+import { Interface } from 'ethers'
+
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerMeta, IrCall } from '../../interfaces'
+import { getAction, getKnownAbi, getLabel, getOnBehalfOf, getToken } from '../../utils'
 
 export const aaveLendingPoolV2 = (humanizerInfo: HumanizerMeta): { [key: string]: Function } => {
-  const iface = new ethers.Interface(getKnownAbi(humanizerInfo, 'AaveLendingPoolV2'))
+  const iface = new Interface(getKnownAbi(humanizerInfo, 'AaveLendingPoolV2'))
   const matcher = {
     [iface.getFunction('deposit')?.selector!]: (accountOp: AccountOp, call: IrCall) => {
       const [asset, amount, onBehalf] = iface.parseTransaction(call)?.args || []

--- a/src/libs/humanizer/modules/Aave/aaveWethGatewayV2.ts
+++ b/src/libs/humanizer/modules/Aave/aaveWethGatewayV2.ts
@@ -1,16 +1,17 @@
-import { ethers } from 'ethers'
-import { HumanizerMeta, IrCall } from '../../interfaces'
-import { getAction, getOnBehalfOf, getToken, getLabel, getKnownAbi } from '../../utils'
+import { Interface, ZeroAddress } from 'ethers'
+
 import { AccountOp } from '../../../accountOp/accountOp'
+import { HumanizerMeta, IrCall } from '../../interfaces'
+import { getAction, getKnownAbi, getLabel, getOnBehalfOf, getToken } from '../../utils'
 
 export const aaveWethGatewayV2 = (humanizerInfo: HumanizerMeta): { [key: string]: Function } => {
-  const iface = new ethers.Interface(getKnownAbi(humanizerInfo, 'AaveWethGatewayV2'))
+  const iface = new Interface(getKnownAbi(humanizerInfo, 'AaveWethGatewayV2'))
   return {
     [iface.getFunction('depositETH')?.selector!]: (accountOp: AccountOp, call: IrCall) => {
       const [, onBehalfOf] = iface.parseTransaction(call)?.args || []
       return [
         getAction('Deposit'),
-        getToken(ethers.ZeroAddress, call.value),
+        getToken(ZeroAddress, call.value),
         getLabel('to Aave lending pool'),
         ...getOnBehalfOf(onBehalfOf, accountOp.accountAddr)
       ]
@@ -19,7 +20,7 @@ export const aaveWethGatewayV2 = (humanizerInfo: HumanizerMeta): { [key: string]
       const [, /* lendingPool */ amount, to] = iface.parseTransaction(call)?.args || []
       return [
         getAction('Withdraw'),
-        getToken(ethers.ZeroAddress, amount),
+        getToken(ZeroAddress, amount),
         getLabel('from Aave lending pool'),
         ...getOnBehalfOf(to, accountOp.accountAddr)
       ]
@@ -29,7 +30,7 @@ export const aaveWethGatewayV2 = (humanizerInfo: HumanizerMeta): { [key: string]
         iface.parseTransaction(call)?.args || []
       return [
         getAction('Repay'),
-        getToken(ethers.ZeroAddress, call.value),
+        getToken(ZeroAddress, call.value),
         getLabel('to Aave lending pool'),
         getOnBehalfOf(onBehalfOf, accountOp.accountAddr)
       ]
@@ -38,7 +39,7 @@ export const aaveWethGatewayV2 = (humanizerInfo: HumanizerMeta): { [key: string]
       const [, /* lendingPool */ amount] = iface.parseTransaction(call)?.args || []
       return [
         getAction('Borrow '),
-        getToken(ethers.ZeroAddress, amount),
+        getToken(ZeroAddress, amount),
         getLabel('from Aave lending pool')
       ]
     }

--- a/src/libs/humanizer/modules/Uniswap/uniUnivarsalRouter.ts
+++ b/src/libs/humanizer/modules/Uniswap/uniUnivarsalRouter.ts
@@ -1,21 +1,22 @@
-import { ethers } from 'ethers'
+import { AbiCoder, ZeroAddress } from 'ethers'
+
+import { AccountOp } from '../../../accountOp/accountOp'
+import { HumanizerMeta, IrCall } from '../../interfaces'
 import {
   getAction,
+  getAddressVisualization,
   getDeadline,
+  getKnownAbi,
   getLabel,
   getRecipientText,
   getToken,
-  getWraping,
-  getAddressVisualization,
   getUnknownVisualization,
-  getKnownAbi
+  getWraping
 } from '../../utils'
-import { AccountOp } from '../../../accountOp/accountOp'
-import { HumanizerMeta, IrCall } from '../../interfaces'
 import { COMMANDS, COMMANDS_DESCRIPTIONS } from './Commands'
 import { parsePath } from './utils'
 
-const coder = new ethers.AbiCoder()
+const coder = new AbiCoder()
 
 const extractParams = (inputsDetails: any, input: any) => {
   const types = inputsDetails.map((i: any) => i.type)
@@ -53,9 +54,7 @@ export const uniUniversalRouter = (
   humanizerInfo: HumanizerMeta,
   options?: any
 ): { [x: string]: (a: AccountOp, c: IrCall) => IrCall[] } => {
-  const ifaceUniversalRouter = new ethers.Interface(
-    getKnownAbi(humanizerInfo, 'UniswapUniversalRouter')
-  )
+  const ifaceUniversalRouter = new Interface(getKnownAbi(humanizerInfo, 'UniswapUniversalRouter'))
   return {
     [`${
       ifaceUniversalRouter.getFunction(
@@ -186,7 +185,7 @@ export const uniUniversalRouter = (
               params.amountMin &&
                 parsed.push({
                   ...call,
-                  fullVisualization: getWraping(ethers.ZeroAddress, params.amountMin)
+                  fullVisualization: getWraping(ZeroAddress, params.amountMin)
                 })
             } else if (command === COMMANDS.UNWRAP_WETH) {
               const { inputsDetails } = COMMANDS_DESCRIPTIONS.UNWRAP_WETH
@@ -197,7 +196,7 @@ export const uniUniversalRouter = (
                   ...call,
                   fullVisualization: [
                     getAction('Unwrap'),
-                    getToken(ethers.ZeroAddress, params.amountMin),
+                    getToken(ZeroAddress, params.amountMin),
                     ...getRecipientText(accountOp.accountAddr, params.recipient)
                   ]
                 })

--- a/src/libs/humanizer/modules/Uniswap/uniUnivarsalRouter.ts
+++ b/src/libs/humanizer/modules/Uniswap/uniUnivarsalRouter.ts
@@ -1,4 +1,4 @@
-import { AbiCoder, ZeroAddress } from 'ethers'
+import { AbiCoder, Interface, ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerMeta, IrCall } from '../../interfaces'

--- a/src/libs/humanizer/modules/Uniswap/uniV2.ts
+++ b/src/libs/humanizer/modules/Uniswap/uniV2.ts
@@ -1,22 +1,22 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ethers } from 'ethers'
-import {
-  getAction,
-  getLabel,
-  getToken,
-  getRecipientText,
-  getDeadline,
-  getKnownAbi
-} from '../../utils'
+import { Interface, ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerMeta, IrCall } from '../../interfaces'
+import {
+  getAction,
+  getDeadline,
+  getKnownAbi,
+  getLabel,
+  getRecipientText,
+  getToken
+} from '../../utils'
 
 const uniV2Mapping = (
   humanizerInfo: HumanizerMeta,
   _options?: any
 ): { [key: string]: (a: AccountOp, c: IrCall) => IrCall[] } => {
-  const iface = new ethers.Interface(getKnownAbi(humanizerInfo, 'UniV2Router'))
+  const iface = new Interface(getKnownAbi(humanizerInfo, 'UniV2Router'))
   return {
     // ordered in the same order as the router
     [iface.getFunction('swapExactTokensForTokens')?.selector!]: (
@@ -72,7 +72,7 @@ const uniV2Mapping = (
           ...call,
           fullVisualization: [
             getAction('Swap'),
-            getToken(ethers.ZeroAddress, value),
+            getToken(ZeroAddress, value),
             getLabel('for at least'),
             getToken(outputAsset, amountOutMin),
             ...getRecipientText(accountOp.accountAddr, to),
@@ -94,7 +94,7 @@ const uniV2Mapping = (
             getLabel('up to'),
             getToken(path[0], amountInMax),
             getLabel('for at least'),
-            getToken(ethers.ZeroAddress, amountOut),
+            getToken(ZeroAddress, amountOut),
             ...getRecipientText(accountOp.accountAddr, to),
             getDeadline(deadline)
           ]
@@ -113,7 +113,7 @@ const uniV2Mapping = (
             getAction('Swap'),
             getToken(path[0], amountIn),
             getLabel('for at least'),
-            getToken(ethers.ZeroAddress, amountOutMin),
+            getToken(ZeroAddress, amountOutMin),
             ...getRecipientText(accountOp.accountAddr, to),
             getDeadline(deadline)
           ]
@@ -133,7 +133,7 @@ const uniV2Mapping = (
           fullVisualization: [
             getAction('Swap'),
             getLabel('up to'),
-            getToken(ethers.ZeroAddress, value),
+            getToken(ZeroAddress, value),
             getLabel('for at least'),
             getToken(outputAsset, amountOut),
             ...getRecipientText(accountOp.accountAddr, to),
@@ -185,7 +185,7 @@ const uniV2Mapping = (
             getAction('Add liquidity'),
             getToken(token, amountTokenDesired),
             getLabel('and'),
-            getToken(ethers.ZeroAddress, value),
+            getToken(ZeroAddress, value),
             ...getRecipientText(accountOp.accountAddr, to),
             getDeadline(deadline)
           ]
@@ -227,7 +227,7 @@ const uniV2Mapping = (
             getLabel('at least'),
             getToken(token, amountTokenMin),
             getLabel('and'),
-            getToken(ethers.ZeroAddress, amountETHMin),
+            getToken(ZeroAddress, amountETHMin),
             ...getRecipientText(accountOp.accountAddr, to),
             getDeadline(deadline)
           ]

--- a/src/libs/humanizer/modules/Uniswap/uniV3.ts
+++ b/src/libs/humanizer/modules/Uniswap/uniV3.ts
@@ -1,19 +1,19 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-console */
-import { ethers } from 'ethers'
-import {
-  getAction,
-  getLabel,
-  getToken,
-  getRecipientText,
-  getAddressVisualization,
-  getDeadline,
-  getUnknownVisualization,
-  getKnownAbi
-} from '../../utils'
+import { Interface, ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerMeta, IrCall } from '../../interfaces'
+import {
+  getAction,
+  getAddressVisualization,
+  getDeadline,
+  getKnownAbi,
+  getLabel,
+  getRecipientText,
+  getToken,
+  getUnknownVisualization
+} from '../../utils'
 import { parsePath } from './utils'
 
 // Stolen from ambire-wallet
@@ -21,7 +21,7 @@ const uniV32Mapping = (
   humanizerInfo: HumanizerMeta,
   _options?: any
 ): { [key: string]: (a: AccountOp, c: IrCall) => IrCall[] } => {
-  const ifaceV32 = new ethers.Interface(getKnownAbi(humanizerInfo, 'UniV3Router2'))
+  const ifaceV32 = new Interface(getKnownAbi(humanizerInfo, 'UniV3Router2'))
   return {
     // uint256 is deadline
     // 0x5ae401dc
@@ -233,7 +233,7 @@ const uniV32Mapping = (
       return [
         {
           ...call,
-          fullVisualization: [getAction('Unwrap'), getToken(ethers.ZeroAddress, amountMin)]
+          fullVisualization: [getAction('Unwrap'), getToken(ZeroAddress, amountMin)]
         }
       ]
     },
@@ -249,7 +249,7 @@ const uniV32Mapping = (
           ...call,
           fullVisualization: [
             getAction('Unwrap'),
-            getToken(ethers.ZeroAddress, amountMin),
+            getToken(ZeroAddress, amountMin),
             ...getRecipientText(accountOp.accountAddr, recipient)
           ]
         }
@@ -341,7 +341,7 @@ const uniV3Mapping = (
   humanizerInfo: HumanizerMeta,
   _options?: any
 ): { [key: string]: (a: AccountOp, c: IrCall) => IrCall[] } => {
-  const ifaceV3 = new ethers.Interface(getKnownAbi(humanizerInfo, 'UniV3Router'))
+  const ifaceV3 = new Interface(getKnownAbi(humanizerInfo, 'UniV3Router'))
   return {
     // 0xac9650d8
     [ifaceV3.getFunction('multicall')?.selector!]: (
@@ -458,7 +458,7 @@ const uniV3Mapping = (
           ...call,
           fullVisualization: [
             getAction('Unwrap'),
-            getToken(ethers.ZeroAddress, amountMin),
+            getToken(ZeroAddress, amountMin),
             ...getRecipientText(accountOp.accountAddr, recipient)
           ]
         }
@@ -476,9 +476,9 @@ const uniV3Mapping = (
           ...call,
           fullVisualization: [
             getAction('Unwrap'),
-            getToken(ethers.ZeroAddress, amountMin),
+            getToken(ZeroAddress, amountMin),
             getLabel('with fee'),
-            getToken(ethers.ZeroAddress, feeBips),
+            getToken(ZeroAddress, feeBips),
             getLabel('to'),
             getAddressVisualization(feeRecipient),
             ...getRecipientText(accountOp.accountAddr, recipient)

--- a/src/libs/humanizer/modules/WALLET/WALLETSupplyController.ts
+++ b/src/libs/humanizer/modules/WALLET/WALLETSupplyController.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ethers } from 'ethers'
+import { Interface } from 'ethers'
 
+import WALLETSupplyControllerABI from '../../../../../contracts/compiled/WALLETSupplyController.json'
+import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerVisualization, IrCall } from '../../interfaces'
 import { getAction, getLabel } from '../../utils'
-import { AccountOp } from '../../../accountOp/accountOp'
-import WALLETSupplyControllerABI from '../../../../../contracts/compiled/WALLETSupplyController.json'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const WALLETSupplyControllerMapping = (
   humanizerMeta: any
 ): { [key: string]: (arg0: AccountOp, arg1: IrCall) => HumanizerVisualization[] } => {
-  const iface = new ethers.Interface(WALLETSupplyControllerABI)
+  const iface = new Interface(WALLETSupplyControllerABI)
 
   return {
     [iface.getFunction('claim')?.selector!]: (

--- a/src/libs/humanizer/modules/WALLET/stakingPools.ts
+++ b/src/libs/humanizer/modules/WALLET/stakingPools.ts
@@ -1,7 +1,8 @@
-import { ethers } from 'ethers'
-import { getAction, getLabel, getToken, getAddressVisualization, getKnownAbi } from '../../utils'
+import { Interface } from 'ethers'
+
 import { AccountOp } from '../../../accountOp/accountOp'
 import { IrCall } from '../../interfaces'
+import { getAction, getAddressVisualization, getKnownAbi, getLabel, getToken } from '../../utils'
 
 const STAKING_POOLS: { [key: string]: { [key: string]: string } } = {
   '0x47cd7e91c3cbaaf266369fe8518345fc4fc12935': {
@@ -21,7 +22,7 @@ const STAKING_POOLS: { [key: string]: { [key: string]: string } } = {
 // const WALLET_TOKEN_ADDR = '0x88800092ff476844f74dc2fc427974bbee2794ae'
 
 export const StakingPools = (humanizerInfo: any) => {
-  const iface = new ethers.Interface(getKnownAbi(humanizerInfo, 'StakingPool'))
+  const iface = new Interface(getKnownAbi(humanizerInfo, 'StakingPool'))
   return {
     [iface.getFunction('enter')?.selector!]: (accountOp: AccountOp, call: IrCall) => {
       const { amount } = iface.parseTransaction(call)!.args

--- a/src/libs/humanizer/modules/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/fallBackHumanizer.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-await-in-loop */
-import { ethers } from 'ethers'
+import { Interface, isAddress, ZeroAddress } from 'ethers'
+
 import { AccountOp } from '../../accountOp/accountOp'
 import {
-  HumanizerFragment,
   HumanizerCallModule,
+  HumanizerFragment,
+  HumanizerMeta,
   HumanizerVisualization,
-  IrCall,
-  HumanizerMeta
+  IrCall
 } from '../interfaces'
 import {
   checkIfUnknownAction,
@@ -127,13 +128,13 @@ async function fetchFunc4bytes(selector: string, options: any): Promise<Humanize
 
 function extractAddresses(data: string, _selector: string): string[] {
   const selector = _selector.startsWith('function') ? _selector : `function ${_selector}`
-  const iface = new ethers.Interface([selector])
+  const iface = new Interface([selector])
   const args = iface.decodeFunctionData(selector, data)
   const deepSearchForAddress = (obj: { [prop: string]: any }): string[] => {
     return (
       Object.values(obj)
         .map((o: any): string[] | undefined => {
-          if (typeof o === 'string' && ethers.isAddress(o)) return [o] as string[]
+          if (typeof o === 'string' && isAddress(o)) return [o] as string[]
           if (typeof o === 'object') return deepSearchForAddress(o).filter((x) => x) as string[]
           return undefined
         })
@@ -206,7 +207,7 @@ export const fallbackHumanizer: HumanizerCallModule = (
     }
     if (call.value) {
       if (call.data !== '0x') visualization.push(getLabel('and'))
-      visualization.push(getAction('Send'), getToken(ethers.ZeroAddress, call.value))
+      visualization.push(getAction('Send'), getToken(ZeroAddress, call.value))
       if (call.data === '0x') visualization.push(getLabel('to'), getAddressVisualization(call.to))
     }
     return {

--- a/src/libs/humanizer/modules/gasTankModule.ts
+++ b/src/libs/humanizer/modules/gasTankModule.ts
@@ -1,4 +1,5 @@
-import { ethers } from 'ethers'
+import { ZeroAddress } from 'ethers'
+
 import { AccountOp } from '../../accountOp/accountOp'
 import { HumanizerCallModule, IrCall } from '../interfaces'
 import { getAction, getKnownName, getToken } from '../utils'
@@ -14,10 +15,7 @@ export const gasTankModule: HumanizerCallModule = (
     if (getKnownName(accountOp.humanizerMeta, call.to) === 'Gas Tank')
       return {
         ...call,
-        fullVisualization: [
-          getAction('Fuel gas tank with'),
-          getToken(ethers.ZeroAddress, call.value)
-        ]
+        fullVisualization: [getAction('Fuel gas tank with'), getToken(ZeroAddress, call.value)]
       }
     if (
       call.fullVisualization?.[0]?.content === 'Send' &&

--- a/src/libs/humanizer/modules/oneInch.ts
+++ b/src/libs/humanizer/modules/oneInch.ts
@@ -1,4 +1,5 @@
-import { ethers } from 'ethers'
+import { Interface, ZeroAddress } from 'ethers'
+
 import { AccountOp } from '../../accountOp/accountOp'
 import { HumanizerCallModule, HumanizerMeta, IrCall } from '../interfaces'
 import { getAction, getLabel, getToken, getUnknownVisualization } from '../utils'
@@ -10,7 +11,7 @@ const parseZeroAddressIfNeeded = (address: string) => {
 }
 
 const OneInchMapping = (humanizerInfo: HumanizerMeta) => {
-  const iface = new ethers.Interface(Object.values(humanizerInfo?.abis.Swappin))
+  const iface = new Interface(Object.values(humanizerInfo?.abis.Swappin))
 
   return {
     [iface.getFunction('swap')?.selector!]: (_: any, call: IrCall) => {
@@ -30,7 +31,7 @@ const OneInchMapping = (humanizerInfo: HumanizerMeta) => {
         getToken(parseZeroAddressIfNeeded(srcToken), amount),
         getLabel('for at least'),
         // @TODO not correct look at next comment
-        getToken(parseZeroAddressIfNeeded(ethers.ZeroAddress), minReturn)
+        getToken(parseZeroAddressIfNeeded(ZeroAddress), minReturn)
         // @TODO no idea what this is, ask Lubo (taken from ambire wallet)
         // getToken(parseZeroAddressIfNeeded(dstToken), minReturn)
       ]

--- a/src/libs/humanizer/modules/privileges.ts
+++ b/src/libs/humanizer/modules/privileges.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers'
+import { Interface, ZeroHash } from 'ethers'
 
 import AmbireAccount from '../../../../contracts/compiled/AmbireAccount.json'
 import { ENTRY_POINT_MARKER } from '../../../consts/deploy'
@@ -6,7 +6,7 @@ import { AccountOp } from '../../accountOp/accountOp'
 import { HumanizerCallModule, HumanizerVisualization, IrCall } from '../interfaces'
 import { getAction, getAddressVisualization, getKnownName, getLabel } from '../utils'
 
-const iface = new ethers.Interface(AmbireAccount.abi)
+const iface = new Interface(AmbireAccount.abi)
 
 const parsePriviligeCall = (accountOp: AccountOp, call: IrCall): HumanizerVisualization[] => {
   const { addr, priv } = iface.parseTransaction(call)!.args
@@ -15,7 +15,7 @@ const parsePriviligeCall = (accountOp: AccountOp, call: IrCall): HumanizerVisual
     priv === ENTRY_POINT_MARKER
   )
     return [getAction('Enable'), getAddressVisualization(addr)]
-  if (priv === ethers.ZeroHash)
+  if (priv === ZeroHash)
     return [getAction('Revoke access'), getLabel('of'), getAddressVisualization(addr)]
   return [
     getAction('Update access status'),

--- a/src/libs/humanizer/modules/sushiSwapModule.ts
+++ b/src/libs/humanizer/modules/sushiSwapModule.ts
@@ -1,14 +1,15 @@
+import { Interface, ZeroAddress } from 'ethers'
 import { AccountOp } from 'libs/accountOp/accountOp'
-import { ethers } from 'ethers'
+
 import { HumanizerCallModule, IrCall } from '../interfaces'
 import {
-  getKnownAbi,
   getAction,
+  getKnownAbi,
+  getKnownName,
   getLabel,
   getRecipientText,
   getToken,
-  getUnknownVisualization,
-  getKnownName
+  getUnknownVisualization
 } from '../utils'
 
 export const sushiSwapModule: HumanizerCallModule = (
@@ -17,7 +18,7 @@ export const sushiSwapModule: HumanizerCallModule = (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   options?: any
 ) => {
-  const routeProcessorIface = new ethers.Interface(
+  const routeProcessorIface = new Interface(
     Object.values(getKnownAbi(accountOp.humanizerMeta, 'RouteProcessor', options))
   )
   const matcher = {
@@ -28,8 +29,8 @@ export const sushiSwapModule: HumanizerCallModule = (
       const params = routeProcessorIface.parseTransaction(call)!.args
       let { tokenIn, tokenOut /* route */ } = params
       const { amountIn, amountOutMin, to } = params
-      if (tokenIn === '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') tokenIn = ethers.ZeroAddress
-      if (tokenOut === '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') tokenOut = ethers.ZeroAddress
+      if (tokenIn === '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') tokenIn = ZeroAddress
+      if (tokenOut === '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') tokenOut = ZeroAddress
 
       return {
         ...call,

--- a/src/libs/humanizer/modules/tokens.ts
+++ b/src/libs/humanizer/modules/tokens.ts
@@ -1,17 +1,17 @@
-import { ethers } from 'ethers'
+import { Interface, ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../accountOp/accountOp'
 import { HumanizerCallModule, HumanizerFragment, IrCall } from '../interfaces'
 import {
-  getKnownAbi,
   getAction,
   getAddressVisualization,
+  getKnownAbi,
+  getKnownToken,
   getLabel,
   getNft,
   getToken,
   getTokenInfo,
-  getUnknownVisualization,
-  getKnownToken
+  getUnknownVisualization
 } from '../utils'
 
 export const genericErc721Humanizer: HumanizerCallModule = (
@@ -20,7 +20,7 @@ export const genericErc721Humanizer: HumanizerCallModule = (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   options?: any
 ) => {
-  const iface = new ethers.Interface(getKnownAbi(accountOp.humanizerMeta, 'ERC721', options))
+  const iface = new Interface(getKnownAbi(accountOp.humanizerMeta, 'ERC721', options))
   const nftTransferVisualization = (call: IrCall) => {
     const args = iface.parseTransaction(call)?.args.toArray() || []
     return args[0] === accountOp.accountAddr
@@ -42,7 +42,7 @@ export const genericErc721Humanizer: HumanizerCallModule = (
   const matcher = {
     [iface.getFunction('approve')?.selector!]: (call: IrCall) => {
       const args = iface.parseTransaction(call)?.args.toArray() || []
-      return args[0] === ethers.ZeroAddress
+      return args[0] === ZeroAddress
         ? [getAction('Revoke approval'), getLabel('for'), getNft(call.to, args[1])]
         : [
             getAction('Grant approval'),
@@ -102,7 +102,7 @@ export const genericErc20Humanizer: HumanizerCallModule = (
   options?: any
 ) => {
   const asyncOps: Promise<HumanizerFragment | null>[] = []
-  const iface = new ethers.Interface(getKnownAbi(accountOp.humanizerMeta, 'ERC20', options))
+  const iface = new Interface(getKnownAbi(accountOp.humanizerMeta, 'ERC20', options))
   const matcher = {
     [iface.getFunction('approve')?.selector!]: (call: IrCall) => {
       const args = iface.parseTransaction(call)?.args.toArray() || []

--- a/src/libs/humanizer/modules/wrapped.ts
+++ b/src/libs/humanizer/modules/wrapped.ts
@@ -1,10 +1,11 @@
-import { ethers } from 'ethers'
-import { HumanizerCallModule, IrCall } from '../interfaces'
+import { Interface, ZeroAddress } from 'ethers'
+
 import { AccountOp } from '../../accountOp/accountOp'
+import { HumanizerCallModule, IrCall } from '../interfaces'
 import { getKnownAbi, getUnknownVisualization, getUnwraping, getWraping } from '../utils'
 
 const WRAPPEDISH_ADDRESSES: { [kjey: string]: string } = {
-  [ethers.ZeroAddress]: 'native',
+  [ZeroAddress]: 'native',
   '0x4200000000000000000000000000000000000042': 'OP',
   '0x4200000000000000000000000000000000000006': 'WETHOptimism',
   '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2': 'WETH',
@@ -24,7 +25,7 @@ const wrapSwapReducer = (calls: IrCall[]) => {
       calls[i]?.fullVisualization?.[3].amount === calls[i + 1]?.fullVisualization?.[1]?.amount
     ) {
       const newVisualization = calls[i]?.fullVisualization!
-      newVisualization[3].address = ethers.ZeroAddress
+      newVisualization[3].address = ZeroAddress
 
       newCalls.push({
         to: calls[i].to,
@@ -43,7 +44,7 @@ const wrapSwapReducer = (calls: IrCall[]) => {
       WRAPPEDISH_ADDRESSES[calls[i + 1]?.fullVisualization?.[1].address!]
     ) {
       const newVisualization = calls[i + 1]?.fullVisualization!
-      newVisualization[1].address = ethers.ZeroAddress
+      newVisualization[1].address = ZeroAddress
       newCalls.push({
         to: calls[i + 1].to,
         value: calls[i].value + calls[i + 1].value,
@@ -66,7 +67,7 @@ export const wrappingModule: HumanizerCallModule = (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   options?: any
 ) => {
-  const iface = new ethers.Interface(getKnownAbi(accountOp.humanizerMeta, 'WETH', options))
+  const iface = new Interface(getKnownAbi(accountOp.humanizerMeta, 'WETH', options))
   const newCalls = irCalls.map((call: IrCall) => {
     const knownAddressData = accountOp.humanizerMeta?.knownAddresses[call.to.toLowerCase()]
     if (
@@ -80,7 +81,7 @@ export const wrappingModule: HumanizerCallModule = (
       if (call.data.slice(0, 10) === iface.getFunction('deposit')?.selector) {
         return {
           ...call,
-          fullVisualization: getWraping(ethers.ZeroAddress, call.value)
+          fullVisualization: getWraping(ZeroAddress, call.value)
         }
       }
       // 0x2e1a7d4d
@@ -88,7 +89,7 @@ export const wrappingModule: HumanizerCallModule = (
         const [amount] = iface.parseTransaction(call)?.args || []
         return {
           ...call,
-          fullVisualization: getUnwraping(ethers.ZeroAddress, amount)
+          fullVisualization: getUnwraping(ZeroAddress, amount)
         }
       }
       if (!call?.fullVisualization)

--- a/src/libs/humanizer/parsers/humanizerMetaParsing.ts
+++ b/src/libs/humanizer/parsers/humanizerMetaParsing.ts
@@ -1,4 +1,5 @@
-import { ethers } from 'ethers'
+import { ZeroAddress } from 'ethers'
+
 import { networks } from '../../../consts/networks'
 import {
   HumanizerFragment,
@@ -17,7 +18,7 @@ export const humanizerMetaParsing: HumanizerParsingModule = (
   const asyncOps: Promise<HumanizerFragment | null>[] = []
   const res: HumanizerVisualization[] = visualization.map((v) => {
     if (v.address) {
-      if (v.address === ethers.ZeroAddress) {
+      if (v.address === ZeroAddress) {
         if (v.type === 'token') {
           const symbol = networks.find(
             ({ id }) => id === humanizerSettings.networkId

--- a/src/libs/humanizer/utils.ts
+++ b/src/libs/humanizer/utils.ts
@@ -1,7 +1,7 @@
-import dotenv from 'dotenv'
-import { ethers } from 'ethers'
-
 import { ErrorRef } from 'controllers/eventEmitter/eventEmitter'
+import dotenv from 'dotenv'
+import { ZeroAddress } from 'ethers'
+
 import { geckoIdMapper, geckoNetworkIdMapper } from '../../consts/coingecko'
 import { networks } from '../../consts/networks'
 import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
@@ -92,7 +92,7 @@ export function shortenAddress(addr: string): string {
  */
 // @TODO this shouldn't be here, a more suitable place would be portfolio/gecko
 export async function getNativePrice(network: NetworkDescriptor, fetch: Function): Promise<number> {
-  const platformId = geckoIdMapper(ethers.ZeroAddress, network.id)
+  const platformId = geckoIdMapper(ZeroAddress, network.id)
   if (!platformId) {
     throw new Error(`getNativePrice: ${network.name} is not supported`)
   }
@@ -172,7 +172,7 @@ export function getUnknownVisualization(name: string, call: IrCall): HumanizerVi
   ]
   if (call.value)
     unknownVisualization.push(
-      ...[getLabel('and'), getAction('Send'), getToken(ethers.ZeroAddress, call.value)]
+      ...[getLabel('and'), getAction('Send'), getToken(ZeroAddress, call.value)]
     )
   return unknownVisualization
 }

--- a/src/libs/keyIterator/keyIterator.ts
+++ b/src/libs/keyIterator/keyIterator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable new-cap */
-import { ethers, HDNodeWallet, Mnemonic, Wallet } from 'ethers'
+import { HDNodeWallet, keccak256, Mnemonic, Wallet } from 'ethers'
 
 import {
   HD_PATH_TEMPLATE_TYPE,
@@ -47,7 +47,7 @@ export function derivePrivateKeyFromAnotherPrivateKey(privateKey: string) {
 
   // Hash the buffer, and convert to a hex string
   // that ultimately represents a derived (second) private key
-  return ethers.keccak256(buffer)
+  return keccak256(buffer)
 }
 
 /**

--- a/src/libs/proxyDeploy/getAmbireAddressTwo.ts
+++ b/src/libs/proxyDeploy/getAmbireAddressTwo.ts
@@ -1,5 +1,5 @@
-import { ethers } from 'ethers'
+import { getCreate2Address, keccak256, toBeHex } from 'ethers'
 
 export function getAmbireAccountAddress(factoryAddress: string, bytecode: string) {
-  return ethers.getCreate2Address(factoryAddress, ethers.toBeHex(0, 32), ethers.keccak256(bytecode))
+  return getCreate2Address(factoryAddress, toBeHex(0, 32), keccak256(bytecode))
 }


### PR DESCRIPTION
Ethers exports the `ethers` object, which contains all the other named exports. Since the Ethers lib is huge, individual module imports are the best practice approach - to bundle only the parts of the lib that we need.

This might enable three shaking in some scenarios (although Ethers should remove the ethers named export or move it to a separate file) and help reduce the file size.

See https://github.com/ethers-io/ethers.js/issues/1009