### PR TITLE
Change/ `reverseLookupEns`  to follow ENS's guidelines

### DIFF
--- a/src/controllers/domains/domains.ts
+++ b/src/controllers/domains/domains.ts
@@ -93,8 +93,7 @@ export class DomainsController extends EventEmitter {
     let udName = null
 
     try {
-      ensName =
-        (await reverseLookupEns(checksummedAddress, this.#providers.ethereum, this.#fetch)) || null
+      ensName = (await reverseLookupEns(checksummedAddress, this.#providers.ethereum)) || null
     } catch (e) {
       console.error('ENS reverse lookup unexpected error', e)
     }

--- a/src/services/ensDomains/ensDomains.ts
+++ b/src/services/ensDomains/ensDomains.ts
@@ -63,42 +63,8 @@ function getBip44Items(coinTicker) {
   return constants.filter((item) => item[1] === coinTicker)
 }
 
-async function queryGraph(endpoint: string, query: string, fetch: Function): Promise<any> {
-  const resp = await fetch(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json'
-    },
-    body: JSON.stringify({ query })
-  })
-
-  return resp.json()
-}
-
-async function getAllEnsDomains(address: string, fetch: Function): Promise<Array<string>> {
-  const endpoint = 'https://api.thegraph.com/subgraphs/name/ensdomains/ens'
-  const query = `{
-    domains(where:{owner:"${address.toLowerCase()}"}) {
-      name
-    }
-  }`
-
-  const res = await queryGraph(endpoint, query, fetch)
-
-  return res.data.domains.map((d: any) => d.name)
-}
-
-async function getPrimaryEnsDomain(ethereumProvider: RPCProvider, address: string) {
-  return ethereumProvider.lookupAddress(address)
-}
-
-async function reverseLookupEns(address: string, provider: RPCProvider, fetch: Function) {
-  const primaryEnsDomain = await getPrimaryEnsDomain(provider, address)
-
-  if (primaryEnsDomain) return primaryEnsDomain
-
-  return (await getAllEnsDomains(address, fetch))[0] || null
+async function reverseLookupEns(address: string, provider: RPCProvider) {
+  return provider.lookupAddress(address)
 }
 
 export { resolveENSDomain, getBip44Items, reverseLookupEns }


### PR DESCRIPTION
The reverse-lookup implementation wasn't following ENS's guidelines:

> An ENS name should only be shown in place of an Ethereum address if the user has set a reverse record for their address, and if the reverse record matches the forward resolution. [Learn more about primary names](https://docs.ens.domains/web/reverse).
- Source: https://docs.ens.domains/web/design#1-replacing-ethereum-addresses-with-ens-names

As it was returning a domain that matched the criteria from above OR the first owned domain of an address, the latter being wrong.

## App change in:
https://github.com/AmbireTech/ambire-common/pull/667