### PR TITLE
Fix / Not Full Tokens List On Cached Data 

### DIFF
--- a/src/hooks/usePortfolio/usePortfolioFetch/useVelcroFetch.ts
+++ b/src/hooks/usePortfolio/usePortfolioFetch/useVelcroFetch.ts
@@ -318,6 +318,12 @@ export default function useVelcroFetch({
 
         // In case we have cached data from velcro - call balance oracle
         if ((!quickResponse && shouldSkipUpdate) || !tokensToUpdateBalance.length) {
+          // If formattedTokens is still empty, update it with the new response tokens
+          // (rather than from assets.tokens - previous response).
+          // This ensures that even if we are using cached data or if there are no tokens to update,
+          // we still populate the tokens list correctly before any further processing or updates.
+          // Otherwise, we will have not full tokens list, but only our tokensList from constants
+          // and we will not update balance on newly removed tokens from the list - they will be still in the list.
           if (!formattedTokens.length) {
             formattedTokens = formatTokensResponse(tokens, assets, networkToFetch?.network, account)
           }

--- a/src/hooks/usePortfolio/usePortfolioFetch/useVelcroFetch.ts
+++ b/src/hooks/usePortfolio/usePortfolioFetch/useVelcroFetch.ts
@@ -318,6 +318,10 @@ export default function useVelcroFetch({
 
         // In case we have cached data from velcro - call balance oracle
         if ((!quickResponse && shouldSkipUpdate) || !tokensToUpdateBalance.length) {
+          if (!formattedTokens.length) {
+            formattedTokens = formatTokensResponse(tokens, assets, networkToFetch?.network, account)
+          }
+
           formattedTokens = removeDuplicatedAssets([
             ...(formattedTokens || []),
             ...(extraTokensAssets?.length ? extraTokensAssets : [])


### PR DESCRIPTION
FIX: When we removed passing the previous tokens on this [last PR](https://github.com/AmbireTech/ambire-common/pull/794/files) this created an edge case which didnt populate the tokens from velcro ( but only from tokensList from jason.ambire.com ) on cached update from velcro. This is seen on the mobile app only since we refetch each time when app opens up.