### PR TITLE
Transfer: Add checks for entered amount in transfer controller

### DIFF
--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -280,8 +280,16 @@ export class TransferController extends EventEmitter {
       ? FEE_COLLECTOR.toLowerCase()
       : this.recipientAddress.toLowerCase()
 
+    if(parseFloat(this.amount)< 1/10**this.selectedToken.decimals)
+      return this.emitError({
+        level: 'major',
+        message:
+          'Token amount too low.',
+        error: new Error('transfer: user requested token transfer amount too low.')
+      })
+
     const bigNumberHexAmount = `0x${parseUnits(
-      this.amount,
+      parseFloat(this.amount).toFixed(this.selectedToken.decimals).toString(),
       Number(this.selectedToken.decimals)
     ).toString(16)}`
 

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -280,14 +280,6 @@ export class TransferController extends EventEmitter {
       ? FEE_COLLECTOR.toLowerCase()
       : this.recipientAddress.toLowerCase()
 
-    if(parseFloat(this.amount)< 1/10**this.selectedToken.decimals)
-      return this.emitError({
-        level: 'major',
-        message:
-          'Token amount too low.',
-        error: new Error('transfer: user requested token transfer amount too low.')
-      })
-
     const bigNumberHexAmount = `0x${parseUnits(
       parseFloat(this.amount).toFixed(this.selectedToken.decimals).toString(),
       Number(this.selectedToken.decimals)

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -126,6 +126,12 @@ const validateSendTransferAmount = (amount: string, selectedAsset: TokenResult) 
 
   try {
     if (amount && selectedAsset && selectedAsset.decimals) {
+      if (Number(amount) < 1 / 10 ** selectedAsset.decimals)
+        return {
+          success: false,
+          message: 'Token amount too low.'
+        }
+
       const selectedAssetMaxAmount = Number(
         formatUnits(getTokenAmount(selectedAsset), Number(selectedAsset.decimals))
       )


### PR DESCRIPTION
fix: We used to throw ethers error when the passed amount in the transfer screen was too small