### PR TITLE
Fix / Connect Dapp on an Uninitialized Extension

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -670,11 +670,9 @@ export class MainController extends EventEmitter {
     const kind = dappRequestMethodToActionKind(request.method)
     const dapp = this.dapps.getDapp(request.origin)
 
-    if (!this.accounts.selectedAccount) {
-      throw ethErrors.rpc.internal()
-    }
-
     if (kind === 'calls') {
+      if (!this.accounts.selectedAccount) throw ethErrors.rpc.internal()
+
       const transaction = request.params[0]
       const accountAddr = getAddress(transaction.from)
       const network = this.networks.networks.find(
@@ -701,6 +699,8 @@ export class MainController extends EventEmitter {
         dappPromise
       } as SignUserRequest
     } else if (kind === 'message') {
+      if (!this.accounts.selectedAccount) throw ethErrors.rpc.internal()
+
       const msg = request.params
       if (!msg) {
         throw ethErrors.rpc.invalidRequest('No msg request to sign')
@@ -741,6 +741,8 @@ export class MainController extends EventEmitter {
         dappPromise
       } as SignUserRequest
     } else if (kind === 'typedMessage') {
+      if (!this.accounts.selectedAccount) throw ethErrors.rpc.internal()
+
       const msg = request.params
       if (!msg) {
         throw ethErrors.rpc.invalidRequest('No msg request to sign')


### PR DESCRIPTION
Fixed: When a dApp requested to connect and the extension was not yet initialized, the request would hang in the wallet without providing a proper response to the dApp.

After the fix, the expected behavior of the extension should be as follows: If the extension is not initialized and receives a "Connect" request from a dApp, it should open the onboarding flow in an action window. Once the user sets up the wallet, the "Connect" request should be prompted in the same action window.

TODO: we should think of how to scale down the content in an action window on small screens
<img width="1352" alt="Screenshot 2024-07-15 at 12 54 21" src="https://github.com/user-attachments/assets/12422e8f-dab8-4d54-8891-3fb02b40396e">

