### PR TITLE
Fix / Selecting default account

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -292,7 +292,7 @@ export class MainController extends EventEmitter {
             )
             if (!defaultSelectedAccount) return Promise.resolve()
 
-            return this.selectAccount(defaultSelectedAccount.addr)
+            return this.#selectAccount(defaultSelectedAccount.addr)
           })()
         ])
       })
@@ -539,25 +539,28 @@ export class MainController extends EventEmitter {
 
   // All operations must be synchronous so the change is instantly reflected in the UI
   async selectAccount(toAccountAddr: string) {
-    this.#statusWrapper('selectAccount', async () => {
-      await this.#initialLoadPromise
+    await this.#statusWrapper('selectAccount', async () => this.#selectAccount(toAccountAddr))
+  }
 
-      if (!this.accounts.find((acc) => acc.addr === toAccountAddr)) {
-        // TODO: error handling, trying to switch to account that does not exist
-        return
-      }
+  async #selectAccount(toAccountAddr: string) {
+    await this.#initialLoadPromise
 
-      this.selectedAccount = toAccountAddr
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.#storage.set('selectedAccount', toAccountAddr)
-      this.activity.init({ filters: { account: toAccountAddr } })
-      this.addressBook.update({
-        selectedAccount: toAccountAddr
-      })
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.updateSelectedAccount(toAccountAddr)
-      this.onUpdateDappSelectedAccount(toAccountAddr)
+    if (!this.accounts.find((acc) => acc.addr === toAccountAddr)) {
+      // TODO: error handling, trying to switch to account that does not exist
+      return
+    }
+
+    this.selectedAccount = toAccountAddr
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.#storage.set('selectedAccount', toAccountAddr)
+    this.activity.init({ filters: { account: toAccountAddr } })
+    this.addressBook.update({
+      selectedAccount: toAccountAddr
     })
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.updateSelectedAccount(toAccountAddr)
+    this.onUpdateDappSelectedAccount(toAccountAddr)
+
     this.emitUpdate()
   }
 


### PR DESCRIPTION
Fix: We were calling this.#statusWrapper inside of this.#statusWrapper, which resulted in mainCtrl.status being overwritten. That is, upon invoking onAccountAdderSuccess(), we were calling this.selectAccount(), which also relied on the status wrapper logic.