### PR TITLE
Feature / Add to Queue Button

### DIFF
--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -149,6 +149,8 @@ export class ActionsController extends EventEmitter {
           ? this.visibleActionsQueue[0] || null
           : this.currentAction || this.visibleActionsQueue[0] || null
         this.#setCurrentAction(currentAction)
+      } else {
+        this.emitUpdate()
       }
       return
     }
@@ -165,6 +167,8 @@ export class ActionsController extends EventEmitter {
         ? this.visibleActionsQueue[0] || null
         : this.currentAction || this.visibleActionsQueue[0] || null
       this.#setCurrentAction(currentAction)
+    } else {
+      this.emitUpdate()
     }
   }
 

--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -168,9 +168,11 @@ export class ActionsController extends EventEmitter {
     }
   }
 
-  removeAction(actionId: Action['id']) {
+  removeAction(actionId: Action['id'], shouldOpenNextAction: boolean) {
     this.actionsQueue = this.actionsQueue.filter((a) => a.id !== actionId)
-    this.#setCurrentAction(this.visibleActionsQueue[0] || null)
+    if (shouldOpenNextAction) {
+      this.#setCurrentAction(this.visibleActionsQueue[0] || null)
+    }
   }
 
   #setCurrentAction(nextAction: Action | null) {

--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -172,7 +172,7 @@ export class ActionsController extends EventEmitter {
     }
   }
 
-  removeAction(actionId: Action['id'], shouldOpenNextAction: boolean) {
+  removeAction(actionId: Action['id'], shouldOpenNextAction: boolean = true) {
     this.actionsQueue = this.actionsQueue.filter((a) => a.id !== actionId)
     if (shouldOpenNextAction) {
       this.#setCurrentAction(this.visibleActionsQueue[0] || null)

--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -120,15 +120,21 @@ export class ActionsController extends EventEmitter {
     })
   }
 
-  addOrUpdateAction(newAction: Action, withPriority?: boolean) {
+  addOrUpdateAction(
+    newAction: Action,
+    withPriority?: boolean,
+    executionType: 'queue' | 'open' = 'open'
+  ) {
     const actionIndex = this.actionsQueue.findIndex((a) => a.id === newAction.id)
     if (actionIndex !== -1) {
       this.actionsQueue[actionIndex] = newAction
-      this.sendNewActionMessage(newAction, 'update')
-      const currentAction = withPriority
-        ? this.visibleActionsQueue[0] || null
-        : this.currentAction || this.visibleActionsQueue[0] || null
-      this.#setCurrentAction(currentAction)
+      if (executionType === 'open') {
+        this.sendNewActionMessage(newAction, 'update')
+        const currentAction = withPriority
+          ? this.visibleActionsQueue[0] || null
+          : this.currentAction || this.visibleActionsQueue[0] || null
+        this.#setCurrentAction(currentAction)
+      }
       return
     }
 
@@ -137,11 +143,14 @@ export class ActionsController extends EventEmitter {
     } else {
       this.actionsQueue.push(newAction)
     }
-    this.sendNewActionMessage(newAction, withPriority ? 'unshift' : 'push')
-    const currentAction = withPriority
-      ? this.visibleActionsQueue[0] || null
-      : this.currentAction || this.visibleActionsQueue[0] || null
-    this.#setCurrentAction(currentAction)
+
+    if (executionType === 'open') {
+      this.sendNewActionMessage(newAction, withPriority ? 'unshift' : 'push')
+      const currentAction = withPriority
+        ? this.visibleActionsQueue[0] || null
+        : this.currentAction || this.visibleActionsQueue[0] || null
+      this.#setCurrentAction(currentAction)
+    }
   }
 
   removeAction(actionId: Action['id']) {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -950,7 +950,8 @@ export class MainController extends EventEmitter {
   async buildTransferUserRequest(
     amount: string,
     recipientAddress: string,
-    selectedToken: TokenResult
+    selectedToken: TokenResult,
+    executionType: 'queue' | 'open' = 'open'
   ) {
     await this.#initialLoadPromise
     if (!this.accounts.selectedAccount) return
@@ -975,7 +976,7 @@ export class MainController extends EventEmitter {
       return
     }
 
-    await this.addUserRequest(userRequest, !account.creation)
+    await this.addUserRequest(userRequest, !account.creation, executionType)
   }
 
   resolveUserRequest(data: any, requestId: UserRequest['id']) {
@@ -1016,7 +1017,11 @@ export class MainController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async addUserRequest(req: UserRequest, withPriority?: boolean) {
+  async addUserRequest(
+    req: UserRequest,
+    withPriority?: boolean,
+    executionType: 'queue' | 'open' = 'open'
+  ) {
     if (withPriority) {
       this.userRequests.unshift(req)
     } else {
@@ -1070,7 +1075,7 @@ export class MainController extends EventEmitter {
           userRequests: this.userRequests,
           actionsQueue: this.actions.actionsQueue
         })
-        this.actions.addOrUpdateAction(accountOpAction, withPriority)
+        this.actions.addOrUpdateAction(accountOpAction, withPriority, executionType)
         if (this.signAccountOp && this.signAccountOp.fromActionId === accountOpAction.id) {
           this.signAccountOp.update({ accountOp: accountOpAction.accountOp })
           this.estimateSignAccountOp()
@@ -1082,7 +1087,7 @@ export class MainController extends EventEmitter {
           nonce: accountState.nonce,
           userRequest: req
         })
-        this.actions.addOrUpdateAction(accountOpAction, withPriority)
+        this.actions.addOrUpdateAction(accountOpAction, withPriority, executionType)
       }
     } else {
       let actionType: 'dappRequest' | 'benzin' | 'signMessage' = 'dappRequest'
@@ -1111,7 +1116,8 @@ export class MainController extends EventEmitter {
           type: actionType,
           userRequest: req as UserRequest as never
         },
-        withPriority
+        withPriority,
+        executionType
       )
     }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1367,12 +1367,16 @@ export class MainController extends EventEmitter {
     this.emitUpdate()
   }
 
-  rejectAccountOpAction(err: string, actionId: AccountOpAction['id']) {
+  rejectAccountOpAction(
+    err: string,
+    actionId: AccountOpAction['id'],
+    shouldOpenNextAction: boolean
+  ) {
     const accountOpAction = this.actions.actionsQueue.find((a) => a.id === actionId)
     if (!accountOpAction) return
 
     const { accountOp } = accountOpAction as AccountOpAction
-    this.actions.removeAction(actionId)
+    this.actions.removeAction(actionId, shouldOpenNextAction)
     // eslint-disable-next-line no-restricted-syntax
     for (const call of accountOp.calls) {
       const uReq = this.userRequests.find((r) => r.id === call.fromUserRequestId)

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -75,6 +75,7 @@ const getTokens = async () => {
 describe('Transfer Controller', () => {
   test('should initialize', async () => {
     transferController = new TransferController(
+      produceMemoryStore(),
       humanizerInfo as HumanizerMeta,
       PLACEHOLDER_SELECTED_ACCOUNT,
       networksCtrl.networks

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -31,6 +31,7 @@ export type Action =
       meta: {
         err: string
         actionId: AccountOpAction['id']
+        shouldOpenNextAction: boolean
       }
     }
   | {

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -64,7 +64,8 @@ export const getAccountOpBanners = ({
               actionName: 'reject-accountOp',
               meta: {
                 err: 'User rejected the transaction request.',
-                actionId: action.id
+                actionId: action.id,
+                shouldOpenNextAction: false
               }
             },
             {


### PR DESCRIPTION
Resolves: https://github.com/AmbireTech/ambire-app/issues/2032

* Added the executionType property to addOrUpdateAction to specify whether the action should open immediately or be queued without opening after being added
* Added shouldSkipTransactionQueuedModal to the transfer controller to control whether the modal appears after queuing a transaction on the TransferScreen
* on removeAction there is a new option to control whether to open next action if any after removal or not