### PR TITLE
Bug/ Portfolio lib swallows `priceIn` errors

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -492,7 +492,12 @@ export class PortfolioController extends EventEmitter {
           tokenPreferences,
           ...portfolioProps
         })
-        _accountState[network.id] = { isReady: true, isLoading: false, errors: [], result }
+        _accountState[network.id] = {
+          isReady: true,
+          isLoading: false,
+          errors: result.errors,
+          result
+        }
         this.emitUpdate()
         return true
       } catch (e: any) {
@@ -569,8 +574,11 @@ export class PortfolioController extends EventEmitter {
         ])
 
         // Persist previousHints in the disk storage for further requests, when:
-        // latest state was updated successful and hints were fetched successful too (no hintsError from portfolio result)
-        if (isSuccessfulLatestUpdate && !accountState[network.id]!.result!.hintsError) {
+        // latest state was updated successful and hints were fetched successful too (no HintsError from portfolio result)
+        if (
+          isSuccessfulLatestUpdate &&
+          !(accountState[network.id]!.result?.errors || []).find((err) => err.name === 'HintsError')
+        ) {
           storagePreviousHints[key] = getHintsWithBalance(
             accountState[network.id]!.result!
             // !hasNonZeroTokens,

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -5,6 +5,7 @@ import { Banner } from '../../interfaces/banner'
 import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
 import { RPCProviders } from '../../interfaces/settings'
 import { UserRequest } from '../../interfaces/userRequest'
+import { PORTFOLIO_LIB_ERROR_NAMES } from '../portfolio/portfolio'
 import { getNetworksWithFailedRPC } from '../settings/settings'
 
 export const getMessageBanners = ({ userRequests }: { userRequests: UserRequest[] }) => {
@@ -217,7 +218,7 @@ export const getNetworksWithFailedRPCBanners = ({
       id: 'rpcs-down',
       type: 'warning',
       title: `Failed to retrieve network data for ${n.name}. You can try selecting another RPC URL`,
-      text: 'Affected features: visible tokens, sign message/transaction, ENS/UD domain resolving, add account.',
+      text: 'Affected features: visible assets, sign message/transaction, ENS/UD domain resolving, add account.',
       actions: [
         {
           label: 'Select',
@@ -254,56 +255,72 @@ export const getNetworksWithPortfolioErrorBanners = ({
 }): Banner[] => {
   const banners: Banner[] = []
 
+  const portfolioLoading = Object.keys(portfolioLatest).some((accId: AccountId) => {
+    const accPortfolio = portfolioLatest[accId]
+
+    return Object.keys(accPortfolio).some((network) => {
+      const portfolioForNetwork = accPortfolio[network]
+
+      return portfolioForNetwork?.isLoading
+    })
+  })
+
+  // Otherwise networks are appended to the banner one by one, which looks weird
+  if (portfolioLoading) return []
+
   Object.keys(portfolioLatest).forEach((accId: AccountId) => {
     const accPortfolio = portfolioLatest[accId]
 
     if (!accPortfolio) return
 
-    const networkNamesToShowBannersFor: string[] = []
+    const networkNamesWithPriceFetchError: string[] = []
+    const networkNamesWithCriticalError: string[] = []
 
-    // @ts-expect-error
     Object.keys(accPortfolio).forEach((network) => {
-      if (['rewards', 'gasTank'].includes(network)) return []
-
       const portfolioForNetwork = accPortfolio[network]
       const criticalError = portfolioForNetwork?.criticalError
+
       const networkData = networks.find((n: NetworkDescriptor) => n.id === network)
 
-      if (!networkData) {
-        // Should never happen
-        console.error(`Network with id ${network} not found in the network list`)
+      if (!portfolioForNetwork || !networkData || portfolioForNetwork.isLoading) return
 
+      if (criticalError) {
+        networkNamesWithCriticalError.push(networkData.name)
+        // If there is a critical error, we don't need to check for price fetch error
         return
       }
 
-      if (portfolioForNetwork?.isLoading) return
+      const priceFetchError = portfolioForNetwork?.errors.find(
+        (err: any) => err?.name === PORTFOLIO_LIB_ERROR_NAMES.PriceFetchError
+      )
 
-      if (!criticalError && portfolioForNetwork?.result) {
-        const priceMissingForAllTokens = portfolioForNetwork?.result.tokens
-          // WALLET prices are not retrieved from coingecko
-          .filter((t) => !t.symbol.includes('WALLET'))
-          .every((token) => !token.priceIn.length)
-
-        if (priceMissingForAllTokens && portfolioForNetwork?.result.tokens.length > 0) {
-          networkNamesToShowBannersFor.push(networkData.name)
-        }
-
-        return
+      if (priceFetchError) {
+        networkNamesWithPriceFetchError.push(networkData.name)
       }
-
-      networkNamesToShowBannersFor.push(networkData.name)
     })
 
-    if (!networkNamesToShowBannersFor.length) return
-
-    banners.push({
-      accountAddr: accId,
-      id: `${accId}-portfolio-critical-error`,
-      type: 'error',
-      title: `Failed to retrieve the portfolio data for ${networkNamesToShowBannersFor.join(', ')}`,
-      text: 'Affected features: account balances, assets. Please try again later or contact support.',
-      actions: []
-    })
+    if (networkNamesWithPriceFetchError.length) {
+      banners.push({
+        accountAddr: accId,
+        id: `${accId}-portfolio-prices-error`,
+        type: 'warning',
+        title: `Failed to retrieve prices for ${networkNamesWithPriceFetchError.join(', ')}`,
+        text: 'Affected features: account balances, asset prices. Please try again later or contact support.',
+        actions: []
+      })
+    }
+    if (networkNamesWithCriticalError.length) {
+      banners.push({
+        accountAddr: accId,
+        id: `${accId}-portfolio-critical-error`,
+        type: 'error',
+        title: `Failed to retrieve the portfolio data for ${networkNamesWithCriticalError.join(
+          ', '
+        )}`,
+        text: 'Affected features: account balances, visible assets. Please try again later or contact support.',
+        actions: []
+      })
+    }
   })
 
   return banners

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -72,21 +72,21 @@ interface ExtendedError extends Error {
   simulationErrorMsg?: string
 }
 
+export type NetworkState = {
+  isReady: boolean
+  isLoading: boolean
+  criticalError?: ExtendedError
+  errors: ExtendedError[]
+  result?: PortfolioGetResult
+  // We store the previously simulated AccountOps only for the pending state.
+  // Prior to triggering a pending state update, we compare the newly passed AccountOp[] (updateSelectedAccount) with the cached version.
+  // If there are no differences, the update is canceled unless the `forceUpdate` flag is set.
+  accountOps?: AccountOp[]
+}
+
 export type AccountState = {
   // network id
-  [key: string]:
-    | {
-        isReady: boolean
-        isLoading: boolean
-        criticalError?: ExtendedError
-        errors: ExtendedError[]
-        result?: PortfolioGetResult
-        // We store the previously simulated AccountOps only for the pending state.
-        // Prior to triggering a pending state update, we compare the newly passed AccountOp[] (updateSelectedAccount) with the cached version.
-        // If there are no differences, the update is canceled unless the `forceUpdate` flag is set.
-        accountOps?: AccountOp[]
-      }
-    | undefined
+  [key: string]: NetworkState | undefined
 }
 
 export type AdditionalAccountState = {
@@ -133,7 +133,7 @@ export interface PortfolioGetResult {
   collections: CollectionResult[]
   total: { [name: string]: bigint }
   hints: Hints
-  hintsError?: string
+  errors: ExtendedError[]
 }
 
 export interface LimitsOptions {

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -247,8 +247,6 @@ export class Portfolio {
 
     const oracleCallDone = Date.now()
 
-    const tokensWithPriceErrors: PortfolioGetResult['tokenErrors'] = []
-
     // Update prices and set the priceIn for each token by reference,
     // updating the final tokens array as a result
     const tokensWithPrices = await Promise.all(
@@ -297,13 +295,6 @@ export class Portfolio {
           }
         }
 
-        if (!priceIn.length) {
-          tokensWithPriceErrors.push({
-            error: `Failed to fetch price data from cena.ambire.com for ${token.symbol} on ${networkId}`,
-            address: token.address
-          })
-        }
-
         return {
           ...token,
           priceIn
@@ -324,8 +315,7 @@ export class Portfolio {
       tokens: tokensWithPrices,
       tokenErrors: tokensWithErr
         .filter(([error, result]) => error !== '0x' || result.symbol === '')
-        .map(([error, result]) => ({ error, address: result.address }))
-        .concat(tokensWithPriceErrors),
+        .map(([error, result]) => ({ error, address: result.address })),
       collections: collections.filter((x) => x.collectibles?.length),
       total: tokensWithPrices.reduce((cur, token) => {
         const localCur = cur


### PR DESCRIPTION
## Changes:
- Added `errors` array to the return value of the portfolioLib
- Deleted `hintsError`, which is now stored in `errors`
- Separated portfolio error banners into two:
  - critical error banners- the portfolio doesn't work at all
  - missing prices error banners- tokens are displayed without prices
- Removed param reassigns of `priceIn`

## How to test:
- Block requests to `cena.ambire.com`
- Block requests to `velcro`
- Block requests to `invictus`

Combine the failure of different services or test them separately. The extension should work smoothly and display feedback to the user if a service fails.