### PR TITLE
Fix: nonce discrepancy issues when there's a pending txn

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -970,6 +970,16 @@ export class MainController extends EventEmitter {
       this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!.estimation =
         estimation
 
+      // if the nonce from the estimation is different than the one in localAccountOp,
+      // override localAccountOp.nonce and set it in this.accountOpsToBeSigned as
+      // the nonce from the estimation is the newest one
+      if (estimation && BigInt(estimation.currentAccountNonce) !== localAccountOp.nonce) {
+        localAccountOp.nonce = BigInt(estimation.currentAccountNonce)
+        this.accountOpsToBeSigned[localAccountOp.accountAddr][
+          localAccountOp.networkId
+        ]!.accountOp.nonce = localAccountOp.nonce
+      }
+
       // update the signAccountOp controller once estimation finishes;
       // this eliminates the infinite loading bug if the estimation comes slower
       if (this.signAccountOp && estimation) {

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -389,7 +389,7 @@ describe('SignAccountOp Controller ', () => {
       eoaSigner,
       {
         gasUsed: 10000n,
-        nonce: 0,
+        currentAccountNonce: 0,
         feePaymentOptions: [
           {
             address: '0x0000000000000000000000000000000000000000',
@@ -466,7 +466,7 @@ describe('SignAccountOp Controller ', () => {
       eoaSigner,
       {
         gasUsed: 50000n,
-        nonce: 0,
+        currentAccountNonce: 0,
         feePaymentOptions: [
           {
             address: '0x0000000000000000000000000000000000000000',
@@ -587,7 +587,7 @@ describe('SignAccountOp Controller ', () => {
       eoaSigner,
       {
         gasUsed: 50000n,
-        nonce: 0,
+        currentAccountNonce: 0,
         feePaymentOptions: [
           {
             address: '0x0000000000000000000000000000000000000000',
@@ -705,7 +705,7 @@ describe('SignAccountOp Controller ', () => {
       eoaSigner,
       {
         gasUsed: 10000n,
-        nonce: 0,
+        currentAccountNonce: 0,
         feePaymentOptions: [
           {
             address: '0x0000000000000000000000000000000000000000',
@@ -804,7 +804,7 @@ describe('SignAccountOp Controller ', () => {
       eoaSigner,
       {
         gasUsed: 10000n,
-        nonce: 0,
+        currentAccountNonce: 0,
         feePaymentOptions: [
           {
             address: '0x0000000000000000000000000000000000000000',

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -336,6 +336,8 @@ export class SignAccountOpController extends EventEmitter {
     if (estimation) {
       this.gasUsedTooHigh = estimation.gasUsed > 10000000n
       this.#estimation = estimation
+      // on each estimation update, set the newest account nonce
+      this.accountOp.nonce = BigInt(estimation.currentAccountNonce)
     }
 
     // if estimation is undefined, do not clear the estimation.

--- a/src/libs/estimate/errors.ts
+++ b/src/libs/estimate/errors.ts
@@ -71,7 +71,7 @@ export function estimationErrorFormatted(
 ): EstimateResult {
   return {
     gasUsed: 0n,
-    nonce: 0,
+    currentAccountNonce: 0,
     feePaymentOptions,
     error
   }

--- a/src/libs/estimate/estimate.test.ts
+++ b/src/libs/estimate/estimate.test.ts
@@ -254,7 +254,7 @@ describe('estimate', () => {
     // This is the min gas unit we can spend
     expect(response.gasUsed).toBeGreaterThan(21000n)
     expect(response.feePaymentOptions![0].availableAmount).toBeGreaterThan(0)
-    expect(response.nonce).toBeGreaterThan(1)
+    expect(response.currentAccountNonce).toBeGreaterThan(1)
   })
 
   it('estimates gasUsage, fee and native tokens outcome', async () => {
@@ -302,7 +302,7 @@ describe('estimate', () => {
     // As we swap 1 USDC for 1 USDT, we expect the estimate (outcome) balance of USDT to be greater than before the estimate (portfolio value)
     expect(usdtOutcome!.availableAmount).toBeGreaterThan(usdt?.amount || 0n)
     expect(usdcOutcome!.availableAmount).toBeLessThan(usdc!.amount)
-    expect(response.nonce).toBeGreaterThan(1)
+    expect(response.currentAccountNonce).toBeGreaterThan(1)
 
     // make sure there's a native fee payment option in the same acc addr
     const noFeePaymentViewOnlyAcc = response.feePaymentOptions.find(
@@ -574,21 +574,22 @@ describe('estimate', () => {
     expect(response.error?.message).toBe('Transaction reverted: invalid call in the bundle')
   })
 
-  // TODO: the below test fails with paymaster deposit too low. It shouldn't if we have enough in the paymaster. When we do, reenable it
   it('estimates a 4337 request on the avalanche chain with a deployed account paying in native', async () => {
+    const accountStates = await getAccountsInfo([trezorSlot7v24337Deployed])
+    const networkId = 'avalanche'
+    const accountState = accountStates[trezorSlot7v24337Deployed.addr][networkId]
     const opAvalanche: AccountOp = {
       accountAddr: trezorSlot7v24337Deployed.addr,
       signingKeyAddr: trezorSlot7v24337Deployed.associatedKeys[0],
       signingKeyType: null,
       gasLimit: null,
       gasFeePayment: null,
-      networkId: 'avalanche',
-      nonce: 0n,
+      networkId,
+      nonce: accountState.nonce,
       signature: '0x',
       calls: [{ to, value: BigInt(100), data: '0x' }],
       accountOpToExecuteBefore: null
     }
-    const accountStates = await getAccountsInfo([trezorSlot7v24337Deployed])
 
     const response = await estimate(
       providerAvalanche,

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -121,6 +121,7 @@ export async function estimate4337(
     estimationResult.error instanceof Error
       ? estimationResult.error
       : getInnerCallFailure(accountOp) || getNonceDiscrepancyFailure(op, outcomeNonce)
+  estimationResult.currentAccountNonce = Number(outcomeNonce - 1n)
   return estimationResult
 }
 

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -210,7 +210,7 @@ export async function estimate(
           isGasTank: false
         }
       ],
-      error: result instanceof Error ? result : getNonceDiscrepancyFailure(op, nonce + 1)
+      error: result instanceof Error ? result : null
     }
   }
 

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -23,16 +23,23 @@ import { refund } from './refund'
 
 const abiCoder = new AbiCoder()
 
-function getInnerCallFailure(
-  op: AccountOp,
-  estimationOp: { success: boolean; err: string }
-): Error | null {
+function getInnerCallFailure(estimationOp: { success: boolean; err: string }): Error | null {
   if (estimationOp.success) return null
 
   let error = mapTxnErrMsg(estimationOp.err)
   if (!error) error = 'Transaction reverted: invalid call in the bundle'
   return new Error(error, {
     cause: 'CALLS_FAILURE'
+  })
+}
+
+// the outcomeNonce should always be equat to the nonce in accountOp + 1
+// that's an indication of transaction success
+function getNonceDiscrepancyFailure(op: AccountOp, outcomeNonce: number): Error | null {
+  if (op.nonce !== null && op.nonce + 1n === BigInt(outcomeNonce)) return null
+
+  return new Error("Nonce discrepancy, perhaps there's a pending transaction. Retrying...", {
+    cause: 'NONCE_FAILURE'
   })
 }
 
@@ -108,12 +115,12 @@ export async function estimate4337(
   ]
   const estimations = await reestimate(initializeRequests)
   if (estimations instanceof Error) return estimationErrorFormatted(estimations)
-  const [[, , accountOp]] = estimations[0]
+  const [[, , accountOp, outcomeNonce]] = estimations[0]
   const estimationResult: EstimateResult = estimations[1]
   estimationResult.error =
     estimationResult.error instanceof Error
       ? estimationResult.error
-      : getInnerCallFailure(op, accountOp)
+      : getInnerCallFailure(accountOp) || getNonceDiscrepancyFailure(op, outcomeNonce)
   return estimationResult
 }
 
@@ -193,7 +200,7 @@ export async function estimate(
 
     return {
       gasUsed,
-      nonce,
+      currentAccountNonce: nonce,
       feePaymentOptions: [
         {
           address: ZeroAddress,
@@ -203,7 +210,7 @@ export async function estimate(
           isGasTank: false
         }
       ],
-      error: result instanceof Error ? result : null
+      error: result instanceof Error ? result : getNonceDiscrepancyFailure(op, nonce + 1)
     }
   }
 
@@ -311,7 +318,6 @@ export async function estimate(
       l1GasEstimation // [gasUsed, baseFee, totalFee, gasOracle]
     ]
   ] = estimations[0]
-  /* eslint-enable prefer-const */
 
   let gasUsed = deployment.gasUsed + accountOpToExecuteBefore.gasUsed + accountOp.gasUsed
 
@@ -371,8 +377,10 @@ export async function estimate(
 
   return {
     gasUsed,
-    nonce,
+    // the nonce from EstimateResult is incremented but we always want
+    // to return the current nonce. That's why we subtract 1
+    currentAccountNonce: Number(nonce - 1n),
     feePaymentOptions: [...feeTokenOptions, ...nativeTokenOptions],
-    error: getInnerCallFailure(op, accountOp)
+    error: getInnerCallFailure(accountOp) || getNonceDiscrepancyFailure(op, nonce)
   }
 }

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -153,9 +153,7 @@ export async function bundlerEstimate(
 
   return {
     gasUsed: BigInt(gasData.callGasLimit),
-    // the correct nonce for the userOp cannot be determined here as
-    // if the request type is not standard, it will completely change
-    nonce: Number(BigInt(userOp.nonce).toString()),
+    currentAccountNonce: Number(op.nonce),
     feePaymentOptions,
     erc4337GasLimits: {
       preVerificationGas: gasData.preVerificationGas,

--- a/src/libs/estimate/interfaces.ts
+++ b/src/libs/estimate/interfaces.ts
@@ -17,7 +17,10 @@ export interface ArbitrumL1Fee {
 
 export interface EstimateResult {
   gasUsed: bigint
-  nonce: number
+  // the nonce should always be the current value of account.nonce()
+  // even in ERC-4337 case, we might use the account.nonce() for
+  // signatures. We don't need the EntryPoint nonce
+  currentAccountNonce: number
   feePaymentOptions: {
     availableAmount: bigint
     paidBy: string


### PR DESCRIPTION
Change log:
* rename `nonce` to `currentAccountNonce` in `estimate.ts` for more readability. `EstimateResult` should always return the current nonce, or the one the user will commit to in case of a `execute()` authrorization
* if there's a discrepancy in the accountOp.nonce and the (outcome.nonce - 1), we 1) return an error in `signAccountOp` and do not allow the user to sign 2) set the found nonce from the estimation in `accountOp` as the true nonce and wait for simulation & estimation reruns