### PR TITLE
Fix: bundler call gas limit

### DIFF
--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -13,7 +13,6 @@ import { getProxyDeployBytecode } from '../proxyDeploy/deploy'
 import { getAmbireAccountAddress } from '../proxyDeploy/getAmbireAddressTwo'
 import { UserOperation } from '../userOperation/types'
 import {
-  getOneTimeNonce,
   getPaymasterDataForEstimate,
   getSigForCalculations,
   getUserOperation
@@ -44,16 +43,10 @@ function getUserOpForEstimate(
         factoryInterface.encodeFunctionData('deploy', [bytecode, toBeHex(0, 32)])
       ])
     )
-    uOp.callData = ambireAccount.encodeFunctionData('executeMultiple', [
-      [[getSignableCalls(op), getSigForCalculations()]]
-    ])
-    uOp.nonce = getOneTimeNonce(uOp)
-  } else {
-    // executeBySender as contract is deployed
-    uOp.callData = ambireAccount.encodeFunctionData('executeBySender', [getSignableCalls(op)])
-    uOp.signature = getSigForCalculations()
   }
 
+  uOp.callData = ambireAccount.encodeFunctionData('executeBySender', [getSignableCalls(op)])
+  uOp.signature = getSigForCalculations()
   return uOp
 }
 

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -7,10 +7,11 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers'
 
 import AmbireAccountNoReverts from '../../../contracts/compiled/AmbireAccountNoRevert.json'
 import { ERC_4337_ENTRYPOINT } from '../../../dist/src/consts/deploy'
-import { PROXY_NO_REVERTS } from '../../consts/deploy'
+import { ENTRY_POINT_MARKER, PROXY_NO_REVERTS } from '../../consts/deploy'
 import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
 import { Erc4337GasLimits } from '../../libs/estimate/interfaces'
 import { Gas1559Recommendation } from '../../libs/gasPrice/gasPrice'
+import { privSlot } from '../../libs/proxyDeploy/deploy'
 import { UserOperation } from '../../libs/userOperation/types'
 import { getCleanUserOp } from '../../libs/userOperation/userOperation'
 
@@ -142,16 +143,21 @@ export class Bundler {
     // that doesn't revert in validateUserOp.
     // when deploying, we replace the proxy; otherwise, we replace the
     // code at the sender
+    const stateDiff = {
+      [`0x${privSlot(0, 'address', ERC_4337_ENTRYPOINT, 'bytes32')}`]: ENTRY_POINT_MARKER
+    }
     const stateOverride =
       userOperation.initCode !== '0x'
         ? {
             [PROXY_NO_REVERTS]: {
-              code: AmbireAccountNoReverts.binRuntime
+              code: AmbireAccountNoReverts.binRuntime,
+              stateDiff
             }
           }
         : {
             [userOperation.sender]: {
-              code: AmbireAccountNoReverts.binRuntime
+              code: AmbireAccountNoReverts.binRuntime,
+              stateDiff
             }
           }
 


### PR DESCRIPTION
Fix: give the entry point permissions via state override and do all estimations through it as the bundler otherwise returns a low call gas limit