### PR TITLE
Fix / PortfolioVew use Latest instead of Pending with criticalError

### DIFF
--- a/src/libs/portfolio/portfolioView.ts
+++ b/src/libs/portfolio/portfolioView.ts
@@ -77,10 +77,14 @@ export function calculateAccountPortfolio(
   }
 
   Object.keys(selectedAccountData).forEach((network: string) => {
-    const networkData = selectedAccountData[network] as
-      | AccountState
-      | AdditionalAccountState
-      | undefined
+    // In case we have error on pending state the result does not return the tokens
+    // and we dont want to not display them on dashboard/transfer
+    const accountData =
+      hasPending && !selectedAccountData[network]?.criticalError
+        ? state.pending[selectedAccount]
+        : state.latest[selectedAccount]
+
+    const networkData = accountData[network] as AccountState | AdditionalAccountState | undefined
 
     const result = networkData?.result as
       | PortfolioGetResult


### PR DESCRIPTION
In the case we have a pending we override the latest state on dashboard/transfer. But if the pending network is with a criticalError the tokens are not returned.
Can be reproduced on network with noStateOverride (for example Gnosis) and using force refresh. This causes a criticalError in pending state in portfolio controller. 