### PR TITLE
Fix/math rounding bug

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -451,9 +451,7 @@ export class SignAccountOpController extends EventEmitter {
     // Otherwise, passing the ratio to the BigInt constructor, we will lose the numbers after the decimal point.
     // Later, once we need to normalize this ratio, we should not forget to divide it by 1e18.
     const ratio1e18 = ratio * 1e18
-    console.log(ratio1e18)
     const toBigInt = ratio1e18 % 1 === 0 ? ratio1e18 : ratio1e18.toFixed(0)
-    console.log(toBigInt)
     return BigInt(toBigInt)
   }
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -450,7 +450,7 @@ export class SignAccountOpController extends EventEmitter {
     // Here we multiply it by 1e18, in order to keep the decimal precision.
     // Otherwise, passing the ratio to the BigInt constructor, we will lose the numbers after the decimal point.
     // Later, once we need to normalize this ratio, we should not forget to divide it by 1e18.
-    return BigInt(ratio * 1e18)
+    return BigInt(Math.ceil(ratio * 1e18))
   }
 
   static getAmountAfterFeeTokenConvert(

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -445,12 +445,16 @@ export class SignAccountOpController extends EventEmitter {
 
     if (!nativePrice || !feeTokenPrice) return null
 
-    const ratio = BigInt((nativePrice / feeTokenPrice).toFixed(0))
+    const ratio = nativePrice / feeTokenPrice
 
     // Here we multiply it by 1e18, in order to keep the decimal precision.
     // Otherwise, passing the ratio to the BigInt constructor, we will lose the numbers after the decimal point.
     // Later, once we need to normalize this ratio, we should not forget to divide it by 1e18.
-    return ratio * BigInt(1e18)
+    const ratio1e18 = ratio * 1e18
+    console.log(ratio1e18)
+    const toBigInt = ratio1e18 % 1 === 0 ? ratio1e18 : ratio1e18.toFixed(0)
+    console.log(toBigInt)
+    return BigInt(toBigInt)
   }
 
   static getAmountAfterFeeTokenConvert(

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -445,12 +445,12 @@ export class SignAccountOpController extends EventEmitter {
 
     if (!nativePrice || !feeTokenPrice) return null
 
-    const ratio = parseFloat((nativePrice / feeTokenPrice).toFixed(18))
+    const ratio = BigInt((nativePrice / feeTokenPrice).toFixed(0))
 
     // Here we multiply it by 1e18, in order to keep the decimal precision.
     // Otherwise, passing the ratio to the BigInt constructor, we will lose the numbers after the decimal point.
     // Later, once we need to normalize this ratio, we should not forget to divide it by 1e18.
-    return BigInt(Math.ceil(ratio * 1e18))
+    return ratio * BigInt(1e18)
   }
 
   static getAmountAfterFeeTokenConvert(


### PR DESCRIPTION
Problem:  
dividing nativePrice / feeTokenPrice sometimes resulted in a number that was with deeper decimal precision than 18, resulting in a ratio of type float. Floats cannot be parsed as BigInts, resulting in an error.  
If that is the case, we cut the remaining precision points by doing a `toFixed(0)`  