### PR TITLE
Fix: Portfolio updates, when to do a SignAccountOp destroy, additional hints in simulation

### DIFF
--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -289,7 +289,11 @@ export const tokenFilter = (
     return pinnedToken.networkId === network.id && pinnedToken.address === token.address
   })
 
-  const isInAdditionalHints = additionalHints?.includes(token.address)
+  // make the comparisson to lowercase as otherwise, it doesn't work
+  const hintsLowerCase = additionalHints
+    ? additionalHints.map((hint) => hint.toLowerCase())
+    : undefined
+  const isInAdditionalHints = hintsLowerCase?.includes(token.address.toLowerCase())
 
   // if the amount is 0
   // return the token if it's pinned and requested


### PR DESCRIPTION
Fix:
* additionalHints not caught in simulation sometimes so make the comparison lower case;
* limit portfolio updates to the current network on sign account op interactions;
* destroy the sign account op on reject (on reject there was a case where destroy was not fired)