### PR TITLE
Fix: return back from EstimationError

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -361,6 +361,11 @@ export class SignAccountOpController extends EventEmitter {
     if (this.estimation?.error) {
       this.status = { type: SigningStatus.EstimationError }
     }
+    // if there are estimation errors and the status is estimation error,
+    // reset it as otherwise it stays like that forever
+    else if (this.status?.type === SigningStatus.EstimationError) {
+      this.status = null
+    }
 
     if (feeToken && paidBy) {
       this.paidBy = paidBy


### PR DESCRIPTION
Fix: reset the status to NULL if it was set to EstimationError and there are no errors anymore as otherwise, it does not change forever