### PR TITLE
Tests/ Temporary skip ud reverse lookup test in `domains.test.ts`

### DIFF
--- a/src/controllers/domains/domains.test.ts
+++ b/src/controllers/domains/domains.test.ts
@@ -36,7 +36,7 @@ describe('Domains', () => {
 
     expect(domainsController.domains[ENS.address].ens).toBe(ENS.name)
   })
-  it('should reverse lookup (UD)', async () => {
+  it.skip('should reverse lookup (UD)', async () => {
     await domainsController.reverseLookup(UD.address)
 
     expect(domainsController.domains[UD.address].ud).toBe(UD.name)


### PR DESCRIPTION
Unstoppable domains's domain was hijacked and the API that resolves domains no longer works.
https://twitter.com/unstoppableweb/status/1811711882119508255
https://twitter.com/matthewegould/status/1811721270871867824