### PR TITLE
Fix: SA estimateGas not deployed

### DIFF
--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -85,6 +85,7 @@ export async function estimate4337(
     }
   })
 
+  const accountState = accountStates[op.accountAddr][op.networkId]
   const checkInnerCallsArgs = [
     account.addr,
     ...getAccountDeployParams(account),
@@ -95,7 +96,7 @@ export async function estimate4337(
       op.accountOpToExecuteBefore?.signature || '0x'
     ],
     [account.addr, op.nonce || 1, calls, '0x'],
-    getProbableCallData(account, op, accountStates[op.accountAddr][op.networkId], network),
+    getProbableCallData(account, op, accountState, network),
     account.associatedKeys,
     filteredFeeTokens.map((feeToken) => feeToken.address),
     FEE_COLLECTOR,
@@ -110,7 +111,7 @@ export async function estimate4337(
       })
       .catch(catchEstimationFailure),
     bundlerEstimate(account, accountStates, op, network, feeTokens),
-    estimateGas(account, op, provider).catch(() => 0n)
+    estimateGas(account, op, provider, accountState).catch(() => 0n)
   ])
   const ambireEstimation = estimations[0]
   const bundlerEstimationResult: EstimateResult = estimations[1]
@@ -336,7 +337,7 @@ export async function estimate(
         blockTag
       })
       .catch(catchEstimationFailure),
-    estimateGas(account, op, provider).catch(() => 0n)
+    estimateGas(account, op, provider, accountState).catch(() => 0n)
   ]
   const estimations = await estimateWithRetries(initializeRequests)
   if (estimations instanceof Error) return estimationErrorFormatted(estimations)

--- a/src/libs/estimate/estimateGas.ts
+++ b/src/libs/estimate/estimateGas.ts
@@ -1,24 +1,33 @@
 import { Interface, JsonRpcProvider, Provider } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
+import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import { DEPLOYLESS_SIMULATION_FROM } from '../../consts/deploy'
-import { Account } from '../../interfaces/account'
+import { Account, AccountOnchainState } from '../../interfaces/account'
 import { getSpoof } from '../account/account'
-import { AccountOp, callToTuple } from '../accountOp/accountOp'
+import { AccountOp, getSignableCalls } from '../accountOp/accountOp'
 
 export async function estimateGas(
   account: Account,
   op: AccountOp,
-  provider: Provider | JsonRpcProvider
+  provider: Provider | JsonRpcProvider,
+  accountState: AccountOnchainState
 ): Promise<bigint> {
+  if (!account.creation) throw new Error('Use this estimation only for smart accounts')
+
   const saAbi = new Interface(AmbireAccount.abi)
-  const callData = saAbi.encodeFunctionData('execute', [
-    op.calls.map((call) => callToTuple(call)),
-    getSpoof(account)
-  ])
+  const factoryAbi = new Interface(AmbireFactory.abi)
+  const callData = accountState.isDeployed
+    ? saAbi.encodeFunctionData('execute', [getSignableCalls(op), getSpoof(account)])
+    : factoryAbi.encodeFunctionData('deployAndExecute', [
+        account.creation.bytecode,
+        account.creation.salt,
+        getSignableCalls(op),
+        getSpoof(account)
+      ])
   return provider.estimateGas({
     from: DEPLOYLESS_SIMULATION_FROM,
-    to: account.addr,
+    to: accountState.isDeployed ? account.addr : account.creation.factoryAddr,
     value: 0,
     data: callData,
     nonce: 0


### PR DESCRIPTION
Fix: when doing a smart account `estimateGas`, if the account is not deployed, do a `deployAndExecute` estimation