### PR TITLE
Bug/ Selected token information isn't updated if the token is already selected

### DIFF
--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -89,12 +89,12 @@ export class TransferController extends EventEmitter {
       this.selectedToken?.address !== token?.address ||
       this.selectedToken?.networkId !== token?.networkId
     ) {
-      this.#selectedToken = token
       this.amount = ''
       this.#setSWWarningVisibleIfNeeded()
     }
     // on portfolio update the max available amount can change for the selectedToken
     // in that case don't update the selectedToken and amount in the form but only the maxAmount value
+    this.#selectedToken = token
     this.maxAmount = token ? formatUnits(token.amount, Number(token.decimals)) : '0'
   }
 

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -46,8 +46,6 @@ export class TransferController extends EventEmitter {
 
   amount = ''
 
-  maxAmount = '0'
-
   addressState: AddressState = { ...DEFAULT_ADDRESS_STATE }
 
   isRecipientAddressUnknown = false
@@ -81,25 +79,30 @@ export class TransferController extends EventEmitter {
     if (token?.amount && Number(token?.amount) === 0) {
       this.#selectedToken = null
       this.amount = ''
-      this.maxAmount = '0'
       return
     }
 
+    const prevSelectedToken = { ...this.selectedToken }
+
+    this.#selectedToken = token
+
     if (
-      this.selectedToken?.address !== token?.address ||
-      this.selectedToken?.networkId !== token?.networkId
+      prevSelectedToken?.address !== token?.address ||
+      prevSelectedToken?.networkId !== token?.networkId
     ) {
       this.amount = ''
       this.#setSWWarningVisibleIfNeeded()
     }
-    // on portfolio update the max available amount can change for the selectedToken
-    // in that case don't update the selectedToken and amount in the form but only the maxAmount value
-    this.#selectedToken = token
-    this.maxAmount = token ? formatUnits(token.amount, Number(token.decimals)) : '0'
   }
 
   get selectedToken() {
     return this.#selectedToken
+  }
+
+  get maxAmount() {
+    if (!this.selectedToken?.amount || !this.selectedToken?.decimals) return '0'
+
+    return formatUnits(this.selectedToken.amount, Number(this.selectedToken.decimals))
   }
 
   set tokens(tokenResults: TokenResult[]) {
@@ -116,7 +119,6 @@ export class TransferController extends EventEmitter {
 
   resetForm() {
     this.amount = ''
-    this.maxAmount = '0'
     this.addressState = { ...DEFAULT_ADDRESS_STATE }
     this.selectedToken = null
     this.#selectedTokenNetworkData = null
@@ -378,7 +380,8 @@ export class TransferController extends EventEmitter {
       isFormValid: this.isFormValid,
       isInitialized: this.isInitialized,
       selectedToken: this.selectedToken,
-      tokens: this.tokens
+      tokens: this.tokens,
+      maxAmount: this.maxAmount
     }
   }
 }


### PR DESCRIPTION
If the tokens are updated, the selected token must also be updated. The problem is that if the amount of the currently selected token gets updated in `tokens`, `selectedToken` won't be updated, because it's already selected.
## Changes:
- Fixed the bug
- Made `maxAmount` a getter so the amounts don't get out of sync again

## The bug in action:
Here, the error message gets the max amount from `selectedToken?.amount`, while the max button and label above the field get it from `transferControllerState.maxAmount`.
![image](https://github.com/AmbireTech/ambire-common/assets/68795596/f4f06179-a2af-4aa2-b9ae-33cf6eb97316)
