### PR TITLE
Feature/custom networks improvements

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -20,6 +20,7 @@ const networks: NetworkDescriptor[] = [
     hasDebugTraceCall: true,
     platformId: 'ethereum',
     nativeAssetId: 'ethereum',
+    hasSingleton: true,
     features: [],
     feeOptions: {
       is1559: true
@@ -44,6 +45,7 @@ const networks: NetworkDescriptor[] = [
     hasDebugTraceCall: true,
     platformId: 'polygon-pos',
     nativeAssetId: 'matic-network',
+    hasSingleton: true,
     features: [],
     feeOptions: {
       is1559: false,
@@ -69,6 +71,7 @@ const networks: NetworkDescriptor[] = [
     hasDebugTraceCall: true,
     platformId: 'optimistic-ethereum',
     nativeAssetId: 'ethereum',
+    hasSingleton: true,
     features: [],
     feeOptions: {
       is1559: true,
@@ -98,6 +101,7 @@ const networks: NetworkDescriptor[] = [
     hasDebugTraceCall: true,
     platformId: 'avalanche',
     nativeAssetId: 'avalanche-2',
+    hasSingleton: true,
     features: [],
     feeOptions: {
       is1559: true,
@@ -124,6 +128,7 @@ const networks: NetworkDescriptor[] = [
     hasDebugTraceCall: false,
     platformId: 'arbitrum-one',
     nativeAssetId: 'ethereum',
+    hasSingleton: true,
     features: [],
     feeOptions: {
       is1559: true,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1071,10 +1071,16 @@ export class MainController extends EventEmitter {
         const signedTxn = await signer.signRawTransaction(rawTxn)
         transactionRes = await provider.broadcastTransaction(signedTxn)
       } catch (e: any) {
-        const errorMsg =
-          e?.message || 'Please try again or contact support if the problem persists.'
-        const message = `Failed to broadcast transaction on ${accountOp.networkId}. ${errorMsg}`
+        let errorMsg = 'Please try again or contact support if the problem persists.'
+        if (e?.message) {
+          if (e.message.includes('insufficient funds')) {
+            errorMsg = 'Insufficient funds for intristic transaction cost'
+          } else {
+            errorMsg = e.message.length > 200 ? `${e.message.substring(0, 200)}...` : e.message
+          }
+        }
 
+        const message = `Failed to broadcast transaction on ${accountOp.networkId}: ${errorMsg}`
         return this.#throwAccountOpBroadcastError(new Error(message), message)
       }
     }
@@ -1151,9 +1157,16 @@ export class MainController extends EventEmitter {
         const signedTxn = await signer.signRawTransaction(rawTxn)
         transactionRes = await provider.broadcastTransaction(signedTxn)
       } catch (e: any) {
-        const errorMsg =
-          e?.message || 'Please try again or contact support if the problem persists.'
-        const message = `Failed to broadcast transaction on ${accountOp.networkId}. ${errorMsg}`
+        let errorMsg = 'Please try again or contact support if the problem persists.'
+        if (e?.message) {
+          if (e.message.includes('insufficient funds')) {
+            errorMsg = 'Insufficient funds for intristic transaction cost'
+          } else {
+            errorMsg = e.message.length > 200 ? `${e.message.substring(0, 200)}...` : e.message
+          }
+        }
+
+        const message = `Failed to broadcast transaction on ${accountOp.networkId}: ${errorMsg}`
         return this.#throwAccountOpBroadcastError(new Error(message), message)
       }
     }

--- a/src/controllers/settings/settings.ts
+++ b/src/controllers/settings/settings.ts
@@ -105,7 +105,8 @@ export class SettingsController extends EventEmitter {
           is1559: false
         },
         features,
-        hasRelayer: false
+        hasRelayer: false,
+        hasSingleton: customNetwork.hasSingleton ?? false
       }
     })
 
@@ -133,7 +134,8 @@ export class SettingsController extends EventEmitter {
         platformId: finalNetwork.platformId,
         nativeAssetId: finalNetwork.nativeAssetId,
         flagged: finalNetwork.flagged ?? false,
-        chainId: finalNetwork.chainId
+        chainId: finalNetwork.chainId,
+        hasSingleton: finalNetwork.hasSingleton
       }
 
       finalNetwork.features = getFeaturesByNetworkProperties(info)
@@ -331,7 +333,8 @@ export class SettingsController extends EventEmitter {
       feeOptions,
       platformId,
       nativeAssetId,
-      flagged
+      flagged,
+      hasSingleton
     } = this.networkToAddOrUpdate.info as NetworkInfo
 
     this.#networkPreferences[customNetworkId] = {
@@ -345,7 +348,8 @@ export class SettingsController extends EventEmitter {
       hasDebugTraceCall,
       platformId,
       nativeAssetId,
-      flagged
+      flagged,
+      hasSingleton
     }
 
     await this.#storePreferences()

--- a/src/interfaces/networkDescriptor.ts
+++ b/src/interfaces/networkDescriptor.ts
@@ -20,6 +20,7 @@ interface FeeOptions {
 export type NetworkInfo = {
   chainId: bigint
   isSAEnabled: boolean
+  hasSingleton: boolean
   isOptimistic: boolean
   rpcNoStateOverride: boolean
   erc4337: { enabled: boolean; hasPaymaster: boolean }
@@ -64,6 +65,7 @@ export interface NetworkDescriptor {
   isOptimistic?: boolean
   features: NetworkFeature[]
   hasRelayer: boolean
+  hasSingleton: boolean
   hasDebugTraceCall: boolean
   platformId: string
   nativeAssetId: string

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -29,6 +29,7 @@ export type NetworkPreference = {
   platformId?: string
   nativeAssetId?: string
   areContractsDeployed?: boolean
+  hasSingleton?: boolean
 }
 
 export type CustomNetwork = {
@@ -53,6 +54,7 @@ export type CustomNetwork = {
   platformId?: string
   nativeAssetId?: string
   flagged?: boolean
+  hasSingleton?: boolean
 }
 
 export type NetworkPreferences = {

--- a/src/libs/settings/settings.test.ts
+++ b/src/libs/settings/settings.test.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
+import { describe, expect, test } from '@jest/globals'
+
+import { NetworkInfo } from '../../interfaces/networkDescriptor'
+import { getFeaturesByNetworkProperties } from './settings'
+
+describe('Network features', () => {
+  test('should check if valid messages for smart account support get shown depending on the network properties', async () => {
+    const networkInfo: NetworkInfo = {
+      chainId: 1n,
+      isSAEnabled: false,
+      hasSingleton: true,
+      isOptimistic: false,
+      rpcNoStateOverride: false,
+      erc4337: { enabled: true, hasPaymaster: true },
+      areContractsDeployed: true,
+      feeOptions: { is1559: true },
+      hasDebugTraceCall: true,
+      platformId: 'ethereum',
+      nativeAssetId: 'ethereum',
+      flagged: false
+    }
+    const results = getFeaturesByNetworkProperties(networkInfo)
+    const saSupport = results.find((sup) => sup.id === 'saSupport')
+    expect(saSupport?.msg).toBe(
+      'We were unable to detect smart account support on the network with the provided RPC. Please choose another RPC or try again later.'
+    )
+
+    networkInfo.hasSingleton = false
+    const results2 = getFeaturesByNetworkProperties(networkInfo)
+    const saSupport2 = results2.find((sup) => sup.id === 'saSupport')
+    expect(saSupport2?.msg).toBe(
+      "Unfortunately this network doesn't support smart contract wallets. It can be used only with Basic accounts (EOAs)."
+    )
+  })
+})

--- a/src/libs/settings/settings.ts
+++ b/src/libs/settings/settings.ts
@@ -45,6 +45,7 @@ export async function getNetworkInfo(
   let networkInfo: NetworkInfoLoading<NetworkInfo> = {
     chainId,
     isSAEnabled: 'LOADING',
+    hasSingleton: 'LOADING',
     isOptimistic: 'LOADING',
     rpcNoStateOverride: 'LOADING',
     erc4337: 'LOADING',
@@ -120,6 +121,7 @@ export async function getNetworkInfo(
           saSupport.addressMatches || (!saSupport.supportsStateOverride && areContractsDeployed)
         networkInfo = {
           ...networkInfo,
+          hasSingleton: singletonCode !== '0x',
           isSAEnabled: supportsAmbire && singletonCode !== '0x',
           areContractsDeployed,
           rpcNoStateOverride: !saSupport.supportsStateOverride
@@ -217,7 +219,8 @@ export function getFeaturesByNetworkProperties(
     rpcNoStateOverride,
     hasDebugTraceCall,
     nativeAssetId,
-    chainId
+    chainId,
+    hasSingleton
   } = networkInfo
 
   const updateFeature = (
@@ -245,12 +248,14 @@ export function getFeaturesByNetworkProperties(
     ]
   }
 
-  if ([isSAEnabled, areContractsDeployed, erc4337].every((p) => p !== 'LOADING')) {
+  if ([isSAEnabled, areContractsDeployed, erc4337, hasSingleton].every((p) => p !== 'LOADING')) {
     if (!isSAEnabled) {
       updateFeature('saSupport', {
         level: 'danger',
         title: 'Smart contract wallets are not supported',
-        msg: "Unfortunately this blockchain network don't support smart contract wallets. This network can be used only with Basic accounts (EOAs)."
+        msg: hasSingleton
+          ? 'We were unable to detect smart account support on the network with the provided RPC. Please choose another RPC or try again later.'
+          : "Unfortunately this network doesn't support smart contract wallets. It can be used only with Basic accounts (EOAs)."
       })
     }
 


### PR DESCRIPTION
Change log:
* add `hasSingleton` to `networkInfo`
* use `hasSingleton` to determine whether the reason for sa failure is because there's no singleton on the network the RPC is bad. Change the tooltip message in accordance
* shorten long error message sometimes shown on a failed broadcast

Also, write a test for the above case