### PR TITLE
Parse non hex string to hex 'personal_sign'

### DIFF
--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -1,3 +1,4 @@
+import { hexlify, isHexString, toUtf8Bytes } from 'ethers'
 import { networks } from '../../consts/networks'
 import { Account, AccountStates } from '../../interfaces/account'
 import { ExternalSignerControllers, Key } from '../../interfaces/keystore'
@@ -186,6 +187,11 @@ export class SignMessageController extends EventEmitter {
       let signature
       try {
         if (this.messageToSign.content.kind === 'message') {
+          const message = this.messageToSign.content.message
+          this.messageToSign.content.message = isHexString(message)
+            ? message
+            : hexlify(toUtf8Bytes(message as string))
+
           signature = await getPlainTextSignature(
             this.messageToSign.content.message,
             network,

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -190,7 +190,7 @@ export class SignMessageController extends EventEmitter {
           const message = this.messageToSign.content.message
           this.messageToSign.content.message = isHexString(message)
             ? message
-            : hexlify(toUtf8Bytes(message as string))
+            : hexlify(toUtf8Bytes(message.toString()))
 
           signature = await getPlainTextSignature(
             this.messageToSign.content.message,


### PR DESCRIPTION
Resolves this issue https://github.com/AmbireTech/ambire-app/issues/1903

also sent an email to taskon.xyz 

Taskon sends non hex string for 'personal_sign', which is not correct, according to the ['personal_sign' docs](https://docs.metamask.io/wallet/how-to/sign-data/#use-personal_sign)
Metamask and rabby simply hexlify the string, that what this fix does

We used to sign the string after we have hexed it, but when we try to verify the initial signiture we get err, because we anticipate hex string, it is not with taskon. 

This fix does
```
isHex 
? nothing
: assign it a hex value
```