### PR TITLE
Stop Arb debug_traceCall but show full support for txn simulation on Arb

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -121,7 +121,7 @@ const networks: NetworkDescriptor[] = [
     isSAEnabled: true,
     areContractsDeployed: true,
     hasRelayer: true,
-    hasDebugTraceCall: true,
+    hasDebugTraceCall: false,
     platformId: 'arbitrum-one',
     nativeAssetId: 'ethereum',
     features: [],

--- a/src/controllers/settings/settings.test.ts
+++ b/src/controllers/settings/settings.test.ts
@@ -292,7 +292,6 @@ describe('Settings Controller', () => {
         mantleNetwork = {
           name: 'Mantle',
           rpcUrl: settingsController.networkToAddOrUpdate?.rpcUrl!,
-          chainId: settingsController.networkToAddOrUpdate?.chainId!,
           nativeAssetSymbol: 'MNT',
           explorerUrl: 'https://explorer.mantle.xyz/',
           ...mantleNetworkInfo,

--- a/src/controllers/settings/settings.ts
+++ b/src/controllers/settings/settings.ts
@@ -132,7 +132,8 @@ export class SettingsController extends EventEmitter {
         hasDebugTraceCall: finalNetwork.hasDebugTraceCall,
         platformId: finalNetwork.platformId,
         nativeAssetId: finalNetwork.nativeAssetId,
-        flagged: finalNetwork.flagged ?? false
+        flagged: finalNetwork.flagged ?? false,
+        chainId: finalNetwork.chainId
       }
 
       finalNetwork.features = getFeaturesByNetworkProperties(info)

--- a/src/interfaces/networkDescriptor.ts
+++ b/src/interfaces/networkDescriptor.ts
@@ -18,6 +18,7 @@ interface FeeOptions {
 }
 
 export type NetworkInfo = {
+  chainId: bigint
   isSAEnabled: boolean
   isOptimistic: boolean
   rpcNoStateOverride: boolean

--- a/src/libs/settings/settings.ts
+++ b/src/libs/settings/settings.ts
@@ -11,6 +11,7 @@ import {
   OPTIMISTIC_ORACLE,
   SINGLETON
 } from '../../consts/deploy'
+import { networks as predefinedNetworks } from '../../consts/networks'
 import { NetworkFeature, NetworkInfo, NetworkInfoLoading } from '../../interfaces/networkDescriptor'
 import { RPCProviders } from '../../interfaces/settings'
 import { Bundler } from '../../services/bundlers/bundler'
@@ -42,6 +43,7 @@ export async function getNetworkInfo(
   callback: (networkInfo: NetworkInfoLoading<NetworkInfo>) => void
 ) {
   let networkInfo: NetworkInfoLoading<NetworkInfo> = {
+    chainId,
     isSAEnabled: 'LOADING',
     isOptimistic: 'LOADING',
     rpcNoStateOverride: 'LOADING',
@@ -214,7 +216,8 @@ export function getFeaturesByNetworkProperties(
     erc4337,
     rpcNoStateOverride,
     hasDebugTraceCall,
-    nativeAssetId
+    nativeAssetId,
+    chainId
   } = networkInfo
 
   const updateFeature = (
@@ -271,7 +274,8 @@ export function getFeaturesByNetworkProperties(
   }
 
   if ([rpcNoStateOverride, hasDebugTraceCall].every((p) => p !== 'LOADING')) {
-    if (!rpcNoStateOverride && hasDebugTraceCall) {
+    const isPredefinedNetwork = predefinedNetworks.find((net) => net.chainId === chainId)
+    if (!rpcNoStateOverride && (hasDebugTraceCall || isPredefinedNetwork)) {
       updateFeature('simulation', {
         level: 'success',
         title: 'Transaction simulation is fully supported',


### PR DESCRIPTION
Change log:
* network settings for Arbitrum change and debug trace call is stopped as it's not supported
* add `chainId` to networkInfo and make the simulation feature show success if the network is predefined (as our predefined networks have token discovery (velcro) and a good humanizer => good simulation)