### PR TITLE
Bug / Prevent triggering to sign an account op more than once

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -507,7 +507,7 @@ export class MainController extends EventEmitter {
 
         return this.signAccountOp.sign()
       },
-      false
+      true
     )
 
     // Error handling on the prev step will notify the user, it's fine to return here
@@ -516,7 +516,7 @@ export class MainController extends EventEmitter {
     return this.withStatus(
       'broadcastSignedAccountOp',
       async () => this.#broadcastSignedAccountOp(),
-      false
+      true
     )
   }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -490,7 +490,7 @@ export class MainController extends EventEmitter {
     this.estimateSignAccountOp()
   }
 
-  async handleSignAccountOp() {
+  async handleSignAndBroadcastAccountOp() {
     await this.withStatus(
       'signAccountOp',
       async () => {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -79,7 +79,7 @@ import { SignMessageController } from '../signMessage/signMessage'
 
 const STATUS_WRAPPED_METHODS = {
   onAccountAdderSuccess: 'INITIAL',
-  handleSignAccountOp: 'INITIAL',
+  signAccountOp: 'INITIAL',
   broadcastSignedAccountOp: 'INITIAL',
   removeAccount: 'INITIAL',
   handleAccountAdderInitLedger: 'INITIAL'
@@ -387,9 +387,9 @@ export class MainController extends EventEmitter {
     this.estimateSignAccountOp()
   }
 
-  async handleSignAccountOp(n) {
+  async handleSignAccountOp() {
     await this.withStatus(
-      'handleSignAccountOp',
+      'signAccountOp',
       async () => {
         const wasAlreadySigned = this.signAccountOp?.status?.type === SigningStatus.Done
         if (wasAlreadySigned) return Promise.resolve()
@@ -408,7 +408,7 @@ export class MainController extends EventEmitter {
     )
 
     // Error handling on the prev step will notify the user, it's fine to return here
-    if (this.signAccountOp?.status?.type !== SigningStatus.Done) return Promise.reject()
+    if (this.signAccountOp?.status?.type !== SigningStatus.Done) return
 
     return this.withStatus(
       'broadcastSignedAccountOp',

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -388,6 +388,8 @@ export class MainController extends EventEmitter {
   }
 
   async #handleSignAccountOp() {
+    console.log('handleSignAccountOp gets called')
+
     if (!this.signAccountOp) {
       const message =
         'The signing process was not initialized as expected. Please try again later or contact Ambire support if the issue persists.'
@@ -398,13 +400,17 @@ export class MainController extends EventEmitter {
     await this.signAccountOp.sign()
 
     // Error handling on the prev step will notify the user, it's fine to return here
-    if (this.signAccountOp.status?.type !== SigningStatus.Done) return
+    if (this.signAccountOp.status?.type !== SigningStatus.Done) return Promise.reject()
 
-    await this.withStatus('broadcastSignedAccountOp', async () => this.#broadcastSignedAccountOp())
+    await this.withStatus(
+      'broadcastSignedAccountOp',
+      async () => this.#broadcastSignedAccountOp(),
+      false
+    )
   }
 
   async handleSignAccountOp() {
-    await this.withStatus('handleSignAccountOp', async () => this.#handleSignAccountOp())
+    await this.withStatus('handleSignAccountOp', async () => this.#handleSignAccountOp(), false)
   }
 
   destroySignAccOp() {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -81,7 +81,8 @@ const STATUS_WRAPPED_METHODS = {
   onAccountAdderSuccess: 'INITIAL',
   broadcastSignedAccountOp: 'INITIAL',
   removeAccount: 'INITIAL',
-  handleAccountAdderInitLedger: 'INITIAL'
+  handleAccountAdderInitLedger: 'INITIAL',
+  handleSignAccountOp: 'INITIAL'
 } as const
 
 export class MainController extends EventEmitter {
@@ -386,7 +387,7 @@ export class MainController extends EventEmitter {
     this.estimateSignAccountOp()
   }
 
-  async handleSignAccountOp() {
+  async #handleSignAccountOp() {
     if (!this.signAccountOp) {
       const message =
         'The signing process was not initialized as expected. Please try again later or contact Ambire support if the issue persists.'
@@ -400,6 +401,10 @@ export class MainController extends EventEmitter {
     if (this.signAccountOp.status?.type !== SigningStatus.Done) return
 
     await this.withStatus('broadcastSignedAccountOp', async () => this.#broadcastSignedAccountOp())
+  }
+
+  async handleSignAccountOp() {
+    await this.withStatus('handleSignAccountOp', async () => this.#handleSignAccountOp())
   }
 
   destroySignAccOp() {

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -610,7 +610,7 @@ describe('SignAccountOp Controller ', () => {
     expect(errors.length).toBe(1)
     expect(errors[0]).toBe('Insufficient funds to cover the fee.')
 
-    await controller.sign()
+    await expect(controller.sign()).rejects.toThrow()
     expect(controller.status?.type).toBe('unable-to-sign')
   })
 
@@ -685,7 +685,7 @@ describe('SignAccountOp Controller ', () => {
     expect(errors.length).toBe(1)
     expect(errors[0]).toBe('Insufficient funds to cover the fee.')
 
-    await controller.sign()
+    await expect(controller.sign()).rejects.toThrow()
     expect(controller.status?.type).toBe('unable-to-sign')
   })
 
@@ -951,7 +951,7 @@ describe('SignAccountOp Controller ', () => {
       `Currently, ${controller.availableFeeOptions[0].token.symbol} is unavailable as a fee token as we're experiencing troubles fetching its price. Please select another or contact support`
     )
 
-    await controller.sign()
+    await expect(controller.sign()).rejects.toThrow()
     expect(controller.accountOp?.signature).toBe(null)
   })
 
@@ -1354,7 +1354,7 @@ describe('SignAccountOp Controller ', () => {
       "Signing is not possible with the selected account's token as it doesn't have sufficient funds to cover the gas payment fee."
     )
 
-    await controller.sign()
+    await expect(controller.sign()).rejects.toThrow()
     expect(controller.status?.type).toBe('unable-to-sign')
   })
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -86,6 +86,9 @@ const CRITICAL_ERRORS = {
   eoaInsufficientFunds: 'Insufficient funds to cover the fee.'
 }
 
+const RETRY_TO_INIT_ACCOUNT_OP_MSG =
+  'Please attempt to initiate the transaction again or contact Ambire support.'
+
 export class SignAccountOpController extends EventEmitter {
   #accounts: AccountsController
 
@@ -888,24 +891,22 @@ export class SignAccountOpController extends EventEmitter {
   }
 
   async sign() {
-    if (!this.readyToSign)
-      return this.#setSigningError(
-        'Unable to sign the transaction. During the preparation step, required transaction data failed to get received. Please try again later or contact Ambire support.'
-      )
+    if (!this.readyToSign) {
+      const message = `Unable to sign the transaction. During the preparation step, the necessary transaction data was not received. ${RETRY_TO_INIT_ACCOUNT_OP_MSG}`
+      return this.#setSigningError(message)
+    }
 
     // when signing begings, we stop immediatelly state updates on the controller
     // by changing the status to InProgress. Check update() for more info
     this.status = { type: SigningStatus.InProgress }
 
     if (!this.accountOp?.signingKeyAddr || !this.accountOp?.signingKeyType) {
-      const message =
-        'Unable to sign the transaction. During the preparation step, required signing key information was found missing. Please try again later or contact Ambire support.'
+      const message = `Unable to sign the transaction. During the preparation step, required signing key information was found missing. ${RETRY_TO_INIT_ACCOUNT_OP_MSG}`
       return this.#setSigningError(message)
     }
 
     if (!this.accountOp?.gasFeePayment) {
-      const message =
-        'Unable to sign the transaction. During the preparation step, required information about paying the gas fee was found missing. Please try again later or contact Ambire support.'
+      const message = `Unable to sign the transaction. During the preparation step, required information about paying the gas fee was found missing. ${RETRY_TO_INIT_ACCOUNT_OP_MSG}`
       return this.#setSigningError(message)
     }
 
@@ -913,10 +914,10 @@ export class SignAccountOpController extends EventEmitter {
       this.accountOp.signingKeyAddr,
       this.accountOp.signingKeyType
     )
-    if (!signer)
-      return this.#setSigningError(
-        'Unable to sign the transaction. During the preparation step, required account key information was found missing. Please try again later or contact Ambire support.'
-      )
+    if (!signer) {
+      const message = `Unable to sign the transaction. During the preparation step, required account key information was found missing. ${RETRY_TO_INIT_ACCOUNT_OP_MSG}`
+      return this.#setSigningError(message)
+    }
 
     // we update the FE with the changed status (in progress) only after the checks
     // above confirm everything is okay to prevent two different state updates

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -889,24 +889,33 @@ export class SignAccountOpController extends EventEmitter {
   async sign() {
     if (!this.readyToSign)
       return this.#setSigningError(
-        'We are unable to sign your transaction as some of the mandatory signing fields have not been set.'
+        'Unable to sign the transaction. During the preparation step, required transaction data failed to get received. Please try again later or contact Ambire support.'
       )
 
     // when signing begings, we stop immediatelly state updates on the controller
     // by changing the status to InProgress. Check update() for more info
     this.status = { type: SigningStatus.InProgress }
 
-    if (!this.accountOp?.signingKeyAddr || !this.accountOp?.signingKeyType)
-      return this.#setSigningError('We cannot sign your transaction. Please choose a signer key.')
+    if (!this.accountOp?.signingKeyAddr || !this.accountOp?.signingKeyType) {
+      const message =
+        'Unable to sign the transaction. During the preparation step, required signing key information was found missing. Please try again later or contact Ambire support.'
+      return this.#setSigningError(message, SigningStatus.ReadyToSign)
+    }
 
-    if (!this.accountOp?.gasFeePayment)
-      return this.#setSigningError('Please select a token and an account for paying the gas fee.')
+    if (!this.accountOp?.gasFeePayment) {
+      const message =
+        'Unable to sign the transaction. During the preparation step, required information about paying the gas fee was found missing. Please try again later or contact Ambire support.'
+      return this.#setSigningError(message, SigningStatus.ReadyToSign)
+    }
 
     const signer = await this.#keystore.getSigner(
       this.accountOp.signingKeyAddr,
       this.accountOp.signingKeyType
     )
-    if (!signer) return this.#setSigningError('no available signer')
+    if (!signer)
+      return this.#setSigningError(
+        'Unable to sign the transaction. During the preparation step, required account key information was found missing. Please try again later or contact Ambire support.'
+      )
 
     // we update the FE with the changed status (in progress) only after the checks
     // above confirm everything is okay to prevent two different state updates

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -961,7 +961,7 @@ export class SignAccountOpController extends EventEmitter {
       if (!isSmartAccount(this.account)) {
         if (this.accountOp.calls.length !== 1) {
           const callCount = this.accountOp.calls.length > 1 ? 'multiple' : 'zero'
-          const message = `Unable to sign the transaction, because it has ${callCount} calls. Please try again later or contact Ambire support.`
+          const message = `Unable to sign the transaction because it has ${callCount} calls. ${RETRY_TO_INIT_ACCOUNT_OP_MSG}`
           return this.#setSigningError(message)
         }
 
@@ -986,7 +986,7 @@ export class SignAccountOpController extends EventEmitter {
           (!this.accountOp.meta || !this.accountOp.meta.entryPointAuthorization)
         )
           return this.#setSigningError(
-            'Entry point privileges not granted. Please try again later or contact Ambire support.'
+            `Unable to sign the transaction because entry point privileges were not granted. ${RETRY_TO_INIT_ACCOUNT_OP_MSG}`
           )
 
         const userOperation = getUserOperation(

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -900,13 +900,13 @@ export class SignAccountOpController extends EventEmitter {
     if (!this.accountOp?.signingKeyAddr || !this.accountOp?.signingKeyType) {
       const message =
         'Unable to sign the transaction. During the preparation step, required signing key information was found missing. Please try again later or contact Ambire support.'
-      return this.#setSigningError(message, SigningStatus.ReadyToSign)
+      return this.#setSigningError(message)
     }
 
     if (!this.accountOp?.gasFeePayment) {
       const message =
         'Unable to sign the transaction. During the preparation step, required information about paying the gas fee was found missing. Please try again later or contact Ambire support.'
-      return this.#setSigningError(message, SigningStatus.ReadyToSign)
+      return this.#setSigningError(message)
     }
 
     const signer = await this.#keystore.getSigner(

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -958,10 +958,11 @@ export class SignAccountOpController extends EventEmitter {
     try {
       // In case of EOA account
       if (!isSmartAccount(this.account)) {
-        if (this.accountOp.calls.length !== 1)
-          return this.#setSigningError(
-            'Unable to sign the transaction, because it has multiple or zero calls. Please try again later or contact Ambire support.'
-          )
+        if (this.accountOp.calls.length !== 1) {
+          const callCount = this.accountOp.calls.length > 1 ? 'multiple' : 'zero'
+          const message = `Unable to sign the transaction, because it has ${callCount} calls. Please try again later or contact Ambire support.`
+          return this.#setSigningError(message)
+        }
 
         // In legacy mode, we sign the transaction directly.
         // that means the signing will happen on broadcast and here


### PR DESCRIPTION
Improves the sign and broadcast flow by:

- Fixed: Prevention for triggering to sign an account op more than once by wrapping `withStatus` the two parts of `handleSignAndBroadcastAccountOp` - 1) Signing and 2) Broadcasting. So that in addition to the loading statuses, this solves a race that may happen when the user clicks (really fast) twice the Sign button (because the button gets disabled on event emit, which might get delayed in some scenarios).
- Fixed: Improve the sign error messaging, so that they sound less asparagus (although, ideally, these situations should never happen).