### PR TITLE
Bug / Missing `expect` import in domains.test.ts

### DIFF
--- a/src/controllers/domains/domains.test.ts
+++ b/src/controllers/domains/domains.test.ts
@@ -2,7 +2,7 @@ import { JsonRpcProvider } from 'ethers'
 // @ts-ignore
 import fetch from 'node-fetch'
 
-import { jest } from '@jest/globals'
+import { expect, jest } from '@jest/globals'
 
 import { networks } from '../../consts/networks'
 import { DomainsController } from './domains'


### PR DESCRIPTION
Resolves a missing import in https://github.com/AmbireTech/ambire-common/pull/656 (tests were failing on the CI otherwise)