### PR TITLE
Fix: duplicate networks

### DIFF
--- a/src/controllers/settings/settings.ts
+++ b/src/controllers/settings/settings.ts
@@ -76,10 +76,18 @@ export class SettingsController extends EventEmitter {
 
   get networks(): (NetworkDescriptor & (NetworkPreference | CustomNetwork))[] {
     // set the custom networks that do not exist in ambire-common networks
-    const customPrefIds = Object.keys(this.#networkPreferences)
-    const predefinedNetworkIds = networks.map((net) => net.id)
-    const customNetworkIds = customPrefIds.filter((x) => !predefinedNetworkIds.includes(x))
-    const customNetworks = customNetworkIds.map((id: NetworkId) => {
+    const customPrefIds: { id: NetworkId; chainId: bigint }[] = []
+    Object.keys(this.#networkPreferences).forEach((networkId) => {
+      if (this.#networkPreferences[networkId] && this.#networkPreferences[networkId].chainId)
+        customPrefIds.push({
+          id: networkId,
+          chainId: this.#networkPreferences[networkId].chainId as bigint
+        })
+    })
+
+    const predefinedNetworkIds = networks.map((net) => net.chainId)
+    const customNetworkIds = customPrefIds.filter((x) => !predefinedNetworkIds.includes(x.chainId))
+    const customNetworks = customNetworkIds.map(({ id }) => {
       // @ts-ignore
       // checked with the logic for customNetworkIds
       const customNetwork: CustomNetwork = this.#networkPreferences[id]
@@ -120,7 +128,7 @@ export class SettingsController extends EventEmitter {
       // erc4337 settings should not be inherited from networkPreferences
       // for predefined networks
       if (
-        predefinedNetworkIds.includes(network.id) &&
+        predefinedNetworkIds.includes(network.chainId) &&
         networkPreferences &&
         'erc4337' in networkPreferences
       )


### PR DESCRIPTION
Fix: if there's a custom network with the same chain id already added, remove it and place the predefined network instead