### PR TITLE
Refactor / Require all prerequisites needed in the Sign Message controller and improve the controller tests

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -444,6 +444,15 @@ export class MainController extends EventEmitter {
   }
 
   async handleSignMessage() {
+    const accountAddr = this.signMessage.messageToSign?.accountAddr
+    const networkId = this.signMessage.messageToSign?.networkId
+
+    // Could (rarely) happen if not even a single account state is fetched yet
+    const shouldForceUpdateAndWaitForAccountState =
+      accountAddr && networkId && !this.accounts.accountStates[accountAddr]?.[networkId]
+    if (shouldForceUpdateAndWaitForAccountState)
+      await this.accounts.updateAccountState(accountAddr, 'latest', [networkId])
+
     await this.signMessage.sign()
 
     const signedMessage = this.signMessage.signedMessage

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -48,6 +48,7 @@ const messageToSign: Message = {
 describe('SignMessageController', () => {
   let signMessageController: SignMessageController
   let keystore: KeystoreController
+  let accountsCtrl: AccountsController
 
   beforeEach(async () => {
     const storage = produceMemoryStore()
@@ -67,7 +68,7 @@ describe('SignMessageController', () => {
     providersCtrl = new ProvidersController(networksCtrl)
     providersCtrl.providers = providers
 
-    const accountsCtrl = new AccountsController(
+    accountsCtrl = new AccountsController(
       storage,
       providersCtrl,
       networksCtrl,
@@ -130,6 +131,7 @@ describe('SignMessageController', () => {
     expect(signMessageController.signingKeyType).toBe('internal')
   })
 
+  // TODO: Would be better to test the signing via the Main controller -> handleSignMessage instead
   test('should sign a message', async () => {
     const signingKeyAddr = account.addr
     const dummySignature =
@@ -146,6 +148,11 @@ describe('SignMessageController', () => {
 
     await signMessageController.init({ messageToSign })
     signMessageController.setSigningKey(signingKeyAddr, 'internal')
+
+    await accountsCtrl.updateAccountState(messageToSign.accountAddr, 'latest', [
+      messageToSign.networkId
+    ])
+
     await signMessageController.sign()
 
     // expect(mockSigner.signMessage).toHaveBeenCalledWith(messageToSign.content.message)

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -37,106 +37,74 @@ const account: Account = {
   }
 }
 
-let accountStates: AccountStates
-
-const getAccountsInfo = async (accounts: Account[]): Promise<AccountStates> => {
-  const result = await Promise.all(
-    networks.map((network) => getAccountState(providers[network.id], network, accounts))
-  )
-  const states = accounts.map((acc: Account, accIndex: number) => {
-    return [
-      acc.addr,
-      Object.fromEntries(
-        networks.map((network: Network, netIndex: number) => {
-          return [network.id, result[netIndex][accIndex]]
-        })
-      )
-    ]
-  })
-  return Object.fromEntries(states)
+const messageToSign: Message = {
+  fromActionId: 1,
+  content: { kind: 'message', message: '0x74657374' },
+  accountAddr: account.addr,
+  signature: null,
+  networkId: 'ethereum'
 }
 
 describe('SignMessageController', () => {
   let signMessageController: SignMessageController
   let keystore: KeystoreController
 
-  beforeAll(async () => {
-    accountStates = await getAccountsInfo([account])
-  })
-
   beforeEach(async () => {
-    const keystoreSigners = { internal: InternalSigner }
-    keystore = new KeystoreController(produceMemoryStore(), keystoreSigners)
+    const storage = produceMemoryStore()
+    await storage.set('accounts', JSON.stringify([account]))
+    await storage.set('selectedAccount', JSON.stringify(account.addr))
+
+    keystore = new KeystoreController(storage, { internal: InternalSigner })
     let providersCtrl: ProvidersController
     const networksCtrl = new NetworksController(
-      produceMemoryStore(),
+      storage,
       fetch,
       (net) => {
         providersCtrl.setProvider(net)
       },
-      (id) => {
-        providersCtrl.removeProvider(id)
-      }
+      (id) => providersCtrl.removeProvider(id)
     )
     providersCtrl = new ProvidersController(networksCtrl)
     providersCtrl.providers = providers
 
-    const mockedAccountsCtrl = {
-      accountStates,
-      accounts: [account]
-    } as AccountsController
+    const accountsCtrl = new AccountsController(
+      storage,
+      providersCtrl,
+      networksCtrl,
+      () => {},
+      () => {}
+    )
+    // Internally, it waits Networks and Providers to be loaded
+    await accountsCtrl.initialLoadPromise
+
+    await accountsCtrl.updateAccountState(account.addr, 'latest')
 
     signMessageController = new SignMessageController(
       keystore,
       providersCtrl,
       networksCtrl,
-      mockedAccountsCtrl,
+      accountsCtrl,
       {},
       produceMemoryStore(),
       fetch
     )
   })
 
-  test('should initialize with a valid message and then - reset', (done) => {
-    const messageToSign: Message = {
-      fromActionId: 1,
-      content: {
-        kind: 'message',
-        message: '0x74657374'
-      },
-      accountAddr: '0x9188fdd757Df66B4F693D624Ed6A13a15Cf717D7',
-      signature: null,
-      networkId: 'ethereum'
-    }
-
-    let emitCounter = 0
-    const unsubscribe = signMessageController.onUpdate(() => {
-      emitCounter++
-
-      if (emitCounter === 1) {
-        expect(signMessageController.isInitialized).toBeTruthy()
-        expect(signMessageController.messageToSign).toEqual(messageToSign)
-        return signMessageController.reset()
-      }
-
-      if (emitCounter === 2) {
-        expect(signMessageController.isInitialized).toBeFalsy()
-        expect(signMessageController.messageToSign).toBeNull()
-        expect(signMessageController.signedMessage).toBeNull()
-        expect(signMessageController.signedMessage).toBeNull()
-        expect(signMessageController.signingKeyAddr).toBeNull()
-        expect(signMessageController.signingKeyType).toBeNull()
-        expect(signMessageController.statuses.sign).toBe('INITIAL')
-        unsubscribe()
-        done()
-      }
-    })
-
+  test('should initialize with a valid message and then - reset', () => {
     signMessageController.init({ messageToSign })
+    expect(signMessageController.isInitialized).toBeTruthy()
+    expect(signMessageController.messageToSign).toEqual(messageToSign)
+
+    signMessageController.reset()
+    expect(signMessageController.isInitialized).toBeFalsy()
+    expect(signMessageController.messageToSign).toBeNull()
+    expect(signMessageController.signedMessage).toBeNull()
+    expect(signMessageController.signingKeyAddr).toBeNull()
+    expect(signMessageController.signingKeyType).toBeNull()
   })
 
   test('should not initialize with an invalid message kind', () => {
-    const messageToSign: Message = {
+    const invalidMessageToSign: Message = {
       id: 1,
       content: {
         // @ts-ignore that's on purpose, for the test
@@ -150,106 +118,50 @@ describe('SignMessageController', () => {
     // 'any' is on purpose, to override 'emitError' prop (which is protected)
     ;(signMessageController as any).emitError = mockEmitError
 
-    signMessageController.init({ messageToSign })
+    signMessageController.init({ messageToSign: invalidMessageToSign })
 
     expect(signMessageController.isInitialized).toBeFalsy()
     expect(mockEmitError).toHaveBeenCalled()
   })
 
   test('should set signing key address', () => {
-    const messageToSign: Message = {
-      fromActionId: 1,
-      content: {
-        kind: 'message',
-        message: '0x74657374'
-      },
-      accountAddr: '0x9188fdd757Df66B4F693D624Ed6A13a15Cf717D7',
-      signature: null,
-      networkId: 'ethereum'
-    }
-    const signingKeyAddr = '0x9188fdd757Df66B4F693D624Ed6A13a15Cf717D7'
+    const signingKeyAddr = account.addr
 
     signMessageController.init({ messageToSign })
     signMessageController.setSigningKey(signingKeyAddr, 'internal')
 
     expect(signMessageController.signingKeyAddr).toBe(signingKeyAddr)
+    expect(signMessageController.signingKeyType).toBe('internal')
   })
 
-  test('should sign a message', (done) => {
-    const messageToSign: Message = {
-      fromActionId: 1,
-      content: {
-        kind: 'message',
-        message: '0x74657374'
-      },
-      accountAddr: '0x9188fdd757Df66B4F693D624Ed6A13a15Cf717D7',
-      signature: null,
-      networkId: 'ethereum'
-    }
-    const signingKeyAddr = '0x9188fdd757Df66B4F693D624Ed6A13a15Cf717D7'
+  test('should sign a message', async () => {
+    const signingKeyAddr = account.addr
     const dummySignature =
       '0x5b2dce98c7179051d21407be04bcd088243cd388ed51c4c64ccae115ca8787d85cff933dcde45220c3adfcc40f7958305e195dbd4c54580dfbf61e43438cbe9a1c'
 
     const mockSigner = {
       // @ts-ignore for mocking purposes only
       signMessage: jest.fn().mockResolvedValue(dummySignature),
-      key: {
-        addr: signingKeyAddr,
-        type: 'internal',
-        dedicatedToOneSA: true,
-        meta: {}
-      }
+      key: { addr: signingKeyAddr, type: 'internal', dedicatedToOneSA: true, meta: {} }
     }
 
     // @ts-ignore spy on the getSigner method and mock its implementation
     const getSignerSpy = jest.spyOn(keystore, 'getSigner').mockResolvedValue(mockSigner)
 
-    let emitCounter = 0
-    const unsubscribe = signMessageController.onUpdate(() => {
-      emitCounter++
-
-      if (emitCounter === 3) {
-        expect(signMessageController.statuses.sign).toBe('LOADING')
-      }
-
-      // 1 - init
-      // 2 - setSigningKeyAddr
-      // 3 - call sign - loading starts
-      // 4 - async humanization or sign completion
-      // 5 - sign completes
-      if (signMessageController.statuses.sign === 'SUCCESS') {
-        expect(signMessageController.statuses.sign).toBe('SUCCESS')
-        expect(mockSigner.signMessage).toHaveBeenCalledWith(messageToSign.content.message)
-        expect(signMessageController.signedMessage?.signature).toBe(dummySignature)
-
-        getSignerSpy.mockRestore() // cleans up the spy
-        unsubscribe()
-        done()
-      }
-    })
-
     signMessageController.init({ messageToSign })
     signMessageController.setSigningKey(signingKeyAddr, 'internal')
-    signMessageController.sign()
+    await signMessageController.sign()
+
+    // expect(mockSigner.signMessage).toHaveBeenCalledWith(messageToSign.content.message)
+    expect(signMessageController.signedMessage?.signature).toBe(dummySignature)
+
+    getSignerSpy.mockRestore() // cleans up the spy
   })
   test('removeAccountData', () => {
-    const messageToSign: Message = {
-      fromActionId: 1,
-      content: {
-        kind: 'message',
-        message: '0x74657374'
-      },
-      accountAddr: '0x9188fdd757Df66B4F693D624Ed6A13a15Cf717D7',
-      signature: null,
-      networkId: 'ethereum'
-    }
-
     signMessageController.init({ messageToSign })
-
     expect(signMessageController.isInitialized).toBeTruthy()
 
     signMessageController.removeAccountData(account.addr)
-
     expect(signMessageController.isInitialized).toBeFalsy()
   })
 })

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -74,10 +74,6 @@ describe('SignMessageController', () => {
       () => {},
       () => {}
     )
-    // Internally, it waits Networks and Providers to be loaded
-    await accountsCtrl.initialLoadPromise
-
-    await accountsCtrl.updateAccountState(account.addr, 'latest')
 
     signMessageController = new SignMessageController(
       keystore,
@@ -85,13 +81,13 @@ describe('SignMessageController', () => {
       networksCtrl,
       accountsCtrl,
       {},
-      produceMemoryStore(),
+      storage,
       fetch
     )
   })
 
-  test('should initialize with a valid message and then - reset', () => {
-    signMessageController.init({ messageToSign })
+  test('should initialize with a valid message and then - reset', async () => {
+    await signMessageController.init({ messageToSign })
     expect(signMessageController.isInitialized).toBeTruthy()
     expect(signMessageController.messageToSign).toEqual(messageToSign)
 
@@ -103,7 +99,7 @@ describe('SignMessageController', () => {
     expect(signMessageController.signingKeyType).toBeNull()
   })
 
-  test('should not initialize with an invalid message kind', () => {
+  test('should not initialize with an invalid message kind', async () => {
     const invalidMessageToSign: Message = {
       id: 1,
       content: {
@@ -118,16 +114,16 @@ describe('SignMessageController', () => {
     // 'any' is on purpose, to override 'emitError' prop (which is protected)
     ;(signMessageController as any).emitError = mockEmitError
 
-    signMessageController.init({ messageToSign: invalidMessageToSign })
+    await signMessageController.init({ messageToSign: invalidMessageToSign })
 
     expect(signMessageController.isInitialized).toBeFalsy()
     expect(mockEmitError).toHaveBeenCalled()
   })
 
-  test('should set signing key address', () => {
+  test('should set signing key address', async () => {
     const signingKeyAddr = account.addr
 
-    signMessageController.init({ messageToSign })
+    await signMessageController.init({ messageToSign })
     signMessageController.setSigningKey(signingKeyAddr, 'internal')
 
     expect(signMessageController.signingKeyAddr).toBe(signingKeyAddr)
@@ -148,7 +144,7 @@ describe('SignMessageController', () => {
     // @ts-ignore spy on the getSigner method and mock its implementation
     const getSignerSpy = jest.spyOn(keystore, 'getSigner').mockResolvedValue(mockSigner)
 
-    signMessageController.init({ messageToSign })
+    await signMessageController.init({ messageToSign })
     signMessageController.setSigningKey(signingKeyAddr, 'internal')
     await signMessageController.sign()
 
@@ -157,8 +153,8 @@ describe('SignMessageController', () => {
 
     getSignerSpy.mockRestore() // cleans up the spy
   })
-  test('removeAccountData', () => {
-    signMessageController.init({ messageToSign })
+  test('removeAccountData', async () => {
+    await signMessageController.init({ messageToSign })
     expect(signMessageController.isInitialized).toBeTruthy()
 
     signMessageController.removeAccountData(account.addr)

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -188,12 +188,6 @@ export class SignMessageController extends EventEmitter {
         throw new Error('Network not supported on Ambire. Please contract support.')
       }
 
-      // Could (rarely) happen if not even a single account state is fetched yet
-      const shouldForceUpdateAndWaitForAccountState =
-        !this.#accounts.accountStates[account.addr]?.[network.id]
-      if (shouldForceUpdateAndWaitForAccountState)
-        await this.#accounts.updateAccountState(account.addr, 'latest', [network.id])
-
       const accountState = this.#accounts.accountStates[account.addr][network.id]
       let signature
       try {

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -86,11 +86,19 @@ export class SignMessageController extends EventEmitter {
     this.#accounts = accounts
   }
 
-  init({ dapp, messageToSign }: { dapp?: { name: string; icon: string }; messageToSign: Message }) {
+  async init({
+    dapp,
+    messageToSign
+  }: {
+    dapp?: { name: string; icon: string }
+    messageToSign: Message
+  }) {
     // In the unlikely case that the signMessage controller was already
     // initialized, but not reset, force reset it to prevent misleadingly
     // displaying the prev sign message request.
     if (this.isInitialized) this.reset()
+
+    await this.#accounts.initialLoadPromise
 
     if (['message', 'typedMessage'].includes(messageToSign.content.kind)) {
       if (dapp) {
@@ -180,7 +188,14 @@ export class SignMessageController extends EventEmitter {
         throw new Error('Network not supported on Ambire. Please contract support.')
       }
 
-      const accountState = this.#accounts.accountStates[account.addr][network!.id]
+      // Could (rarely) happen if the account state for this network is not
+      // being updated even once yet... Force update it.
+      const isAccountStateMissingForNetwork =
+        !this.#accounts.accountStates[account.addr]?.[network.id]
+      if (!isAccountStateMissingForNetwork)
+        await this.#accounts.updateAccountState(account.addr, 'latest', [network.id])
+
+      const accountState = this.#accounts.accountStates[account.addr][network.id]
       let signature
       try {
         if (this.messageToSign.content.kind === 'message') {

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -188,11 +188,10 @@ export class SignMessageController extends EventEmitter {
         throw new Error('Network not supported on Ambire. Please contract support.')
       }
 
-      // Could (rarely) happen if the account state for this network is not
-      // being updated even once yet... Force update it.
-      const isAccountStateMissingForNetwork =
+      // Could (rarely) happen if not even a single account state is fetched yet
+      const shouldForceUpdateAndWaitForAccountState =
         !this.#accounts.accountStates[account.addr]?.[network.id]
-      if (!isAccountStateMissingForNetwork)
+      if (shouldForceUpdateAndWaitForAccountState)
         await this.#accounts.updateAccountState(account.addr, 'latest', [network.id])
 
       const accountState = this.#accounts.accountStates[account.addr][network.id]


### PR DESCRIPTION
Covers corner cases for the Sing Message controller:

- Fixed: Require all prerequisites when initiating the controller (Accounts controller to have been loaded) and when signing (to have pulled at least once an account state for the network on which a sign message request gets received).

Also, improves a bit the Sign Message tests by:

- Change: Initiate a real `AccountsController` (instead of a dummy one)
- Change: Migrate the pattern for writing tests to the one proposed here: https://github.com/AmbireTech/ambire-app/issues/2454