### PR TITLE
Remove / Estimation from Main

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1063,18 +1063,17 @@ export class MainController extends EventEmitter {
    * Otherwise, if either of the variables has not been recently updated, it may lead to an incorrect gas amount result.
    */
   async reestimateSignAccountOpAndUpdateGasPrices(accountAddr: AccountId, networkId: NetworkId) {
-    const accountOp = this.accountOpsToBeSigned[accountAddr]?.[networkId]?.accountOp
-    if (!this.signAccountOp || !accountOp) return
+    if (!this.signAccountOp) return
 
     await Promise.all([this.#updateGasPrice(), this.#estimateSignAccountOp()])
 
     // there's a chance signAccountOp gets destroyed between the time
     // the first "if (!this.signAccountOp) return" is performed and
     // the time we get here. To prevent issues, we check one more time
-    if (this.signAccountOp) {
-      this.signAccountOp.update({ gasPrices: this.gasPrices[networkId] })
-      this.emitUpdate()
-    }
+    if (!this.signAccountOp) return
+
+    this.signAccountOp.update({ gasPrices: this.gasPrices[networkId] })
+    this.emitUpdate()
   }
 
   // @TODO: protect this from race conditions/simultanous executions

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -142,11 +142,7 @@ export class MainController extends EventEmitter {
   // 2) it's easier to mutate this - to add/remove accountOps, to find the right accountOp to extend, etc.
   // accountAddr => networkId => { accountOp, estimation }
   // @TODO consider getting rid of the `| null` ugliness, but then we need to auto-delete
-  accountOpsToBeSigned: {
-    [key: string]: {
-      [key: string]: { accountOp: AccountOp; estimation: EstimateResult | null } | null
-    }
-  } = {}
+  accountOpsToBeSigned: { [key: string]: { [key: string]: { accountOp: AccountOp } | null } } = {}
 
   accountOpsToBeConfirmed: { [key: string]: { [key: string]: AccountOp } } = {}
 
@@ -369,7 +365,10 @@ export class MainController extends EventEmitter {
         this.signAccountOp.accountOp.signature &&
         this.signAccountOp.status?.type === SigningStatus.Done
       ) {
-        await this.broadcastSignedAccountOp(this.signAccountOp.accountOp)
+        await this.broadcastSignedAccountOp(
+          this.signAccountOp.accountOp,
+          this.signAccountOp.estimation!
+        )
       }
     }
     MainController.signAccountOpListener = this.signAccountOp.onUpdate(
@@ -378,7 +377,7 @@ export class MainController extends EventEmitter {
 
     this.emitUpdate()
 
-    this.reestimateAndUpdatePrices(accountAddr, networkId)
+    this.reestimateSignAccountOpAndUpdateGasPrices(accountAddr, networkId)
   }
 
   destroySignAccOp() {
@@ -657,10 +656,10 @@ export class MainController extends EventEmitter {
     // pass the accountOps if any so we could reflect the pending state
     const accountOps = this.accountOpsToBeSigned[selectedAccount]
       ? Object.fromEntries(
-          Object.entries(this.accountOpsToBeSigned[selectedAccount])
-            // filter out account ops that have an estimation error
-            .filter(([, accOp]) => accOp && (!accOp.estimation || !accOp.estimation.error))
-            .map(([networkId, x]) => [networkId, [x!.accountOp]])
+          Object.entries(this.accountOpsToBeSigned[selectedAccount]).map(([networkId, x]) => [
+            networkId,
+            [x!.accountOp]
+          ])
         )
       : undefined
 
@@ -862,10 +861,7 @@ export class MainController extends EventEmitter {
       const accountOp = this.#makeAccountOpFromUserRequests(meta.accountAddr, meta.networkId)
       if (accountOp) {
         this.accountOpsToBeSigned[meta.accountAddr] ||= {}
-        this.accountOpsToBeSigned[meta.accountAddr][meta.networkId] = {
-          accountOp,
-          estimation: null
-        }
+        this.accountOpsToBeSigned[meta.accountAddr][meta.networkId] = { accountOp }
         const account = this.accounts.filter((x) => x.addr === meta.accountAddr)[0]
         this.actions.addToActionsQueue(
           {
@@ -882,8 +878,8 @@ export class MainController extends EventEmitter {
           this.signAccountOp.accountOp.networkId === accountOp.networkId
         ) {
           this.signAccountOp.update({ accountOp })
+          this.#estimateSignAccountOp()
         }
-        this.#estimateAccountOp(accountOp)
       }
     } else if (action.kind === 'typedMessage' || action.kind === 'message') {
       if (!this.messagesToBeSigned[meta.accountAddr]) {
@@ -943,16 +939,14 @@ export class MainController extends EventEmitter {
       const account = this.accounts.filter((x) => x.addr === meta.accountAddr)[0]
       if (accountOp) {
         this.accountOpsToBeSigned[meta.accountAddr] ||= {}
-        this.accountOpsToBeSigned[meta.accountAddr][meta.networkId] = {
-          accountOp,
-          estimation: null
-        }
+        this.accountOpsToBeSigned[meta.accountAddr][meta.networkId] = { accountOp }
         if (
           this.signAccountOp &&
           this.signAccountOp.accountOp.accountAddr === accountOp.accountAddr &&
           this.signAccountOp.accountOp.networkId === accountOp.networkId
         ) {
           this.signAccountOp.update({ accountOp, estimation: null })
+          this.#estimateSignAccountOp()
         }
         if (account.creation) {
           // if the rejectAccountOp is called we remove the calls one by one in case of multiple calls in the op
@@ -969,7 +963,6 @@ export class MainController extends EventEmitter {
         } else {
           this.actions.removeFromActionsQueue(id)
         }
-        this.#estimateAccountOp(accountOp)
       } else {
         delete this.accountOpsToBeSigned[meta.accountAddr]?.[meta.networkId]
         if (!Object.keys(this.accountOpsToBeSigned[meta.accountAddr] || {}).length)
@@ -1069,34 +1062,28 @@ export class MainController extends EventEmitter {
    * it would be preferable to update them simultaneously.
    * Otherwise, if either of the variables has not been recently updated, it may lead to an incorrect gas amount result.
    */
-  async reestimateAndUpdatePrices(accountAddr: AccountId, networkId: NetworkId) {
-    if (!this.signAccountOp) return
-
+  async reestimateSignAccountOpAndUpdateGasPrices(accountAddr: AccountId, networkId: NetworkId) {
     const accountOp = this.accountOpsToBeSigned[accountAddr]?.[networkId]?.accountOp
-    const reestimate = accountOp
-      ? this.#estimateAccountOp(accountOp)
-      : new Promise((resolve) => {
-          resolve(true)
-        })
+    if (!this.signAccountOp || !accountOp) return
 
-    await Promise.all([this.#updateGasPrice(), reestimate])
+    await Promise.all([this.#updateGasPrice(), this.#estimateSignAccountOp()])
 
     // there's a chance signAccountOp gets destroyed between the time
     // the first "if (!this.signAccountOp) return" is performed and
     // the time we get here. To prevent issues, we check one more time
     if (this.signAccountOp) {
-      const gasPrices = this.gasPrices[networkId]
-      const estimation = this.accountOpsToBeSigned[accountAddr]?.[networkId]?.estimation
-      this.signAccountOp.update({ gasPrices, ...(estimation && { estimation }) })
+      this.signAccountOp.update({ gasPrices: this.gasPrices[networkId] })
       this.emitUpdate()
     }
   }
 
   // @TODO: protect this from race conditions/simultanous executions
-  async #estimateAccountOp(accountOp: AccountOp) {
+  async #estimateSignAccountOp() {
     try {
+      if (!this.signAccountOp) return
+
       // make a local copy to avoid updating the main reference
-      const localAccountOp: AccountOp = { ...accountOp }
+      const localAccountOp: AccountOp = { ...this.signAccountOp.accountOp }
 
       await this.#initialLoadPromise
       // new accountOps should have spoof signatures so that they can be easily simulated
@@ -1118,10 +1105,14 @@ export class MainController extends EventEmitter {
       const EOAaccounts = account?.creation ? this.accounts.filter((acc) => !acc.creation) : []
 
       if (!account)
-        throw new Error(`estimateAccountOp: ${localAccountOp.accountAddr}: account does not exist`)
+        throw new Error(
+          `estimateSignAccountOp: ${localAccountOp.accountAddr}: account does not exist`
+        )
       const network = this.settings.networks.find((x) => x.id === localAccountOp.networkId)
       if (!network)
-        throw new Error(`estimateAccountOp: ${localAccountOp.networkId}: network does not exist`)
+        throw new Error(
+          `estimateSignAccountOp: ${localAccountOp.networkId}: network does not exist`
+        )
 
       // Take the fee tokens from two places: the user's tokens and his gasTank
       // The gastTank tokens participate on each network as they belong everywhere
@@ -1143,8 +1134,11 @@ export class MainController extends EventEmitter {
         // 65gwei, try to make it work most of the times on ethereum
         let gasPrice = 65000000000n
         // calculate the fast gas price to use in simulation
-        if (this.gasPrices[accountOp.networkId] && this.gasPrices[accountOp.networkId].length) {
-          const fast = this.gasPrices[accountOp.networkId][2]
+        if (
+          this.gasPrices[localAccountOp.networkId] &&
+          this.gasPrices[localAccountOp.networkId].length
+        ) {
+          const fast = this.gasPrices[localAccountOp.networkId][2]
           gasPrice =
             'gasPrice' in fast ? fast.gasPrice : fast.baseFeePerGas + fast.maxPriorityFeePerGas
           // increase the gas price with 10% to try to get above the min baseFee
@@ -1152,15 +1146,8 @@ export class MainController extends EventEmitter {
         }
         // 200k, try to make it work most of the times on ethereum
         let gas = 200000n
-        if (
-          this.accountOpsToBeSigned[localAccountOp.accountAddr] &&
-          this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId] &&
-          this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!
-            .estimation
-        ) {
-          gas =
-            this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!
-              .estimation!.gasUsed
+        if (this.signAccountOp.estimation) {
+          gas = this.signAccountOp.estimation.gasUsed
         }
         const provider = this.settings.providers[localAccountOp.networkId]
         promises = localAccountOp.calls.map((call) => {
@@ -1271,21 +1258,10 @@ export class MainController extends EventEmitter {
       // if the account op has been deleted from this.accountOpsToBeSigned,
       // don't continue as the request has already finished
       if (
-        !this.accountOpsToBeSigned[localAccountOp.accountAddr] ||
-        !this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]
+        !this.signAccountOp ||
+        !this.accountOpsToBeSigned?.[localAccountOp.accountAddr]?.[localAccountOp.networkId]
       )
         return
-
-      // @race
-      // we check this in the if statement above but in the event of a race which
-      // deletes this.accountOpsToBeSigned just before coming here,
-      // it's better an error to be thrown and caught instead of creating
-      // a new entry in this.accountOpsToBeSigned. That's why we use "!" and we should
-      // keep it that way
-      this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!.accountOp =
-        localAccountOp
-      this.accountOpsToBeSigned[localAccountOp.accountAddr][localAccountOp.networkId]!.estimation =
-        estimation
 
       // if the nonce from the estimation is different than the one in localAccountOp,
       // override all places that contain the old nonce with the correct one
@@ -1296,10 +1272,7 @@ export class MainController extends EventEmitter {
           localAccountOp.networkId
         ]!.accountOp.nonce = localAccountOp.nonce
 
-        if (
-          this.accountStates[localAccountOp.accountAddr] &&
-          this.accountStates[localAccountOp.accountAddr][localAccountOp.networkId]
-        )
+        if (this.accountStates?.[localAccountOp.accountAddr]?.[localAccountOp.networkId])
           this.accountStates[localAccountOp.accountAddr][localAccountOp.networkId].nonce =
             localAccountOp.nonce
       }
@@ -1336,7 +1309,7 @@ export class MainController extends EventEmitter {
    *   4. for smart accounts, when the Relayer does the broadcast.
    *
    */
-  async broadcastSignedAccountOp(accountOp: AccountOp) {
+  async broadcastSignedAccountOp(accountOp: AccountOp, estimation: EstimateResult) {
     this.broadcastStatus = 'LOADING'
     this.emitUpdate()
 
@@ -1367,8 +1340,6 @@ export class MainController extends EventEmitter {
     }
 
     let transactionRes: TransactionResponse | { hash: string; nonce: number } | null = null
-    const estimation =
-      this.accountOpsToBeSigned[accountOp.accountAddr][accountOp.networkId]!.estimation!
     const feeTokenEstimation = estimation.feePaymentOptions.find(
       (option) =>
         option.token.address === accountOp.gasFeePayment?.inToken &&

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -103,7 +103,7 @@ export class SignAccountOpController extends EventEmitter {
 
   gasPrices: GasRecommendation[] | null = null
 
-  #estimation: EstimateResult | null = null
+  estimation: EstimateResult | null = null
 
   feeSpeeds: {
     [identifier: string]: SpeedCalc[]
@@ -159,7 +159,7 @@ export class SignAccountOpController extends EventEmitter {
   }
 
   get isInitialized(): boolean {
-    return !!this.#estimation
+    return !!this.estimation
   }
 
   #setDefaults() {
@@ -211,8 +211,8 @@ export class SignAccountOpController extends EventEmitter {
     if (!this.isInitialized) return errors
 
     // if there's an estimation error, show it
-    if (this.#estimation?.error) {
-      errors.push(this.#estimation.error.message)
+    if (this.estimation?.error) {
+      errors.push(this.estimation.error.message)
     }
 
     const availableFeeOptions = this.availableFeeOptions
@@ -340,16 +340,16 @@ export class SignAccountOpController extends EventEmitter {
 
     if (estimation) {
       this.gasUsedTooHigh = estimation.gasUsed > 10000000n
-      this.#estimation = estimation
+      this.estimation = estimation
       // on each estimation update, set the newest account nonce
       this.accountOp.nonce = BigInt(estimation.currentAccountNonce)
     }
 
     // if estimation is undefined, do not clear the estimation.
     // We do this only if strictly specified as null
-    if (estimation === null) this.#estimation = null
+    if (estimation === null) this.estimation = null
 
-    if (this.#estimation?.error) {
+    if (this.estimation?.error) {
       this.status = { type: SigningStatus.EstimationError }
     }
 
@@ -372,7 +372,7 @@ export class SignAccountOpController extends EventEmitter {
     // Set defaults, if some of the optional params are omitted
     this.#setDefaults()
 
-    if (this.#estimation && this.paidBy && this.feeTokenResult) {
+    if (this.estimation && this.paidBy && this.feeTokenResult) {
       this.selectedOption = this.availableFeeOptions.find(
         (option) =>
           option.paidBy === this.paidBy &&
@@ -403,7 +403,7 @@ export class SignAccountOpController extends EventEmitter {
 
     if (
       this.isInitialized &&
-      this.#estimation &&
+      this.estimation &&
       this.accountOp?.signingKeyAddr &&
       this.accountOp?.signingKeyType &&
       this.accountOp?.gasFeePayment &&
@@ -425,7 +425,7 @@ export class SignAccountOpController extends EventEmitter {
 
   reset() {
     this.gasPrices = null
-    this.#estimation = null
+    this.estimation = null
     this.selectedFeeSpeed = FeeSpeed.Fast
     this.paidBy = null
     this.feeTokenResult = null
@@ -522,7 +522,7 @@ export class SignAccountOpController extends EventEmitter {
     // reset the fee speeds at the beginning to avoid duplications
     this.feeSpeeds = {}
 
-    const gasUsed = this.#estimation!.gasUsed
+    const gasUsed = this.estimation!.gasUsed
     const callDataAdditionalGasCost = getCallDataAdditionalByNetwork(
       this.accountOp!,
       this.#network,
@@ -543,7 +543,7 @@ export class SignAccountOpController extends EventEmitter {
         return
       }
 
-      const erc4337GasLimits = this.#estimation?.erc4337GasLimits
+      const erc4337GasLimits = this.estimation?.erc4337GasLimits
       if (erc4337GasLimits) {
         const speeds: SpeedCalc[] = []
         const usesPaymaster = shouldUsePaymaster(this.#network)
@@ -734,7 +734,7 @@ export class SignAccountOpController extends EventEmitter {
     if (!this.isInitialized) return []
 
     // FeeOptions having amount
-    return this.#estimation!.feePaymentOptions.filter((feeOption) => feeOption.availableAmount)
+    return this.estimation!.feePaymentOptions.filter((feeOption) => feeOption.availableAmount)
   }
 
   get accountKeyStoreKeys(): Key[] {
@@ -866,10 +866,9 @@ export class SignAccountOpController extends EventEmitter {
         )
       } else if (this.accountOp.gasFeePayment.isERC4337) {
         const userOperation = getUserOperation(this.account, accountState, this.accountOp)
-        userOperation.preVerificationGas = this.#estimation!.erc4337GasLimits!.preVerificationGas
-        userOperation.callGasLimit = this.#estimation!.erc4337GasLimits!.callGasLimit
-        userOperation.verificationGasLimit =
-          this.#estimation!.erc4337GasLimits!.verificationGasLimit
+        userOperation.preVerificationGas = this.estimation!.erc4337GasLimits!.preVerificationGas
+        userOperation.callGasLimit = this.estimation!.erc4337GasLimits!.callGasLimit
+        userOperation.verificationGasLimit = this.estimation!.erc4337GasLimits!.verificationGasLimit
         userOperation.maxFeePerGas = toBeHex(gasFeePayment.gasPrice)
         userOperation.maxPriorityFeePerGas = toBeHex(gasFeePayment.maxPriorityFeePerGas!)
         const usesOneTimeNonce = shouldUseOneTimeNonce(userOperation)

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -6,7 +6,6 @@ import { RPCProviders } from '../../interfaces/settings'
 import { UserRequest } from '../../interfaces/userRequest'
 // eslint-disable-next-line import/no-cycle
 import { AccountOp } from '../accountOp/accountOp'
-import { EstimateResult } from '../estimate/interfaces'
 import { PORTFOLIO_LIB_ERROR_NAMES } from '../portfolio/portfolio'
 import { getNetworksWithFailedRPC } from '../settings/settings'
 
@@ -18,7 +17,7 @@ export const getAccountOpBanners = ({
   networks
 }: {
   accountOpsToBeSignedByNetwork: {
-    [key: string]: { accountOp: AccountOp; estimation: EstimateResult | null } | null
+    [key: string]: { accountOp: AccountOp } | null
   }
   selectedAccount: string
   userRequests: UserRequest[]


### PR DESCRIPTION
* estimation is currently used only in the signAccountOp therefore there is no need to store expired estimation values for every accountOpToBeSigned

removing estimation from accountOpsToBeSigned will allow us for easier actions pagination implementation especially for EOA. The plan is to make accountOpsToBeSigned[addr][networkId] an array of accountOps or completely remove accountOpsToBeSigned in favor of actions of type accountOp