### PR TITLE
Bug / `dedicatedToOneSA` flag being wrongly set for the internal key iterator

### DIFF
--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -469,7 +469,7 @@ describe('AccountAdder', () => {
         expect(internalKeys).toHaveLength(3)
         expect(internalKeys).toContainEqual({
           privateKey: key1PrivateKey,
-          dedicatedToOneSA: true
+          dedicatedToOneSA: false
         })
         expect(internalKeys).toContainEqual({
           privateKey: key1UsedForSmartAccKeysOnlyPrivateKey,

--- a/src/controllers/keystore/keystore.test.ts
+++ b/src/controllers/keystore/keystore.test.ts
@@ -157,8 +157,8 @@ describe('KeystoreController', () => {
   test('should not add twice internal key that is already added', (done) => {
     // two keys with the same private key
     const keysWithPrivateKeyAlreadyAdded = [
-      { privateKey: privKey, dedicatedToOneSA: true },
-      { privateKey: privKey, dedicatedToOneSA: true }
+      { privateKey: privKey, dedicatedToOneSA: false },
+      { privateKey: privKey, dedicatedToOneSA: false }
     ]
 
     const anotherPrivateKeyNotAddedYet =
@@ -194,7 +194,7 @@ describe('KeystoreController', () => {
     keystore.addKeysExternallyStored([
       {
         addr: publicAddress,
-        dedicatedToOneSA: true,
+        dedicatedToOneSA: false,
         type: 'trezor',
         meta: {
           deviceId: '1',
@@ -224,7 +224,7 @@ describe('KeystoreController', () => {
       {
         addr: publicAddress,
         type: 'trezor' as 'trezor',
-        dedicatedToOneSA: true,
+        dedicatedToOneSA: false,
         meta: {
           deviceId: '1',
           deviceModel: 'trezor',
@@ -236,7 +236,7 @@ describe('KeystoreController', () => {
       {
         addr: publicAddress,
         type: 'trezor' as 'trezor',
-        dedicatedToOneSA: true,
+        dedicatedToOneSA: false,
         meta: {
           deviceId: '1',
           deviceModel: 'trezor',
@@ -252,7 +252,7 @@ describe('KeystoreController', () => {
       {
         addr: anotherAddressNotAddedYet,
         type: 'trezor' as 'trezor',
-        dedicatedToOneSA: true,
+        dedicatedToOneSA: false,
         meta: {
           deviceId: '1',
           deviceModel: 'trezor',
@@ -264,7 +264,7 @@ describe('KeystoreController', () => {
       {
         addr: anotherAddressNotAddedYet,
         type: 'trezor' as 'trezor',
-        dedicatedToOneSA: true,
+        dedicatedToOneSA: false,
         meta: {
           deviceId: '1',
           deviceModel: 'trezor',
@@ -298,7 +298,7 @@ describe('KeystoreController', () => {
       {
         addr: keyPublicAddress,
         type: 'trezor' as 'trezor',
-        dedicatedToOneSA: true,
+        dedicatedToOneSA: false,
         meta: {
           deviceId: '1',
           deviceModel: 'trezor',
@@ -309,7 +309,7 @@ describe('KeystoreController', () => {
       {
         addr: keyPublicAddress,
         type: 'trezor' as 'trezor',
-        dedicatedToOneSA: true,
+        dedicatedToOneSA: false,
         meta: {
           deviceId: '1',
           deviceModel: 'trezor',
@@ -320,7 +320,7 @@ describe('KeystoreController', () => {
       {
         addr: keyPublicAddress,
         type: 'ledger' as 'ledger',
-        dedicatedToOneSA: true,
+        dedicatedToOneSA: false,
         meta: {
           deviceId: '1',
           deviceModel: 'trezor',
@@ -468,6 +468,6 @@ describe('import/export with pub key test', () => {
         unsubscribe2()
       }
     })
-    keystore.addKeys([{ privateKey: wallet.privateKey.slice(2), dedicatedToOneSA: true }])
+    keystore.addKeys([{ privateKey: wallet.privateKey.slice(2), dedicatedToOneSA: false }])
   })
 })

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -124,11 +124,11 @@ export type KeystoreSignerType = {
  * (for the accounts that were just imported by the AccountAdder Controller).
  */
 export type ReadyToAddKeys = {
-  internal: { privateKey: string; dedicatedToOneSA: boolean }[]
+  internal: { privateKey: string; dedicatedToOneSA: Key['dedicatedToOneSA'] }[]
   external: {
     addr: Key['addr']
     type: Key['type']
-    dedicatedToOneSA: boolean
+    dedicatedToOneSA: Key['dedicatedToOneSA']
     meta: ExternalKey['meta']
   }[]
 }

--- a/src/libs/account/account.test.ts
+++ b/src/libs/account/account.test.ts
@@ -123,7 +123,7 @@ describe('Account', () => {
     const key: Key = {
       addr: basicAccount.addr,
       type: 'internal',
-      dedicatedToOneSA: true,
+      dedicatedToOneSA: false,
       meta: null,
       isExternallyStored: false
     }
@@ -249,7 +249,7 @@ describe('Account', () => {
     const anotherBasicAccountKeyWithTheSameKeyType: Key = {
       addr: anotherBasicAccount.addr,
       type: 'trezor',
-      dedicatedToOneSA: true,
+      dedicatedToOneSA: false,
       meta: {
         deviceId: '123',
         deviceModel: '1',
@@ -262,7 +262,7 @@ describe('Account', () => {
     const anotherBasicAccountKeyWithDifferentKeyType: Key = {
       addr: anotherBasicAccount.addr,
       type: 'internal',
-      dedicatedToOneSA: true,
+      dedicatedToOneSA: false,
       meta: null,
       isExternallyStored: false
     }

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -168,8 +168,8 @@ export const isSmartAccount = (account: Account) => !!account && !!account.creat
  * Checks if a (basic) EOA account is a derived one,
  * that is meant to be used as a smart account key only.
  */
-export const isDerivedForSmartAccountKeyOnly = (index: number) =>
-  index >= SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
+export const isDerivedForSmartAccountKeyOnly = (index?: number) =>
+  typeof index === 'number' && index >= SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
 
 export const getDefaultSelectedAccount = (accounts: Account[]) => {
   if (accounts.length === 0) return null

--- a/src/libs/keyIterator/keyIterator.ts
+++ b/src/libs/keyIterator/keyIterator.ts
@@ -8,8 +8,8 @@ import {
 } from '../../consts/derivation'
 import { SelectedAccountForImport } from '../../interfaces/account'
 import { KeyIterator as KeyIteratorInterface } from '../../interfaces/keyIterator'
-import { isDerivedForSmartAccountKeyOnly } from '../account/account'
 import { getHdPathFromTemplate } from '../../utils/hdPath'
+import { isDerivedForSmartAccountKeyOnly } from '../account/account'
 
 export function isValidPrivateKey(value: string): boolean {
   try {
@@ -154,7 +154,7 @@ export class KeyIterator implements KeyIteratorInterface {
 
         // Private keys for accounts used as smart account keys should be derived
         const isPrivateKeyThatShouldBeDerived =
-          this.#privateKey &&
+          !!this.#privateKey &&
           isValidPrivateKey(this.#privateKey) &&
           index >= SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
 

--- a/src/libs/keyIterator/keyIterator.ts
+++ b/src/libs/keyIterator/keyIterator.ts
@@ -8,6 +8,7 @@ import {
 } from '../../consts/derivation'
 import { SelectedAccountForImport } from '../../interfaces/account'
 import { KeyIterator as KeyIteratorInterface } from '../../interfaces/keyIterator'
+import { isDerivedForSmartAccountKeyOnly } from '../account/account'
 import { getHdPathFromTemplate } from '../../utils/hdPath'
 
 export function isValidPrivateKey(value: string): boolean {
@@ -128,8 +129,6 @@ export class KeyIterator implements KeyIteratorInterface {
       }
 
       return acc.accountKeys.flatMap(({ index }: { index: number }) => {
-        const dedicatedToOneSA = !acc.isLinked
-
         // In case it is a seed, the private keys have to be extracted
         if (this.subType === 'seed') {
           if (!this.#seedPhrase) {
@@ -141,7 +140,7 @@ export class KeyIterator implements KeyIteratorInterface {
           return [
             {
               privateKey: getPrivateKeyFromSeed(this.#seedPhrase, index, hdPathTemplate),
-              dedicatedToOneSA
+              dedicatedToOneSA: isDerivedForSmartAccountKeyOnly(index)
             }
           ]
         }
@@ -159,14 +158,12 @@ export class KeyIterator implements KeyIteratorInterface {
           isValidPrivateKey(this.#privateKey) &&
           index >= SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
 
-        return [
-          {
-            privateKey: isPrivateKeyThatShouldBeDerived
-              ? derivePrivateKeyFromAnotherPrivateKey(this.#privateKey)
-              : this.#privateKey,
-            dedicatedToOneSA
-          }
-        ]
+        const privateKey = isPrivateKeyThatShouldBeDerived
+          ? derivePrivateKeyFromAnotherPrivateKey(this.#privateKey)
+          : this.#privateKey
+        const dedicatedToOneSA = isPrivateKeyThatShouldBeDerived
+
+        return [{ privateKey, dedicatedToOneSA }]
       })
     })
   }


### PR DESCRIPTION
On a Key Iterator level:

- Fixed: The `dedicatedToOneSA` flag is supposed to be `true` only for the derived with an offset of 100,000 EOAs that Ambire use for smart account keys.