### PR TITLE
Fix: estimate gas fallback

### DIFF
--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -109,7 +109,7 @@ export async function estimate4337(
       })
       .catch(catchEstimationFailure),
     bundlerEstimate(account, accountStates, op, network, feeTokens),
-    estimateGas(account, op, provider, accountState).catch(() => 0n)
+    estimateGas(account, op, provider, accountState, network).catch(() => 0n)
   ])
   const ambireEstimation = estimations[0]
   const bundlerEstimationResult: EstimateResult = estimations[1]
@@ -329,7 +329,7 @@ export async function estimate(
         blockTag
       })
       .catch(catchEstimationFailure),
-    estimateGas(account, op, provider, accountState).catch(() => 0n)
+    estimateGas(account, op, provider, accountState, network).catch(() => 0n)
   ]
   const estimations = await estimateWithRetries(initializeRequests)
   if (estimations instanceof Error) return estimationErrorFormatted(estimations)

--- a/src/libs/estimate/estimateGas.ts
+++ b/src/libs/estimate/estimateGas.ts
@@ -4,6 +4,8 @@ import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import { DEPLOYLESS_SIMULATION_FROM } from '../../consts/deploy'
 import { Account, AccountOnchainState } from '../../interfaces/account'
+import { Network } from '../../interfaces/network'
+import { getRpcProvider } from '../../services/provider'
 import { getSpoof } from '../account/account'
 import { AccountOp, getSignableCalls } from '../accountOp/accountOp'
 
@@ -11,7 +13,8 @@ export async function estimateGas(
   account: Account,
   op: AccountOp,
   provider: Provider | JsonRpcProvider,
-  accountState: AccountOnchainState
+  accountState: AccountOnchainState,
+  network: Network
 ): Promise<bigint> {
   if (!account.creation) throw new Error('Use this estimation only for smart accounts')
 
@@ -25,11 +28,45 @@ export async function estimateGas(
         getSignableCalls(op),
         getSpoof(account)
       ])
-  return provider.estimateGas({
-    from: DEPLOYLESS_SIMULATION_FROM,
-    to: accountState.isDeployed ? account.addr : account.creation.factoryAddr,
-    value: 0,
-    data: callData,
-    nonce: 0
-  })
+
+  // try estimating the gas without state override. If an error of type
+  // insufficient funds is encountered, try re-estimating with state override
+  return provider
+    .estimateGas({
+      from: DEPLOYLESS_SIMULATION_FROM,
+      to: accountState.isDeployed ? account.addr : account.creation.factoryAddr,
+      value: 0,
+      data: callData,
+      nonce: 0
+    })
+    .catch(async (e) => {
+      if (!e.message.includes('insufficient funds')) return 0n
+
+      const isolatedProvider = getRpcProvider(
+        network.rpcUrls,
+        network.chainId,
+        network.selectedRpcUrl,
+        { batchMaxCount: 1 }
+      )
+      const withOverrides = await isolatedProvider
+        .send('eth_estimateGas', [
+          {
+            to: accountState.isDeployed ? account.addr : account.creation!.factoryAddr,
+            value: '0x0',
+            data: callData,
+            from: DEPLOYLESS_SIMULATION_FROM,
+            nonce: '0x0'
+          },
+          'latest',
+          {
+            [DEPLOYLESS_SIMULATION_FROM]: {
+              balance: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+            }
+          }
+        ])
+        .catch(() => '0x0')
+
+      isolatedProvider.destroy()
+      return BigInt(withOverrides)
+    })
 }


### PR DESCRIPTION
Add: a state override fallback to estimateGas() that gets triggered if estimateGas returns insufficient funds when estimating with SA