### PR TITLE
Fix: add custom network fee option

### DIFF
--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -163,7 +163,7 @@ export class NetworksController extends EventEmitter {
       id: networkId,
       ...network,
       ...info,
-      ...feeOptions,
+      feeOptions,
       features: getFeaturesByNetworkProperties(info),
       hasRelayer: false,
       predefined: false


### PR DESCRIPTION
Fix: when adding a custom network, add the `feeOption` to the correct place