### PR TITLE
Bug/ Partial or old balance displayed on the dashboard

### DIFF
--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -5,6 +5,7 @@ import gasTankFeeTokens from '../../consts/gasTankFeeTokens'
 import { Account } from '../../interfaces/account'
 import { NetworkId } from '../../interfaces/networkDescriptor'
 import { RPCProvider } from '../../interfaces/settings'
+import { isSmartAccount } from '../../libs/account/account'
 
 export function getFlags(
   networkData: any,
@@ -76,7 +77,6 @@ export const validateERC20Token = async (
   return [isValid, type]
 }
 
-export const shouldGetAdditionalPortfolio = (account?: Account) => {
-  // portfolio additional data is available only for smart accounts
-  return !!account?.creation
+export const shouldGetAdditionalPortfolio = (account: Account) => {
+  return isSmartAccount(account)
 }


### PR DESCRIPTION
## Changes:
- Call fetch additionalPortfolio before portfolio- may seem odd at first, because `additionalPortfolio` sounds like something that isn't as important, but we currently display assets from additional portfolio first, so it makes more sense to fetch them first. Otherwise the tokens on the dashboard are reordered once additional is fetched.
- Made all operations synchronous in selectAccount
- Updated portfolio helpers

## Linked with:
https://github.com/AmbireTech/ambire-app/pull/2107
