### PR TITLE
Add: BroadcastButStuck transaction status

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -315,13 +315,13 @@ export class ActivityController extends EventEmitter {
 
             shouldEmitUpdate = true
 
-            const declareRejectedIfQuaterPassed = (op: SubmittedAccountOp) => {
+            const declareStuckIfQuaterPassed = (op: SubmittedAccountOp) => {
               const accountOpDate = new Date(op.timestamp)
               accountOpDate.setMinutes(accountOpDate.getMinutes() + 15)
               const aQuaterHasPassed = accountOpDate < new Date()
               if (aQuaterHasPassed) {
                 this.#accountsOps[selectedAccount][networkId][accountOpIndex].status =
-                  AccountOpStatus.Failure
+                  AccountOpStatus.BroadcastButStuck
               }
             }
 
@@ -360,7 +360,7 @@ export class ActivityController extends EventEmitter {
                     txnId = userOps[0].transactionHash
                     this.#accountsOps[selectedAccount][networkId][accountOpIndex].txnId = txnId
                   } else {
-                    declareRejectedIfQuaterPassed(accountOp)
+                    declareStuckIfQuaterPassed(accountOp)
                     return
                   }
                 }
@@ -384,7 +384,7 @@ export class ActivityController extends EventEmitter {
               // if there's no receipt, confirm there's a txn
               // if there's no txn and 15 minutes have passed, declare it a failure
               const txn = await provider.getTransaction(txnId)
-              if (!txn) declareRejectedIfQuaterPassed(accountOp)
+              if (!txn) declareStuckIfQuaterPassed(accountOp)
             } catch {
               this.emitError({
                 level: 'silent',

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -31,7 +31,8 @@ export enum AccountOpStatus {
   Success = 'success',
   Failure = 'failure',
   Rejected = 'rejected',
-  UnknownButPastNonce = 'unknown-but-past-nonce'
+  UnknownButPastNonce = 'unknown-but-past-nonce',
+  BroadcastButStuck = 'broadcast-but-stuck'
 }
 
 // Equivalent to ERC-4337 UserOp, but more universal than it since a AccountOp can be transformed to


### PR DESCRIPTION
Add: after a quarter passes, set the txn status to BroadcastButStuck instead of Failure

We do this so we could differentiate transactions in history. For example, Failure has a transaction receipt and so it could be opened in benzina / explorer. On the other hand, BroadcastButStuck does not as it is either dropped or stuck in the mempool