### PR TITLE
Config / Network ID to Coingecko platform ID (constant)

### DIFF
--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -382,4 +382,8 @@ export const coingeckoNets = {
   scroll: 'scroll'
 }
 
+export const networkIdToCoingeckoPlatformId = Object.fromEntries(
+  Object.entries(coingeckoNets).map(([key, value]) => [value, key])
+);
+
 export default networks


### PR DESCRIPTION
Adds one more config, a reversed structure of `coingeckoNets`.