### PR TITLE
Fix / Additional Portfolio In AccountPortfolio Lost in Pending State from Force Update

### DIFF
--- a/src/libs/portfolio/portfolioView.ts
+++ b/src/libs/portfolio/portfolioView.ts
@@ -1,4 +1,7 @@
+import { Account } from 'interfaces/account'
+
 import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
+import { shouldGetAdditionalPortfolio } from './helpers'
 import {
   AccountState,
   AdditionalAccountState,
@@ -19,7 +22,8 @@ interface AccountPortfolio {
 export function calculateAccountPortfolio(
   selectedAccount: string | null,
   state: { latest: PortfolioControllerState; pending: PortfolioControllerState },
-  accountPortfolio: AccountPortfolio
+  accountPortfolio: AccountPortfolio,
+  account: Account
 ) {
   const updatedTokens: TokenResultInterface[] = []
   const updatedCollections: CollectionResultInterface[] = []
@@ -53,6 +57,19 @@ export function calculateAccountPortfolio(
   const selectedAccountData = hasPending
     ? state.pending[selectedAccount]
     : state.latest[selectedAccount]
+
+  // In the case we have a pending state we lose the gasTank and rewards data which is fetched on latest only
+  // Either that or we populate pending with them as well on forceUpdate in controller.
+  if (
+    shouldGetAdditionalPortfolio(account) &&
+    hasPending &&
+    state.latest[selectedAccount].gasTank &&
+    state.latest[selectedAccount].rewards
+  ) {
+    selectedAccountData.gasTank = state.latest[selectedAccount].gasTank
+
+    selectedAccountData.rewards = state.latest[selectedAccount].rewards
+  }
 
   const isNetworkReady = (networkData: AccountState | AdditionalAccountState | undefined) => {
     return (

--- a/src/libs/portfolio/portfolioView.ts
+++ b/src/libs/portfolio/portfolioView.ts
@@ -1,5 +1,4 @@
-import { Account } from 'interfaces/account'
-
+import { Account } from '../../interfaces/account'
 import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
 import { shouldGetAdditionalPortfolio } from './helpers'
 import {


### PR DESCRIPTION
Currently on calculating account portfolio in the case of pending state we lose the additional portfolio networks, which erases them and doesnt show them on dashboard.

Reproduce:
1. Click on refresh portfolio button which causes forceUpdate
2. AdditionalPortfolio gets all data from pending state - but additional portfolio networks are not there.