### PR TITLE
Fix / PendingUserRequests Duplicating Id With AccountOpEoaBanners Id

### DIFF
--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -100,7 +100,7 @@ export const getPendingAccountOpBannersForEOA = ({
 
   return [
     {
-      id: pendingUserRequests[0].id,
+      id: pendingUserRequests[1].id,
       type: 'info',
       title: `${numberOfPendingRequest} More pending transactions are waiting to be signed`,
       text: '' // TODO:


### PR DESCRIPTION
Fix: pendingUserRequests duplicating id with accountOpEoaBanners transaction id. 

In the case we have two transactions waiting to be signed, the pendingUserRequests banner gets the id of the first transaction in the array. The issue is we have already displayed it and get duplicated id warning


![Screenshot 2024-04-22 at 12 47 24](https://github.com/AmbireTech/ambire-common/assets/29689645/68399b36-03c4-4455-aa68-2a49f340e45c)
