### PR TITLE
Fix: native fee payment option for custom network first SA txn

### DIFF
--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -344,7 +344,7 @@ export async function estimate(
   )
 
   // this is for EOAs paying for SA in native
-  const nativeToken = filteredFeeTokens.find(
+  const nativeToken = feeTokens.find(
     (token) => token.address === ZeroAddress && !token.flags.onGasTank
   )
   const nativeTokenOptions: FeePaymentOption[] = nativeAssetBalances.map(


### PR DESCRIPTION
Fix: native fee payment option was filtered for custom networks's non-erc-4337 requests (the first smart account txn)