### PR TITLE
Bug/ Portfolio controller state prepare racing condition

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -660,11 +660,6 @@ export class MainController extends EventEmitter {
       ? { forceUpdate, additionalHints }
       : { forceUpdate }
 
-    // Additional portfolio is displayed first on the dashboard, so we need to fetch it first
-    const account = this.accounts.find(({ addr }) => addr === selectedAccount)
-    if (account && shouldGetAdditionalPortfolio(account))
-      this.portfolio.getAdditionalPortfolio(selectedAccount)
-
     this.portfolio.updateSelectedAccount(
       this.accounts,
       this.settings.networks,
@@ -919,7 +914,7 @@ export class MainController extends EventEmitter {
       const stringAddr: any = result.length ? result.flat(Infinity) : []
       additionalHints!.push(...stringAddr)
 
-      const [, , estimation] = await Promise.all([
+      const [, estimation] = await Promise.all([
         // NOTE: we are not emitting an update here because the portfolio controller will do that
         // NOTE: the portfolio controller has it's own logic of constructing/caching providers, this is intentional, as
         // it may have different needs
@@ -937,8 +932,6 @@ export class MainController extends EventEmitter {
             additionalHints
           }
         ),
-        shouldGetAdditionalPortfolio(account) &&
-          this.portfolio.getAdditionalPortfolio(localAccountOp.accountAddr),
         estimate(
           this.settings.providers[localAccountOp.networkId],
           network,

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -379,7 +379,6 @@ describe('Portfolio Controller ', () => {
         emptyAccount.addr,
         undefined
       )
-      await controller.getAdditionalPortfolio(emptyAccount.addr)
 
       PINNED_TOKENS.filter((token) => token.onGasTank && token.networkId === 'ethereum').forEach(
         (pinnedToken) => {
@@ -399,8 +398,6 @@ describe('Portfolio Controller ', () => {
       const controller = new PortfolioController(storage, settings, relayerUrl)
 
       await controller.updateSelectedAccount([account], [ethereum], account.addr, undefined)
-
-      await controller.getAdditionalPortfolio(account.addr)
 
       controller.latest[account.addr].ethereum?.result?.tokens.forEach((token) => {
         expect(token.amount > 0)

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -17,7 +17,11 @@ import {
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { CustomToken } from '../../libs/portfolio/customToken'
 import getAccountNetworksWithAssets from '../../libs/portfolio/getNetworksWithAssets'
-import { getFlags, validateERC20Token } from '../../libs/portfolio/helpers'
+import {
+  getFlags,
+  shouldGetAdditionalPortfolio,
+  validateERC20Token
+} from '../../libs/portfolio/helpers'
 /* eslint-disable no-param-reassign */
 /* eslint-disable import/no-extraneous-dependencies */
 import {
@@ -189,6 +193,39 @@ export class PortfolioController extends EventEmitter {
     }
   }
 
+  #prepareLatestState(selectedAccount: Account, networks: NetworkDescriptor[]) {
+    const state = this.latest
+    const accountId = selectedAccount.addr
+
+    if (!state[accountId])
+      state[accountId] = networks.reduce((acc: AccountState, network) => {
+        acc[network.id] = { isReady: false, isLoading: false, errors: [] }
+
+        return acc
+      }, {} as AccountState)
+
+    if (shouldGetAdditionalPortfolio(selectedAccount)) {
+      state[accountId]['gasTank'] = { isReady: false, isLoading: false, errors: [] }
+      state[accountId]['rewards'] = { isReady: false, isLoading: false, errors: [] }
+    }
+
+    const accountState = state[accountId]
+    // Remove networks that are not in the list of networks. For example:
+    // If the user adds a custom network, the portfolio fetches assets for it but the user
+    // removes the network, the portfolio should remove the assets for that network.
+    for (const networkId of Object.keys(accountState)) {
+      if (![...networks, { id: 'gasTank' }, { id: 'rewards' }].find((x) => x.id === networkId))
+        delete accountState[networkId]
+    }
+    this.emitUpdate()
+  }
+
+  #preparePendingState(selectedAccountId: AccountId) {
+    if (!this.pending[selectedAccountId]) this.pending[selectedAccountId] = {}
+
+    this.emitUpdate()
+  }
+
   resetAdditionalHints() {
     this.#additionalHints = []
   }
@@ -283,8 +320,7 @@ export class PortfolioController extends EventEmitter {
     }
   }
 
-  async getAdditionalPortfolio(accountId: AccountId) {
-    if (!this.latest[accountId]) this.latest[accountId] = {}
+  async #getAdditionalPortfolio(accountId: AccountId) {
     const hasNonZeroTokens = !!this.#networksWithAssetsByAccounts?.[accountId]?.length
 
     const start = Date.now()
@@ -437,21 +473,15 @@ export class PortfolioController extends EventEmitter {
     const selectedAccount = accounts.find((x) => x.addr === accountId)
     if (!selectedAccount) throw new Error('selected account does not exist')
 
-    const prepareState = (state: PortfolioControllerState): void => {
-      if (!state[accountId]) state[accountId] = {}
+    this.#prepareLatestState(selectedAccount, networks)
+    this.#preparePendingState(selectedAccount.addr)
 
-      const accountState = state[accountId]
-      for (const networkId of Object.keys(accountState)) {
-        if (![...networks, { id: 'gasTank' }, { id: 'rewards' }].find((x) => x.id === networkId))
-          delete accountState[networkId]
-      }
-      this.emitUpdate()
-    }
-
-    prepareState(this.latest)
-    prepareState(this.pending)
     const accountState = this.latest[accountId]
     const pendingState = this.pending[accountId]
+
+    if (shouldGetAdditionalPortfolio(selectedAccount)) {
+      this.#getAdditionalPortfolio(accountId)
+    }
 
     const updatePortfolioState = async (
       _accountState: AccountState,


### PR DESCRIPTION
## The bug:
We determine if the portfolio is loading based on the flags `network.isReady`, `network.isLoading` and `network.criticalError` of every network. The problem is that this state is missing in the beginning so the flag `isAllReady`'s value changes like this: false, false, false, true, `(gasTank and rewards keys are added here) ---->` false, `(gasTank and rewards load here --->` true, true

## The fix:
The fix is obvious- prepare the state for all networks in the beginning, emit an update and start fetching.

## How to reproduce:
Add `await wait(3000)` to `getAdditionalPortfolio`