### PR TITLE
Bug / Detect differences for account stored associated keys, the keys coming from the account found on page and cover different scenarios with having associatedKeys and imported keys alongside

### DIFF
--- a/src/libs/account/account.test.ts
+++ b/src/libs/account/account.test.ts
@@ -238,17 +238,29 @@ describe('Account', () => {
       },
       isExternallyStored: false
     }
-    const anotherOfTheSmartAccountKeys: Account = {
+    const anotherBasicAccount: Account = {
       // random ethereum address
       addr: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
       associatedKeys: ['0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'],
       initialPrivileges: [],
       creation: null
     }
+    const anotherBasicAccountKey: Key = {
+      addr: anotherBasicAccount.addr,
+      type: 'trezor',
+      dedicatedToOneSA: true,
+      meta: {
+        deviceId: '123',
+        deviceModel: '1',
+        hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+        index: 1
+      },
+      isExternallyStored: false
+    }
 
     const accountsOnPageWithUpToDateAssociatedKeys: Omit<AccountOnPage, 'importStatus'>[] = [
       {
-        account: { ...anotherOfTheSmartAccountKeys, usedOnNetworks: [] },
+        account: { ...anotherBasicAccount, usedOnNetworks: [] },
         slot: 1,
         index: 0,
         isLinked: false
@@ -259,7 +271,7 @@ describe('Account', () => {
           associatedKeys: [
             ...smartAccountWithIncompleteAssociatedKeys.associatedKeys,
             // Include another (a new one) associated key!
-            anotherOfTheSmartAccountKeys.addr
+            anotherBasicAccountKey.addr
           ],
           usedOnNetworks: []
         },
@@ -274,6 +286,19 @@ describe('Account', () => {
         account: smartAccountWithIncompleteAssociatedKeys,
         alreadyImportedAccounts: [smartAccountWithIncompleteAssociatedKeys],
         keys: [oneOfTheSmartAccountKeys],
+        accountsOnPage: accountsOnPageWithUpToDateAssociatedKeys,
+        keyIteratorType: 'trezor'
+      })
+    ).toBe(ImportStatus.ImportedWithSomeOfTheKeys)
+
+    expect(
+      getAccountImportStatus({
+        account: smartAccountWithIncompleteAssociatedKeys,
+        alreadyImportedAccounts: [smartAccountWithIncompleteAssociatedKeys],
+        // Similar scenario, but both keys already previously imported!
+        // Should still return ImportedWithSomeOfTheKeys,
+        // because the associated keys are not up-to-date.
+        keys: [oneOfTheSmartAccountKeys, anotherBasicAccountKey],
         accountsOnPage: accountsOnPageWithUpToDateAssociatedKeys,
         keyIteratorType: 'trezor'
       })

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -198,7 +198,9 @@ export const getAccountImportStatus = ({
 
   // Check if the account has been imported with at least one of the keys
   // that the account was originally associated with, when it was imported.
-  const importedKeysForThisAcc = keys.filter((key) => account.associatedKeys.includes(key.addr))
+  const storedAssociatedKeys =
+    alreadyImportedAccounts.find((x) => x.addr === account.addr)?.associatedKeys || []
+  const importedKeysForThisAcc = keys.filter((key) => storedAssociatedKeys.includes(key.addr))
   // Could be imported as a view only account (and therefore, without a key)
   if (!importedKeysForThisAcc.length) return ImportStatus.ImportedWithoutKey
 
@@ -213,7 +215,7 @@ export const getAccountImportStatus = ({
       ...accountsOnPage
         .filter((x) => x.account.addr === account.addr)
         .flatMap((x) => x.account.associatedKeys),
-      ...account.associatedKeys
+      ...storedAssociatedKeys
     ])
   )
 
@@ -245,10 +247,10 @@ export const getAccountImportStatus = ({
     const associatedKeysFoundOnPageAreDifferent = accountsOnPage
       .filter((x) => x.account.addr === account.addr)
       .some((x) => {
-        const pageKeysSet = new Set(x.account.associatedKeys)
-        const accountKeysSet = new Set(account.associatedKeys)
+        const incomingAssociatedKeysSet = new Set(x.account.associatedKeys)
+        const storedAssociatedKeysSet = new Set(storedAssociatedKeys)
 
-        return ![...pageKeysSet].every((k) => accountKeysSet.has(k))
+        return ![...incomingAssociatedKeysSet].every((k) => storedAssociatedKeysSet.has(k))
       })
 
     return associatedKeysFoundOnPageAreDifferent

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -248,7 +248,7 @@ export const getAccountImportStatus = ({
         const pageKeysSet = new Set(x.account.associatedKeys)
         const accountKeysSet = new Set(account.associatedKeys)
 
-        return [...pageKeysSet].every((k) => accountKeysSet.has(k))
+        return ![...pageKeysSet].every((k) => accountKeysSet.has(k))
       })
 
     return associatedKeysFoundOnPageAreDifferent


### PR DESCRIPTION
Although the `associatedKeys` from the account instances found on the page were merged with the `associatedKeys` of the account from the extension storage, there was one more scenario that was wrongly returning `ImportedWithTheSameKeys`, where it should have returned `ImportedWithDifferentKeys`.

It is the case where the user has already imported the keys from the incoming (new) `associatedKeys` as accounts (keys) previously. To cover this scenario, we now detect differences in the `associatedKeys` and imported keys alongside.

This is an additional nuance that was missed in https://github.com/AmbireTech/ambire-common/pull/668