### PR TITLE
Bug / Account Adder - impors import fallback (+ add missing tests)

### DIFF
--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -190,7 +190,7 @@ export class SignMessageController extends EventEmitter {
           const message = this.messageToSign.content.message
           this.messageToSign.content.message = isHexString(message)
             ? message
-            : hexlify(toUtf8Bytes(message as string))
+            : hexlify(toUtf8Bytes(message.toString()))
 
           signature = await getPlainTextSignature(
             this.messageToSign.content.message,

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -218,5 +218,5 @@ export const getAccountImportStatus = ({
       : ImportStatus.ImportedWithTheSameKeys
   }
 
-  return ImportStatus.NotImported
+  return ImportStatus.ImportedWithDifferentKeys
 }


### PR DESCRIPTION
Accounts that has some of their associated keys already imported, but not with the same explicit type, were misleadingly marked with import status being `ImportStatus.NotImported`, where the status should be `ImportStatus.ImportedWithDifferentKeys` instead, since these accounts have keys!