### PR TITLE
Add pre-parsig for humanizer calls

### DIFF
--- a/src/libs/humanizer/index.ts
+++ b/src/libs/humanizer/index.ts
@@ -27,6 +27,7 @@ import { WALLETModule } from './modules/WALLET'
 import { wrappingModule } from './modules/wrapped'
 import { parseCalls, parseMessage } from './parsers'
 import { humanizerMetaParsing } from './parsers/humanizerMetaParsing'
+import { preProcessHumanizer } from './modules/preProcessModule'
 import {
   erc20Module,
   erc721Module,
@@ -38,6 +39,7 @@ import { HUMANIZER_META_KEY } from './utils'
 // from most generic to least generic
 // the final humanization is the final triggered module
 export const humanizerCallModules: HumanizerCallModule[] = [
+  preProcessHumanizer,
   genericErc20Humanizer,
   genericErc721Humanizer,
   gasTankModule,

--- a/src/libs/humanizer/modules/preProcessModule.ts
+++ b/src/libs/humanizer/modules/preProcessModule.ts
@@ -1,0 +1,22 @@
+import { Interface, ZeroAddress } from 'ethers'
+
+import { AccountOp } from '../../accountOp/accountOp'
+import { HumanizerCallModule, HumanizerMeta, HumanizerPromise, IrCall } from '../interfaces'
+
+
+export const preProcessHumanizer: HumanizerCallModule = (
+  accountOp: AccountOp,
+  currentIrCalls: IrCall[],
+  humanizerMeta: HumanizerMeta,
+  options?: any
+) => {
+
+  const newCalls = currentIrCalls.map((_call) => {
+    let call = {..._call}
+    if(call.data === null){
+        call.data = '0x'
+    }
+    return call
+  })
+  return [newCalls,[]]
+}

--- a/src/libs/humanizer/modules/preProcessModule.ts
+++ b/src/libs/humanizer/modules/preProcessModule.ts
@@ -1,14 +1,11 @@
-import { Interface, ZeroAddress } from 'ethers'
-
 import { AccountOp } from '../../accountOp/accountOp'
-import { HumanizerCallModule, HumanizerMeta, HumanizerPromise, IrCall } from '../interfaces'
+import { HumanizerCallModule, IrCall } from '../interfaces'
 
 
 export const preProcessHumanizer: HumanizerCallModule = (
   accountOp: AccountOp,
   currentIrCalls: IrCall[],
-  humanizerMeta: HumanizerMeta,
-  options?: any
+  _,
 ) => {
 
   const newCalls = currentIrCalls.map((_call) => {


### PR DESCRIPTION
If `call.data` is `null` the humanizer breaks
test with `https://ambiretech.github.io/ambire-deploy-contracts/` wit hand EOA that is not used on ethereum

The fix is to parse such calls beforehand