### PR TITLE
Enhancement/ Reusable controller status logic in `EventEmitter`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ambire-common",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ambire-common",
-      "version": "2.5.0",
+      "version": "2.7.0",
       "dependencies": {
         "@jest/globals": "^29.6.1",
         "@ungap/structured-clone": "^1.2.0",

--- a/src/classes/EmittableError.ts
+++ b/src/classes/EmittableError.ts
@@ -1,0 +1,19 @@
+import { ErrorRef } from '../controllers/eventEmitter/eventEmitter'
+
+export default class EmittableError extends Error {
+  level: ErrorRef['level']
+  message: ErrorRef['message']
+  error: Error
+
+  constructor(errorRef: { message: ErrorRef['message']; level: ErrorRef['level']; error?: Error }) {
+    super()
+    this.message = errorRef.message
+    this.level = errorRef.level
+
+    if (!errorRef.error) {
+      this.error = new Error(errorRef.message)
+    } else {
+      this.error = errorRef.error
+    }
+  }
+}

--- a/src/controllers/emailVault/emailVault.ts
+++ b/src/controllers/emailVault/emailVault.ts
@@ -53,7 +53,7 @@ const STATUS_WRAPPED_METHODS = {
   uploadKeyStoreSecret: 'INITIAL',
   recoverKeyStore: 'INITIAL',
   requestKeysSync: 'INITIAL',
-  finalizeSyncRequest: 'INITIAL'
+  finalizeSyncKeys: 'INITIAL'
 } as const
 
 /**
@@ -264,7 +264,7 @@ export class EmailVaultController extends EventEmitter {
   }
 
   async getEmailVaultInfo(email: string) {
-    await this.withStatus('getEmailVaultInfo', () => this.#getEmailVaultInfo(email))
+    await this.withStatus(this.getEmailVaultInfo.name, () => this.#getEmailVaultInfo(email))
   }
 
   async #getEmailVaultInfo(email: string): Promise<void> {
@@ -304,7 +304,7 @@ export class EmailVaultController extends EventEmitter {
   }
 
   async uploadKeyStoreSecret(email: string) {
-    await this.withStatus('uploadKeyStoreSecret', () => this.#uploadKeyStoreSecret(email))
+    await this.withStatus(this.uploadKeyStoreSecret.name, () => this.#uploadKeyStoreSecret(email))
   }
 
   async #uploadKeyStoreSecret(email: string) {
@@ -357,7 +357,9 @@ export class EmailVaultController extends EventEmitter {
   }
 
   async recoverKeyStore(email: string, newPassword: string) {
-    await this.withStatus('recoverKeyStore', () => this.#recoverKeyStore(email, newPassword))
+    await this.withStatus(this.recoverKeyStore.name, () =>
+      this.#recoverKeyStore(email, newPassword)
+    )
   }
 
   async #recoverKeyStore(email: string, newPassword: string): Promise<void> {
@@ -448,7 +450,7 @@ export class EmailVaultController extends EventEmitter {
   }
 
   async requestKeysSync(email: string, keys: string[]) {
-    await this.withStatus('requestKeysSync', () => this.#requestKeysSync(email, keys))
+    await this.withStatus(this.requestKeysSync.name, () => this.#requestKeysSync(email, keys))
   }
 
   async #requestKeysSync(email: string, keys: string[]) {
@@ -523,7 +525,9 @@ export class EmailVaultController extends EventEmitter {
         return { ...res, password }
       })
       .filter((x) => x)
-    await this.withStatus('finalizeSyncRequest', () => this.#finalizeSyncKeys(email, operations))
+    await this.withStatus(this.finalizeSyncKeys.name, () =>
+      this.#finalizeSyncKeys(email, operations)
+    )
   }
 
   // DOCS

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -94,7 +94,14 @@ export default class EventEmitter {
       this.forceEmitUpdate()
     } catch (error: any) {
       this.status = 'ERROR'
-      this.emitError(error)
+      if ('message' in error && 'level' in error && 'error' in error) {
+        this.emitError(error)
+      }
+      this.emitError({
+        message: error?.message || 'An unexpected error occurred',
+        level: 'major',
+        error
+      })
       this.forceEmitUpdate()
     }
 

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -86,6 +86,10 @@ export default class EventEmitter {
   protected async withStatus(callName: string, fn: Function, allowMultipleActions = false) {
     const someStatusIsLoading = Object.values(this.statuses).some((status) => status !== 'INITIAL')
 
+    if (!this.statuses[callName]) {
+      console.error(`${callName} is not defined in "statuses".`)
+    }
+
     if ((someStatusIsLoading && !allowMultipleActions) || this.statuses[callName] !== 'INITIAL') {
       this.emitError({
         level: 'minor',

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -110,7 +110,10 @@ export default class EventEmitter {
       this.statuses[callName] = 'ERROR'
       if ('message' in error && 'level' in error && 'error' in error) {
         this.emitError(error)
-      } else {
+
+        // Sometimes we don't want to show an error message to the user. For example, if the user cancels a request
+        // we don't want to go through the SUCCESS state, but we also don't want to show an error message.
+      } else if (error?.message) {
         this.emitError({
           message: error?.message || 'An unexpected error occurred',
           level: 'major',

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -99,13 +99,13 @@ export default class EventEmitter {
     }
 
     this.statuses[callName] = 'LOADING'
-    this.forceEmitUpdate()
+    await this.forceEmitUpdate()
 
     try {
       await fn()
 
       this.statuses[callName] = 'SUCCESS'
-      this.forceEmitUpdate()
+      await this.forceEmitUpdate()
     } catch (error: any) {
       this.statuses[callName] = 'ERROR'
       if ('message' in error && 'level' in error && 'error' in error) {
@@ -117,13 +117,11 @@ export default class EventEmitter {
           error
         })
       }
-      this.forceEmitUpdate()
+      await this.forceEmitUpdate()
     }
 
-    await wait(1)
-
     this.statuses[callName] = 'INITIAL'
-    this.forceEmitUpdate()
+    await this.forceEmitUpdate()
   }
 
   // Prevents memory leaks and storing huge amount of errors

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -82,7 +82,16 @@ export default class EventEmitter {
   }
 
   protected async withStatus(callName: string, fn: () => Promise<ErrorRef | void> | void) {
-    if (this.status !== 'INITIAL') return
+    if (this.status !== 'INITIAL') {
+      this.emitError({
+        level: 'minor',
+        message: `Please wait for the completion of the previous action before initiating another one.', ${callName}`,
+        error: new Error(
+          'Another function is already being handled by #statusWrapper; refrain from invoking a second function.'
+        )
+      })
+      return
+    }
     this.latestMethodCall = callName
     this.status = 'LOADING'
     this.forceEmitUpdate()

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -106,7 +106,7 @@ export default class EventEmitter {
     }
 
     this.status = 'INITIAL'
-    this.emitUpdate()
+    this.forceEmitUpdate()
   }
 
   // Prevents memory leaks and storing huge amount of errors

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -32,6 +32,7 @@ const KEYSTORE_UNEXPECTED_ERROR_MESSAGE =
 const STATUS_WRAPPED_METHODS = {
   unlockWithSecret: 'INITIAL',
   addSecret: 'INITIAL',
+  removeSecret: 'INITIAL',
   addKeys: 'INITIAL',
   addKeysExternallyStored: 'INITIAL',
   changeKeystorePassword: 'INITIAL'
@@ -211,7 +212,9 @@ export class KeystoreController extends EventEmitter {
   }
 
   async unlockWithSecret(secretId: string, secret: string) {
-    await this.withStatus('unlockWithSecret', () => this.#unlockWithSecret(secretId, secret))
+    await this.withStatus(this.unlockWithSecret.name, () =>
+      this.#unlockWithSecret(secretId, secret)
+    )
   }
 
   async #addSecret(
@@ -296,7 +299,7 @@ export class KeystoreController extends EventEmitter {
   }
 
   async addSecret(secretId: string, secret: string, extraEntropy: string, leaveUnlocked: boolean) {
-    await this.withStatus('addSecret', () =>
+    await this.withStatus(this.addSecret.name, () =>
       this.#addSecret(secretId, secret, extraEntropy, leaveUnlocked)
     )
   }
@@ -316,7 +319,7 @@ export class KeystoreController extends EventEmitter {
   }
 
   async removeSecret(secretId: string) {
-    await this.withStatus('removeSecret', () => this.#removeSecret(secretId))
+    await this.withStatus(this.removeSecret.name, () => this.#removeSecret(secretId))
   }
 
   get keys(): Key[] {
@@ -378,7 +381,9 @@ export class KeystoreController extends EventEmitter {
   }
 
   async addKeysExternallyStored(keysToAdd: ExternalKey[]) {
-    await this.withStatus('addKeysExternallyStored', () => this.#addKeysExternallyStored(keysToAdd))
+    await this.withStatus(this.addKeysExternallyStored.name, () =>
+      this.#addKeysExternallyStored(keysToAdd)
+    )
   }
 
   async #addKeys(keysToAdd: { privateKey: string; dedicatedToOneSA: boolean }[]) {
@@ -438,7 +443,7 @@ export class KeystoreController extends EventEmitter {
   }
 
   async addKeys(keysToAdd: { privateKey: string; dedicatedToOneSA: boolean }[]) {
-    await this.withStatus('addKeys', () => this.#addKeys(keysToAdd))
+    await this.withStatus(this.addKeys.name, () => this.#addKeys(keysToAdd))
   }
 
   async removeKey(addr: Key['addr'], type: Key['type']) {
@@ -595,7 +600,7 @@ export class KeystoreController extends EventEmitter {
   }
 
   async changeKeystorePassword(newSecret: string, oldSecret?: string) {
-    await this.withStatus('changeKeystorePassword', () =>
+    await this.withStatus(this.changeKeystorePassword.name, () =>
       this.#changeKeystorePassword(newSecret, oldSecret)
     )
   }

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -200,11 +200,8 @@ export class KeystoreController extends EventEmitter {
     const mac = keccak256(concat([macPrefix, aesEncrypted.ciphertext]))
     if (mac !== aesEncrypted.mac) {
       this.errorMessage = 'Invalid Device Password.'
-      throw new EmittableError({
-        message: 'Invalid Device Password.',
-        level: 'major',
-        error: new Error('keystore: wrong secret')
-      })
+      this.emitUpdate()
+      return
     }
     this.errorMessage = ''
 

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -12,6 +12,7 @@ import {
 import { concat, getBytes, hexlify, keccak256, randomBytes, toUtf8Bytes, Wallet } from 'ethers'
 import scrypt from 'scrypt-js'
 
+import EmittableError from '../../classes/EmittableError'
 import {
   ExternalKey,
   Key,
@@ -21,11 +22,20 @@ import {
   StoredKey
 } from '../../interfaces/keystore'
 import { Storage } from '../../interfaces/storage'
-import wait from '../../utils/wait'
-import EventEmitter from '../eventEmitter/eventEmitter'
+import EventEmitter, { Statuses } from '../eventEmitter/eventEmitter'
 
 const scryptDefaults = { N: 131072, r: 8, p: 1, dkLen: 64 }
 const CIPHER = 'aes-128-ctr'
+const KEYSTORE_UNEXPECTED_ERROR_MESSAGE =
+  'Keystore unexpected error. If the problem persists, please contact support.'
+
+const STATUS_WRAPPED_METHODS = {
+  unlockWithSecret: 'INITIAL',
+  addSecret: 'INITIAL',
+  addKeys: 'INITIAL',
+  addKeysExternallyStored: 'INITIAL',
+  changeKeystorePassword: 'INITIAL'
+} as const
 
 function getBytesForSecret(secret: string): ArrayLike<number> {
   // see https://github.com/ethers-io/ethers.js/blob/v5/packages/json-wallets/src.ts/utils.ts#L19-L24
@@ -73,11 +83,9 @@ export class KeystoreController extends EventEmitter {
 
   isReadyToStoreKeys: boolean = false
 
-  status: 'INITIAL' | 'LOADING' | 'SUCCESS' | 'DONE' = 'INITIAL'
-
   errorMessage: string = ''
 
-  latestMethodCall: string | null = null
+  statuses: Statuses<keyof typeof STATUS_WRAPPED_METHODS> = STATUS_WRAPPED_METHODS
 
   // Holds the initial load promise, so that one can wait until it completes
   #initialLoadPromise: Promise<void>
@@ -145,17 +153,31 @@ export class KeystoreController extends EventEmitter {
 
     // @TODO should we check if already locked? probably not cause this function can  be used in order to verify if a secret is correct
     if (!this.#keystoreSecrets.length) {
-      throw new Error('keystore: no secrets yet')
+      throw new EmittableError({
+        message:
+          'Trying to unlock Ambire, but the lock mechanism was not fully configured yet. Please try again or contact support if the problem persists.',
+        level: 'major',
+        error: new Error('keystore: no secrets yet')
+      })
     }
 
     const secretEntry = this.#keystoreSecrets.find((x) => x.id === secretId)
     if (!secretEntry) {
-      throw new Error(`keystore: secret not found: ${secretId}`)
+      throw new EmittableError({
+        message: `Something went wrong when trying to unlock Ambire. Please try again or contact support if the problem persists.`,
+        level: 'major',
+        error: new Error('keystore: secret not found')
+      })
     }
 
     const { scryptParams, aesEncrypted } = secretEntry
     if (aesEncrypted.cipherType !== CIPHER) {
-      throw new Error(`keystore: unsupported cipherType ${aesEncrypted.cipherType}`)
+      throw new EmittableError({
+        message:
+          'Something went wrong when trying to unlock Ambire. Please try again or contact support if the problem persists.',
+        level: 'major',
+        error: new Error(`keystore: unsupported cipherType ${aesEncrypted.cipherType}`)
+      })
     }
     // @TODO: progressCallback?
 
@@ -175,18 +197,21 @@ export class KeystoreController extends EventEmitter {
     const aesCtr = new aes.ModeOfOperation.ctr(derivedKey, counter)
     const mac = keccak256(concat([macPrefix, aesEncrypted.ciphertext]))
     if (mac !== aesEncrypted.mac) {
-      // Throw, because that's handled as a form field error
-      throw new Error('keystore: wrong secret')
+      this.errorMessage = 'Invalid Device Password.'
+      throw new EmittableError({
+        message: 'Invalid Device Password.',
+        level: 'major',
+        error: new Error('keystore: wrong secret')
+      })
     }
+    this.errorMessage = ''
 
     const decrypted = aesCtr.decrypt(getBytes(aesEncrypted.ciphertext))
     this.#mainKey = { key: decrypted.slice(0, 16), iv: decrypted.slice(16, 32) }
   }
 
   async unlockWithSecret(secretId: string, secret: string) {
-    return this.#wrapKeystoreAction('unlockWithSecret', () =>
-      this.#unlockWithSecret(secretId, secret)
-    )
+    await this.withStatus('unlockWithSecret', () => this.#unlockWithSecret(secretId, secret))
   }
 
   async #addSecret(
@@ -199,7 +224,11 @@ export class KeystoreController extends EventEmitter {
 
     // @TODO test
     if (this.#keystoreSecrets.find((x) => x.id === secretId))
-      throw new Error(`keystore: trying to add duplicate secret ${secretId}`)
+      throw new EmittableError({
+        message: KEYSTORE_UNEXPECTED_ERROR_MESSAGE,
+        level: 'major',
+        error: new Error(`keystore: trying to add duplicate secret ${secretId}`)
+      })
 
     let mainKey: MainKey | null = this.#mainKey
     // We are not unlocked
@@ -213,7 +242,12 @@ export class KeystoreController extends EventEmitter {
           key,
           iv: randomBytes(16)
         }
-      } else throw new Error('keystore: must unlock keystore before adding secret')
+      } else
+        throw new EmittableError({
+          message: KEYSTORE_UNEXPECTED_ERROR_MESSAGE,
+          level: 'major',
+          error: new Error('keystore: must unlock keystore before adding secret')
+        })
 
       if (leaveUnlocked) {
         this.#mainKey = mainKey
@@ -262,7 +296,7 @@ export class KeystoreController extends EventEmitter {
   }
 
   async addSecret(secretId: string, secret: string, extraEntropy: string, leaveUnlocked: boolean) {
-    await this.#wrapKeystoreAction('addSecret', () =>
+    await this.withStatus('addSecret', () =>
       this.#addSecret(secretId, secret, extraEntropy, leaveUnlocked)
     )
   }
@@ -271,14 +305,18 @@ export class KeystoreController extends EventEmitter {
     await this.#initialLoadPromise
 
     if (!this.#keystoreSecrets.find((x) => x.id === secretId))
-      throw new Error(`keystore: secret$ ${secretId} not found`)
+      throw new EmittableError({
+        message: KEYSTORE_UNEXPECTED_ERROR_MESSAGE,
+        level: 'major',
+        error: new Error(`keystore: secret$ ${secretId} not found`)
+      })
 
     this.#keystoreSecrets = this.#keystoreSecrets.filter((x) => x.id !== secretId)
     await this.#storage.set('keystoreSecrets', this.#keystoreSecrets)
   }
 
   async removeSecret(secretId: string) {
-    await this.#wrapKeystoreAction('removeSecret', () => this.#removeSecret(secretId))
+    await this.withStatus('removeSecret', () => this.#removeSecret(secretId))
   }
 
   get keys(): Key[] {
@@ -340,15 +378,18 @@ export class KeystoreController extends EventEmitter {
   }
 
   async addKeysExternallyStored(keysToAdd: ExternalKey[]) {
-    await this.#wrapKeystoreAction('addKeysExternallyStored', () =>
-      this.#addKeysExternallyStored(keysToAdd)
-    )
+    await this.withStatus('addKeysExternallyStored', () => this.#addKeysExternallyStored(keysToAdd))
   }
 
   async #addKeys(keysToAdd: { privateKey: string; dedicatedToOneSA: boolean }[]) {
     await this.#initialLoadPromise
     if (!keysToAdd.length) return
-    if (this.#mainKey === null) throw new Error('keystore: needs to be unlocked')
+    if (this.#mainKey === null)
+      throw new EmittableError({
+        message: KEYSTORE_UNEXPECTED_ERROR_MESSAGE,
+        level: 'major',
+        error: new Error('keystore: needs to be unlocked')
+      })
 
     // Strip out keys with duplicated private keys. One unique key is enough.
     const uniquePrivateKeysToAddSet = new Set()
@@ -397,17 +438,27 @@ export class KeystoreController extends EventEmitter {
   }
 
   async addKeys(keysToAdd: { privateKey: string; dedicatedToOneSA: boolean }[]) {
-    await this.#wrapKeystoreAction('addKeys', () => this.#addKeys(keysToAdd))
+    await this.withStatus('addKeys', () => this.#addKeys(keysToAdd))
   }
 
   async removeKey(addr: Key['addr'], type: Key['type']) {
     await this.#initialLoadPromise
-    if (!this.isUnlocked) throw new Error('keystore: not unlocked')
+    if (!this.isUnlocked)
+      throw new EmittableError({
+        message:
+          'Extension not unlocked. Please try again or contact support if the problem persists.',
+        level: 'major',
+        error: new Error('keystore: not unlocked')
+      })
     const keys = this.#keystoreKeys
     if (!keys.find((x) => x.addr === addr && x.type === type))
-      throw new Error(
-        `keystore: trying to remove key that does not exist: address: ${addr}, type: ${type}`
-      )
+      throw new EmittableError({
+        message: KEYSTORE_UNEXPECTED_ERROR_MESSAGE,
+        level: 'major',
+        error: new Error(
+          `keystore: trying to remove key that does not exist: address: ${addr}, type: ${type}`
+        )
+      })
 
     this.#keystoreKeys = keys.filter((x) => x.addr === addr && x.type === type)
     await this.#storage.set('keystoreKeys', this.#keystoreKeys)
@@ -510,76 +561,6 @@ export class KeystoreController extends EventEmitter {
     return new SignerInitializer(key)
   }
 
-  async #wrapKeystoreAction(callName: string, fn: Function) {
-    // We should not allow executing a second function simultaneously while another function execution is already in progress,
-    // as both functions manipulate the same status property, which may lead to unexpected behavior.
-    // Keeping this in mind, if we have an application logic (hook) that automatically invokes a function wrapped with #statusWrapper,
-    // we should always check if the status is INITIAL and only then invoke the function.
-    // You can see such an example in `authContext.tsx`.
-    if (this.status !== 'INITIAL') {
-      this.emitError({
-        level: 'minor',
-        message: `Please wait for the completion of the previous action before initiating another one.', ${callName}`,
-        error: new Error(
-          'Another function is already being handled by #statusWrapper; refrain from invoking a second function.'
-        )
-      })
-
-      return
-    }
-
-    this.latestMethodCall = callName
-    this.errorMessage = ''
-    this.status = 'LOADING'
-    await this.forceEmitUpdate()
-    try {
-      await fn()
-      this.status = 'SUCCESS'
-      await this.forceEmitUpdate()
-    } catch (error: any) {
-      if (error?.message === 'keystore: wrong secret') {
-        this.errorMessage = 'Invalid Device Password.'
-      } else if (error?.message === 'keystore: not unlocked') {
-        this.emitError({
-          message: 'App not unlocked. Please try again or contact support if the problem persists.',
-          level: 'major',
-          error
-        })
-      } else if (error?.message === 'keystore: no secrets yet') {
-        this.emitError({
-          message:
-            'Trying to unlock Ambire, but the lock mechanism was not fully configured yet. Please try again or contact support if the problem persists.',
-          level: 'major',
-          error
-        })
-      } else if (
-        error?.message?.includes('keystore: secret not found:') ||
-        error?.message?.includes('keystore: unsupported cipherType')
-      ) {
-        this.emitError({
-          message:
-            'Something went wrong when trying to unlock Ambire. Please try again or contact support if the problem persists.',
-          level: 'major',
-          error
-        })
-      } else {
-        this.emitError({
-          message: 'Keystore unexpected error. If the problem persists, please contact support.',
-          level: 'major',
-          error
-        })
-      }
-    }
-
-    this.status = 'DONE'
-    await this.forceEmitUpdate()
-
-    if (this.latestMethodCall === callName) {
-      this.status = 'INITIAL'
-      await this.forceEmitUpdate()
-    }
-  }
-
   async #changeKeystorePassword(newSecret: string, oldSecret?: string) {
     await this.#initialLoadPromise
 
@@ -602,14 +583,19 @@ export class KeystoreController extends EventEmitter {
     // and not unlock the Keystore with the recovery secret unless the user provides a new passphrase.
     if (oldSecret) await this.#unlockWithSecret('password', oldSecret)
 
-    if (!this.isUnlocked) throw new Error('keystore: not unlocked')
+    if (!this.isUnlocked)
+      throw new EmittableError({
+        message: 'App not unlocked. Please try again or contact support if the problem persists.',
+        level: 'major',
+        error: new Error('keystore: not unlocked')
+      })
 
     await this.#removeSecret('password')
     await this.#addSecret('password', newSecret, '', true)
   }
 
   async changeKeystorePassword(newSecret: string, oldSecret?: string) {
-    await this.#wrapKeystoreAction('changeKeystorePassword', () =>
+    await this.withStatus('changeKeystorePassword', () =>
       this.#changeKeystorePassword(newSecret, oldSecret)
     )
   }

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -228,10 +228,7 @@ describe('Main Controller ', () => {
         emitCounter++
         if (emitCounter === 2 && controller.isReady) addAccounts()
 
-        if (
-          controller.status === 'SUCCESS' &&
-          controller.latestMethodCall === 'onAccountAdderSuccess'
-        ) {
+        if (controller.statuses.onAccountAdderSuccess === 'LOADING') {
           expect(controller.accounts).toContainEqual({
             ...accountPendingCreation.account,
             newlyCreated: false

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -273,8 +273,6 @@ describe('Main Controller ', () => {
     const unsubscribe = mainCtrl.onUpdate(() => {
       emitCounter++
 
-      console.log(emitCounter, mainCtrl.accounts[0].associatedKeys)
-
       if (emitCounter === 3) {
         expect(mainCtrl.accounts[0].associatedKeys.length).toEqual(2)
         expect(mainCtrl.accounts[0].associatedKeys).toContain(

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -226,9 +226,10 @@ describe('Main Controller ', () => {
     await new Promise((resolve) => {
       const unsubscribe = controller.onUpdate(() => {
         emitCounter++
+
         if (emitCounter === 2 && controller.isReady) addAccounts()
 
-        if (controller.statuses.onAccountAdderSuccess === 'LOADING') {
+        if (controller.statuses.onAccountAdderSuccess === 'SUCCESS') {
           expect(controller.accounts).toContainEqual({
             ...accountPendingCreation.account,
             newlyCreated: false
@@ -271,6 +272,8 @@ describe('Main Controller ', () => {
     let emitCounter = 0
     const unsubscribe = mainCtrl.onUpdate(() => {
       emitCounter++
+
+      console.log(emitCounter, mainCtrl.accounts[0].associatedKeys)
 
       if (emitCounter === 3) {
         expect(mainCtrl.accounts[0].associatedKeys.length).toEqual(2)

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -505,7 +505,11 @@ export class MainController extends EventEmitter {
 
   // All operations must be synchronous so the change is instantly reflected in the UI
   async selectAccount(toAccountAddr: string) {
-    await this.withStatus('selectAccount', async () => this.#selectAccount(toAccountAddr), true)
+    await this.withStatus(
+      this.selectAccount.name,
+      async () => this.#selectAccount(toAccountAddr),
+      true
+    )
   }
 
   async #selectAccount(toAccountAddr: string) {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -48,7 +48,7 @@ import { ActivityController, SignedMessage, SubmittedAccountOp } from '../activi
 import { AddressBookController } from '../addressBook/addressBook'
 import { DomainsController } from '../domains/domains'
 import { EmailVaultController } from '../emailVault/emailVault'
-import EventEmitter, { getDefaultStatuses, Statuses } from '../eventEmitter/eventEmitter'
+import EventEmitter, { Statuses } from '../eventEmitter/eventEmitter'
 import { KeystoreController } from '../keystore/keystore'
 import { PortfolioController } from '../portfolio/portfolio'
 import { SettingsController } from '../settings/settings'
@@ -57,7 +57,10 @@ import { SignAccountOpController, SigningStatus } from '../signAccountOp/signAcc
 import { SignMessageController } from '../signMessage/signMessage'
 import { TransferController } from '../transfer/transfer'
 
-const STATUS_WRAPPED_METHODS = ['selectAccount', 'onAccountAdderSuccess']
+const STATUS_WRAPPED_METHODS = {
+  onAccountAdderSuccess: 'INITIAL',
+  selectAccount: 'INITIAL'
+} as const
 
 export class MainController extends EventEmitter {
   #storage: Storage
@@ -139,7 +142,7 @@ export class MainController extends EventEmitter {
 
   broadcastStatus: 'INITIAL' | 'LOADING' | 'DONE' = 'INITIAL'
 
-  statuses: Statuses<typeof STATUS_WRAPPED_METHODS> = getDefaultStatuses(STATUS_WRAPPED_METHODS)
+  statuses: Statuses<keyof typeof STATUS_WRAPPED_METHODS> = STATUS_WRAPPED_METHODS
 
   #relayerUrl: string
 

--- a/src/controllers/settings/settings.test.ts
+++ b/src/controllers/settings/settings.test.ts
@@ -205,7 +205,7 @@ describe('Settings Controller', () => {
   test('should check if network features get displayed correctly for ethereum', (done) => {
     let checks = 0
     settingsController.onUpdate(() => {
-      if (checks === 5) {
+      if (checks === 4) {
         checks++
         const eth = settingsController.networks.find((net) => net.id === 'ethereum')!
         expect(eth.areContractsDeployed).toBe(true)
@@ -213,7 +213,7 @@ describe('Settings Controller', () => {
       }
 
       // skip updates until the correct one comes
-      if (checks === 2 || checks === 3 || checks === 4) {
+      if (checks === 2 || checks === 3) {
         checks++
       }
 

--- a/src/controllers/settings/settings.test.ts
+++ b/src/controllers/settings/settings.test.ts
@@ -271,7 +271,7 @@ describe('Settings Controller', () => {
         if (isLoading) return
         const mantleNetworkInfo: NetworkInfo = networkInfoLoading as NetworkInfo
         // mantle has the entry point uploaded
-        // TODO: expect(mantleNetworkInfo?.erc4337.enabled).toBe(true)
+        expect(mantleNetworkInfo?.erc4337.enabled).toBe(true)
         expect(mantleNetworkInfo?.erc4337.hasPaymaster).toBe(false)
         // has smart accounts
         expect(mantleNetworkInfo?.isSAEnabled).toBe(true)

--- a/src/controllers/settings/settings.test.ts
+++ b/src/controllers/settings/settings.test.ts
@@ -190,7 +190,10 @@ describe('Settings Controller', () => {
         expect(modifiedNetwork?.rpcUrls).toEqual(ethereumStatic?.rpcUrls)
         expect(modifiedNetwork?.explorerUrl).toEqual('https://etherscan.io/custom') // Should remain the same
       }
-      done()
+
+      if (settingsController.statuses.updateNetworkPreferences === 'INITIAL') {
+        done()
+      }
     })
 
     settingsController.updateNetworkPreferences(
@@ -205,11 +208,13 @@ describe('Settings Controller', () => {
   test('should check if network features get displayed correctly for ethereum', (done) => {
     let checks = 0
     settingsController.onUpdate(() => {
+      if (settingsController.statuses.updateNetworkPreferences === 'INITIAL') {
+        done()
+      }
       if (checks === 4) {
         checks++
         const eth = settingsController.networks.find((net) => net.id === 'ethereum')!
         expect(eth.areContractsDeployed).toBe(true)
-        done()
       }
 
       // skip updates until the correct one comes
@@ -262,42 +267,28 @@ describe('Settings Controller', () => {
         const networkInfoLoading = settingsController.networkToAddOrUpdate?.info
         if (!networkInfoLoading) return
 
-        let isLoading = false
-        // eslint-disable-next-line no-restricted-syntax
-        for (const [, value] of Object.entries(networkInfoLoading)) {
-          if (value === 'LOADING') {
-            isLoading = true
-            break
-          }
-        }
-
+        const isLoading = Object.values(networkInfoLoading).some((v) => v === 'LOADING')
         if (isLoading) return
         const mantleNetworkInfo: NetworkInfo = networkInfoLoading as NetworkInfo
-
         // mantle has the entry point uploaded
-        expect(mantleNetworkInfo?.erc4337.enabled).toBe(true)
+        // TODO: expect(mantleNetworkInfo?.erc4337.enabled).toBe(true)
         expect(mantleNetworkInfo?.erc4337.hasPaymaster).toBe(false)
-
         // has smart accounts
         expect(mantleNetworkInfo?.isSAEnabled).toBe(true)
 
         // contracts are deployed
         expect(mantleNetworkInfo?.areContractsDeployed).toBe(true)
-
         // is not 1559
         expect(mantleNetworkInfo?.feeOptions!.is1559).toBe(true)
 
         // mantle is optimistic
         expect(mantleNetworkInfo?.isOptimistic).toBe(true)
-
         // coingecko
         expect(mantleNetworkInfo?.platformId).toBe('mantle')
         expect(mantleNetworkInfo?.nativeAssetId).toBe('mantle')
-
         // simulation is somewhat supported
         expect(mantleNetworkInfo?.rpcNoStateOverride).toBe(false)
         expect(mantleNetworkInfo?.hasDebugTraceCall).toBe(false)
-
         mantleNetwork = {
           name: 'Mantle',
           rpcUrls: [settingsController.networkToAddOrUpdate?.rpcUrl],
@@ -377,10 +368,7 @@ describe('Settings Controller', () => {
     //   }
     // })
 
-    settingsController.setNetworkToAddOrUpdate({
-      rpcUrl: 'https://rpc.mantle.xyz',
-      chainId: 5000n
-    })
+    settingsController.setNetworkToAddOrUpdate({ rpcUrl: 'https://rpc.mantle.xyz', chainId: 5000n })
   })
 
   // TODO: Refactor Fantom test as well

--- a/src/controllers/settings/settings.test.ts
+++ b/src/controllers/settings/settings.test.ts
@@ -160,11 +160,7 @@ describe('Settings Controller', () => {
 
     let checkComplete = false
     settingsController.onUpdate(() => {
-      if (
-        settingsController.latestMethodCall === 'updateNetworkPreferences' &&
-        settingsController.status === 'SUCCESS' &&
-        !checkComplete
-      ) {
+      if (settingsController.statuses.updateNetworkPreferences === 'SUCCESS' && !checkComplete) {
         const modifiedNetwork = settingsController.networks.find(({ id }) => id === 'ethereum')
         expect(modifiedNetwork?.explorerUrl).toEqual('https://etherscan.io/custom')
         expect(modifiedNetwork?.rpcUrls).toEqual([

--- a/src/controllers/settings/settings.ts
+++ b/src/controllers/settings/settings.ts
@@ -22,9 +22,12 @@ import { Storage } from '../../interfaces/storage'
 import { getFeaturesByNetworkProperties, getNetworkInfo } from '../../libs/settings/settings'
 import { isValidAddress } from '../../services/address'
 import { getRpcProvider } from '../../services/provider'
-import EventEmitter, { getDefaultStatuses, Statuses } from '../eventEmitter/eventEmitter'
+import EventEmitter, { Statuses } from '../eventEmitter/eventEmitter'
 
-const STATUS_WRAPPED_METHODS = ['addCustomNetwork', 'updateNetworkPreferences']
+const STATUS_WRAPPED_METHODS = {
+  addCustomNetwork: 'INITIAL',
+  updateNetworkPreferences: 'INITIAL'
+} as const
 
 export class SettingsController extends EventEmitter {
   accountPreferences: AccountPreferences = {}
@@ -37,7 +40,7 @@ export class SettingsController extends EventEmitter {
 
   #storage: Storage
 
-  statuses: Statuses<typeof STATUS_WRAPPED_METHODS> = getDefaultStatuses(STATUS_WRAPPED_METHODS)
+  statuses: Statuses<keyof typeof STATUS_WRAPPED_METHODS> = STATUS_WRAPPED_METHODS
 
   networkToAddOrUpdate: {
     chainId: NetworkDescriptor['chainId']
@@ -403,7 +406,7 @@ export class SettingsController extends EventEmitter {
   }
 
   async addCustomNetwork(customNetwork: CustomNetwork) {
-    this.withStatus(this.addCustomNetwork.name, () => this.#addCustomNetwork(customNetwork))
+    await this.withStatus(this.addCustomNetwork.name, () => this.#addCustomNetwork(customNetwork))
   }
 
   async removeCustomNetwork(id: NetworkDescriptor['id']) {

--- a/src/controllers/settings/settings.ts
+++ b/src/controllers/settings/settings.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+import EmittableError from '../../classes/EmittableError'
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { networks } from '../../consts/networks'
 import { Key } from '../../interfaces/keystore'
@@ -21,7 +22,6 @@ import { Storage } from '../../interfaces/storage'
 import { getFeaturesByNetworkProperties, getNetworkInfo } from '../../libs/settings/settings'
 import { isValidAddress } from '../../services/address'
 import { getRpcProvider } from '../../services/provider'
-import wait from '../../utils/wait'
 import EventEmitter from '../eventEmitter/eventEmitter'
 
 export class SettingsController extends EventEmitter {
@@ -35,9 +35,7 @@ export class SettingsController extends EventEmitter {
 
   #storage: Storage
 
-  status: 'INITIAL' | 'LOADING' | 'SUCCESS' | 'DONE' = 'INITIAL'
-
-  latestMethodCall: string | null = null
+  latestMethodCall: 'addCustomNetwork' | 'updateNetworkPreferences' | null = null
 
   networkToAddOrUpdate: {
     chainId: NetworkDescriptor['chainId']
@@ -367,14 +365,22 @@ export class SettingsController extends EventEmitter {
     // make sure the network has not been added already
     const chainIds = this.networks.map((net) => net.chainId)
     if (chainIds.indexOf(BigInt(customNetwork.chainId)) !== -1) {
-      throw new Error('settings: addCustomNetwork chain already added')
+      throw new EmittableError({
+        message:
+          'Failed to detect network, perhaps an RPC issue. Please change the RPC and try again.',
+        level: 'major'
+      })
     }
 
     // make sure the id of the network is unique
     const customNetworkId = customNetwork.name.toLowerCase()
     const ids = this.networks.map((net) => net.id)
     if (ids.indexOf(customNetworkId) !== -1) {
-      throw new Error('settings: addCustomNetwork chain already added')
+      throw new EmittableError({
+        message:
+          'Failed to detect network, perhaps an RPC issue. Please change the RPC and try again.',
+        level: 'major'
+      })
     }
 
     const info = { ...(this.networkToAddOrUpdate.info as NetworkInfo) }
@@ -395,7 +401,7 @@ export class SettingsController extends EventEmitter {
   }
 
   async addCustomNetwork(customNetwork: CustomNetwork) {
-    await this.#wrapSettingsAction('addCustomNetwork', () => this.#addCustomNetwork(customNetwork))
+    this.withStatus(this.addCustomNetwork.name, () => this.#addCustomNetwork(customNetwork))
   }
 
   async removeCustomNetwork(id: NetworkDescriptor['id']) {
@@ -499,7 +505,7 @@ export class SettingsController extends EventEmitter {
     networkPreferences: Partial<NetworkPreference>,
     networkId: NetworkDescriptor['id']
   ) {
-    await this.#wrapSettingsAction('updateNetworkPreferences', () =>
+    await this.withStatus('updateNetworkPreferences', () =>
       this.#updateNetworkPreferences(networkPreferences, networkId)
     )
   }
@@ -536,67 +542,6 @@ export class SettingsController extends EventEmitter {
         error: new Error(`settings: failed to set areContractsDeployed to true for ${network.id}`)
       })
     })
-  }
-
-  async #wrapSettingsAction(callName: string, fn: Function) {
-    // We should not allow executing a second function simultaneously while another function execution is already in progress,
-    // as both functions manipulate the same status property, which may lead to unexpected behavior.
-    // Keeping this in mind, if we have an application logic (hook) that automatically invokes a function wrapped with #statusWrapper,
-    // we should always check if the status is INITIAL and only then invoke the function.
-    // You can see such an example in `authContext.tsx`.
-    if (this.status !== 'INITIAL') {
-      this.emitError({
-        level: 'minor',
-        message: `Please wait for the completion of the previous action before initiating another one.', ${callName}`,
-        error: new Error(
-          'Another function is already being handled by #statusWrapper; refrain from invoking a second function.'
-        )
-      })
-
-      return
-    }
-
-    this.latestMethodCall = callName
-    this.status = 'LOADING'
-    await this.forceEmitUpdate()
-    try {
-      await fn()
-      this.status = 'SUCCESS'
-      await this.forceEmitUpdate()
-    } catch (error: any) {
-      if (error?.message === 'settings: addCustomNetwork chain already added') {
-        this.emitError({
-          message:
-            'Failed to detect network, perhaps an RPC issue. Please change the RPC and try again.',
-          level: 'major',
-          error
-        })
-      } else if (error?.message === 'settings: failed to detect network') {
-        this.emitError({
-          message:
-            'Failed to detect network, perhaps an RPC issue. Please change the RPC and try again.',
-          level: 'major',
-          error
-        })
-      } else if (
-        error?.message === 'settings: initialized network before calling addCustomNetwork'
-      ) {
-        this.emitError({
-          message:
-            'Adding custom network failed because the network was not initialized properly. Please try again.',
-          level: 'major',
-          error
-        })
-      }
-    }
-
-    this.status = 'DONE'
-    await this.forceEmitUpdate()
-
-    if (this.latestMethodCall === callName) {
-      this.status = 'INITIAL'
-      await this.forceEmitUpdate()
-    }
   }
 
   #throwInvalidAddress(addresses: string[]) {

--- a/src/controllers/settings/settings.ts
+++ b/src/controllers/settings/settings.ts
@@ -507,7 +507,7 @@ export class SettingsController extends EventEmitter {
     networkPreferences: Partial<NetworkPreference>,
     networkId: NetworkDescriptor['id']
   ) {
-    await this.withStatus('updateNetworkPreferences', () =>
+    await this.withStatus(this.updateNetworkPreferences.name, () =>
       this.#updateNetworkPreferences(networkPreferences, networkId)
     )
   }

--- a/src/controllers/settings/settings.ts
+++ b/src/controllers/settings/settings.ts
@@ -366,7 +366,6 @@ export class SettingsController extends EventEmitter {
     ) {
       return
     }
-
     // make sure the network has not been added already
     const chainIds = this.networks.map((net) => net.chainId)
     if (chainIds.indexOf(BigInt(customNetwork.chainId)) !== -1) {

--- a/src/controllers/settings/settings.ts
+++ b/src/controllers/settings/settings.ts
@@ -22,7 +22,9 @@ import { Storage } from '../../interfaces/storage'
 import { getFeaturesByNetworkProperties, getNetworkInfo } from '../../libs/settings/settings'
 import { isValidAddress } from '../../services/address'
 import { getRpcProvider } from '../../services/provider'
-import EventEmitter from '../eventEmitter/eventEmitter'
+import EventEmitter, { getDefaultStatuses, Statuses } from '../eventEmitter/eventEmitter'
+
+const STATUS_WRAPPED_METHODS = ['addCustomNetwork', 'updateNetworkPreferences']
 
 export class SettingsController extends EventEmitter {
   accountPreferences: AccountPreferences = {}
@@ -35,7 +37,7 @@ export class SettingsController extends EventEmitter {
 
   #storage: Storage
 
-  latestMethodCall: 'addCustomNetwork' | 'updateNetworkPreferences' | null = null
+  statuses: Statuses<typeof STATUS_WRAPPED_METHODS> = getDefaultStatuses(STATUS_WRAPPED_METHODS)
 
   networkToAddOrUpdate: {
     chainId: NetworkDescriptor['chainId']


### PR DESCRIPTION
## Summary:
The method `wrap[InsertControllerName]Action` was used in main, email-vault, keystore and settings. Making a change in one of the controllers always requires a change in every other implementation. 
This PR aims to reduce repetition by defining a reusable, enhanced `withStatus` method in the `eventEmitter`, because all controllers extend it.
The new implementation replaces `latestMethodCall` and `status` with `statuses`, an object in which every key is a method name and its corresponding value is the status of the method. This is done, because methods in the main controller should be callable in parallel, contrary to sub-controllers.

## Example of `statuses`:
```
{
  getEmailVaultInfo: 'INITIAL',
  uploadKeyStoreSecret: 'INITIAL',
  recoverKeyStore: 'INITIAL',
  requestKeysSync: 'INITIAL',
  finalizeSyncKeys: 'INITIAL'
}
```
## Front-end usage:
```
mainControllerState.status === 'SUCCESS' &&
mainControllerState.latestMethodCall === 'onAccountAdderSuccess'
```
is replaced with
```
mainControllerState.statuses.onAccountAdderSuccess === 'SUCCESS'
```