### PR TITLE
Config / Remove fallback error notes for the broadcast transaction flow

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1420,6 +1420,7 @@ export class MainController extends EventEmitter {
     const accountOp = this.signAccountOp?.accountOp
     const estimation = this.signAccountOp?.estimation
     const actionId = this.signAccountOp?.fromActionId
+    const contactSupportPrompt = 'Please try again or contact support if the problem persists.'
 
     if (
       !accountOp ||
@@ -1429,7 +1430,8 @@ export class MainController extends EventEmitter {
       !accountOp.signingKeyType ||
       !accountOp.signature
     ) {
-      return this.#throwBroadcastAccountOp({ message: 'Missing mandatory transaction details.' })
+      const message = `Missing mandatory transaction details. ${contactSupportPrompt}`
+      return this.#throwBroadcastAccountOp({ message })
     }
 
     const provider = this.providers.providers[accountOp.networkId]
@@ -1437,21 +1439,20 @@ export class MainController extends EventEmitter {
     const network = this.networks.networks.find((n) => n.id === accountOp.networkId)
 
     if (!provider) {
-      return this.#throwBroadcastAccountOp({
-        message: `Provider for ${network?.name || `with id ${accountOp.networkId}`} not found.`
-      })
+      const networkName = network?.name || `network with id ${accountOp.networkId}`
+      const message = `Provider for ${networkName} not found. ${contactSupportPrompt}`
+      return this.#throwBroadcastAccountOp({ message })
     }
 
     if (!account) {
-      return this.#throwBroadcastAccountOp({
-        message: `Account with address ${shortenAddress(accountOp.accountAddr, 13)} not found.`
-      })
+      const addr = shortenAddress(accountOp.accountAddr, 13)
+      const message = `Account with address ${addr} not found. ${contactSupportPrompt}`
+      return this.#throwBroadcastAccountOp({ message })
     }
 
     if (!network) {
-      return this.#throwBroadcastAccountOp({
-        message: `Network with id ${accountOp.networkId} not found.`
-      })
+      const message = `Network with id ${accountOp.networkId} not found. ${contactSupportPrompt}`
+      return this.#throwBroadcastAccountOp({ message })
     }
 
     let transactionRes: TransactionResponse | { hash: string; nonce: number } | null = null
@@ -1467,12 +1468,10 @@ export class MainController extends EventEmitter {
           // TODO: Implement a way to choose the key type to broadcast with.
           feePayerKeys.find((key) => key.type === accountOp.signingKeyType) || feePayerKeys[0]
         if (!feePayerKey) {
-          return await this.#throwBroadcastAccountOp({
-            message: `Key with address ${shortenAddress(
-              accountOp.gasFeePayment!.paidBy,
-              13
-            )} for account with address ${shortenAddress(accountOp.accountAddr, 13)} not found.`
-          })
+          const missingKeyAddr = shortenAddress(accountOp.gasFeePayment!.paidBy, 13)
+          const accAddr = shortenAddress(accountOp.accountAddr, 13)
+          const message = `Key with address ${missingKeyAddr} for account with address ${accAddr} not found. ${contactSupportPrompt}`
+          return await this.#throwBroadcastAccountOp({ message })
         }
         this.feePayerKey = feePayerKey
         this.emitUpdate()
@@ -1529,12 +1528,10 @@ export class MainController extends EventEmitter {
         // TODO: Implement a way to choose the key type to broadcast with.
         feePayerKeys.find((key) => key.type === accountOp.signingKeyType) || feePayerKeys[0]
       if (!feePayerKey) {
-        return this.#throwBroadcastAccountOp({
-          message: `Key with address ${shortenAddress(
-            accountOp.gasFeePayment!.paidBy,
-            13
-          )} for account with address ${shortenAddress(accountOp.accountAddr, 13)} not found.`
-        })
+        const missingKeyAddr = shortenAddress(accountOp.gasFeePayment!.paidBy, 13)
+        const accAddr = shortenAddress(accountOp.accountAddr, 13)
+        const message = `Key with address ${missingKeyAddr} for account with address ${accAddr} not found.`
+        return this.#throwBroadcastAccountOp({ message })
       }
 
       this.feePayerKey = feePayerKey
@@ -1604,12 +1601,9 @@ export class MainController extends EventEmitter {
     else if (accountOp.gasFeePayment && accountOp.gasFeePayment.isERC4337) {
       const userOperation = accountOp.asUserOperation
       if (!userOperation) {
-        return this.#throwBroadcastAccountOp({
-          message: `Trying to broadcast an ERC-4337 request but userOperation is not set for the account with address ${shortenAddress(
-            accountOp.accountAddr,
-            13
-          )}`
-        })
+        const accAddr = shortenAddress(accountOp.accountAddr, 13)
+        const message = `Trying to broadcast an ERC-4337 request but userOperation is not set for the account with address ${accAddr}`
+        return this.#throwBroadcastAccountOp({ message })
       }
 
       // broadcast through bundler's service
@@ -1712,7 +1706,7 @@ export class MainController extends EventEmitter {
   }
 
   #throwBroadcastAccountOp({ message: _msg, error: _err }: { message?: string; error?: Error }) {
-    let message = _msg || `Unable to broadcast the transaction. ${_err?.message || 'unknown'}`
+    let message = _msg || _err?.message || 'Unable to broadcast the transaction.'
 
     // Enhance the error incoming for this corner case
     if (message.includes('insufficient funds'))
@@ -1720,10 +1714,6 @@ export class MainController extends EventEmitter {
 
     // Trip the error message, errors coming from the RPC can be huuuuuge
     message = message.length > 300 ? `${message.substring(0, 300)}...` : message
-
-    // If not explicitly stated, add a generic message to contact support
-    if (!message.includes('contact support'))
-      message += ' Please try again or contact support for help.'
 
     const error = _err || new Error(message)
     const replacementFeeLow = error?.message.includes('replacement fee too low')

--- a/src/libs/ledger/ledger.ts
+++ b/src/libs/ledger/ledger.ts
@@ -18,7 +18,7 @@ export const normalizeLedgerMessage = (error?: string): string => {
     error.includes('0x650f') ||
     error.includes('0x6511')
   ) {
-    return 'Could not connect to your Ledger device. Please make sure it is connected, unlocked and running the Ethereum app.'
+    return 'Could not connect to your Ledger device. Please make sure it is unlocked and running the Ethereum app.'
   }
   if (error.includes('0x6e00') || error.includes('0x6b00')) {
     return 'Your Ledger device requires a firmware and Ethereum App update.'


### PR DESCRIPTION
The fallback messages that we were unable to broadcast the transaction and the contact support prompt didn't work very well alongside all other error notes.

They get displayed even if user rejects manually a transaction:

<img width="1372" alt="Screenshot 2024-07-19 at 14 58 34" src="https://github.com/user-attachments/assets/a990de3b-1eb5-4f9c-bc0e-c2ad35913388">

 or when the hardware wallet is not connected (or the connection gets interrupted):

<img width="1339" alt="Screenshot 2024-07-19 at 14 58 10" src="https://github.com/user-attachments/assets/b6846290-8c10-4858-acfc-74504c3947bc">

Which was overcomplicating the most common errors we display. So instead of one generic case - flip to writing specific errors, including prompt to contact support and fallback messages only when needed.