### PR TITLE
Fix: humanizer: async token info learning custom networks

### DIFF
--- a/src/libs/humanizer/modules/tokens.ts
+++ b/src/libs/humanizer/modules/tokens.ts
@@ -18,7 +18,6 @@ export const genericErc721Humanizer: HumanizerCallModule = (
   accountOp: AccountOp,
   currentIrCalls: IrCall[],
   humanizerMeta: HumanizerMeta,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   options?: any
 ) => {
   const iface = new Interface(getKnownAbi(humanizerMeta, 'ERC721', options))

--- a/src/libs/humanizer/utils.ts
+++ b/src/libs/humanizer/utils.ts
@@ -1,9 +1,8 @@
 import dotenv from 'dotenv'
 import { ZeroAddress } from 'ethers'
-import { ErrorRef } from '../../controllers/eventEmitter/eventEmitter'
 
 import { geckoIdMapper } from '../../consts/coingecko'
-import { networks } from '../../consts/networks'
+import { ErrorRef } from '../../controllers/eventEmitter/eventEmitter'
 import { NetworkDescriptor } from '../../interfaces/networkDescriptor'
 import {
   AbiFragment,
@@ -115,9 +114,7 @@ export async function getTokenInfo(
   address: string,
   options: any
 ): Promise<HumanizerFragment | null> {
-  const network = networks.find((n: NetworkDescriptor) => n.id === humanizerSettings.networkId)
-  if (!network) return null
-  let platformId = network.platformId
+  let platformId = options?.network?.platformId
   if (!platformId) {
     options.emitError({
       message: 'getTokenInfo: could not find platform id for token info api',


### PR DESCRIPTION
The humanizer was not able to async-ly learn token info for custom networks.
Test try to swap WALLET on base