### PR TITLE
Add post processing for additional token hint

### DIFF
--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -246,7 +246,8 @@ describe('Humanizer main function', () => {
         getAction('Send'),
         getToken('0x0000000000000000000000000000000000000000', 1000000000000000000n),
         getLabel('to'),
-        getAddressVisualization('0xc4ce03b36f057591b2a360d773edb9896255051e')
+        getAddressVisualization('0xc4ce03b36f057591b2a360d773edb9896255051e'),
+        getToken('0xc4ce03b36f057591b2a360d773edb9896255051e', 0n, true)
       ],
       [
         getAction('Grant approval'),
@@ -256,7 +257,8 @@ describe('Humanizer main function', () => {
           115792089237316195423570985008687907853269984665640564039457584007913129639935n
         ),
         getLabel('to'),
-        getAddressVisualization('0xe5c783ee536cf5e63e792988335c4255169be4e1')
+        getAddressVisualization('0xe5c783ee536cf5e63e792988335c4255169be4e1'),
+        getToken('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 0n, true)
       ]
     ]
     const onUpdate = jest.fn((newCalls: IrCall[]) => {
@@ -271,15 +273,16 @@ describe('Humanizer main function', () => {
     const expectedVisualizations = [
       getAction('Call buy(uint256)'),
       getLabel('from'),
-      getAddressVisualization('0x519856887af544de7e67f51a4f2271521b01432b')
+      getAddressVisualization('0x519856887af544de7e67f51a4f2271521b01432b'),
+      getToken('0x519856887af544de7e67f51a4f2271521b01432b', 0n, true)
     ]
     let iterations = 0
     const onUpdate = jest.fn((newCalls: IrCall[]) => {
       if (iterations === 0) {
-        expect(newCalls[0]?.fullVisualization?.length).toBe(3)
+        expect(newCalls[0]?.fullVisualization?.length).toBe(4)
         compareVisualizations([newCalls[0].fullVisualization?.[0]!], [getAction('Unknown action')])
       } else if (iterations === 1) {
-        expect(newCalls[0]?.fullVisualization?.length).toBe(3)
+        expect(newCalls[0]?.fullVisualization?.length).toBe(4)
         compareVisualizations(newCalls[0].fullVisualization || [], expectedVisualizations)
       }
       iterations += 1
@@ -401,14 +404,16 @@ describe('with (Account | Key)[] arg', () => {
         getLabel('for'),
         getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 1000000000n),
         getLabel('to'),
-        getAddressVisualization(accounts[0].addr.toLowerCase())
+        getAddressVisualization(accounts[0].addr.toLowerCase()),
+        getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 0n, true)
       ],
       [
         getAction('Grant approval'),
         getLabel('for'),
         getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 1000000000n),
         getLabel('to'),
-        getAddressVisualization(keys[0].addr.toLowerCase())
+        getAddressVisualization(keys[0].addr.toLowerCase()),
+        getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 0n, true)
       ]
     ]
     accountOp.calls = [...transactions.accountOrKeyArg]

--- a/src/libs/humanizer/index.ts
+++ b/src/libs/humanizer/index.ts
@@ -22,6 +22,7 @@ import curveModule from './modules/Curve'
 import fallbackHumanizer from './modules/FallbackHumanizer'
 import gasTankModule from './modules/GasTankModule'
 import KyberSwap from './modules/KyberSwap'
+import { postProcessing } from './modules/PostProcessing/postProcessModule'
 import preProcessHumanizer from './modules/PreProcess'
 import privilegeHumanizer from './modules/Privileges'
 import { SocketModule } from './modules/Socket'
@@ -53,7 +54,8 @@ export const humanizerCallModules: HumanizerCallModule[] = [
   WALLETModule,
   privilegeHumanizer,
   sushiSwapModule,
-  fallbackHumanizer
+  fallbackHumanizer,
+  postProcessing
 ]
 
 // from least generic to most generic

--- a/src/libs/humanizer/modules/PostProcessing/index.ts
+++ b/src/libs/humanizer/modules/PostProcessing/index.ts
@@ -1,0 +1,3 @@
+import { postProcessing } from './postProcessModule'
+
+export default postProcessing

--- a/src/libs/humanizer/modules/PostProcessing/postProcessModule.ts
+++ b/src/libs/humanizer/modules/PostProcessing/postProcessModule.ts
@@ -1,0 +1,11 @@
+import { AccountOp } from '../../../accountOp/accountOp'
+import { HumanizerCallModule, IrCall } from '../../interfaces'
+import { getToken } from '../../utils'
+
+export const postProcessing: HumanizerCallModule = (_: AccountOp, currentIrCalls: IrCall[]) => {
+  const newCalls = currentIrCalls.map((_call) => ({
+    ..._call,
+    fullVisualization: [...(_call?.fullVisualization || []), getToken(_call.to, 0n, true)]
+  }))
+  return [newCalls, []]
+}

--- a/src/libs/humanizer/modules/PostProcessing/postProcessing.test.ts
+++ b/src/libs/humanizer/modules/PostProcessing/postProcessing.test.ts
@@ -1,0 +1,30 @@
+import { ZeroAddress } from 'ethers'
+
+import { compareHumanizerVisualizations } from '../../testHelpers'
+import { EMPTY_HUMANIZER_META, getAction, getToken } from '../../utils'
+import { postProcessing } from './postProcessModule'
+
+describe('postProcessing', () => {
+  test('add hidden token hint', () => {
+    const [irCalls] = postProcessing(
+      {} as any,
+      [
+        {
+          to: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          data: '0xd0e30db0',
+          value: 100n,
+          fullVisualization: [getAction('Wrap'), getToken(ZeroAddress, 100n)]
+        }
+      ],
+      EMPTY_HUMANIZER_META,
+      {}
+    )
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('Wrap'),
+        getToken(ZeroAddress, 100n),
+        getToken('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 0n, true)
+      ]
+    ])
+  })
+})

--- a/src/libs/humanizer/modules/Wrapping/wrapping.test.ts
+++ b/src/libs/humanizer/modules/Wrapping/wrapping.test.ts
@@ -85,13 +85,11 @@ describe('wrapping', () => {
     const expectedHumanization = [
       [
         getAction('Wrap'),
-        getToken('0x0000000000000000000000000000000000000000', transactions.weth[0].value),
-        getToken('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 0n, true)
+        getToken('0x0000000000000000000000000000000000000000', transactions.weth[0].value)
       ],
       [
         getAction('Unwrap'),
-        getToken('0x0000000000000000000000000000000000000000', 8900000000000000n),
-        getToken('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 0n, true)
+        getToken('0x0000000000000000000000000000000000000000', 8900000000000000n)
       ],
       []
     ]

--- a/src/libs/humanizer/modules/Wrapping/wrapping.ts
+++ b/src/libs/humanizer/modules/Wrapping/wrapping.ts
@@ -25,7 +25,7 @@ export const wrappingModule: HumanizerCallModule = (
       if (call.data.slice(0, 10) === iface.getFunction('deposit')?.selector) {
         return {
           ...call,
-          fullVisualization: getWrapping(ZeroAddress, call.value, call.to)
+          fullVisualization: getWrapping(ZeroAddress, call.value)
         }
       }
       // 0x2e1a7d4d
@@ -33,7 +33,7 @@ export const wrappingModule: HumanizerCallModule = (
         const [amount] = iface.parseTransaction(call)?.args || []
         return {
           ...call,
-          fullVisualization: getUnwrapping(ZeroAddress, amount, call.to)
+          fullVisualization: getUnwrapping(ZeroAddress, amount)
         }
       }
       if (!call?.fullVisualization)

--- a/src/libs/humanizer/utils.ts
+++ b/src/libs/humanizer/utils.ts
@@ -174,28 +174,12 @@ export function getUnknownVisualization(name: string, call: IrCall): HumanizerVi
   return unknownVisualization
 }
 
-export function getWrapping(
-  address: string,
-  amount: bigint,
-  hiddenAssetAddress?: string
-): HumanizerVisualization[] {
-  return [
-    getAction('Wrap'),
-    getToken(address, amount),
-    hiddenAssetAddress && { ...getToken(hiddenAssetAddress, 0n), isHidden: true }
-  ].filter((x) => x) as HumanizerVisualization[]
+export function getWrapping(address: string, amount: bigint): HumanizerVisualization[] {
+  return [getAction('Wrap'), getToken(address, amount)]
 }
 
-export function getUnwrapping(
-  address: string,
-  amount: bigint,
-  hiddenAssetAddress?: string
-): HumanizerVisualization[] {
-  return [
-    getAction('Unwrap'),
-    getToken(address, amount),
-    hiddenAssetAddress && { ...getToken(hiddenAssetAddress, 0n), isHidden: true }
-  ].filter((x) => x) as HumanizerVisualization[]
+export function getUnwrapping(address: string, amount: bigint): HumanizerVisualization[] {
+  return [getAction('Unwrap'), getToken(address, amount)]
 }
 
 // @TODO cant this be used in the <Address component>


### PR DESCRIPTION
Adds additional hidden token hint (call.to) for simulation only via the new module `postProcessing` and old `fallback`



Once we fully disable additional hidden token hints we will remove those two
