### PR TITLE
Fix: taking gas price

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1411,11 +1411,6 @@ export class MainController extends EventEmitter {
     }
 
     let transactionRes: TransactionResponse | { hash: string; nonce: number } | null = null
-    const feeTokenEstimation = estimation.feePaymentOptions.find(
-      (option) =>
-        option.token.address === accountOp.gasFeePayment?.inToken &&
-        option.paidBy === accountOp.gasFeePayment?.paidBy
-    )!
 
     // Basic account (EOA)
     if (!isSmartAccount(account)) {
@@ -1451,14 +1446,12 @@ export class MainController extends EventEmitter {
         }
 
         // if it's eip1559, send it as such. If no, go to legacy
-        const gasPrice =
-          (gasFeePayment.amount - feeTokenEstimation.addedNative) / gasFeePayment.simulatedGasLimit
         if (gasFeePayment.maxPriorityFeePerGas !== undefined) {
-          rawTxn.maxFeePerGas = gasPrice
+          rawTxn.maxFeePerGas = gasFeePayment.gasPrice
           rawTxn.maxPriorityFeePerGas = gasFeePayment.maxPriorityFeePerGas
           rawTxn.type = 2
         } else {
-          rawTxn.gasPrice = gasPrice
+          rawTxn.gasPrice = gasFeePayment.gasPrice
           rawTxn.type = 0
         }
 
@@ -1524,9 +1517,6 @@ export class MainController extends EventEmitter {
         const signer = await this.keystore.getSigner(feePayerKey.addr, feePayerKey.type)
         if (signer.init) signer.init(this.#externalSignerControllers[feePayerKey.type])
 
-        const gasPrice =
-          (accountOp.gasFeePayment.amount - feeTokenEstimation.addedNative) /
-          accountOp.gasFeePayment.simulatedGasLimit
         const rawTxn: TxnRequest = {
           to,
           data,
@@ -1540,11 +1530,11 @@ export class MainController extends EventEmitter {
         }
 
         if (accountOp.gasFeePayment.maxPriorityFeePerGas !== undefined) {
-          rawTxn.maxFeePerGas = gasPrice
+          rawTxn.maxFeePerGas = accountOp.gasFeePayment.gasPrice
           rawTxn.maxPriorityFeePerGas = accountOp.gasFeePayment.maxPriorityFeePerGas
           rawTxn.type = 2
         } else {
-          rawTxn.gasPrice = gasPrice
+          rawTxn.gasPrice = accountOp.gasFeePayment.gasPrice
           rawTxn.type = 0
         }
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -558,24 +558,26 @@ export class SignAccountOpController extends EventEmitter {
    * If the nonce of the current account op and the last account op are the same,
    * do an RBF increase or otherwise the user cannot broadcast the txn
    */
-  #rbfIncrease(accId: string, amount: bigint): bigint {
-    // TODO: think this over
+  #rbfIncrease(accId: string, gasPrice: bigint): bigint {
     // if there was an error on the signed account op with a
     // replacement fee too low, we increase by 12.5% the signed account op
+    // IF the new estimation is not actually higher
     if (this.replacementFeeLow && this.signedAccountOp && this.signedAccountOp.gasFeePayment) {
       const bumpFees =
-        this.signedAccountOp.gasFeePayment.amount + this.signedAccountOp.gasFeePayment.amount / 8n
-      return amount > bumpFees ? amount : bumpFees
+        this.signedAccountOp.gasFeePayment.gasPrice +
+        this.signedAccountOp.gasFeePayment.gasPrice / 8n
+      return gasPrice > bumpFees ? gasPrice : bumpFees
     }
 
     // if no RBF option for this paidBy option, return the amount
     const rbfOp = this.rbfAccountOps[accId]
-    if (!rbfOp || !rbfOp.gasFeePayment) return amount
+    if (!rbfOp || !rbfOp.gasFeePayment) return gasPrice
 
     // increase by a minimum of 12.5% the last broadcast txn and use that
     // or use the current gas estimation if it's more
-    const lastTxnAmountIncreased = rbfOp.gasFeePayment.amount + rbfOp.gasFeePayment.amount / 8n
-    return amount > lastTxnAmountIncreased ? amount : lastTxnAmountIncreased
+    const lastTxnGasPriceIncreased =
+      rbfOp.gasFeePayment.gasPrice + rbfOp.gasFeePayment.gasPrice / 8n
+    return gasPrice > lastTxnGasPriceIncreased ? gasPrice : lastTxnGasPriceIncreased
   }
 
   get #feeSpeedsLoading() {
@@ -666,6 +668,7 @@ export class SignAccountOpController extends EventEmitter {
 
         // EOA
         if (!isSmartAccount(this.account)) {
+          gasPrice = this.#rbfIncrease(this.account.addr, gasPrice)
           simulatedGasLimit = gasUsed
 
           if (getAddress(this.accountOp.calls[0].to) === SINGLETON) {
@@ -673,14 +676,14 @@ export class SignAccountOpController extends EventEmitter {
           }
 
           amount = simulatedGasLimit * gasPrice + option.addedNative
-          amount = this.#rbfIncrease(this.account.addr, amount)
         } else if (option.paidBy !== this.accountOp.accountAddr) {
           // Smart account, but EOA pays the fee
+          gasPrice = this.#rbfIncrease(option.paidBy, gasPrice)
           simulatedGasLimit = gasUsed + callDataAdditionalGasCost
           amount = simulatedGasLimit * gasPrice + option.addedNative
-          amount = this.#rbfIncrease(option.paidBy, amount)
         } else {
           // Relayer
+          gasPrice = this.#rbfIncrease(this.account.addr, gasPrice)
           simulatedGasLimit = gasUsed + callDataAdditionalGasCost + option.gasUsed!
           amount = SignAccountOpController.getAmountAfterFeeTokenConvert(
             simulatedGasLimit,
@@ -690,7 +693,6 @@ export class SignAccountOpController extends EventEmitter {
             option.addedNative
           )
           amount = this.#increaseFee(amount)
-          amount = this.#rbfIncrease(this.account.addr, amount)
         }
 
         const feeSpeed: SpeedCalc = {


### PR DESCRIPTION
Fix:
* when broadcasting, take the gas price directly from gasFeePayment;
* adjust the RBF so it increases gas price, not amount

When broadcasting an userOp, we take the bundler's maxFeePerGas and set it as `gasPrice` in `gasFeePayment`. If we decide to broadcast with EOA though, we calculated the gas in main.ts by a formula of (amount - oracleFee) / gasLimit. When broadcasting on base in this way, this may lead to "max fee less than priority fee" error.

Until now, the RBF was set on the amount field and eventually the correct gas price was set, but this is no longer the case. So I adjusted the RBF to work on gasPrice as well