### PR TITLE
Bug / Do not always auto-reset Sign Account OP errors on every update

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1631,7 +1631,7 @@ export class MainController extends EventEmitter {
     this.emitError({ level: 'major', message, error })
     // To enable another try for signing in case of broadcast fail
     // broadcast is called in the FE only after successful signing
-    this.signAccountOp?.updateStatusToReadyToSign({ shouldResetStatusIfConditionsUnmet: true })
+    this.signAccountOp?.updateStatusToReadyToSign()
     this.broadcastStatus = 'INITIAL'
     this.emitUpdate()
   }

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1631,7 +1631,7 @@ export class MainController extends EventEmitter {
     this.emitError({ level: 'major', message, error })
     // To enable another try for signing in case of broadcast fail
     // broadcast is called in the FE only after successful signing
-    this.signAccountOp?.updateStatusToReadyToSign()
+    this.signAccountOp?.updateStatusToReadyToSign({ shouldResetStatusIfConditionsUnmet: true })
     this.broadcastStatus = 'INITIAL'
     this.emitUpdate()
   }

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -920,7 +920,6 @@ export class SignAccountOpController extends EventEmitter {
               userOperation.nonce = getOneTimeNonce(userOperation)
             }
           } catch (e: any) {
-            // TODO: Should not be a signing error maybe?
             return this.#setSigningError(e.message)
           }
         }
@@ -953,10 +952,6 @@ export class SignAccountOpController extends EventEmitter {
       this.status = { type: SigningStatus.Done }
       this.emitUpdate()
     } catch (error: any) {
-      // TODO: To be discussed: errors appearing as toasts
-      // this.emitError(error)
-      // this.resetStatus()
-      // TODO: To be discussed: errors appearing as UI errors, but sometime disappearing quickly
       this.#setSigningError(error?.message, SigningStatus.ReadyToSign)
     }
   }

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -399,9 +399,7 @@ export class SignAccountOpController extends EventEmitter {
     this.updateStatusToReadyToSign()
   }
 
-  updateStatusToReadyToSign(
-    { shouldResetStatusIfConditionsUnmet } = { shouldResetStatusIfConditionsUnmet: false }
-  ) {
+  updateStatusToReadyToSign() {
     const isInTheMiddleOfSigning = this.status?.type === SigningStatus.InProgress
 
     const criticalErrors = this.errors.filter(
@@ -424,8 +422,6 @@ export class SignAccountOpController extends EventEmitter {
       (!this.gasUsedTooHigh || this.gasUsedTooHighAgreed)
     ) {
       this.status = { type: SigningStatus.ReadyToSign }
-    } else if (shouldResetStatusIfConditionsUnmet) {
-      this.status = null
     }
 
     this.emitUpdate()

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -949,7 +949,11 @@ export class SignAccountOpController extends EventEmitter {
       this.status = { type: SigningStatus.Done }
       this.emitUpdate()
     } catch (error: any) {
-      this.#setSigningError(error?.message, SigningStatus.ReadyToSign)
+      // TODO: To be discussed: errors appearing as toasts
+      this.emitError(error)
+      this.resetStatus()
+      // TODO: To be discussed: errors appearing as UI errors, but sometime disappearing quickly
+      // this.#setSigningError(error?.message, SigningStatus.ReadyToSign)
     }
   }
 


### PR DESCRIPTION
Some Account Op errors are not critical (meaning the Account Op is ready to be signed), but should NOT disappear (get reset) on every update (updateStatusToReadyToSign) tick.

That's the case with the errors coming by the signing process, for example when signing with hw wallet goes wrong:

<img width="1334" alt="Screenshot 2024-06-07 at 15 06 18" src="https://github.com/AmbireTech/ambire-common/assets/2548061/e26d9761-5be2-4956-9af5-034d0b7a43e2">

<img width="1325" alt="Screenshot 2024-06-07 at 15 08 03" src="https://github.com/AmbireTech/ambire-common/assets/2548061/de79ee07-7128-4ddb-8d0e-471fe619f705">

Before the changes in this PR, these errors disappeared on every update (for example when the estimation updates), so depending on when the error happened in the update circle, one could be visible only for a couple of seconds.

The errors coming by the broadcast should not always reset the Sign Account Op status either, since they get displayed as error toasts:

<img width="1331" alt="Screenshot 2024-06-07 at 15 23 39" src="https://github.com/AmbireTech/ambire-common/assets/2548061/f841ab8c-4603-4c43-ac08-fba26dd230d9">