### PR TITLE
Bug/ Infinite loading on selected account change in Transaction History/Signed Messages

### DIFF
--- a/src/controllers/activity/activity.test.ts
+++ b/src/controllers/activity/activity.test.ts
@@ -5,6 +5,14 @@ import { AccountStates } from '../../interfaces/account'
 import { SettingsController } from '../settings/settings'
 import { ActivityController, SignedMessage, SubmittedAccountOp } from './activity'
 
+const INIT_PARAMS = {
+  selectedAccount: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
+  filters: {
+    account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
+    network: 'ethereum'
+  }
+}
+
 describe('Activity Controller ', () => {
   const accounts = {
     '0xa07D75aacEFd11b425AF7181958F0F85c312f143': {
@@ -41,12 +49,7 @@ describe('Activity Controller ', () => {
       const settings = new SettingsController(storage)
       const controller = new ActivityController(storage, accounts, settings)
 
-      controller.init({
-        filters: {
-          account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          network: 'ethereum'
-        }
-      })
+      controller.init(INIT_PARAMS)
 
       const accountOp = {
         accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
@@ -87,12 +90,7 @@ describe('Activity Controller ', () => {
       const settings = new SettingsController(storage)
       const controller = new ActivityController(storage, accounts, settings)
 
-      controller.init({
-        filters: {
-          account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          network: 'ethereum'
-        }
-      })
+      controller.init(INIT_PARAMS)
 
       const accountsOps = [
         {
@@ -216,12 +214,7 @@ describe('Activity Controller ', () => {
       const settings = new SettingsController(storage)
       const controller = new ActivityController(storage, accounts, settings)
 
-      controller.init({
-        filters: {
-          account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          network: 'ethereum'
-        }
-      })
+      controller.init(INIT_PARAMS)
 
       const accountOp = {
         accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
@@ -260,12 +253,7 @@ describe('Activity Controller ', () => {
       const settings = new SettingsController(storage)
       const controller = new ActivityController(storage, accounts, settings)
 
-      controller.init({
-        filters: {
-          account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          network: 'ethereum'
-        }
-      })
+      controller.init(INIT_PARAMS)
 
       const accountOp = {
         accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
@@ -305,6 +293,7 @@ describe('Activity Controller ', () => {
       const controller = new ActivityController(storage, accounts, settings)
 
       controller.init({
+        selectedAccount: '0xa07D75aacEFd11b425AF7181958F0F85c312f143',
         filters: {
           account: '0xa07D75aacEFd11b425AF7181958F0F85c312f143',
           network: 'ethereum'
@@ -348,12 +337,7 @@ describe('Activity Controller ', () => {
       const settings = new SettingsController(storage)
       const controller = new ActivityController(storage, accounts, settings)
 
-      controller.init({
-        filters: {
-          account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          network: 'ethereum'
-        }
-      })
+      controller.init(INIT_PARAMS)
 
       const accountOp = {
         accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
@@ -401,12 +385,7 @@ describe('Activity Controller ', () => {
       const settings = new SettingsController(storage)
       const controller = new ActivityController(storage, accounts, settings)
 
-      controller.init({
-        filters: {
-          account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          network: 'ethereum'
-        }
-      })
+      controller.init(INIT_PARAMS)
 
       const signedMessage: SignedMessage = {
         id: 1,
@@ -445,12 +424,7 @@ describe('Activity Controller ', () => {
       const settings = new SettingsController(storage)
       const controller = new ActivityController(storage, accounts, settings)
 
-      controller.init({
-        filters: {
-          account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          network: 'ethereum'
-        }
-      })
+      controller.init(INIT_PARAMS)
 
       const signedMessage: SignedMessage = {
         id: 1,
@@ -495,12 +469,7 @@ describe('Activity Controller ', () => {
       const settings = new SettingsController(storage)
       const controller = new ActivityController(storage, accounts, settings)
 
-      controller.init({
-        filters: {
-          account: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          network: 'ethereum'
-        }
-      })
+      controller.init(INIT_PARAMS)
 
       const signedMessage: SignedMessage = {
         id: 1,

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -3,7 +3,7 @@
 import { SettingsController } from 'controllers/settings/settings'
 import fetch from 'node-fetch'
 
-import { AccountStates } from '../../interfaces/account'
+import { AccountId, AccountStates } from '../../interfaces/account'
 import { Banner } from '../../interfaces/banner'
 import { Storage } from '../../interfaces/storage'
 import { Message } from '../../interfaces/userRequest'
@@ -128,6 +128,8 @@ export class ActivityController extends EventEmitter {
 
   #settings: SettingsController
 
+  #selectedAccount: AccountId | null = null
+
   constructor(storage: Storage, accountStates: AccountStates, settings: SettingsController) {
     super()
     this.#storage = storage
@@ -148,23 +150,28 @@ export class ActivityController extends EventEmitter {
     this.emitUpdate()
   }
 
-  init({ filters }: { filters: Filters }) {
-    this.filters = filters
+  init({ selectedAccount, filters }: { selectedAccount: AccountId | null; filters?: Filters }) {
+    this.#selectedAccount = selectedAccount
     this.isInitialized = true
 
-    this.accountsOps = this.filterAndPaginateAccountOps(
-      this.#accountsOps,
-      this.accountsOpsPagination
-    )
-    this.signedMessages = this.filterAndPaginateSignedMessages(
-      this.#signedMessages,
-      this.signedMessagesPagination
-    )
+    if (filters) {
+      this.filters = filters
+
+      this.accountsOps = this.filterAndPaginateAccountOps(
+        this.#accountsOps,
+        this.accountsOpsPagination
+      )
+      this.signedMessages = this.filterAndPaginateSignedMessages(
+        this.#signedMessages,
+        this.signedMessagesPagination
+      )
+    }
 
     this.emitUpdate()
   }
 
   reset() {
+    this.#selectedAccount = null
     this.filters = null
     this.isInitialized = false
     this.emitUpdate()
@@ -181,11 +188,14 @@ export class ActivityController extends EventEmitter {
       return
     }
 
-    let filteredItems = []
-    if (this.filters!.network) {
-      filteredItems = items?.[this.filters!.account]?.[this.filters!.network] || []
-    } else {
-      filteredItems = Object.values(items?.[this.filters!.account] || []).flat()
+    let filteredItems: T[] = []
+
+    if (this.filters) {
+      if (this.filters.network) {
+        filteredItems = items?.[this.filters.account]?.[this.filters.network] || []
+      } else {
+        filteredItems = Object.values(items?.[this.filters.account] || []).flat()
+      }
     }
 
     const { fromPage, itemsPerPage } = pagination
@@ -208,7 +218,7 @@ export class ActivityController extends EventEmitter {
       this.#throwNotInitialized()
       return
     }
-    const filteredItems = items?.[this.filters!.account] || []
+    const filteredItems = this.filters?.account ? items?.[this.filters.account] || [] : []
     const { fromPage, itemsPerPage } = pagination
 
     return {
@@ -264,7 +274,7 @@ export class ActivityController extends EventEmitter {
 
     // Here we don't rely on `this.isInitialized` flag, as it checks for both `this.filters.account` and `this.filters.network` existence.
     // Banners are network agnostic, and that's the reason we check for `this.filters.account` only and having this.#accountsOps loaded.
-    if (!this.filters?.account || !this.#accountsOps[this.filters.account])
+    if (!this.#selectedAccount || !this.#accountsOps[this.#selectedAccount])
       return { shouldEmitUpdate: false, shouldUpdatePortfolio: false }
 
     // This flag tracks the changes to AccountsOps statuses
@@ -274,105 +284,107 @@ export class ActivityController extends EventEmitter {
     let shouldUpdatePortfolio = false
 
     await Promise.all(
-      Object.keys(this.#accountsOps[this.filters.account]).map(async (network) => {
+      Object.keys(this.#accountsOps[this.#selectedAccount]).map(async (network) => {
         const networkConfig = this.#settings.networks.find((x) => x.id === network)!
         const provider = this.#settings.providers[networkConfig.id]
 
+        const selectedAccount = this.#selectedAccount
+
+        if (!selectedAccount) return
+
         return Promise.all(
-          this.#accountsOps[this.filters!.account][network].map(
-            async (accountOp, accountOpIndex) => {
-              // Don't update the current network account ops statuses,
-              // as the statuses are already updated in the previous calls.
-              if (accountOp.status !== AccountOpStatus.BroadcastedButNotConfirmed) return
+          this.#accountsOps[selectedAccount][network].map(async (accountOp, accountOpIndex) => {
+            // Don't update the current network account ops statuses,
+            // as the statuses are already updated in the previous calls.
+            if (accountOp.status !== AccountOpStatus.BroadcastedButNotConfirmed) return
 
-              shouldEmitUpdate = true
+            shouldEmitUpdate = true
 
-              const declareFailedIfQuaterPassed = (op: SubmittedAccountOp) => {
-                const accountOpDate = new Date(op.timestamp)
-                accountOpDate.setMinutes(accountOpDate.getMinutes() + 15)
-                const aQuaterHasPassed = accountOpDate < new Date()
-                if (aQuaterHasPassed) {
-                  this.#accountsOps[this.filters!.account][network][accountOpIndex].status =
-                    AccountOpStatus.Failure
-                }
-              }
-
-              try {
-                let txnId = accountOp.txnId
-                if (accountOp.userOpHash) {
-                  const [response, bundlerResult] = await Promise.all([
-                    fetchUserOp(accountOp.userOpHash, fetch, getExplorerId(networkConfig)),
-                    Bundler.getStatusAndTxnId(accountOp.userOpHash, networkConfig)
-                  ])
-
-                  if (bundlerResult.transactionHash) {
-                    txnId = bundlerResult.transactionHash
-                    this.#accountsOps[this.filters!.account][network][accountOpIndex].txnId = txnId
-                  } else {
-                    // nothing we can do if we don't have information
-                    if (response.status !== 200) return
-
-                    const data = await response.json()
-                    const userOps = data.userOps
-
-                    // if there are not user ops, it means the userOpHash is not
-                    // indexed, yet, so we wait
-                    if (userOps.length) {
-                      txnId = userOps[0].transactionHash
-                      this.#accountsOps[this.filters!.account][network][accountOpIndex].txnId =
-                        txnId
-                    } else {
-                      declareFailedIfQuaterPassed(accountOp)
-                      return
-                    }
-                  }
-                }
-
-                const receipt = await provider.getTransactionReceipt(txnId)
-                if (receipt) {
-                  this.#accountsOps[this.filters!.account][network][accountOpIndex].status =
-                    receipt.status ? AccountOpStatus.Success : AccountOpStatus.Failure
-
-                  if (receipt.status) {
-                    shouldUpdatePortfolio = true
-                  }
-
-                  if (accountOp.isSingletonDeploy && receipt.status) {
-                    // the below promise has a catch() inside
-                    /* eslint-disable @typescript-eslint/no-floating-promises */
-                    this.#settings.setContractsDeployedToTrueIfDeployed(networkConfig)
-                  }
-                  return
-                }
-
-                // if there's no receipt, confirm there's a txn
-                // if there's no txn and 15 minutes have passed, declare it a failure
-                const txn = await provider.getTransaction(txnId)
-                if (!txn) declareFailedIfQuaterPassed(accountOp)
-              } catch {
-                this.emitError({
-                  level: 'silent',
-                  message: `Failed to determine transaction status on ${accountOp.networkId} for ${accountOp.txnId}.`,
-                  error: new Error(
-                    `activity: failed to get transaction receipt for ${accountOp.txnId}`
-                  )
-                })
-              }
-
-              if (
-                (!accountOp.userOpHash &&
-                  this.#accountStates[accountOp.accountAddr][accountOp.networkId].nonce >
-                    accountOp.nonce) ||
-                (accountOp.userOpHash &&
-                  this.#accountStates[accountOp.accountAddr][accountOp.networkId].erc4337Nonce >
-                    accountOp.nonce)
-              ) {
-                this.#accountsOps[this.filters!.account][network][accountOpIndex].status =
-                  AccountOpStatus.UnknownButPastNonce
-                shouldUpdatePortfolio = true
+            const declareFailedIfQuaterPassed = (op: SubmittedAccountOp) => {
+              const accountOpDate = new Date(op.timestamp)
+              accountOpDate.setMinutes(accountOpDate.getMinutes() + 15)
+              const aQuaterHasPassed = accountOpDate < new Date()
+              if (aQuaterHasPassed) {
+                this.#accountsOps[selectedAccount][network][accountOpIndex].status =
+                  AccountOpStatus.Failure
               }
             }
-          )
+
+            try {
+              let txnId = accountOp.txnId
+              if (accountOp.userOpHash) {
+                const [response, bundlerResult] = await Promise.all([
+                  fetchUserOp(accountOp.userOpHash, fetch, getExplorerId(networkConfig)),
+                  Bundler.getStatusAndTxnId(accountOp.userOpHash, networkConfig)
+                ])
+
+                if (bundlerResult.transactionHash) {
+                  txnId = bundlerResult.transactionHash
+                  this.#accountsOps[selectedAccount][network][accountOpIndex].txnId = txnId
+                } else {
+                  // nothing we can do if we don't have information
+                  if (response.status !== 200) return
+
+                  const data = await response.json()
+                  const userOps = data.userOps
+
+                  // if there are not user ops, it means the userOpHash is not
+                  // indexed, yet, so we wait
+                  if (userOps.length) {
+                    txnId = userOps[0].transactionHash
+                    this.#accountsOps[selectedAccount][network][accountOpIndex].txnId = txnId
+                  } else {
+                    declareFailedIfQuaterPassed(accountOp)
+                    return
+                  }
+                }
+              }
+
+              const receipt = await provider.getTransactionReceipt(txnId)
+              if (receipt) {
+                this.#accountsOps[selectedAccount][network][accountOpIndex].status = receipt.status
+                  ? AccountOpStatus.Success
+                  : AccountOpStatus.Failure
+
+                if (receipt.status) {
+                  shouldUpdatePortfolio = true
+                }
+
+                if (accountOp.isSingletonDeploy && receipt.status) {
+                  // the below promise has a catch() inside
+                  /* eslint-disable @typescript-eslint/no-floating-promises */
+                  this.#settings.setContractsDeployedToTrueIfDeployed(networkConfig)
+                }
+                return
+              }
+
+              // if there's no receipt, confirm there's a txn
+              // if there's no txn and 15 minutes have passed, declare it a failure
+              const txn = await provider.getTransaction(txnId)
+              if (!txn) declareFailedIfQuaterPassed(accountOp)
+            } catch {
+              this.emitError({
+                level: 'silent',
+                message: `Failed to determine transaction status on ${accountOp.networkId} for ${accountOp.txnId}.`,
+                error: new Error(
+                  `activity: failed to get transaction receipt for ${accountOp.txnId}`
+                )
+              })
+            }
+
+            if (
+              (!accountOp.userOpHash &&
+                this.#accountStates[accountOp.accountAddr][accountOp.networkId].nonce >
+                  accountOp.nonce) ||
+              (accountOp.userOpHash &&
+                this.#accountStates[accountOp.accountAddr][accountOp.networkId].erc4337Nonce >
+                  accountOp.nonce)
+            ) {
+              this.#accountsOps[selectedAccount][network][accountOpIndex].status =
+                AccountOpStatus.UnknownButPastNonce
+              shouldUpdatePortfolio = true
+            }
+          })
         )
       })
     )
@@ -411,13 +423,14 @@ export class ActivityController extends EventEmitter {
     this.emitUpdate()
   }
 
-  setFilters(filters: Filters): void {
+  setFilters(filters: Filters) {
     if (!this.isInitialized) {
       this.#throwNotInitialized()
       return
     }
 
     this.filters = filters
+
     this.accountsOps = this.filterAndPaginateAccountOps(
       this.#accountsOps,
       this.accountsOpsPagination
@@ -472,9 +485,9 @@ export class ActivityController extends EventEmitter {
   get broadcastedButNotConfirmed(): SubmittedAccountOp[] {
     // Here we don't rely on `this.isInitialized` flag, as it checks for both `this.filters.account` and `this.filters.network` existence.
     // Banners are network agnostic, and that's the reason we check for `this.filters.account` only and having this.#accountsOps loaded.
-    if (!this.filters?.account || !this.#accountsOps[this.filters.account]) return []
+    if (!this.#selectedAccount || !this.#accountsOps[this.#selectedAccount]) return []
 
-    return Object.values(this.#accountsOps[this.filters.account])
+    return Object.values(this.#accountsOps[this.#selectedAccount])
       .flat()
       .filter((accountOp) => accountOp.status === AccountOpStatus.BroadcastedButNotConfirmed)
   }

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -256,7 +256,7 @@ export class MainController extends EventEmitter {
     this.activity = new ActivityController(this.#storage, this.accountStates, this.settings)
 
     if (this.selectedAccount) {
-      this.activity.init({ filters: { account: this.selectedAccount } })
+      this.activity.init({ selectedAccount: this.selectedAccount })
       this.addressBook.update({
         selectedAccount
       })
@@ -527,7 +527,11 @@ export class MainController extends EventEmitter {
     this.selectedAccount = toAccountAddr
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.#storage.set('selectedAccount', toAccountAddr)
-    this.activity.init({ filters: { account: toAccountAddr } })
+
+    this.activity.init({
+      selectedAccount: toAccountAddr
+    })
+
     this.addressBook.update({
       selectedAccount: toAccountAddr
     })


### PR DESCRIPTION
## Before this PR:
Changing the `filters` param of the `activity` controller was resulting in two side effects:
1. Signed messages or signed account ops were filtered, depending on the history page
2. Transaction status banners on the dashboard were recomputed, based on the account 

This wasn't okay because activity banners on the dashboard should always be visualized for the currently selected account, while history pages can be filtered by either account. Because of the fact that activity banners should always be computed for the currently selected account `filters` had to be updated on selected account change.
```
-- main.ts:530
this.activity.init({ filters: { account: toAccountAddr } })
```
 As a consequence the existing filters were deleted, for example, if the user is on a txn history page.

## The bug:
A user could change the selected account from popup, which was updating `filters`, thus resulting in infinite loading because the filters in the UI don't match the filters in the BG. Adding a `useEffect` to match the two variables (tried here https://github.com/AmbireTech/ambire-app/pull/2234/files) isn't a viable option because the user may change the selected account while the history tab isn't focused and also results in unnecessary rerenders(because filters have to be updated twice)

## The fix:
The fix is quite simple- separate `filters` into two variables - `filters` and `#selectedAccount`. Use `filters` for history pages only and `selectedAccount` for current transactions/signed messages and other related things.