### PR TITLE
Fix / Filter out native erc20 representations

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -542,6 +542,49 @@ describe('Portfolio Controller ', () => {
       expect(previousHintsStorage.learnedTokens?.ethereum).not.toHaveProperty(SMART_CONTRACT_ADDR)
     })
 
+    test('Portfolio should filter out ER20 tokens these mimic native tokens (same symbol and amount)', async () => {
+      const ERC_20_MATIC_ADDR = '0x0000000000000000000000000000000000001010'
+      const { controller } = prepareTest()
+
+      await controller.learnTokens([ERC_20_MATIC_ADDR], 'polygon')
+
+      await controller.updateSelectedAccount(account.addr, undefined, undefined, {
+        forceUpdate: true
+      })
+
+      const hasErc20Matic = controller.latest[account.addr].polygon!.result!.tokens.find(
+        (token) => token.address === ERC_20_MATIC_ADDR
+      )
+
+      expect(hasErc20Matic).toBeFalsy()
+    })
+
+    test('Portfolio should not filter out ERC20 tokens that mimic native tokens when they are added as preferences (custom tokens)', async () => {
+      const ERC_20_MATIC_ADDR = '0x0000000000000000000000000000000000001010'
+      const { controller } = prepareTest()
+
+      const tokenInPreferences = {
+        address: ERC_20_MATIC_ADDR,
+        networkId: 'polygon',
+        standard: 'ERC20',
+        name: 'MATIC',
+        symbol: 'MATIC',
+        decimals: 18
+      }
+
+      await controller.updateTokenPreferences([tokenInPreferences])
+
+      await controller.updateSelectedAccount(account.addr, undefined, undefined, {
+        forceUpdate: true
+      })
+
+      const hasErc20Matic = controller.latest[account.addr].polygon!.result!.tokens.find(
+        (token) => token.address === ERC_20_MATIC_ADDR
+      )
+
+      expect(hasErc20Matic).toBeTruthy()
+    })
+
     test("Learned token timestamp isn't updated if the token is found by the external hints api", async () => {
       const { storage, controller } = prepareTest()
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -487,7 +487,14 @@ export class PortfolioController extends EventEmitter {
         result: {
           ...result,
           tokens: result.tokens.filter((token) =>
-            tokenFilter(token, network, hasNonZeroTokens, additionalHints, tokenPreferences)
+            tokenFilter(
+              token,
+              result.tokens,
+              network,
+              hasNonZeroTokens,
+              additionalHints,
+              tokenPreferences
+            )
           ),
           total: getTotal(result.tokens)
         }

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -22,8 +22,8 @@ import {
   getPinnedGasTankTokens,
   getTotal,
   getUpdatedHints,
+  processTokens,
   shouldGetAdditionalPortfolio,
-  tokenFilter,
   validateERC20Token
 } from '../../libs/portfolio/helpers'
 /* eslint-disable no-param-reassign */
@@ -480,23 +480,22 @@ export class PortfolioController extends EventEmitter {
 
       const additionalHints = portfolioProps.additionalHints || []
 
+      const processedTokens = processTokens(
+        result.tokens,
+        network,
+        hasNonZeroTokens,
+        additionalHints,
+        tokenPreferences
+      )
+
       _accountState[network.id] = {
         isReady: true,
         isLoading: false,
         errors: result.errors,
         result: {
           ...result,
-          tokens: result.tokens.filter((token) =>
-            tokenFilter(
-              token,
-              result.tokens,
-              network,
-              hasNonZeroTokens,
-              additionalHints,
-              tokenPreferences
-            )
-          ),
-          total: getTotal(result.tokens)
+          tokens: processedTokens,
+          total: getTotal(processedTokens)
         }
       }
       this.emitUpdate()

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -320,9 +320,6 @@ export const tokenFilter = (
     token.isHidden = isTokenPreference.isHidden
   }
 
-  // always include > 0 amount and native token
-  if (token.amount > 0 || token.address === ZeroAddress) return true
-
   const nativeToken = tokens.find((t) => t.address === ZeroAddress)
   const isERC20NativeRepresentation =
     token.symbol === nativeToken?.symbol &&
@@ -331,6 +328,9 @@ export const tokenFilter = (
     !isTokenPreference
 
   if (isERC20NativeRepresentation) return false
+
+  // always include > 0 amount and native token
+  if (token.amount > 0 || token.address === ZeroAddress) return true
 
   const isPinned = !!PINNED_TOKENS.find((pinnedToken) => {
     return pinnedToken.networkId === network.id && pinnedToken.address === token.address

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -307,6 +307,7 @@ export function getUpdatedHints(
 
 export const tokenFilter = (
   token: TokenResult,
+  tokens: TokenResult[],
   network: { id: NetworkId },
   hasNonZeroTokens: boolean,
   additionalHints: string[] | undefined,
@@ -321,6 +322,15 @@ export const tokenFilter = (
 
   // always include > 0 amount and native token
   if (token.amount > 0 || token.address === ZeroAddress) return true
+
+  const nativeToken = tokens.find((t) => t.address === ZeroAddress)
+  const isERC20NativeRepresentation =
+    token.symbol === nativeToken?.symbol &&
+    token.amount === nativeToken.amount &&
+    token.address !== ZeroAddress &&
+    !isTokenPreference
+
+  if (isERC20NativeRepresentation) return false
 
   const isPinned = !!PINNED_TOKENS.find((pinnedToken) => {
     return pinnedToken.networkId === network.id && pinnedToken.address === token.address


### PR DESCRIPTION
- Fix: Filter out native ERC20 representations from Portfolio, but allow them to be added as custom tokens.(https://github.com/AmbireTech/ambire-app/pull/2517).
- Fix: Refactor tokenFilter function to be a pure boolean filter. Instead of introducing side effects and mutating the token item by setting the `isHidden` flag, the tokenFilter function will now return a boolean value. The TokenResult[] array will be processed using `reduce` instead of `filter` since we are performing two actions: filtering tokens and mutating data.
- Fix: In PortfolioController, use the result of processTokens for setting both result.tokens: processedTokens and result.total: getTotal(processedTokens). Previously, for the total, we were passing the PortfolioLib result, not the already filtered tokens. It was working because of the isHidden mutation we were applying, but with the current changes, adding a new filtration rule would break the total calculations.
- Add: Unit tests.