### PR TITLE
Fix: estimation failure on reject

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -922,11 +922,13 @@ export class MainController extends EventEmitter {
           this.accounts,
           this.settings.networks,
           localAccountOp.accountAddr,
-          Object.fromEntries(
-            Object.entries(this.accountOpsToBeSigned[localAccountOp.accountAddr])
-              .filter(([, accOp]) => accOp)
-              .map(([networkId, x]) => [networkId, [x!.accountOp]])
-          ),
+          this.accountOpsToBeSigned[localAccountOp.accountAddr]
+            ? Object.fromEntries(
+                Object.entries(this.accountOpsToBeSigned[localAccountOp.accountAddr])
+                  .filter(([, accOp]) => accOp)
+                  .map(([networkId, x]) => [networkId, [x!.accountOp]])
+              )
+            : undefined,
           {
             forceUpdate: true,
             additionalHints


### PR DESCRIPTION
Fix: when rejecting a txn with multiple calls, there was a portfolio update failure because `this.accountOpsToBeSigned` got deleted in another handler