### PR TITLE
Fix: custom network deploy txn estimation

### DIFF
--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -19,7 +19,6 @@ import {
   shouldIncludeActivatorCall,
   shouldUsePaymaster
 } from '../userOperation/userOperation'
-import { estimateCustomNetwork } from './customNetworks'
 import { catchEstimationFailure, estimationErrorFormatted, mapTxnErrMsg } from './errors'
 import { estimateArbitrumL1GasUsed } from './estimateArbitrum'
 import { bundlerEstimate } from './estimateBundler'
@@ -278,7 +277,7 @@ export async function estimate(
       .catch(catchEstimationFailure),
     estimateArbitrumL1GasUsed(op, account, accountState, provider).catch(catchEstimationFailure),
     isCustomNetwork
-      ? estimateCustomNetwork(account, op, accountStates, network, provider)
+      ? estimate4337(account, op, calls, accountStates, network, provider, feeTokens, blockTag)
       : new Promise((resolve) => {
           resolve(0n)
         })
@@ -304,7 +303,10 @@ export async function estimate(
 
   // we're touching the calculations for custom networks only
   // customlyEstimatedGas is 0 when the network is not custom
-  const customlyEstimatedGas = estimations[2]
+  const customlyEstimatedGas = isCustomNetwork
+    ? BigInt(estimations[2].erc4337GasLimits.callGasLimit) +
+      BigInt(estimations[2].erc4337GasLimits.preVerificationGas)
+    : 0n
   if (gasUsed < customlyEstimatedGas) gasUsed = customlyEstimatedGas
 
   // WARNING: calculateRefund will 100% NOT work in all cases we have

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -31,7 +31,7 @@ export class Bundler {
    * @returns Receipt | null
    */
   async getReceipt(userOperationHash: string, network: NetworkDescriptor) {
-    const url = `https://api.pimlico.io/v1/${network.id}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
+    const url = `https://api.pimlico.io/v1/${network.chainId}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
     const provider = getRpcProvider([url], network.chainId)
     return provider.send('eth_getUserOperationReceipt', [userOperationHash])
   }
@@ -86,7 +86,7 @@ export class Bundler {
    * @returns userOperationHash
    */
   async broadcast(userOperation: UserOperation, network: NetworkDescriptor): Promise<string> {
-    const url = `https://api.pimlico.io/v1/${network.id}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
+    const url = `https://api.pimlico.io/v1/${network.chainId}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
     const provider = getRpcProvider([url], network.chainId)
 
     return provider.send('eth_sendUserOperation', [
@@ -96,13 +96,13 @@ export class Bundler {
   }
 
   static async getStatusAndTxnId(userOperationHash: string, network: NetworkDescriptor) {
-    const url = `https://api.pimlico.io/v1/${network.id}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
+    const url = `https://api.pimlico.io/v1/${network.chainId}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
     const provider = getRpcProvider([url], network.chainId)
     return provider.send('pimlico_getUserOperationStatus', [userOperationHash])
   }
 
   static async getUserOpGasPrice(network: NetworkDescriptor) {
-    const url = `https://api.pimlico.io/v1/${network.id}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
+    const url = `https://api.pimlico.io/v1/${network.chainId}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
     const provider = getRpcProvider([url], network.chainId)
     return provider.send('pimlico_getUserOperationGasPrice', [])
   }
@@ -156,7 +156,7 @@ export class Bundler {
     userOperation: UserOperation,
     network: NetworkDescriptor
   ): Promise<Erc4337GasLimits> {
-    const url = `https://api.pimlico.io/v1/${network.id}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
+    const url = `https://api.pimlico.io/v1/${network.chainId}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
     const provider = getRpcProvider([url], network.chainId)
 
     // stateOverride is needed as our main AmbireAccount.sol contract
@@ -194,7 +194,7 @@ export class Bundler {
     medium: { maxFeePerGas: string; maxPriorityFeePerGas: string }
     fast: { maxFeePerGas: string; maxPriorityFeePerGas: string }
   }> {
-    const url = `https://api.pimlico.io/v1/${network.id}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
+    const url = `https://api.pimlico.io/v1/${network.chainId}/rpc?apikey=${process.env.REACT_APP_PIMLICO_API_KEY}`
     const provider = getRpcProvider([url], network.chainId)
     const results = await provider.send('pimlico_getUserOperationGasPrice', [])
     return {


### PR DESCRIPTION
Fix:
* when estimating the deploy txn for a custom network, use the bundler estimation instead of our custom one
* use chainId for bundler identification, not name