### PR TITLE
Fix / Portfolio Race Condition

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -1,6 +1,5 @@
 import { ethers, ZeroAddress } from 'ethers'
 import { CollectionResult } from 'libs/portfolio/interfaces'
-import wait from 'utils/wait'
 
 import { describe, expect, jest } from '@jest/globals'
 
@@ -25,8 +24,6 @@ networks.forEach((network) => {
   providers[network.id] = getRpcProvider(network.rpcUrls, network.chainId)
   providers[network.id].isWorking = true
 })
-
-const ethereum = networks.find((network) => network.id === 'ethereum')!
 
 const prepareTest = () => {
   const storage = produceMemoryStore()
@@ -119,16 +116,21 @@ describe('Portfolio Controller ', () => {
       providersCtrl = new ProvidersController(networksCtrl)
       providersCtrl.providers = providers
       const controller = new PortfolioController(storage, providersCtrl, networksCtrl, relayerUrl)
-      await controller.updateSelectedAccount([account2], account2.addr, ethereum)
+      console.log('1')
+      await controller.updateSelectedAccount([account2], account2.addr)
+      console.log('2')
       const storagePreviousHints = await storage.get('previousHints', {})
-      const storageErc20s = storagePreviousHints.fromExternalAPI[`ethereum:${account2.addr}`].erc20s
+      const ethereumHints = storagePreviousHints.fromExternalAPI[`ethereum:${account2.addr}`]
+      const polygonHints = storagePreviousHints.fromExternalAPI[`polygon:${account2.addr}`]
+      const optimismHints = storagePreviousHints.fromExternalAPI[`polygon:${account2.addr}`]
 
       // Controller persists tokens having balance for the current account.
-      // @TODO - here we can enhance the test to cover two more scenarios:
+      // @TODO - here we can enhance the test to cover one more scenarios:
       //  #1) Does the account really have amount for the persisted tokens.
-      //  #2) Currently, the tests covers only erc20s tokens. We should do the same check for erc721s too.
-      //  The current account2, doesn't have erc721s.
-      expect(storageErc20s.length).toBeGreaterThan(0)
+      expect(ethereumHints.erc20s.length).toBeGreaterThan(0)
+      expect(Object.keys(ethereumHints.erc721s).length).toBeGreaterThan(0)
+      expect(polygonHints.erc20s.length).toBeGreaterThan(0)
+      expect(optimismHints.erc20s.length).toBeGreaterThan(0)
     })
   })
 

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -116,9 +116,7 @@ describe('Portfolio Controller ', () => {
       providersCtrl = new ProvidersController(networksCtrl)
       providersCtrl.providers = providers
       const controller = new PortfolioController(storage, providersCtrl, networksCtrl, relayerUrl)
-      console.log('1')
       await controller.updateSelectedAccount([account2], account2.addr)
-      console.log('2')
       const storagePreviousHints = await storage.get('previousHints', {})
       const ethereumHints = storagePreviousHints.fromExternalAPI[`ethereum:${account2.addr}`]
       const polygonHints = storagePreviousHints.fromExternalAPI[`polygon:${account2.addr}`]

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -396,7 +396,7 @@ export class PortfolioController extends EventEmitter {
     this.emitUpdate()
   }
 
-  // NOTE: we always pass in all `accounts` and `networks` to ensure that the user of this
+  // NOTE: we always pass in all `accounts` to ensure that the user of this
   // controller doesn't have to update this controller every time that those are updated
 
   // The recommended behavior of the application that this API encourages is:
@@ -419,9 +419,6 @@ export class PortfolioController extends EventEmitter {
     await this.#initialLoadPromise
 
     const hasNonZeroTokens = !!this.#networksWithAssetsByAccounts?.[accountId]?.length
-    // Load storage cached hints
-    const storagePreviousHints = this.#previousHints
-
     const selectedAccount = accounts.find((x) => x.addr === accountId)
     if (!selectedAccount) throw new Error('selected account does not exist')
 
@@ -528,16 +525,16 @@ export class PortfolioController extends EventEmitter {
         const forceUpdate = opts?.forceUpdate || areAccountOpsChanged
 
         // Pass in learnedTokens as additionalHints only on areAccountOpsChanged
-        const fallbackHints = (storagePreviousHints?.fromExternalAPI &&
-          storagePreviousHints?.fromExternalAPI[key]) ?? {
+        const fallbackHints = (this.#previousHints?.fromExternalAPI &&
+          this.#previousHints?.fromExternalAPI[key]) ?? {
           erc20s: [],
           erc721s: {}
         }
         const additionalHints =
           (forceUpdate &&
             Object.keys(
-              (storagePreviousHints?.learnedTokens &&
-                storagePreviousHints?.learnedTokens[network.id]) ??
+              (this.#previousHints?.learnedTokens &&
+                this.#previousHints?.learnedTokens[network.id]) ??
                 {}
             )) ||
           []
@@ -589,13 +586,12 @@ export class PortfolioController extends EventEmitter {
             accountState[network.id]!.result!.hintsFromExternalAPI as ExternalHintsAPIResponse,
             accountState[network.id]!.result!.tokens,
             network.id,
-            storagePreviousHints,
+            this.#previousHints,
             key,
             this.tokenPreferences
           )
 
           this.#previousHints = updatedStoragePreviousHints
-
           await this.#storage.set('previousHints', updatedStoragePreviousHints)
         }
 
@@ -612,7 +608,6 @@ export class PortfolioController extends EventEmitter {
     )
 
     await this.#updateNetworksWithAssets(accounts, accountId, accountState)
-
     this.emitUpdate()
   }
 


### PR DESCRIPTION
FIXED: previousHints are not properly stored when updateSelectedAccount is called

ISSUE EXPLAINED: 
1. We assign the previous hints to a constant named storagePreviousHints.
2. Then, we iterate through each network. For each network, we attempt to update storagePreviousHints.fromExternalAPI. However, if fromExternalAPI is not defined in storagePreviousHints, a new object value is assigned to it. This behavior overrides any previously set values for fromExternalAPI in storagePreviousHints.
This leads to only the latest network that defines fromExternalAPI having its value stored in this.#previuosHints. All previous network hints are overwritten.

TODO: Consider making similar changes to the learnTokens functions - to use this.#previousHinds the latest value instead of an older value to avoid data loss when updating in a very close ticks