### PR TITLE
Fix: estimation nonce

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1290,10 +1290,10 @@ export class MainController extends EventEmitter {
       // if the signAccountOp has been deleted, don't continue as the request has already finished
       if (!this.signAccountOp) return
 
-      // if the nonce from the estimation is different than the one in localAccountOp,
-      // override all places that contain the old nonce with the correct one
+      // if the nonce from the estimation is bigger than the one in localAccountOp,
+      // override the accountState and accountOp with the newly detected nonce
       // and start a new estimation
-      if (estimation && BigInt(estimation.currentAccountNonce) !== localAccountOp.nonce) {
+      if (estimation && BigInt(estimation.currentAccountNonce) > (localAccountOp.nonce ?? 0n)) {
         localAccountOp.nonce = BigInt(estimation.currentAccountNonce)
         this.signAccountOp.accountOp.nonce = BigInt(estimation.currentAccountNonce)
 

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -157,7 +157,12 @@ export async function estimate4337(
     bundlerEstimationResult.error instanceof Error
       ? bundlerEstimationResult.error
       : ambireEstimationError
-  bundlerEstimationResult.currentAccountNonce = Number(outcomeNonce - 1n)
+
+  // if Estimation.sol estimate is a success, it means the nonce has incremented
+  // so we subtract 1 from it. If it's an error, we return the old one
+  bundlerEstimationResult.currentAccountNonce = accountOp.success
+    ? Number(outcomeNonce - 1n)
+    : Number(outcomeNonce)
 
   // if there's a bundler error but there's no ambire estimator error,
   // set the estimation to standard EOA broadcast and continue
@@ -394,9 +399,9 @@ export async function estimate(
 
   return {
     gasUsed,
-    // the nonce from EstimateResult is incremented but we always want
-    // to return the current nonce. That's why we subtract 1
-    currentAccountNonce: Number(nonce - 1n),
+    // if Estimation.sol estimate is a success, it means the nonce has incremented
+    // so we subtract 1 from it. If it's an error, we return the old one
+    currentAccountNonce: accountOp.success ? Number(nonce - 1n) : Number(nonce),
     feePaymentOptions: [...feeTokenOptions, ...nativeTokenOptions],
     error: getInnerCallFailure(accountOp) || getNonceDiscrepancyFailure(op, nonce)
   }


### PR DESCRIPTION
Fix:
* when Estimation.sol returns an error, do not return a -1 subtracted nonce;
* use the nonce from the estimation only if it is bigger than the one in the account state