### PR TITLE
Add errors on wrong signer requested by dapp for signing

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -557,7 +557,7 @@ export class MainController extends EventEmitter {
       // TODO: if address is in this.accounts in theory the user should be able to sign
       // e.g. if an acc from the wallet is used as a signer of another wallet
       if (getAddress(msdAddress) !== this.accounts.selectedAccount) {
-        dappPromise.resolve('Invalid parameters: must use the current user address to sign')
+        dappPromise.reject(ethErrors.provider.userRejectedRequest('must use the current user address to sign'))
         return
       }
 
@@ -592,7 +592,7 @@ export class MainController extends EventEmitter {
       // TODO: if address is in this.accounts in theory the user should be able to sign
       // e.g. if an acc from the wallet is used as a signer of another wallet
       if (getAddress(msdAddress) !== this.accounts.selectedAccount) {
-        dappPromise.resolve('Invalid parameters: must use the current user address to sign')
+        dappPromise.reject(ethErrors.provider.userRejectedRequest('must use the current user address to sign'))
         return
       }
 


### PR DESCRIPTION
When the dapp requests a signature for a signer that is not the selected signer we should return an error