### PR TITLE
Do not show nonce discrepancy error

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -629,6 +629,7 @@ export class MainController extends EventEmitter {
     ])
   }
 
+  // eslint-disable-next-line default-param-last
   async updateSelectedAccountPortfolio(forceUpdate: boolean = false, network?: Network) {
     await this.#initialLoadPromise
     if (!this.accounts.selectedAccount) return
@@ -1304,6 +1305,11 @@ export class MainController extends EventEmitter {
             localAccountOp.nonce
 
         this.estimateSignAccountOp()
+
+        // returning here means estimation will not be set => better UX as
+        // the user will not see the error "nonce discrepancy" but instead
+        // just wait for the new estimation
+        return
       }
 
       // check if an RBF should be applied for the incoming transaction


### PR DESCRIPTION
Fix:
* do not show the nonce discrepancy error, instead just wait for the re-estimation to finish