### PR TITLE
Humanizer: Add hidden wrapping token for wrap/unwrap

### DIFF
--- a/src/libs/humanizer/humanizerFuncs.ts
+++ b/src/libs/humanizer/humanizerFuncs.ts
@@ -48,7 +48,7 @@ export function humanizeCalls(
 
 export const visualizationToText = (call: IrCall, options: any): string => {
   let text = ''
-  const visualization = call?.fullVisualization
+  const visualization = call?.fullVisualization?.filter((i) => !i.isHidden)
   visualization?.forEach((v: HumanizerVisualization, i: number) => {
     // if not first iteration
     if (i) text += ' '

--- a/src/libs/humanizer/humanizerModules.test.ts
+++ b/src/libs/humanizer/humanizerModules.test.ts
@@ -470,22 +470,33 @@ describe('module tests', () => {
     accountOp.calls = [...transactions.weth]
     let irCalls: IrCall[] = accountOp.calls
     ;[irCalls] = wrappingModule(accountOp, irCalls, humanizerInfo)
-    expect(irCalls[0].fullVisualization?.length).toBe(2)
+    expect(irCalls[0].fullVisualization?.length).toBe(3)
     expect(irCalls[0]?.fullVisualization![0]).toMatchObject({ type: 'action', content: 'Wrap' })
     expect(irCalls[0]?.fullVisualization![1]).toMatchObject({
       type: 'token',
       address: '0x0000000000000000000000000000000000000000',
       amount: transactions.weth[0].value
     })
+    expect(irCalls[0]?.fullVisualization![2]).toMatchObject({
+      type: 'token',
+      address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+      amount: 0n,
+      isHidden: true
+    })
 
-    expect(irCalls[1].fullVisualization?.length).toBe(2)
+    expect(irCalls[1].fullVisualization?.length).toBe(3)
     expect(irCalls[1]?.fullVisualization![0]).toMatchObject({ type: 'action', content: 'Unwrap' })
     expect(irCalls[1]?.fullVisualization![1]).toMatchObject({
       type: 'token',
       address: '0x0000000000000000000000000000000000000000',
       amount: 8900000000000000n
     })
-    expect(irCalls[2]?.fullVisualization).toBeUndefined()
+    expect(irCalls[0]?.fullVisualization![2]).toMatchObject({
+      type: 'token',
+      address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+      amount: 0n,
+      isHidden: true
+    })
   })
 
   test('SWAP WRAP/UNWRAPS', () => {

--- a/src/libs/humanizer/modules/wrapped.ts
+++ b/src/libs/humanizer/modules/wrapped.ts
@@ -72,7 +72,7 @@ export const wrappingModule: HumanizerCallModule = (
       if (call.data.slice(0, 10) === iface.getFunction('deposit')?.selector) {
         return {
           ...call,
-          fullVisualization: getWraping(ZeroAddress, call.value)
+          fullVisualization: getWraping(ZeroAddress, call.value, call.to)
         }
       }
       // 0x2e1a7d4d
@@ -80,7 +80,7 @@ export const wrappingModule: HumanizerCallModule = (
         const [amount] = iface.parseTransaction(call)?.args || []
         return {
           ...call,
-          fullVisualization: getUnwraping(ZeroAddress, amount)
+          fullVisualization: getUnwraping(ZeroAddress, amount, call.to)
         }
       }
       if (!call?.fullVisualization)

--- a/src/libs/humanizer/utils.ts
+++ b/src/libs/humanizer/utils.ts
@@ -170,12 +170,28 @@ export function getUnknownVisualization(name: string, call: IrCall): HumanizerVi
   return unknownVisualization
 }
 
-export function getWraping(address: string, amount: bigint): HumanizerVisualization[] {
-  return [getAction('Wrap'), getToken(address, amount)]
+export function getWraping(
+  address: string,
+  amount: bigint,
+  hiddenAsseAddress?: string
+): HumanizerVisualization[] {
+  return [
+    getAction('Wrap'),
+    getToken(address, amount),
+    hiddenAsseAddress && { ...getToken(hiddenAsseAddress, 0n), isHidden: true }
+  ].filter((x) => x) as HumanizerVisualization[]
 }
 
-export function getUnwraping(address: string, amount: bigint): HumanizerVisualization[] {
-  return [getAction('Unwrap'), getToken(address, amount)]
+export function getUnwraping(
+  address: string,
+  amount: bigint,
+  hiddenAsseAddress?: string
+): HumanizerVisualization[] {
+  return [
+    getAction('Unwrap'),
+    getToken(address, amount),
+    hiddenAsseAddress && { ...getToken(hiddenAsseAddress, 0n), isHidden: true }
+  ].filter((x) => x) as HumanizerVisualization[]
 }
 
 export function getKnownAbi(


### PR DESCRIPTION
The simulation relies on tokens in the humanizer to get new addresses it should track. In the case of wrapping we did not return the extra, for example weth, address. 