### PR TITLE
Fix: check if fee speeds are set before declaring error in sign account op

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -283,7 +283,10 @@ export class SignAccountOpController extends EventEmitter {
 
     if (this.selectedOption) {
       const identifier = getFeeSpeedIdentifier(this.selectedOption, this.accountOp.accountAddr)
-      if (this.feeSpeeds[identifier].some((speed) => speed.amountUsd === null)) {
+      if (
+        this.hasSpeeds(identifier) &&
+        this.feeSpeeds[identifier].some((speed) => speed.amountUsd === null)
+      ) {
         errors.push(NON_CRITICAL_ERRORS.feeUsdEstimation)
       }
     }


### PR DESCRIPTION
Fix: check if fee speeds are set before declaring error in sign account op