### PR TITLE
Fix / Portfolio Additional Assigning critical Error On empty error object

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -169,7 +169,7 @@ export class PortfolioController extends EventEmitter {
     const accountState = this.latest[accountId]
     if (!accountState[network]) accountState[network] = { errors: [], isReady: false, isLoading }
     accountState[network]!.isLoading = isLoading
-    if (!error) {
+    if (error) {
       if (!accountState[network]!.isReady) accountState[network]!.criticalError = error
       else accountState[network]!.errors.push(error)
     }


### PR DESCRIPTION
Same as title. The check was wrong in `setNetworkLoading` and on !error we were assigning error = undefined.

Closes https://github.com/AmbireTech/ambire-app/issues/2358