### PR TITLE
Humanizer: no async ops when options.noAsyncOperations is passed

### DIFF
--- a/src/libs/humanizer/humanizerFuncs.test.ts
+++ b/src/libs/humanizer/humanizerFuncs.test.ts
@@ -210,7 +210,8 @@ describe('asyncOps tests', () => {
       fetch,
       emitError: mockEmitError
     })
-    const asyncData = await Promise.all(asyncOps)
+    const asyncData = await Promise.all(asyncOps.map((i) => i()))
+
     expect(asyncData[0]).toMatchObject({
       key: irCalls[0].to.toLowerCase(),
       type: 'token',

--- a/src/libs/humanizer/humanizerFuncs.test.ts
+++ b/src/libs/humanizer/humanizerFuncs.test.ts
@@ -332,7 +332,7 @@ describe('module tests', () => {
       fetch,
       emitError: mockEmitError
     })
-    asyncOps = (await Promise.all(asyncOps)).filter((a) => a) as HumanizerFragment[]
+    asyncOps = (await Promise.all(asyncOps.map((i) => i()))).filter((a) => a) as HumanizerFragment[]
     expect(asyncOps.length).toBe(1)
     expect(asyncOps[0]).toMatchObject({ key: '0x095ea7b3' })
     ;[irCalls, asyncOps] = fallbackHumanizer(

--- a/src/libs/humanizer/humanizerFuncs.ts
+++ b/src/libs/humanizer/humanizerFuncs.ts
@@ -20,7 +20,7 @@ export function humanizeCalls(
   humanizerModules: HumanizerCallModule[],
   _humanizerMeta: HumanizerMeta,
   options?: any
-): [IrCall[], Array<Promise<HumanizerFragment | null>>, ErrorRef | null] {
+): [IrCall[], Array<() => Promise<HumanizerFragment | null>>, ErrorRef | null] {
   let error = null
   const accountOp = {
     ..._accountOp,
@@ -29,7 +29,7 @@ export function humanizeCalls(
   const humanizerMeta = integrateFragments(_humanizerMeta, accountOp.humanizerMetaFragments || [])
 
   let currentCalls: IrCall[] = accountOp.calls
-  let asyncOps: Promise<HumanizerFragment | null>[] = []
+  let asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
   try {
     humanizerModules.forEach((hm) => {
       let newPromises = []

--- a/src/libs/humanizer/humanizerFuncs.ts
+++ b/src/libs/humanizer/humanizerFuncs.ts
@@ -6,8 +6,8 @@ import { Message, PlainTextMessage, TypedMessage } from '../../interfaces/userRe
 import { AccountOp } from '../accountOp/accountOp'
 import {
   HumanizerCallModule,
-  HumanizerFragment,
   HumanizerMeta,
+  HumanizerPromise,
   HumanizerTypedMessaageModule,
   HumanizerVisualization,
   IrCall,
@@ -20,7 +20,7 @@ export function humanizeCalls(
   humanizerModules: HumanizerCallModule[],
   _humanizerMeta: HumanizerMeta,
   options?: any
-): [IrCall[], Array<() => Promise<HumanizerFragment | null>>, ErrorRef | null] {
+): [IrCall[], HumanizerPromise[], ErrorRef | null] {
   let error = null
   const accountOp = {
     ..._accountOp,
@@ -29,7 +29,7 @@ export function humanizeCalls(
   const humanizerMeta = integrateFragments(_humanizerMeta, accountOp.humanizerMetaFragments || [])
 
   let currentCalls: IrCall[] = accountOp.calls
-  let asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
+  let asyncOps: HumanizerPromise[] = []
   try {
     humanizerModules.forEach((hm) => {
       let newPromises = []

--- a/src/libs/humanizer/humanizerModules.test.ts
+++ b/src/libs/humanizer/humanizerModules.test.ts
@@ -255,7 +255,7 @@ describe('module tests', () => {
     )
     irCalls = parsedCalls
     asyncOps.push(...newAsyncOps)
-    const frags: HumanizerFragment[] = (await Promise.all(asyncOps)).filter(
+    const frags: HumanizerFragment[] = (await Promise.all(asyncOps.map((i) => i()))).filter(
       (x) => x
     ) as HumanizerFragment[]
     // @TODO use new combination function

--- a/src/libs/humanizer/index.ts
+++ b/src/libs/humanizer/index.ts
@@ -95,6 +95,7 @@ const sharedHumanization = async <InputDataType extends AccountOp | Message>(
     message = parse(stringify(data))
   }
   for (let i = 0; i <= 3; i++) {
+    // @TODO refactor conditional for nocache
     const totalHumanizerMetaToBeUsed = await lazyReadHumanizerMeta(storage, {
       nocache: options && !options?.isExtension
     })
@@ -141,7 +142,7 @@ const sharedHumanization = async <InputDataType extends AccountOp | Message>(
     }
 
     // if we are in the history no more than 1 cycle and no async operations
-    if (options?.history) return
+    if (options?.noAsyncOperations) return
 
     const humanizerFragments = await Promise.all(
       asyncOps.map((asyncOperation) => asyncOperation())

--- a/src/libs/humanizer/interfaces.ts
+++ b/src/libs/humanizer/interfaces.ts
@@ -48,7 +48,7 @@ export interface HumanizerFragment {
 export interface HumanizerCallModule {
   (AccountOp: AccountOp, calls: IrCall[], humanizerMeta: HumanizerMeta, options?: any): [
     IrCall[],
-    Promise<HumanizerFragment | null>[]
+    Array<() => Promise<HumanizerFragment | null>>
   ]
 }
 
@@ -94,7 +94,7 @@ export interface HumanizerParsingModule {
   (humanizerSettings: HumanizerSettings, visualization: HumanizerVisualization[], options?: any): [
     HumanizerVisualization[],
     HumanizerWarning[],
-    Promise<HumanizerFragment | null>[]
+    Array<() => Promise<HumanizerFragment | null>>
   ]
 }
 

--- a/src/libs/humanizer/interfaces.ts
+++ b/src/libs/humanizer/interfaces.ts
@@ -43,12 +43,12 @@ export interface HumanizerFragment {
   key: string
   value: string | Array<any> | AbiFragment | any
 }
-
+export type HumanizerPromise = () => Promise<HumanizerFragment | null>
 // @TODO make humanizer options interface
 export interface HumanizerCallModule {
   (AccountOp: AccountOp, calls: IrCall[], humanizerMeta: HumanizerMeta, options?: any): [
     IrCall[],
-    Array<() => Promise<HumanizerFragment | null>>
+    HumanizerPromise[]
   ]
 }
 
@@ -94,7 +94,7 @@ export interface HumanizerParsingModule {
   (humanizerSettings: HumanizerSettings, visualization: HumanizerVisualization[], options?: any): [
     HumanizerVisualization[],
     HumanizerWarning[],
-    Array<() => Promise<HumanizerFragment | null>>
+    HumanizerPromise[]
   ]
 }
 

--- a/src/libs/humanizer/modules/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/fallBackHumanizer.ts
@@ -6,6 +6,7 @@ import {
   HumanizerCallModule,
   HumanizerFragment,
   HumanizerMeta,
+  HumanizerPromise,
   HumanizerVisualization,
   IrCall
 } from '../interfaces'
@@ -151,7 +152,7 @@ export const fallbackHumanizer: HumanizerCallModule = (
   humanizerMeta: HumanizerMeta,
   options?: any
 ) => {
-  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
+  const asyncOps: HumanizerPromise[] = []
   const newCalls = currentIrCalls.map((call) => {
     if (call.fullVisualization && !checkIfUnknownAction(call?.fullVisualization)) return call
 

--- a/src/libs/humanizer/modules/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/fallBackHumanizer.ts
@@ -151,7 +151,7 @@ export const fallbackHumanizer: HumanizerCallModule = (
   humanizerMeta: HumanizerMeta,
   options?: any
 ) => {
-  const asyncOps: Promise<HumanizerFragment | null>[] = []
+  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
   const newCalls = currentIrCalls.map((call) => {
     if (call.fullVisualization && !checkIfUnknownAction(call?.fullVisualization)) return call
 
@@ -196,9 +196,7 @@ export const fallbackHumanizer: HumanizerCallModule = (
           )
         )
       } else {
-        // const promise = fetchFuncEtherface(call.data.slice(0, 10), options)
-        const promise = fetchFunc4bytes(call.data.slice(0, 10), options)
-        asyncOps.push(promise)
+        asyncOps.push(() => fetchFunc4bytes(call.data.slice(0, 10), options))
 
         visualization.push(
           getAction('Unknown action'),

--- a/src/libs/humanizer/modules/tokens.ts
+++ b/src/libs/humanizer/modules/tokens.ts
@@ -1,7 +1,7 @@
 import { Interface, ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../accountOp/accountOp'
-import { HumanizerCallModule, HumanizerFragment, HumanizerMeta, IrCall } from '../interfaces'
+import { HumanizerCallModule, HumanizerMeta, HumanizerPromise, IrCall } from '../interfaces'
 import {
   getAction,
   getAddressVisualization,
@@ -103,7 +103,7 @@ export const genericErc20Humanizer: HumanizerCallModule = (
   humanizerMeta: HumanizerMeta,
   options?: any
 ) => {
-  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
+  const asyncOps: HumanizerPromise[] = []
   const iface = new Interface(getKnownAbi(humanizerMeta, 'ERC20', options))
   const matcher = {
     [iface.getFunction('approve')?.selector!]: (call: IrCall) => {

--- a/src/libs/humanizer/modules/tokens.ts
+++ b/src/libs/humanizer/modules/tokens.ts
@@ -103,7 +103,7 @@ export const genericErc20Humanizer: HumanizerCallModule = (
   humanizerMeta: HumanizerMeta,
   options?: any
 ) => {
-  const asyncOps: Promise<HumanizerFragment | null>[] = []
+  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
   const iface = new Interface(getKnownAbi(humanizerMeta, 'ERC20', options))
   const matcher = {
     [iface.getFunction('approve')?.selector!]: (call: IrCall) => {
@@ -165,16 +165,15 @@ export const genericErc20Humanizer: HumanizerCallModule = (
     const isToKnownToken = !!getKnownToken(humanizerMeta, call.to)
     // if proper func selector and no such token found in meta
     // console.log(matcher[sigHash], isToKnownToken)
-    if (matcher[sigHash] && !isToKnownToken) {
-      const asyncTokenInfo = getTokenInfo(accountOp, call.to, options)
-      asyncOps.push(asyncTokenInfo)
-    }
-    if (matcher[sigHash] && isToKnownToken) {
+    if (matcher[sigHash] && !isToKnownToken)
+      asyncOps.push(() => getTokenInfo(accountOp, call.to, options))
+
+    if (matcher[sigHash] && isToKnownToken)
       return {
         ...call,
         fullVisualization: matcher[sigHash](call)
       }
-    }
+
     if (isToKnownToken && !matcher[sigHash])
       return {
         ...call,

--- a/src/libs/humanizer/parsers/humanizerMetaParsing.ts
+++ b/src/libs/humanizer/parsers/humanizerMetaParsing.ts
@@ -2,7 +2,7 @@ import { ZeroAddress } from 'ethers'
 
 import { networks } from '../../../consts/networks'
 import {
-  HumanizerFragment,
+  HumanizerPromise,
   HumanizerSettings,
   HumanizerVisualization,
   HumanizerWarning
@@ -15,7 +15,7 @@ export const humanizerMetaParsing: HumanizerParsingModule = (
   options?: any
 ) => {
   const humanizerWarnings: HumanizerWarning[] = []
-  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
+  const asyncOps: HumanizerPromise[] = []
   const res: HumanizerVisualization[] = visualization.map((v) => {
     if (v.address) {
       if (v.address === ZeroAddress) {
@@ -54,6 +54,6 @@ export interface HumanizerParsingModule {
   (humanizerSettings: HumanizerSettings, visualization: HumanizerVisualization[], options?: any): [
     HumanizerVisualization[],
     HumanizerWarning[],
-    Array<() => Promise<HumanizerFragment | null>>
+    HumanizerPromise[]
   ]
 }

--- a/src/libs/humanizer/parsers/humanizerMetaParsing.ts
+++ b/src/libs/humanizer/parsers/humanizerMetaParsing.ts
@@ -15,7 +15,7 @@ export const humanizerMetaParsing: HumanizerParsingModule = (
   options?: any
 ) => {
   const humanizerWarnings: HumanizerWarning[] = []
-  const asyncOps: Promise<HumanizerFragment | null>[] = []
+  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
   const res: HumanizerVisualization[] = visualization.map((v) => {
     if (v.address) {
       if (v.address === ZeroAddress) {
@@ -32,8 +32,8 @@ export const humanizerMetaParsing: HumanizerParsingModule = (
 
       const humanizerMeta =
         humanizerSettings?.humanizerMeta?.knownAddresses[v.address.toLowerCase()]
-      if (v.type === 'token' && !humanizerMeta?.token && !v.isHidden) {
-        asyncOps.push(getTokenInfo(humanizerSettings, v.address, options))
+      if (v.type === 'token' && !humanizerMeta?.token && !v.isHidden && v.address) {
+        asyncOps.push(() => getTokenInfo(humanizerSettings, v.address!, options))
         return {
           ...v,
           humanizerMeta
@@ -54,6 +54,6 @@ export interface HumanizerParsingModule {
   (humanizerSettings: HumanizerSettings, visualization: HumanizerVisualization[], options?: any): [
     HumanizerVisualization[],
     HumanizerWarning[],
-    Promise<HumanizerFragment | null>[]
+    Array<() => Promise<HumanizerFragment | null>>
   ]
 }

--- a/src/libs/humanizer/parsers/index.ts
+++ b/src/libs/humanizer/parsers/index.ts
@@ -1,8 +1,8 @@
 import { AccountOp } from '../../accountOp/accountOp'
 import {
-  HumanizerFragment,
   HumanizerMeta,
   HumanizerParsingModule,
+  HumanizerPromise,
   HumanizerSettings,
   HumanizerVisualization,
   HumanizerWarning,
@@ -16,13 +16,9 @@ const runModules = (
   settings: HumanizerSettings,
   modules: HumanizerParsingModule[],
   options?: any
-): [
-  HumanizerVisualization[],
-  HumanizerWarning[],
-  Array<() => Promise<HumanizerFragment | null>>
-] => {
+): [HumanizerVisualization[], HumanizerWarning[], HumanizerPromise[]] => {
   const warnings: HumanizerWarning[] = []
-  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
+  const asyncOps: HumanizerPromise[] = []
 
   let visualization = _visualization
   modules.forEach((m) => {
@@ -41,8 +37,8 @@ export function parseCalls(
   modules: HumanizerParsingModule[],
   humanizerMeta: HumanizerMeta,
   options?: any
-): [IrCall[], Array<() => Promise<HumanizerFragment | null>>] {
-  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
+): [IrCall[], HumanizerPromise[]] {
+  const asyncOps: HumanizerPromise[] = []
   const newCalls = calls.map((call) => {
     const humanizerSettings: HumanizerSettings = {
       accountAddr: accountOp.accountAddr,
@@ -67,7 +63,7 @@ export function parseMessage(
   message: IrMessage,
   modules: HumanizerParsingModule[],
   options?: any
-): [IrMessage, Array<() => Promise<HumanizerFragment | null>>] {
+): [IrMessage, HumanizerPromise[]] {
   const humanizerSettings: HumanizerSettings = {
     ...settings,
     humanizerMeta: integrateFragments(

--- a/src/libs/humanizer/parsers/index.ts
+++ b/src/libs/humanizer/parsers/index.ts
@@ -16,9 +16,13 @@ const runModules = (
   settings: HumanizerSettings,
   modules: HumanizerParsingModule[],
   options?: any
-): [HumanizerVisualization[], HumanizerWarning[], Promise<HumanizerFragment | null>[]] => {
+): [
+  HumanizerVisualization[],
+  HumanizerWarning[],
+  Array<() => Promise<HumanizerFragment | null>>
+] => {
   const warnings: HumanizerWarning[] = []
-  const asyncOps: Promise<HumanizerFragment | null>[] = []
+  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
 
   let visualization = _visualization
   modules.forEach((m) => {
@@ -37,8 +41,8 @@ export function parseCalls(
   modules: HumanizerParsingModule[],
   humanizerMeta: HumanizerMeta,
   options?: any
-): [IrCall[], Promise<HumanizerFragment | null>[]] {
-  const asyncOps: Promise<HumanizerFragment | null>[] = []
+): [IrCall[], Array<() => Promise<HumanizerFragment | null>>] {
+  const asyncOps: Array<() => Promise<HumanizerFragment | null>> = []
   const newCalls = calls.map((call) => {
     const humanizerSettings: HumanizerSettings = {
       accountAddr: accountOp.accountAddr,
@@ -63,7 +67,7 @@ export function parseMessage(
   message: IrMessage,
   modules: HumanizerParsingModule[],
   options?: any
-): [IrMessage, Promise<HumanizerFragment | null>[]] {
+): [IrMessage, Array<() => Promise<HumanizerFragment | null>>] {
   const humanizerSettings: HumanizerSettings = {
     ...settings,
     humanizerMeta: integrateFragments(


### PR DESCRIPTION
Humanizer internal refactoring of the async ops system:
When the humanizer has no data about something is used to start fetching immediately and return the promise, that can be later awaited. 
Now it returns the callbacks that can trigger the fetching

Also added 
`type HumanizerPromise = ()=>Promise<HumanizerFragment | null>`