### PR TITLE
Fix failing portolio tests

### DIFF
--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -211,14 +211,16 @@ export async function getTokens(
   }
   const deploylessOpts = getDeploylessOpts(accountAddr, network, opts)
   if (!opts.simulation) {
-   
     const [results, blockNumber] = await deployless.call(
       'getBalances',
       [accountAddr, tokenAddrs],
       deploylessOpts
     )
 
-    return [results.map((token: any, i: number) => [token.error, mapToken(token, tokenAddrs[i])]), blockNumber]
+    return [
+      results.map((token: any, i: number) => [token.error, mapToken(token, tokenAddrs[i])]),
+      blockNumber
+    ]
   }
   const { accountOps, account } = opts.simulation
   const simulationOps = accountOps.map(({ nonce, calls }, idx) => ({
@@ -227,18 +229,19 @@ export async function getTokens(
     calls: calls.map(callToTuple)
   }))
   const [factory, factoryCalldata] = getAccountDeployParams(account)
-  const [before, after, simulationErr, ,blockNumber, deltaAddressesMapping] = await deployless.call(
-    'simulateAndGetBalances',
-    [
-      accountAddr,
-      account.associatedKeys,
-      tokenAddrs,
-      factory,
-      factoryCalldata,
-      simulationOps.map((op) => Object.values(op))
-    ],
-    deploylessOpts
-  )
+  const [before, after, simulationErr, , blockNumber, deltaAddressesMapping] =
+    await deployless.call(
+      'simulateAndGetBalances',
+      [
+        accountAddr,
+        account.associatedKeys,
+        tokenAddrs,
+        factory,
+        factoryCalldata,
+        simulationOps.map((op) => Object.values(op))
+      ],
+      deploylessOpts
+    )
 
   const beforeNonce = before[1]
   const afterNonce = after[1]
@@ -254,29 +257,32 @@ export async function getTokens(
         addr: deltaAddressesMapping[tokenIndex]
       }))
     : null
-  return [before[0].map((token: any, i: number) => {
-    const simulation = simulationTokens
-      ? simulationTokens.find((simulationToken: any) => simulationToken.addr === tokenAddrs[i])
-      : null
+  return [
+    before[0].map((token: any, i: number) => {
+      const simulation = simulationTokens
+        ? simulationTokens.find((simulationToken: any) => simulationToken.addr === tokenAddrs[i])
+        : null
 
-    // Here's the math before `simulationAmount` and `amountPostSimulation`.
-    // AccountA initial balance: 10 USDC.
-    // AccountA attempts to transfer 5 USDC (not signed yet).
-    // An external entity sends 3 USDC to AccountA on-chain.
-    // Deployless simulation contract processing:
-    //   - Balance before simulation (before[0]): 10 USDC + 3 USDC = 13 USDC.
-    //   - Balance after simulation (after[0]): 10 USDC - 5 USDC + 3 USDC = 8 USDC.
-    // Simulation-only balance displayed on the Sign Screen (we will call it `simulationAmount`):
-    //   - difference between after simulation and before: 8 USDC - 13 USDC = -5 USDC
-    // Final balance displayed on the Dashboard (we will call it `amountPostSimulation`):
-    //   - after[0], 8 USDC.
-    return [
-      token.error,
-      {
-        ...mapToken(token, tokenAddrs[i]),
-        simulationAmount: simulation ? simulation.amount - token.amount : undefined,
-        amountPostSimulation: simulation ? simulation.amount : token.amount
-      }
-    ]
-  }), blockNumber]
+      // Here's the math before `simulationAmount` and `amountPostSimulation`.
+      // AccountA initial balance: 10 USDC.
+      // AccountA attempts to transfer 5 USDC (not signed yet).
+      // An external entity sends 3 USDC to AccountA on-chain.
+      // Deployless simulation contract processing:
+      //   - Balance before simulation (before[0]): 10 USDC + 3 USDC = 13 USDC.
+      //   - Balance after simulation (after[0]): 10 USDC - 5 USDC + 3 USDC = 8 USDC.
+      // Simulation-only balance displayed on the Sign Screen (we will call it `simulationAmount`):
+      //   - difference between after simulation and before: 8 USDC - 13 USDC = -5 USDC
+      // Final balance displayed on the Dashboard (we will call it `amountPostSimulation`):
+      //   - after[0], 8 USDC.
+      return [
+        token.error,
+        {
+          ...mapToken(token, tokenAddrs[i]),
+          simulationAmount: simulation ? simulation.amount - token.amount : undefined,
+          amountPostSimulation: simulation ? simulation.amount : token.amount
+        }
+      ]
+    }),
+    blockNumber
+  ]
 }

--- a/src/libs/portfolio/portfolio.test.ts
+++ b/src/libs/portfolio/portfolio.test.ts
@@ -20,7 +20,6 @@ describe('Portfolio', () => {
   const ethereum = networks.find((x) => x.id === 'ethereum')
   if (!ethereum) throw new Error('unable to find ethereum network in consts')
   const provider = new JsonRpcProvider('https://invictus.ambire.com/ethereum')
-  const usdtContract = new Contract(USDT_ADDRESS, ERC20, provider)
   const portfolio = new Portfolio(fetch, provider, ethereum, velcroUrl)
 
   async function getNonce(address: string) {
@@ -28,6 +27,7 @@ describe('Portfolio', () => {
     return accountContract.nonce()
   }
   async function getSafeSendUSDTTransaction(from: string, to: string, amount: bigint) {
+    const usdtContract = new Contract(USDT_ADDRESS, ERC20, provider)
     const usdtBalance = await usdtContract.balanceOf(from)
     expect(usdtBalance).toBeGreaterThan(amount)
     return {
@@ -230,10 +230,7 @@ describe('Portfolio', () => {
   })
 
   test('simulation works for EOAs', async () => {
-    const sendingAmount = 5259434n
     const acc = '0x7a15866aFfD2149189Aa52EB8B40a8F9166441D9'
-    const usdtBalance = await usdtContract.balanceOf(acc)
-    expect(usdtBalance).toBeGreaterThan(sendingAmount)
     const accountOp: any = {
       accountAddr: acc,
       signingKeyAddr: acc,
@@ -243,14 +240,11 @@ describe('Portfolio', () => {
       nonce: BigInt(EOA_SIMULATION_NONCE),
       signature: '0x',
       calls: [
-        {
-          to: USDT_ADDRESS,
-          value: BigInt(0),
-          data: usdtContract.interface.encodeFunctionData('transfer', [
-            '0xe5a4dad2ea987215460379ab285df87136e83bea',
-            sendingAmount
-          ])
-        }
+        await getSafeSendUSDTTransaction(
+          acc,
+          '0xe5a4dad2ea987215460379ab285df87136e83bea',
+          5259434n
+        )
       ]
     }
     const account: Account = {
@@ -337,11 +331,7 @@ describe('Portfolio', () => {
   })
 
   test('token simulation should throw a simulation error if the account op nonce is lower or higher than the original contract nonce', async () => {
-    const sendingAmount = 5259434n
-
     const acc = '0x7a15866aFfD2149189Aa52EB8B40a8F9166441D9'
-    const usdtBalance = await usdtContract.balanceOf(acc)
-    expect(usdtBalance).toBeGreaterThan(sendingAmount)
     const accountOp: any = {
       accountAddr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
       signingKeyAddr: '0xe5a4Dad2Ea987215460379Ab285DF87136E83BEA',
@@ -351,14 +341,11 @@ describe('Portfolio', () => {
       nonce: 0n,
       signature: '0x',
       calls: [
-        {
-          to: USDT_ADDRESS,
-          value: BigInt(0),
-          data: usdtContract.interface.encodeFunctionData('transfer', [
-            '0xe5a4dad2ea987215460379ab285df87136e83bea',
-            sendingAmount
-          ])
-        }
+        await getSafeSendUSDTTransaction(
+          acc,
+          '0xe5a4dad2ea987215460379ab285df87136e83bea',
+          5259434n
+        )
       ]
     }
     const account = {

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -191,7 +191,7 @@ export class Portfolio {
         )
       )
     ])
-    const [ tokensWithErrResult, blockNumber ] = tokensWithErr
+    const [tokensWithErrResult, blockNumber] = tokensWithErr
 
     // Re-map/filter into our format
     const getPriceFromCache = (address: string) => {
@@ -209,7 +209,7 @@ export class Portfolio {
       error === '0x' && !!result.symbol
 
     const tokensWithoutPrices = tokensWithErrResult
-      .filter((tokensWithErrResult: [string,TokenResult]) => tokenFilter(tokensWithErrResult))
+      .filter((_tokensWithErrResult: [string, TokenResult]) => tokenFilter(_tokensWithErrResult))
       .map(([, result]: [any, TokenResult]) => result)
 
     const unfilteredCollections = collectionsWithErr.map(([error, x], i) => {


### PR DESCRIPTION
One of the hardcoded accounts we used for testing the portfolio library had to have at least ~5 USDT for the test to pass. 

The onchain USDT balance of this account dropped under 5 USDT, which caused the tests to fail without being updated.

The solution for this is to update the tests to use 1 USDT instead of fueling the account on ethereum.

To prevent confusion in such future occurrences this PR adds `getSafeSendUSDTTransaction`, which checks the balance of the sender before returning the full `{to, value,data}` for USDT transfer

also linting