### PR TITLE
Refactor / Flow for adding accounts

### DIFF
--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -292,6 +292,13 @@ export const getDefaultAccountPreferences = (
   }
 }
 
+export const DEFAULT_KEY_LABEL_PATTERN = /^Key (\d+)$/
+export const getDefaultKeyLabel = (prevKeys: Key[], i: number) => {
+  const number = prevKeys.length + i + 1
+
+  return `Key ${number}`
+}
+
 // As of version 4.25.0, a new Account interface has been introduced,
 // merging the previously separate Account and AccountPreferences interfaces.
 // This change requires a migration due to the introduction of a new controller, AccountsController,


### PR DESCRIPTION
Refactors the flow for adding accounts, so that:

1. It is moved from the background process to the Main controller and
2. Improves the flow by introducing `handleAddAccounts` (similar to the `handleSignAccountOp` and `handleSignMessage`) instead of listening to controller updates.