### PR TITLE
Fix/ Logic around portfolio hints refactoring

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -421,7 +421,7 @@ describe('Portfolio Controller ', () => {
     })
   })
 
-  describe.only('Hints', () => {
+  describe('Hints', () => {
     test('Zero balance token is fetched after being learned', async () => {
       const BANANA_TOKEN_ADDR = '0x94e496474F1725f1c1824cB5BDb92d7691A4F03a'
       const { controller } = prepareTest()

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -26,6 +26,18 @@ networks.forEach((network) => {
 
 const ethereum = networks.find((network) => network.id === 'ethereum')!
 
+const prepareTest = () => {
+  const storage = produceMemoryStore()
+
+  const settings = new SettingsController(storage)
+  settings.providers = providers
+  const controller = new PortfolioController(storage, settings, relayerUrl)
+
+  return {
+    controller
+  }
+}
+
 describe('Portfolio Controller ', () => {
   const account = {
     addr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
@@ -114,7 +126,7 @@ describe('Portfolio Controller ', () => {
           expect(latestState.isReady).toEqual(true)
           expect(latestState.result?.tokens.length).toBeGreaterThan(0)
           expect(latestState.result?.collections.length).toBeGreaterThan(0)
-          expect(latestState.result?.hints).toBeTruthy()
+          expect(latestState.result?.hintsFromExternalAPI).toBeTruthy()
           expect(latestState.result?.total.usd).toBeGreaterThan(1000)
           expect(pendingState).toBeFalsy()
           done()
@@ -166,13 +178,13 @@ describe('Portfolio Controller ', () => {
           expect(latestState.isReady).toEqual(true)
           expect(latestState.result?.tokens.length).toBeGreaterThan(0)
           expect(latestState.result?.collections.length).toBeGreaterThan(0)
-          expect(latestState.result?.hints).toBeTruthy()
+          expect(latestState.result?.hintsFromExternalAPI).toBeTruthy()
           expect(latestState.result?.total.usd).toBeGreaterThan(1000)
 
           expect(pendingState.isReady).toEqual(true)
           expect(pendingState.result?.tokens.length).toBeGreaterThan(0)
           expect(pendingState.result?.collections.length).toBeGreaterThan(0)
-          expect(pendingState.result?.hints).toBeTruthy()
+          expect(pendingState.result?.hintsFromExternalAPI).toBeTruthy()
           expect(pendingState.result?.total.usd).toBeGreaterThan(1000)
           done()
         }
@@ -204,7 +216,7 @@ describe('Portfolio Controller ', () => {
 
         expect(pendingState.result?.tokens.length).toBeGreaterThan(0)
         expect(pendingState.result?.collections.length).toBeGreaterThan(0)
-        expect(pendingState.result?.hints).toBeTruthy()
+        expect(pendingState.result?.hintsFromExternalAPI).toBeTruthy()
         expect(pendingState.result?.total.usd).toBeGreaterThan(1000)
         // Expect amount post simulation to be calculated correctly
         expect(collection?.amountPostSimulation).toBe(0n)
@@ -408,13 +420,9 @@ describe('Portfolio Controller ', () => {
     })
   })
 
-  test('Additional hints', async () => {
-    const storage = produceMemoryStore()
+  test('Zero balance token is fetched after being learned', async () => {
     const BANANA_TOKEN_ADDR = '0x94e496474F1725f1c1824cB5BDb92d7691A4F03a'
-
-    const settings = new SettingsController(storage)
-    settings.providers = providers
-    const controller = new PortfolioController(storage, settings, relayerUrl)
+    const { controller } = prepareTest()
 
     await controller.learnTokens([BANANA_TOKEN_ADDR], 'ethereum')
 

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -438,7 +438,7 @@ describe('Portfolio Controller ', () => {
 
       expect(token).toBeTruthy()
     })
-    test("Learned token timestamps aren't updated if the token is in velcro or velcro doesn't work", async () => {
+    test("Learned token timestamp isn't updated if the token is found by the external hints api", async () => {
       const { controller, storage } = prepareTest()
 
       await controller.updateSelectedAccount([account], networks, account.addr, undefined)
@@ -454,25 +454,16 @@ describe('Portfolio Controller ', () => {
       // Learn a token discovered by velcro
       await controller.learnTokens([firstTokenOnEth!.address], 'ethereum')
 
+      await controller.updateSelectedAccount([account], networks, account.addr, undefined, {
+        forceUpdate: true
+      })
+
       const previousHintsStorage = await storage.get('previousHints', {})
       const firstTokenOnEthInLearned =
         previousHintsStorage.learnedTokens['ethereum'][firstTokenOnEth!.address]
 
       // Expect the timestamp to be null
       expect(firstTokenOnEthInLearned).toBeNull()
-
-      ethereum.hasRelayer = false
-
-      await controller.updateSelectedAccount([account], networks, account.addr, undefined, {
-        forceUpdate: true
-      })
-
-      const previousHintsStoragePostUpdate = await storage.get('previousHints', {})
-      const firstTokenOnEthInLearnedPostUpdate =
-        previousHintsStoragePostUpdate.learnedTokens['ethereum'][firstTokenOnEth!.address]
-
-      // Expect the timestamp to be set
-      expect(firstTokenOnEthInLearnedPostUpdate).toBeNull()
     })
   })
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -606,15 +606,19 @@ export class PortfolioController extends EventEmitter {
   // Learn new tokens from humanizer and debug_traceCall
   async learnTokens(tokenAddresses: string[] | undefined, networkId: NetworkId) {
     if (!tokenAddresses) return
+
     const storagePreviousHints = this.#previousHints
-    storagePreviousHints.learnedTokens = {}
-    const learnedTokens = storagePreviousHints.learnedTokens || {}
+
+    if (!storagePreviousHints.learnedTokens) storagePreviousHints.learnedTokens = {}
+
+    const { learnedTokens } = storagePreviousHints
     let networkLearnedTokens: { [key: string]: string | null } = learnedTokens[networkId] || {}
 
-    const tokensToLearn = tokenAddresses
-      .filter((address) => address !== ZeroAddress && !(address in networkLearnedTokens))
-      .reduce((acc: { [key: string]: null }, curr) => {
-        acc[curr] = null
+    const tokensToLearn = tokenAddresses.reduce((acc: { [key: string]: null }, address) => {
+      if (address === ZeroAddress) return acc
+
+      // Keep the timestamp of all learned tokens
+      acc[address] = acc[address] || null
         return acc
       }, {})
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -31,6 +31,7 @@ import {
 import {
   AccountState,
   AdditionalAccountState,
+  ExternalHintsAPIResponse,
   GetOptions,
   PortfolioControllerState,
   PortfolioGetResult,
@@ -572,9 +573,14 @@ export class PortfolioController extends EventEmitter {
         ])
 
         // Persist latest state in previousHints in the disk storage for further requests
-        if (isSuccessfulLatestUpdate && !areAccountOpsChanged) {
+        if (
+          isSuccessfulLatestUpdate &&
+          !areAccountOpsChanged &&
+          accountState[network.id]?.result?.hintsFromExternalAPI
+        ) {
           const updatedStoragePreviousHints = getUpdatedHints(
-            accountState[network.id]!.result!,
+            accountState[network.id]!.result!.hintsFromExternalAPI as ExternalHintsAPIResponse,
+            accountState[network.id]!.result!.tokens,
             network.id,
             storagePreviousHints,
             key,
@@ -619,8 +625,8 @@ export class PortfolioController extends EventEmitter {
 
       // Keep the timestamp of all learned tokens
       acc[address] = acc[address] || null
-        return acc
-      }, {})
+      return acc
+    }, {})
 
     if (!Object.keys(tokensToLearn).length) return
     // Add new tokens in the beginning of the list

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -44,7 +44,6 @@ import EventEmitter from '../eventEmitter/eventEmitter'
 /* eslint-disable @typescript-eslint/no-shadow */
 import { SettingsController } from '../settings/settings'
 
-const LEARNED_TOKENS_CLEAN_THRESHOLD = 10
 const LEARNED_TOKENS_NETWORK_LIMIT = 50
 
 export class PortfolioController extends EventEmitter {

--- a/src/libs/portfolio/helpers.test.ts
+++ b/src/libs/portfolio/helpers.test.ts
@@ -1,0 +1,67 @@
+import fetch from 'node-fetch'
+
+import { networks } from '../../consts/networks'
+import { getRpcProvider } from '../../services/provider'
+import { getUpdatedHints } from './helpers'
+import { Portfolio } from './portfolio'
+
+const ethereum = networks.find((x) => x.id === 'ethereum')
+const polygon = networks.find((x) => x.id === 'polygon')
+
+if (!ethereum || !polygon) throw new Error('Failed to find ethereum in networks')
+
+const provider = getRpcProvider(ethereum.rpcUrls, ethereum.chainId)
+
+const ethPortfolio = new Portfolio(fetch, provider, ethereum)
+
+const TEST_ACCOUNT_ADDRESS = '0xc4A6bB5139123bD6ba0CF387828a9A3a73EF8D1e'
+const LEARNED_TOKEN_WITH_BALANCE_ADDRESS = '0x335F4e66B9B61CEE5CeaDE4e727FCEC20156B2F0'
+
+const getTokens = async () => {
+  const ethAccPortfolio = await ethPortfolio.get(TEST_ACCOUNT_ADDRESS, {
+    additionalHints: [LEARNED_TOKEN_WITH_BALANCE_ADDRESS]
+  })
+
+  return ethAccPortfolio.tokens
+}
+
+describe('Portfolio helpers', () => {
+  test('getUpdatedHints', async () => {
+    const tokens = await getTokens()
+    const key = `ethereum:${TEST_ACCOUNT_ADDRESS}`
+
+    const updatedHints = getUpdatedHints(
+      {
+        networkId: ethereum.id,
+        erc20s: ['0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7'],
+        erc721s: {},
+        prices: {},
+        hasHints: true,
+        accountAddr: TEST_ACCOUNT_ADDRESS
+      },
+      tokens,
+      'ethereum',
+      {
+        learnedTokens: {
+          ethereum: {
+            [LEARNED_TOKEN_WITH_BALANCE_ADDRESS]: null
+          }
+        },
+        fromExternalAPI: {
+          [key]: {
+            erc20s: [],
+            erc721s: {}
+          }
+        }
+      },
+      key,
+      []
+    )
+
+    expect(tokens.find((token) => token.address === LEARNED_TOKEN_WITH_BALANCE_ADDRESS))
+    expect(updatedHints.fromExternalAPI[key]?.erc20s).toContain(
+      '0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7'
+    )
+    expect(updatedHints.learnedTokens.ethereum[LEARNED_TOKEN_WITH_BALANCE_ADDRESS]).toBeDefined()
+  })
+})

--- a/src/libs/portfolio/helpers.test.ts
+++ b/src/libs/portfolio/helpers.test.ts
@@ -1,5 +1,7 @@
 import fetch from 'node-fetch'
 
+import { describe, expect, test } from '@jest/globals'
+
 import { networks } from '../../consts/networks'
 import { getRpcProvider } from '../../services/provider'
 import { getUpdatedHints } from './helpers'

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -8,7 +8,13 @@ import { NetworkId } from '../../interfaces/networkDescriptor'
 import { RPCProvider } from '../../interfaces/settings'
 import { isSmartAccount } from '../account/account'
 import { CustomToken } from './customToken'
-import { PortfolioGetResult, PreviousHintsStorage, TokenResult } from './interfaces'
+import {
+  ExternalHintsAPIResponse,
+  Hints,
+  PortfolioGetResult,
+  PreviousHintsStorage,
+  TokenResult
+} from './interfaces'
 
 const usdcEMapping: { [key: string]: string } = {
   avalanche: '0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664',
@@ -175,53 +181,91 @@ export const getPinnedGasTankTokens = (
   }, [])
 }
 
+export const stripExternalHintsAPIResponse = (
+  response: ExternalHintsAPIResponse | null
+): PortfolioGetResult['hintsFromExternalAPI'] => {
+  if (!response) return null
+
+  return {
+    erc20s: response.erc20s,
+    erc721s: response.erc721s
+  }
+}
+
+const getLowercaseAddressArrayForNetwork = (
+  array: { address: string; networkId?: NetworkId }[],
+  networkId: NetworkId
+) =>
+  array
+    .filter((item) => !networkId || item.networkId === networkId)
+    .map((item) => item.address.toLowerCase())
+
 // Updates the previous hints storage with the latest portfolio get result.
 export function getUpdatedHints(
-  result: PortfolioGetResult,
+  latestHintsFromExternalAPI: ExternalHintsAPIResponse,
+  tokens: TokenResult[],
   networkId: NetworkId,
   storagePreviousHints: PreviousHintsStorage,
   key: string,
   tokenPreferences: CustomToken[]
-) {
-  const hints = { ...storagePreviousHints }
-  if (!hints.fromExternalAPI) hints.fromExternalAPI = {}
-  if (!hints.learnedTokens) hints.learnedTokens = {}
+): PreviousHintsStorage {
+  const previousHints = { ...storagePreviousHints }
 
-  const erc20s = result.tokens.filter((token) => token.amount > 0n).map((token) => token.address)
+  if (!previousHints.fromExternalAPI) previousHints.fromExternalAPI = {}
+  if (!previousHints.learnedTokens) previousHints.learnedTokens = {}
 
-  const erc721s = Object.fromEntries(
-    result.collections.map((collection) => [
-      collection.address,
-      result.hints.erc721s[collection.address]
-    ])
-  )
-  const previousHintsFromExternalAPI =
-    (hints.fromExternalAPI && hints.fromExternalAPI[key] && hints.fromExternalAPI[key]?.erc20s) ||
-    []
+  const { learnedTokens } = previousHints
+  const latestERC20HintsFromExternalAPI = latestHintsFromExternalAPI?.erc20s || []
+  const networkLearnedTokens = learnedTokens[networkId] || {}
 
-  hints.fromExternalAPI[key] = { erc20s, erc721s }
+  // The keys in learnedTokens are addresses of tokens
+  const networkLearnedTokenAddresses = Object.keys(networkLearnedTokens)
 
-  if (Object.keys(previousHintsFromExternalAPI).length > 0) {
-    // eslint-disable-next-line no-restricted-syntax
-    for (const address of erc20s) {
-      const isPinned = PINNED_TOKENS.some(
-        (pinned) =>
-          pinned.address.toLowerCase() === address.toLowerCase() && pinned.networkId === networkId
-      )
-      const isTokenPreference = tokenPreferences.some(
-        (preference) =>
-          preference.address.toLowerCase() === address.toLowerCase() &&
-          preference.networkId === networkId
-      )
+  if (networkLearnedTokenAddresses.length) {
+    // Lowercase all addresses outside of the loop for better performance
+    const lowercaseNetworkPinnedTokenAddresses = getLowercaseAddressArrayForNetwork(
+      PINNED_TOKENS,
+      networkId
+    )
+    const lowercaseNetworkPreferenceTokenAddresses = getLowercaseAddressArrayForNetwork(
+      tokenPreferences,
+      networkId
+    )
+    const networkTokensWithBalance = tokens.filter((token) => token.amount > 0n)
+    const lowercaseNetworkTokenAddressesWithBalance = getLowercaseAddressArrayForNetwork(
+      networkTokensWithBalance,
+      networkId
+    )
+    const lowercaseERC20HintsFromExternalAPI = latestERC20HintsFromExternalAPI.map((hint) =>
+      hint.toLowerCase()
+    )
 
-      if (!previousHintsFromExternalAPI.includes(address) && !isPinned && !isTokenPreference) {
-        if (!hints.learnedTokens[networkId]) hints.learnedTokens[networkId] = {}
-        hints.learnedTokens[networkId][address] = Date.now().toString()
+    // Update the timestamp of learned tokens
+    for (const address of networkLearnedTokenAddresses) {
+      const lowercaseAddress = address.toLowerCase()
+
+      const isPinned = lowercaseNetworkPinnedTokenAddresses.includes(lowercaseAddress)
+      const isTokenPreference = lowercaseNetworkPreferenceTokenAddresses.includes(lowercaseAddress)
+      const isTokenInExternalAPIHints =
+        lowercaseERC20HintsFromExternalAPI.includes(lowercaseAddress)
+      const hasBalance = lowercaseNetworkTokenAddressesWithBalance.includes(lowercaseAddress)
+
+      if (!isTokenInExternalAPIHints && !isPinned && !isTokenPreference && hasBalance) {
+        // Don't set the timestamp back to null if the account doesn't have balance for the token
+        // as learnedTokens aren't account specific and one account can have balance for the token
+        // while other don't
+        learnedTokens[networkId][address] = Date.now().toString()
       }
     }
   }
 
-  return hints
+  // Update the external hints for [network:account] with the latest from the external API
+  previousHints.fromExternalAPI[key] = latestHintsFromExternalAPI
+
+  return {
+    fromExternalAPI: previousHints.fromExternalAPI,
+    learnedTokens
+  }
 }
 
 export const tokenFilter = (

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -50,10 +50,13 @@ export interface ERC721s {
 }
 
 export interface Hints {
-  networkId: string
-  accountAddr: string
   erc20s: string[]
   erc721s: ERC721s
+}
+
+export interface ExternalHintsAPIResponse extends Hints {
+  networkId: string
+  accountAddr: string
   prices: {
     [name: string]: Price
   }
@@ -119,7 +122,7 @@ export interface PortfolioGetResult {
   tokenErrors: { error: string; address: string }[]
   collections: CollectionResult[]
   total: { [name: string]: number }
-  hints: Hints
+  hintsFromExternalAPI: Hints | null
   errors: ExtendedError[]
 }
 

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -114,6 +114,8 @@ export class Portfolio {
           accountAddr,
           baseCurrency
         })
+        if (!!hintsFromExternalAPI)
+          hints = stripExternalHintsAPIResponse(hintsFromExternalAPI) as Hints
       }
     } catch (error: any) {
       errors.push({
@@ -121,9 +123,6 @@ export class Portfolio {
         message: `Failed to fetch hints from Velcro for networkId (${networkId}): ${error.message}`
       })
     }
-
-    // Always add 0x00 to hints
-    hints.erc20s = [...(hintsFromExternalAPI?.erc20s || []), ZeroAddress]
 
     // Enrich hints with the previously found and cached hints, especially in the case the Velcro discovery fails.
     if (localOpts.previousHints) {
@@ -155,8 +154,8 @@ export class Portfolio {
       ]
     }
 
-    // Remove duplicates
-    hints.erc20s = [...new Set(hints.erc20s.map((erc20) => getAddress(erc20)))]
+    // Remove duplicates and always add ZeroAddress
+    hints.erc20s = [...new Set(hints.erc20s.map((erc20) => getAddress(erc20)).concat(ZeroAddress))]
 
     // This also allows getting prices, this is used for more exotic tokens that cannot be retrieved via Coingecko
     const priceCache: PriceCache = localOpts.priceCache || new Map()


### PR DESCRIPTION
## The bugs:

### Learned tokens were reset on every learnTokens call
```    
--- portfolio.learnTokens
    storagePreviousHints.learnedTokens = {} < ---
    const learnedTokens = storagePreviousHints.learnedTokens || {}
    ...
}
```
Together with that bugfix I simplified the function a bit

### lastSeenNonZeroAndNotInExternalAPIHints :see_no_evil:, or just the timestamp of learned tokens, wasn't updating
```
  const erc20s = result.tokens.filter((token) => token.amount > 0n).map((token) => token.address)
  
  const erc721s = Object.fromEntries(
    result.collections.map((collection) => [
      collection.address,
      result.hints.erc721s[collection.address]
    ])
  )
  const previousHintsFromExternalAPI =
    (hints.fromExternalAPI && hints.fromExternalAPI[key] && hints.fromExternalAPI[key]?.erc20s) ||
    []
 
  -----> We were putting the addresses of all tokens with balance, thus the condition !previousHintsFromExternalAPI.includes(address) was never satisfied
  hints.fromExternalAPI[key] = { erc20s, erc721s }
```
This one needed a bit more refactoring as code from the previous hints implementation was no longer needed and could remove the need of calculating hints from the external api. To be exact, `hints`, returned from the portfolio lib were no longer used because of the new structure. So, instead of returning all `hints` it was a better idea to return `hintsFromExternalAPI`, as all other hints were passed TO the lib and were already in the context of the controller. 
Only exposing `hintsFromExternalAPI` wasn't sufficient because the controller had to know when the external api call was successful and because the previous implementation returned `hintsFromExternalAPI` with empty arrays we had to do extra checks, so instead `hintsFromExternalAPI` is only truthy when its call is successful. If it isn't we don't update hints because:
- `learnedTokens` are already learned and their timestamps can't be updated because we don't have the response from the external api
- `fromExternalAPI` can't be updated because that would wipe "fallback" hints

## How to test the fixes:
1. Checkout the testing branch `test/fix-logic-around-portfolio-hints-refactoring`
2. Filter the output of the bg console by 'hints test:'
3. Use `https://app.uniswap.org/swap`, do transfers, block velcro requests, reload the extension as many times as you wish, delete previous hints from the extension storage and etc.