### PR TITLE
Bug/ `rpc-down` banners duplicate id

### DIFF
--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -161,7 +161,7 @@ export const getNetworksWithFailedRPCBanners = ({
 
   networksWithMultipleRpcUrls.forEach((n) => {
     banners.push({
-      id: 'rpcs-down',
+      id: 'custom-rpcs-down',
       type: 'error',
       title: `Failed to retrieve network data for ${n.name}. You can try selecting another RPC URL`,
       text: 'Affected features: visible assets, sign message/transaction, ENS/UD domain resolving, add account.',
@@ -250,7 +250,6 @@ export const getNetworksWithPortfolioErrorBanners = ({
       portfolioForNetwork?.errors.forEach((err: any) => {
         if (err?.name === PORTFOLIO_LIB_ERROR_NAMES.PriceFetchError) {
           networkNamesWithPriceFetchError.push(networkName as string)
-          return
         }
       })
     })

--- a/src/libs/portfolio/portfolioView.ts
+++ b/src/libs/portfolio/portfolioView.ts
@@ -1,4 +1,3 @@
-import { Account } from '../../interfaces/account'
 import {
   AccountState,
   CollectionResult as CollectionResultInterface,
@@ -17,8 +16,7 @@ interface AccountPortfolio {
 export function calculateAccountPortfolio(
   selectedAccount: string | null,
   state: { latest: PortfolioControllerState; pending: PortfolioControllerState },
-  accountPortfolio: AccountPortfolio,
-  account: Account
+  accountPortfolio: AccountPortfolio
 ) {
   const updatedTokens: TokenResultInterface[] = []
   const updatedCollections: CollectionResultInterface[] = []


### PR DESCRIPTION
There are 2 types of RPC banners- an RPC banner for networks with custom RPCs and an RPC banner for networks with the default RPC. If both banners were displayed at once a react key error appeared
