### PR TITLE
Config / Option to toggle searching for linked accounts and getting accounts used on networks for the Account Adder

### DIFF
--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -40,6 +40,7 @@ import { KeystoreController } from '../keystore/keystore'
 export const DEFAULT_PAGE = 1
 export const DEFAULT_PAGE_SIZE = 5
 const DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS = true
+const DEFAULT_SHOULD_GET_ACCOUNTS_USED_ON_NETWORKS = true
 
 /**
  * Account Adder Controller
@@ -62,6 +63,8 @@ export class AccountAdderController extends EventEmitter {
   isInitialized: boolean = false
 
   shouldSearchForLinkedAccounts = DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS
+
+  shouldGetAccountsUsedOnNetworks = DEFAULT_SHOULD_GET_ACCOUNTS_USED_ON_NETWORKS
 
   // This is only the index of the current page
   page: number = DEFAULT_PAGE
@@ -223,13 +226,15 @@ export class AccountAdderController extends EventEmitter {
     page,
     pageSize,
     hdPathTemplate,
-    shouldSearchForLinkedAccounts = DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS
+    shouldSearchForLinkedAccounts = DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS,
+    shouldGetAccountsUsedOnNetworks = DEFAULT_SHOULD_GET_ACCOUNTS_USED_ON_NETWORKS
   }: {
     keyIterator: KeyIterator | null
     page?: number
     pageSize?: number
     hdPathTemplate: HD_PATH_TEMPLATE_TYPE
     shouldSearchForLinkedAccounts?: boolean
+    shouldGetAccountsUsedOnNetworks?: boolean
   }): void {
     this.#keyIterator = keyIterator
     if (!this.#keyIterator) return this.#throwMissingKeyIterator()
@@ -240,6 +245,7 @@ export class AccountAdderController extends EventEmitter {
     this.isInitialized = true
     this.#alreadyImportedAccountsOnControllerInit = this.#accounts.accounts
     this.shouldSearchForLinkedAccounts = shouldSearchForLinkedAccounts
+    this.shouldGetAccountsUsedOnNetworks = shouldGetAccountsUsedOnNetworks
 
     this.emitUpdate()
   }
@@ -259,6 +265,7 @@ export class AccountAdderController extends EventEmitter {
     this.pageSize = DEFAULT_PAGE_SIZE
     this.hdPathTemplate = undefined
     this.shouldSearchForLinkedAccounts = DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS
+    this.shouldGetAccountsUsedOnNetworks = DEFAULT_SHOULD_GET_ACCOUNTS_USED_ON_NETWORKS
 
     this.addAccountsStatus = 'INITIAL'
     this.#derivedAccounts = []
@@ -747,6 +754,10 @@ export class AccountAdderController extends EventEmitter {
     networks: Network[]
     providers: { [key: string]: JsonRpcProvider }
   }): Promise<DerivedAccount[]> {
+    if (!this.shouldGetAccountsUsedOnNetworks) {
+      return accounts.map((a) => ({ ...a, account: { ...a.account, usedOnNetworks: [] } }))
+    }
+
     const accountsObj: { [key: Account['addr']]: DerivedAccount } = Object.fromEntries(
       accounts.map((a) => [a.account.addr, { ...a, account: { ...a.account, usedOnNetworks: [] } }])
     )

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -39,6 +39,7 @@ import { KeystoreController } from '../keystore/keystore'
 
 export const DEFAULT_PAGE = 1
 export const DEFAULT_PAGE_SIZE = 5
+const DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS = true
 
 /**
  * Account Adder Controller
@@ -59,6 +60,8 @@ export class AccountAdderController extends EventEmitter {
   hdPathTemplate?: HD_PATH_TEMPLATE_TYPE
 
   isInitialized: boolean = false
+
+  shouldSearchForLinkedAccounts = DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS
 
   // This is only the index of the current page
   page: number = DEFAULT_PAGE
@@ -219,12 +222,14 @@ export class AccountAdderController extends EventEmitter {
     keyIterator,
     page,
     pageSize,
-    hdPathTemplate
+    hdPathTemplate,
+    shouldSearchForLinkedAccounts = DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS
   }: {
     keyIterator: KeyIterator | null
     page?: number
     pageSize?: number
     hdPathTemplate: HD_PATH_TEMPLATE_TYPE
+    shouldSearchForLinkedAccounts?: boolean
   }): void {
     this.#keyIterator = keyIterator
     if (!this.#keyIterator) return this.#throwMissingKeyIterator()
@@ -234,6 +239,7 @@ export class AccountAdderController extends EventEmitter {
     this.hdPathTemplate = hdPathTemplate
     this.isInitialized = true
     this.#alreadyImportedAccountsOnControllerInit = this.#accounts.accounts
+    this.shouldSearchForLinkedAccounts = shouldSearchForLinkedAccounts
 
     this.emitUpdate()
   }
@@ -252,6 +258,7 @@ export class AccountAdderController extends EventEmitter {
     this.page = DEFAULT_PAGE
     this.pageSize = DEFAULT_PAGE_SIZE
     this.hdPathTemplate = undefined
+    this.shouldSearchForLinkedAccounts = DEFAULT_SHOULD_SEARCH_FOR_LINKED_ACCOUNTS
 
     this.addAccountsStatus = 'INITIAL'
     this.#derivedAccounts = []
@@ -470,6 +477,7 @@ export class AccountAdderController extends EventEmitter {
     }
     this.accountsLoading = false
     this.emitUpdate()
+
     this.#findAndSetLinkedAccounts({
       accounts: this.#derivedAccounts
         .filter(
@@ -821,6 +829,8 @@ export class AccountAdderController extends EventEmitter {
     networks: Network[]
     providers: { [key: string]: JsonRpcProvider }
   }) {
+    if (!this.shouldSearchForLinkedAccounts) return
+
     if (accounts.length === 0) return
 
     this.linkedAccountsLoading = true

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -368,7 +368,9 @@ export class MainController extends EventEmitter {
         this.accountAdder.init({
           keyIterator,
           hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
-          pageSize: 1
+          pageSize: 1,
+          shouldGetAccountsUsedOnNetworks: false,
+          shouldSearchForLinkedAccounts: false
         })
 
         let currentPage: number = 1


### PR DESCRIPTION
For the use-cases in https://github.com/AmbireTech/ambire-app/pull/2507 there is no need for the Account Adder controller to waste time searching for linked accounts and getting accounts used on networks. This PR makes these steps configurable, so they can be now disabled when needed.