### PR TITLE
Fix: declare submitted op failure if not found

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -256,12 +256,16 @@ export class ActivityController extends EventEmitter {
    * 2. If we don't manage to determine its status, we are comparing AccountOp and Account nonce.
    * If Account nonce is greater than AccountOp, then we know that AccountOp has past nonce (AccountOpStatus.UnknownButPastNonce).
    */
-  async updateAccountsOpsStatuses(): Promise<{ shouldEmitUpdate: boolean, shouldUpdatePortfolio: boolean }> {
+  async updateAccountsOpsStatuses(): Promise<{
+    shouldEmitUpdate: boolean
+    shouldUpdatePortfolio: boolean
+  }> {
     await this.#initialLoadPromise
 
     // Here we don't rely on `this.isInitialized` flag, as it checks for both `this.filters.account` and `this.filters.network` existence.
     // Banners are network agnostic, and that's the reason we check for `this.filters.account` only and having this.#accountsOps loaded.
-    if (!this.filters?.account || !this.#accountsOps[this.filters.account]) return { shouldEmitUpdate: false, shouldUpdatePortfolio: false }
+    if (!this.filters?.account || !this.#accountsOps[this.filters.account])
+      return { shouldEmitUpdate: false, shouldUpdatePortfolio: false }
 
     // This flag tracks the changes to AccountsOps statuses
     // and optimizes the number of the emitted updates and storage/state updates.
@@ -282,6 +286,16 @@ export class ActivityController extends EventEmitter {
               if (accountOp.status !== AccountOpStatus.BroadcastedButNotConfirmed) return
 
               shouldEmitUpdate = true
+
+              const declareFailedIfQuaterPassed = (op: SubmittedAccountOp) => {
+                const accountOpDate = new Date(op.timestamp)
+                accountOpDate.setMinutes(accountOpDate.getMinutes() + 15)
+                const aQuaterHasPassed = accountOpDate < new Date()
+                if (aQuaterHasPassed) {
+                  this.#accountsOps[this.filters!.account][network][accountOpIndex].status =
+                    AccountOpStatus.Failure
+                }
+              }
 
               try {
                 let txnId = accountOp.txnId
@@ -308,13 +322,7 @@ export class ActivityController extends EventEmitter {
                       this.#accountsOps[this.filters!.account][network][accountOpIndex].txnId =
                         txnId
                     } else {
-                      const accountOpDate = new Date(accountOp.timestamp)
-                      accountOpDate.setMinutes(accountOpDate.getMinutes() + 15)
-                      const aQuaterHasPassed = accountOpDate < new Date()
-                      if (aQuaterHasPassed) {
-                        this.#accountsOps[this.filters!.account][network][accountOpIndex].status =
-                          AccountOpStatus.Failure
-                      }
+                      declareFailedIfQuaterPassed(accountOp)
                       return
                     }
                   }
@@ -328,7 +336,7 @@ export class ActivityController extends EventEmitter {
                   if (receipt.status) {
                     shouldUpdatePortfolio = true
                   }
-            
+
                   if (accountOp.isSingletonDeploy && receipt.status) {
                     // the below promise has a catch() inside
                     /* eslint-disable @typescript-eslint/no-floating-promises */
@@ -336,6 +344,11 @@ export class ActivityController extends EventEmitter {
                   }
                   return
                 }
+
+                // if there's no receipt, confirm there's a txn
+                // if there's no txn and 15 minutes have passed, declare it a failure
+                const txn = await provider.getTransaction(txnId)
+                if (!txn) declareFailedIfQuaterPassed(accountOp)
               } catch {
                 this.emitError({
                   level: 'silent',


### PR DESCRIPTION
Problem:  
Sometimes the RPC fails to broadcast the transaction even if a success is returned from it OR the transaction enters the mempool for a given period of time only to be dropped after.

Fix: if the **transaction** (not the receipt) is not found 15 minutes after broadcast, declare it a failure

This was working like this for user operations as sometimes there's an error on the bundler side and the bundler doesn't broadcast the transaction without returning any feedback.  
Now, this is implemented for normal transactions as well.  
This gets rid of the "transaction broadcast" banner. I broadcast 1 txn on base, it got dropped and the banner got eternally stuck in the extension until this fix