### PR TITLE
Fix: Return false on allReady flag on acc change

### DIFF
--- a/src/libs/portfolio/portfolioView.ts
+++ b/src/libs/portfolio/portfolioView.ts
@@ -36,8 +36,7 @@ export function calculateAccountPortfolio(
     }
   }
 
-  // 1. On update latest is empty {} in the beginning
-  if (!state.latest) {
+  if (!state.latest || !state.latest[selectedAccount]) {
     return {
       tokens: accountPortfolio?.tokens || [],
       collections: accountPortfolio?.collections || [],
@@ -46,15 +45,7 @@ export function calculateAccountPortfolio(
     }
   }
 
-  const selectedAccountData = state.latest[selectedAccount] || undefined
-  if (!selectedAccountData) {
-    return {
-      tokens: accountPortfolio?.tokens || [],
-      collections: accountPortfolio?.collections || [],
-      totalAmount: accountPortfolio?.totalAmount || 0,
-      isAllReady: false
-    }
-  }
+  const selectedAccountData = state.latest[selectedAccount]
 
   const isNetworkReady = (networkData: AccountState | AdditionalAccountState | undefined) => {
     return (

--- a/src/libs/portfolio/portfolioView.ts
+++ b/src/libs/portfolio/portfolioView.ts
@@ -27,13 +27,22 @@ export function calculateAccountPortfolio(
   let newTotalAmount: number = 0
   let allReady = true
 
-  // 1. On update latest is empty {} in the beginning
-  if (!selectedAccount || !state.latest || !state.latest[selectedAccount]) {
+  if (!selectedAccount) {
     return {
       tokens: accountPortfolio?.tokens || [],
       collections: accountPortfolio?.collections || [],
       totalAmount: accountPortfolio?.totalAmount || 0,
       isAllReady: true
+    }
+  }
+
+  // 1. On update latest is empty {} in the beginning
+  if (!state.latest || !state.latest[selectedAccount]) {
+    return {
+      tokens: accountPortfolio?.tokens || [],
+      collections: accountPortfolio?.collections || [],
+      totalAmount: accountPortfolio?.totalAmount || 0,
+      isAllReady: false
     }
   }
 
@@ -43,7 +52,7 @@ export function calculateAccountPortfolio(
       tokens: accountPortfolio?.tokens || [],
       collections: accountPortfolio?.collections || [],
       totalAmount: accountPortfolio?.totalAmount || 0,
-      isAllReady: true
+      isAllReady: false
     }
   }
 

--- a/src/libs/portfolio/portfolioView.ts
+++ b/src/libs/portfolio/portfolioView.ts
@@ -37,7 +37,7 @@ export function calculateAccountPortfolio(
   }
 
   // 1. On update latest is empty {} in the beginning
-  if (!state.latest || !state.latest[selectedAccount]) {
+  if (!state.latest) {
     return {
       tokens: accountPortfolio?.tokens || [],
       collections: accountPortfolio?.collections || [],


### PR DESCRIPTION
In the logic for calculatingAccountPortfolio when we switch account for which we dont have portfolio state data we return isAllReady: true, but the update has already began.

In order to not have the 0 bug balance shown whilst the loading state is not returned yet from the portfolio we will set it to loading if we dont have the state for this account in the latest object.
