### PR TITLE
Fix / Learned tokens: Remove non-ERC20s

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -525,6 +525,23 @@ describe('Portfolio Controller ', () => {
 
       expect(token).toBeTruthy()
     })
+
+    test('Learned tokens to avoid persisting non-ERC20 tokens', async () => {
+      const BANANA_TOKEN_ADDR = '0x94e496474F1725f1c1824cB5BDb92d7691A4F03a'
+      const SMART_CONTRACT_ADDR = '0xa8202f888b9b2dfa5ceb2204865018133f6f179a'
+      const { storage, controller } = prepareTest()
+
+      await controller.learnTokens([BANANA_TOKEN_ADDR, SMART_CONTRACT_ADDR], 'ethereum')
+
+      await controller.updateSelectedAccount(account.addr, undefined, undefined, {
+        forceUpdate: true
+      })
+
+      const previousHintsStorage = await storage.get('previousHints', {})
+
+      expect(previousHintsStorage.learnedTokens?.ethereum).not.toHaveProperty(SMART_CONTRACT_ADDR)
+    })
+
     test("Learned token timestamp isn't updated if the token is found by the external hints api", async () => {
       const { storage, controller } = prepareTest()
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -646,6 +646,7 @@ export class PortfolioController extends EventEmitter {
             const updatedStoragePreviousHints = getUpdatedHints(
               accountState[network.id]!.result!.hintsFromExternalAPI as ExternalHintsAPIResponse,
               accountState[network.id]!.result!.tokens,
+              accountState[network.id]!.result!.tokenErrors,
               network.id,
               this.#previousHints,
               key,

--- a/src/libs/portfolio/helpers.test.ts
+++ b/src/libs/portfolio/helpers.test.ts
@@ -43,6 +43,7 @@ describe('Portfolio helpers', () => {
         accountAddr: TEST_ACCOUNT_ADDRESS
       },
       tokens,
+      [],
       'ethereum',
       {
         learnedTokens: {


### PR DESCRIPTION
Closes https://github.com/AmbireTech/ambire-app/issues/2417.

---

**Introduce a Self-cleaning mechanism for removing non-ERC20 items from the learned tokens.**

There's a possibility that the discovered tokens (from debug_traceCall or mostly Humanizer) include items that are not ERC20 tokens. For instance, a SmartContract address can be passed as a learned token.

Thanks to BalanceGetter, we know which tokens encounter an error when we try to update the portfolio.
All the errors are collected in `tokenErrors`, and if we cannot retrieve its balance, the contract returns `bytes('unkn')`, which is equal to `0x756e6b6e`.

**Note:**
When we extract tokens from `debug_traceCall`, we are already filtering the tokens the same way as here (relying on BalanceGetter).
However, for the Humanizer tokens, we skipped that check because the Humanizer is invoked more frequently on the Sign screen, and this validation may slow down the performance of the page. Because of this, we perform the check here, where we are calling BalanceGetter anyway.