### PR TITLE
Feature / Notify for Queued Transactions

### DIFF
--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
 import { Account } from '../../interfaces/account'
+import { NotificationManager } from '../../interfaces/notification'
 import { DappUserRequest, SignUserRequest, UserRequest } from '../../interfaces/userRequest'
 import { WindowManager } from '../../interfaces/window'
 import { AccountOp } from '../../libs/accountOp/accountOp'
@@ -52,6 +53,8 @@ export class ActionsController extends EventEmitter {
 
   #windowManager: WindowManager
 
+  #notificationManager: NotificationManager
+
   actionWindow: {
     id: number | null
     loaded: boolean
@@ -94,19 +97,22 @@ export class ActionsController extends EventEmitter {
   constructor({
     accounts,
     windowManager,
+    notificationManager,
     onActionWindowClose
   }: {
     accounts: AccountsController
     windowManager: WindowManager
+    notificationManager: NotificationManager
     onActionWindowClose: () => void
   }) {
     super()
 
     this.#accounts = accounts
     this.#windowManager = windowManager
+    this.#notificationManager = notificationManager
     this.#onActionWindowClose = onActionWindowClose
 
-    this.#windowManager.event.on('windowRemoved', (winId: number) => {
+    this.#windowManager.event.on('windowRemoved', async (winId: number) => {
       if (winId === this.actionWindow.id) {
         this.actionWindow.id = null
         this.actionWindow.loaded = false
@@ -114,6 +120,15 @@ export class ActionsController extends EventEmitter {
         this.currentAction = null
 
         this.actionsQueue = this.actionsQueue.filter((a) => a.type === 'accountOp')
+        if (this.actionsQueue.length) {
+          await this.#notificationManager.create({
+            title:
+              this.actionsQueue.length > 1
+                ? `${this.actionsQueue.length} transactions queued`
+                : 'Transaction queued',
+            message: 'Queued pending transactions are available on your Dashboard'
+          })
+        }
         this.#onActionWindowClose()
         this.emitUpdate()
       }

--- a/src/interfaces/notification.ts
+++ b/src/interfaces/notification.ts
@@ -1,0 +1,11 @@
+export interface NotificationManager {
+  create: ({
+    title,
+    message,
+    icon
+  }: {
+    title: string
+    message: string
+    icon?: string
+  }) => Promise<void>
+}


### PR DESCRIPTION
Resolves: https://github.com/AmbireTech/ambire-app/issues/2100

* Introduced notificationManager
* removed onSignSuccess callback from main because it was used mainly for creating notifications in the background but now the creation of notifications is available in the main controller too
* Added queued transaction notification on force window close from the system (X) button