### PR TITLE
Update/ Allow concurrent actions for some methods in `accounts` ctrl

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -1,13 +1,7 @@
 import { getAddress, isAddress } from 'ethers'
 
-import {
-  Account,
-  AccountId,
-  AccountOnchainState,
-  AccountPreferences,
-  AccountStates
-} from '../../interfaces/account'
-import { Network, NetworkId } from '../../interfaces/network'
+import { Account, AccountId, AccountPreferences, AccountStates } from '../../interfaces/account'
+import { NetworkId } from '../../interfaces/network'
 import { Storage } from '../../interfaces/storage'
 import {
   getDefaultSelectedAccount,
@@ -88,7 +82,7 @@ export class AccountsController extends EventEmitter {
   }
 
   async selectAccount(toAccountAddr: string) {
-    await this.withStatus('selectAccount', async () => this.#selectAccount(toAccountAddr))
+    await this.withStatus('selectAccount', async () => this.#selectAccount(toAccountAddr), true)
   }
 
   async #selectAccount(toAccountAddr: string | null) {
@@ -148,7 +142,7 @@ export class AccountsController extends EventEmitter {
 
           this.#updateProviderIsWorking(network.id, true)
 
-          networkAccountStates.forEach((accountState, index) => {
+          networkAccountStates.forEach((accountState) => {
             const { addr } = accounts.find((acc) => acc.addr === accountState.accountAddr) || {}
 
             if (!addr) return
@@ -224,8 +218,10 @@ export class AccountsController extends EventEmitter {
   }
 
   async updateAccountPreferences(accounts: { addr: string; preferences: AccountPreferences }[]) {
-    await this.withStatus('updateAccountPreferences', async () =>
-      this.#updateAccountPreferences(accounts)
+    await this.withStatus(
+      'updateAccountPreferences',
+      async () => this.#updateAccountPreferences(accounts),
+      true
     )
   }
 


### PR DESCRIPTION
## Changes:
- Allowed concurrent actions for select account and preference updates because the actions may happen in very close succession during import
- Fixed a few ts/eslint errors