### PR TITLE
Enhancement / Dashboard pending state

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -562,6 +562,9 @@ export class ActivityController extends EventEmitter {
       return {
         id: accountOp.txnId,
         type: 'success',
+        // TODO: We should pass the category, once we figure out how to determine the pending to be confirmed account ops:
+        // @link: https://github.com/AmbireTech/ambire-app/issues/2162#issuecomment-2191731436
+        // category: 'pending-to-be-confirmed-acc-op',
         title: 'Transaction successfully signed and sent!\nCheck it out on the block explorer!',
         text: '',
         actions: [

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -3,11 +3,13 @@ import { AccountOpAction } from 'controllers/actions/actions'
 import { Network } from './network'
 
 export type BannerType = 'error' | 'warning' | 'info' | 'success'
+export type BannerCategory = 'pending-to-be-signed-acc-op' | 'pending-to-be-confirmed-acc-op'
 
 export interface Banner {
   id: number | string
   accountAddr?: string
   type: BannerType
+  category?: BannerCategory
   title: string
   text: string
   actions: Action[]

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -56,6 +56,7 @@ export const getAccountOpBanners = ({
         txnBanners.push({
           id: `${selectedAccount}-${netId}`,
           type: 'info',
+          category: 'pending-to-be-signed-acc-op',
           title: `Transaction waiting to be signed ${network.name ? `on ${network.name}` : ''}`,
           text: '', // TODO:
           actions: [


### PR DESCRIPTION
Add: BannerCategory type to Banners, in order to differentiate between PendingToBeSigned and PendingToBeConfirmed banners.