### PR TITLE
Fix: react to incorrect user op nonce

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1346,12 +1346,17 @@ export class MainController extends EventEmitter {
           .then(() => this.estimateSignAccountOp())
           .catch((error) =>
             this.emitError({
-              level: 'silent',
+              level: 'major',
               message:
-                'Failed to refetch the account state after encountering a 4337_INVALID_NONCE error',
+                'Failed to refetch the account state. Please try again to initialize your transaction',
               error
             })
           )
+
+        // returning here means estimation will not be set => better UX as
+        // the user will not see the warning but instead
+        // just wait for the new estimation
+        return
       }
 
       // check if an RBF should be applied for the incoming transaction

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1326,6 +1326,25 @@ export class MainController extends EventEmitter {
         return
       }
 
+      if (
+        estimation &&
+        estimation.nonFatalErrors &&
+        estimation.nonFatalErrors.find((err) => err.cause === '4337_INVALID_NONCE') &&
+        this.accounts.accountStates?.[localAccountOp.accountAddr]?.[localAccountOp.networkId]
+      ) {
+        this.accounts
+          .updateAccountState(localAccountOp.accountAddr, 'latest', [localAccountOp.networkId])
+          .then(() => this.estimateSignAccountOp())
+          .catch((error) =>
+            this.emitError({
+              level: 'silent',
+              message:
+                'Failed to refetch the account state after encountering a 4337_INVALID_NONCE error',
+              error
+            })
+          )
+      }
+
       // check if an RBF should be applied for the incoming transaction
       // for SA conditions are: take the last broadcast but not confirmed accOp
       // and check if the nonce is the same as the current nonce (non 4337 txns)

--- a/src/libs/estimate/errors.ts
+++ b/src/libs/estimate/errors.ts
@@ -86,10 +86,15 @@ export function estimationErrorFormatted(
   opts?: {
     feePaymentOptions?: EstimateResult['feePaymentOptions']
     erc4337GasLimits?: Erc4337GasLimits
+    nonFatalErrors?: Error[]
   }
 ): EstimateResult {
   const feePaymentOptions = opts?.feePaymentOptions ?? []
-  const finalsOps = { ...opts, feePaymentOptions }
+  const finalsOps = {
+    ...opts,
+    feePaymentOptions,
+    nonFatalErrors: opts?.nonFatalErrors ?? undefined
+  }
 
   return {
     gasUsed: 0n,

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -260,8 +260,8 @@ export async function estimate(
   }
 
   // if 4337, delegate
-  if (opts && opts.is4337Broadcast) {
-    const estimationResult: EstimateResult = await estimate4337(
+  if (opts && opts.is4337Broadcast)
+    return estimate4337(
       account,
       op,
       calls,
@@ -272,8 +272,6 @@ export async function estimate(
       blockTag,
       nativeToCheck
     )
-    return estimationResult
-  }
 
   const deploylessEstimator = fromDescriptor(provider, Estimation, !network.rpcNoStateOverride)
   const optimisticOracle = network.isOptimistic ? OPTIMISTIC_ORACLE : ZeroAddress

--- a/src/libs/estimate/interfaces.ts
+++ b/src/libs/estimate/interfaces.ts
@@ -44,4 +44,10 @@ export interface EstimateResult {
   feePaymentOptions: FeePaymentOption[]
   erc4337GasLimits?: Erc4337GasLimits
   error: Error | null
+  // put here errors that are not fatal to the signing process
+  // but reactable if known
+  // example: bundler simulation fails because of incorrect 4337 nonce.
+  // The user can still broadcast with EOA but we can also react
+  // to this error by setting the correct nonce and re-estimating
+  nonFatalErrors?: Error[]
 }


### PR DESCRIPTION
If the estimation returns an AA25 wrong account nonce error, update the account state and re-estimate but show the available EOA options before that