### PR TITLE
Fix: remove token icon fetching from portfolio

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -552,22 +552,4 @@ describe('Portfolio Controller ', () => {
       })
     })
   })
-  // test('token icons are fetched', (done) => {
-  //   const storage = produceMemoryStore()
-
-  //   const settings = new SettingsController(storage)
-  //   settings.providers = providers
-  //   const controller = new PortfolioController(storage, settings, relayerUrl)
-
-  //   controller.updateSelectedAccount([account], networks, account.addr, undefined).catch(() => {
-  //     throw new Error('update failed')
-  //   })
-
-  //   controller.onUpdate(() => {
-  //     if (Object.values(controller.tokenIcons).length) {
-  //       console.log(controller.tokenIcons)
-  //       done()
-  //     }
-  //   })
-  // })
 })

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -5,7 +5,6 @@ import { PINNED_TOKENS } from '../../consts/pinnedTokens'
 import { Account, AccountId } from '../../interfaces/account'
 import { NetworkDescriptor, NetworkId } from '../../interfaces/networkDescriptor'
 /* eslint-disable @typescript-eslint/no-shadow */
-import { CustomNetwork, NetworkPreference } from '../../interfaces/settings'
 import { Storage } from '../../interfaces/storage'
 import { isSmartAccount } from '../../libs/account/account'
 import { AccountOp, isAccountOpsIntentEqual } from '../../libs/accountOp/accountOp'
@@ -21,7 +20,6 @@ import getAccountNetworksWithAssets from '../../libs/portfolio/getNetworksWithAs
 import { getFlags, validateERC20Token } from '../../libs/portfolio/helpers'
 /* eslint-disable no-param-reassign */
 /* eslint-disable import/no-extraneous-dependencies */
-import { getIcon, getIconId } from '../../libs/portfolio/icons'
 import {
   AccountState,
   AdditionalAccountState,
@@ -29,7 +27,6 @@ import {
   Hints,
   PortfolioControllerState,
   PortfolioGetResult,
-  TokenIcon,
   TokenResult
 } from '../../libs/portfolio/interfaces'
 import { Portfolio } from '../../libs/portfolio/portfolio'
@@ -110,8 +107,6 @@ export class PortfolioController extends EventEmitter {
 
   #settings: SettingsController
 
-  tokenIcons: TokenIcon
-
   // Holds the initial load promise, so that one can wait until it completes
   #initialLoadPromise: Promise<void>
 
@@ -123,7 +118,6 @@ export class PortfolioController extends EventEmitter {
     this.#storage = storage
     this.#callRelayer = relayerCall.bind({ url: relayerUrl, fetch })
     this.#settings = settings
-    this.tokenIcons = {}
     this.temporaryTokens = {}
 
     this.#initialLoadPromise = this.#load()
@@ -597,51 +591,8 @@ export class PortfolioController extends EventEmitter {
       })
     )
 
-    const tokenResults: TokenResult[] = []
-    for (const networkId of Object.keys(accountState)) {
-      const tokenResult = accountState[networkId]?.result?.tokens
-      if (tokenResult) {
-        tokenResults.push(...tokenResult)
-      }
-    }
-
-    // start a request for fetching the token icons after a successful update
-    this.getTokenIcons(tokenResults).catch((e) => {
-      // Icons are not so important so they should not stop the execution
-      this.emitError({
-        level: 'silent',
-        message: 'Error while fetching the token icons',
-        error: e
-      })
-    })
-
     await this.#updateNetworksWithAssets(accounts, accountId, accountState)
 
-    this.emitUpdate()
-  }
-
-  async getTokenIcons(tokens: PortfolioGetResult['tokens']) {
-    const storage = await this.#storage.get('tokenIcons', {})
-    const settingsNetworks = this.#settings.networks
-
-    const promises = tokens.map(async (token) => {
-      const icon = await getIcon(
-        settingsNetworks.find((net) => net.id === token.networkId)!,
-        token.address,
-        storage
-      )
-      if (!icon) return null
-      return { [getIconId(token.networkId, token.address)]: icon }
-    })
-
-    const result = await Promise.all(promises)
-    result
-      .filter((icon) => icon) // remove nulls
-      .forEach((icon: any) => {
-        this.tokenIcons[Object.keys(icon)[0] as string] = Object.values(icon)[0] as string
-      })
-
-    await this.#storage.set('tokenIcons', this.tokenIcons)
     this.emitUpdate()
   }
 

--- a/src/libs/portfolio/icons.ts
+++ b/src/libs/portfolio/icons.ts
@@ -1,10 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
-import { ZeroAddress } from 'ethers'
-import fetch from 'node-fetch'
-
-import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
-
 const customIcons: any = {
   '0xb468a1e5596cfbcdf561f21a10490d99b4bb7b68':
     'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Jeff_Sessions_with_Elmo_and_Rosita_%28cropped%29.jpg/220px-Jeff_Sessions_with_Elmo_and_Rosita_%28cropped%29.jpg', // TEST Polygon ELMO token,
@@ -36,36 +31,4 @@ export function getHardcodedIcon(address: string): string | null {
 
 export function getZapperIcon(networkId: string, address: string) {
   return `${zapperStorageTokenIcons}/${networkId.toLowerCase()}/${address.toLowerCase()}.png`
-}
-
-export async function getIcon(
-  network: NetworkDescriptor,
-  addr: string,
-  storageIcons: any
-): Promise<string | null> {
-  // if it's a hardcoded token, return it
-  const hardcodedIcon = getHardcodedIcon(addr)
-  if (hardcodedIcon) return hardcodedIcon
-
-  // try to take the icon from the storage first
-  if (storageIcons) {
-    const storageImage = storageIcons[getIconId(network.id, addr)] ?? null
-    if (storageImage) return storageImage
-  }
-
-  // make a request to cena to fetch the icon
-  const baseUrlCena = 'https://cena.ambire.com/api/v3'
-  const url =
-    addr === ZeroAddress
-      ? `${baseUrlCena}/coins/${network.platformId}`
-      : `${baseUrlCena}/coins/${network.platformId}/contract/${addr}`
-
-  const response = await fetch(url)
-  if (response.status === 200) {
-    const json = await response.json()
-    if (json && json.image && json.image.small) return json.image.small
-  }
-
-  // try to find the icon without making a request
-  return getZapperIcon(network.id, addr)
 }

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -171,7 +171,3 @@ export interface GetOptions {
   additionalHints?: Hints['erc20s']
   disableAutoDiscovery?: boolean
 }
-
-export interface TokenIcon {
-  [networdIdAndAddress: string]: string
-}


### PR DESCRIPTION
IMPORTANT: merging only this will break the app. We need to merge the corresponding PR in ambire-app alongside this one

Fix: remove token icon fetching from portfolio  
We're going to fetch them on the FE through cena.ambire.com

