### PR TITLE
Fix: even if pinned, do not filter it out because simulation suffers

### DIFF
--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -220,7 +220,7 @@ export class Portfolio {
       // return the token if it's pinned and requested
       // or if it's not pinned but under the limit
       const pinnedRequested = isPinned && localOpts.fetchPinned
-      const underLimit = !isPinned && tokensWithErr.length <= limits.erc20 / 2
+      const underLimit = tokensWithErr.length <= limits.erc20 / 2
 
       return !!isTokenPreference || isInAdditionalHints || pinnedRequested || underLimit
     }


### PR DESCRIPTION
Fix: even if pinned, do not filter it out because simulation suffers