### PR TITLE
Bug / Agressively reloading Dashboard race condition (resulting a "Please wait for the completion of the previous action..." warn)

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -77,7 +77,8 @@ import { SignMessageController } from '../signMessage/signMessage'
 
 const STATUS_WRAPPED_METHODS = {
   onAccountAdderSuccess: 'INITIAL',
-  removeAccount: 'INITIAL'
+  removeAccount: 'INITIAL',
+  reloadSelectedAccount: 'INITIAL'
 } as const
 
 export class MainController extends EventEmitter {
@@ -620,14 +621,17 @@ export class MainController extends EventEmitter {
     )
   }
 
-  async reloadSelectedAccount() {
+  async #reloadSelectedAccount() {
     if (!this.accounts.selectedAccount) return
 
     await Promise.all([
-      this.accounts.statuses.updateAccountState !== 'LOADING' &&
-        this.accounts.updateAccountState(this.accounts.selectedAccount, 'pending'),
+      this.accounts.updateAccountState(this.accounts.selectedAccount, 'pending'),
       this.updateSelectedAccountPortfolio(true)
     ])
+  }
+
+  reloadSelectedAccount() {
+    return this.withStatus('reloadSelectedAccount', async () => this.#reloadSelectedAccount())
   }
 
   // eslint-disable-next-line default-param-last

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -624,7 +624,8 @@ export class MainController extends EventEmitter {
     if (!this.accounts.selectedAccount) return
 
     await Promise.all([
-      this.accounts.updateAccountState(this.accounts.selectedAccount, 'pending'),
+      this.accounts.statuses.updateAccountState !== 'LOADING' &&
+        this.accounts.updateAccountState(this.accounts.selectedAccount, 'pending'),
       this.updateSelectedAccountPortfolio(true)
     ])
   }


### PR DESCRIPTION
The reload should either 1) cancel the previous update account state or 2) wait until the previous one has been completed before starting a new one.

I applied the second option since it's easier with the current code state. But TBD with @gergana95 and @PetromirDev if that's the best approach. Probably no 🙄 