### PR TITLE
Config / Silence the "Please wait for the completion of the previous action..." warn in production

### DIFF
--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -96,7 +96,13 @@ export default class EventEmitter {
     // of different sub-controllers simultaneously.
     if ((someStatusIsLoading && !allowConcurrentActions) || this.statuses[callName] !== 'INITIAL') {
       this.emitError({
-        level: 'minor',
+        level:
+          // Silence this error in prod to avoid displaying wired error messages.
+          // The only benefit of displaying it is for devs to see when an action is dispatched twice.
+          // TODO: If this happens on PROD, ideally we should get an error report somehow somewhere.
+          process.env.APP_ENV === 'production' && process.env.IS_TESTING !== 'true'
+            ? 'silent'
+            : 'minor',
         message: `Please wait for the completion of the previous action before initiating another one.', ${callName}`,
         error: new Error(
           'Another function is already being handled by withStatus refrain from invoking a second function.'


### PR DESCRIPTION
Silence this error in production to avoid displaying wired error messages. The only benefit of displaying it is for devs to see when an action is dispatched twice.