### PR TITLE
Only one pending network

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -1,13 +1,7 @@
 import { getAddress, isAddress } from 'ethers'
 
-import {
-  Account,
-  AccountId,
-  AccountOnchainState,
-  AccountPreferences,
-  AccountStates
-} from '../../interfaces/account'
-import { Network, NetworkId } from '../../interfaces/network'
+import { Account, AccountId, AccountPreferences, AccountStates } from '../../interfaces/account'
+import { NetworkId } from '../../interfaces/network'
 import { Storage } from '../../interfaces/storage'
 import {
   getDefaultSelectedAccount,
@@ -148,7 +142,7 @@ export class AccountsController extends EventEmitter {
 
           this.#updateProviderIsWorking(network.id, true)
 
-          networkAccountStates.forEach((accountState, index) => {
+          networkAccountStates.forEach((accountState) => {
             const { addr } = accounts.find((acc) => acc.addr === accountState.accountAddr) || {}
 
             if (!addr) return

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -157,7 +157,10 @@ export class MainController extends EventEmitter {
    * Callback that gets triggered when the signing process of a message or an
    * account op (including the broadcast step) gets finalized.
    */
-  onSignSuccess: (type: 'message' | 'typed-data' | 'account-op') => void
+  onSignSuccess: (
+    type: 'message' | 'typed-data' | 'account-op',
+    meta?: { networkIds?: NetworkId[] }
+  ) => void
 
   constructor({
     storage,
@@ -176,7 +179,10 @@ export class MainController extends EventEmitter {
     keystoreSigners: Partial<{ [key in Key['type']]: KeystoreSignerType }>
     externalSignerControllers: ExternalSignerControllers
     windowManager: WindowManager
-    onSignSuccess?: (type: 'message' | 'typed-data' | 'account-op') => void
+    onSignSuccess?: (
+      type: 'message' | 'typed-data' | 'account-op',
+      meta?: { networkIds?: NetworkId[] }
+    ) => void
   }) {
     super()
     this.#storage = storage
@@ -1648,7 +1654,7 @@ export class MainController extends EventEmitter {
       )
 
       console.log('broadcasted:', transactionRes)
-      this.onSignSuccess('account-op')
+      this.onSignSuccess('account-op', { networkIds: [submittedAccountOp.networkId] })
       this.broadcastStatus = 'DONE'
       this.emitUpdate()
       await wait(1)

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -160,7 +160,7 @@ export class MainController extends EventEmitter {
    */
   onSignSuccess: (
     type: 'message' | 'typed-data' | 'account-op',
-    meta?: { networkIds?: NetworkId[] }
+    meta?: { networkId?: NetworkId }
   ) => void
 
   constructor({
@@ -182,7 +182,7 @@ export class MainController extends EventEmitter {
     windowManager: WindowManager
     onSignSuccess?: (
       type: 'message' | 'typed-data' | 'account-op',
-      meta?: { networkIds?: NetworkId[] }
+      meta?: { networkId?: NetworkId }
     ) => void
   }) {
     super()
@@ -1663,7 +1663,7 @@ export class MainController extends EventEmitter {
       actionId
     )
 
-    this.onSignSuccess('account-op', { networkIds: [submittedAccountOp.networkId] })
+    this.onSignSuccess('account-op', { networkId: submittedAccountOp.networkId })
     return Promise.resolve(submittedAccountOp)
   }
 


### PR DESCRIPTION
Change: set only one network for continuous state updates after broadcasting an account op