### PR TITLE
Fix: do not call coingecko on missing platformId

### DIFF
--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -114,7 +114,7 @@ export class Portfolio {
           accountAddr,
           baseCurrency
         })
-        if (!!hintsFromExternalAPI)
+        if (hintsFromExternalAPI)
           hints = stripExternalHintsAPIResponse(hintsFromExternalAPI) as Hints
       }
     } catch (error: any) {
@@ -242,6 +242,13 @@ export class Portfolio {
         if (cachedPriceIn) {
           priceIn = cachedPriceIn
 
+          return {
+            ...token,
+            priceIn
+          }
+        }
+
+        if (!this.network.platformId) {
           return {
             ...token,
             priceIn


### PR DESCRIPTION
Some custom networks dont have platformId which causes calling coingecko with null in url. Example for networks: Sepolia, Blast Mainnet