### PR TITLE
Bug/ All providers marked as !isWorking on `updateAccountState` call

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -115,13 +115,17 @@ export class AccountsController extends EventEmitter {
     )
   }
 
-  async updateAccountState(accountAddr: Account['addr'], blockTag: string | number = 'latest') {
+  async updateAccountState(
+    accountAddr: Account['addr'],
+    blockTag: 'pending' | 'latest' = 'latest',
+    networks: NetworkId[] = []
+  ) {
     const accountData = this.accounts.find((account) => account.addr === accountAddr)
 
     if (!accountData) return
 
     await this.withStatus('updateAccountState', async () =>
-      this.#updateAccountStates([accountData], blockTag)
+      this.#updateAccountStates([accountData], blockTag, networks)
     )
   }
 
@@ -146,12 +150,12 @@ export class AccountsController extends EventEmitter {
             blockTag
           )
 
+          network.id === 'ethereum' && console.log('account state', networkAccountStates)
+
           this.#updateProviderIsWorking(network.id, true)
 
-          networkAccountStates.forEach((accountState, index) => {
-            const { addr } = accounts.find((acc) => acc.addr === accountState.accountAddr) || {}
-
-            if (!addr) return
+          networkAccountStates.forEach((accountState) => {
+            const addr = accountState.accountAddr
 
             if (!this.accountStates[addr]) {
               this.accountStates[addr] = {}

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -156,7 +156,7 @@ export class AccountsController extends EventEmitter {
             this.accountStates[addr][network.id] = accountState
           })
         } catch (err) {
-          console.error('account state update error: ', err)
+          console.error(`account state update error for ${network.name}: `, err)
           this.#updateProviderIsWorking(network.id, false)
         }
 

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -1,13 +1,7 @@
 import { getAddress, isAddress } from 'ethers'
 
-import {
-  Account,
-  AccountId,
-  AccountOnchainState,
-  AccountPreferences,
-  AccountStates
-} from '../../interfaces/account'
-import { Network, NetworkId } from '../../interfaces/network'
+import { Account, AccountId, AccountPreferences, AccountStates } from '../../interfaces/account'
+import { NetworkId } from '../../interfaces/network'
 import { Storage } from '../../interfaces/storage'
 import {
   getDefaultSelectedAccount,

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -144,8 +144,6 @@ export class AccountsController extends EventEmitter {
             blockTag
           )
 
-          network.id === 'ethereum' && console.log('account state', networkAccountStates)
-
           this.#updateProviderIsWorking(network.id, true)
 
           networkAccountStates.forEach((accountState) => {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -600,7 +600,7 @@ export class MainController extends EventEmitter {
     }
     // If this still didn't work, re-load
     if (!this.accounts.accountStates[accountAddr]?.[networkId])
-      await this.accounts.updateAccountState(accountAddr, networkId)
+      await this.accounts.updateAccountState(accountAddr, 'pending', [networkId])
     // If this still didn't work, throw error: this prob means that we're calling for a non-existent acc/network
     if (!this.accounts.accountStates[accountAddr]?.[networkId])
       this.signAccOpInitError = `Failed to retrieve account info for ${networkId}, because of one of the following reasons: 1) network doesn't exist, 2) RPC is down for this network`


### PR DESCRIPTION
## How to reproduce:
1. Run a local rpc proxy
```
const express = require('express')
const { createProxyMiddleware } = require('http-proxy-middleware')

const app = express()

// Middleware to add delay
const delayMiddleware = (delay) => (req, res, next) => {
	setTimeout(() => {
		next()
	}, delay * 1000)
}

// Proxy middleware
const proxyMiddleware = createProxyMiddleware({
	target: 'https://invictus.ambire.com/ethereum', // Replace with the target URL
	changeOrigin: true,
	onProxyReq: (proxyReq, req, res) => {
		console.log(`Proxying request to: ${proxyReq.protocol}//${proxyReq.host}${proxyReq.path}`)
	}
})

// Route to handle GET requests with delay
app.get('/ethereum', delayMiddleware(10), proxyMiddleware) // Adjust delay (in seconds) as needed
app.post('/ethereum', delayMiddleware(10), proxyMiddleware) // Adjust delay (in seconds) as needed

// Start the server
const PORT = process.env.PORT || 5555
app.listen(PORT, () => {
	console.log(`Proxy server is running on port ${PORT}`)
})
```
2. Add the RPC to the extension and select it
3. Stop the RPC process
4. Reload the extension (so account state is deleted)
5. Open uniswap on ethereum
6. Swap (the swap is expected to stall. This is fixed in another PR)
7. Open the dashboard and see that RPC error banners are displayed for all networks