### PR TITLE
Bug / Updating account preferences failing in the PROD build

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -193,7 +193,7 @@ export class AccountsController extends EventEmitter {
   }
 
   async updateAccountPreferences(accounts: { addr: string; preferences: AccountPreferences }[]) {
-    await this.withStatus(this.updateAccountPreferences.name, async () =>
+    await this.withStatus('updateAccountPreferences', async () =>
       this.#updateAccountPreferences(accounts)
     )
   }


### PR DESCRIPTION
Sometime after the https://github.com/AmbireTech/ambire-common/pull/820 changes, probably due to race condition when merging changes, the `updateAccountPreferences` method was not updated accordingly, causing updating account preferences to fail in the PROD build only.