### PR TITLE
Add destination chain id for bridging tokens

### DIFF
--- a/src/libs/humanizer/interfaces.ts
+++ b/src/libs/humanizer/interfaces.ts
@@ -6,7 +6,7 @@ import { AccountOp } from '../accountOp/accountOp'
 import { Call } from '../accountOp/types'
 
 // @TODO remove property humanizerMeta
-export type HumanizerVisualization =
+export type HumanizerVisualization = (
   | {
       type: 'address' | 'label' | 'action' | 'danger' | 'deadline' | 'chain' | 'message'
       address?: string
@@ -15,7 +15,6 @@ export type HumanizerVisualization =
       humanizerMeta?: HumanizerMetaAddress
       warning?: boolean
       // humanizerMeta?: HumanizerMetaAddress
-      id: number
       chainId?: bigint
       messageContent?: Uint8Array | string
     }
@@ -23,10 +22,9 @@ export type HumanizerVisualization =
       type: 'token'
       address: string
       value: bigint
-      id: number
       chainId?: bigint
-      isHidden?: boolean
     }
+) & { isHidden?: boolean; id: number; content?: string }
 export interface IrCall extends Call {
   fullVisualization?: HumanizerVisualization[]
   warnings?: HumanizerWarning[]

--- a/src/libs/humanizer/interfaces.ts
+++ b/src/libs/humanizer/interfaces.ts
@@ -6,19 +6,27 @@ import { AccountOp } from '../accountOp/accountOp'
 import { Call } from '../accountOp/types'
 
 // @TODO remove property humanizerMeta
-export type HumanizerVisualization = {
-  type: 'token' | 'address' | 'label' | 'action' | 'danger' | 'deadline' | 'chain' | 'message'
-  address?: string
-  content?: string
-  value?: bigint
-  humanizerMeta?: HumanizerMetaAddress
-  warning?: boolean
-  // humanizerMeta?: HumanizerMetaAddress
-  id: number
-  chainId?: bigint
-  isHidden?: boolean
-  messageContent?: Uint8Array | string
-}
+export type HumanizerVisualization =
+  | {
+      type: 'address' | 'label' | 'action' | 'danger' | 'deadline' | 'chain' | 'message'
+      address?: string
+      content?: string
+      value?: bigint
+      humanizerMeta?: HumanizerMetaAddress
+      warning?: boolean
+      // humanizerMeta?: HumanizerMetaAddress
+      id: number
+      chainId?: bigint
+      messageContent?: Uint8Array | string
+    }
+  | {
+      type: 'token'
+      address: string
+      value: bigint
+      id: number
+      chainId?: bigint
+      isHidden?: boolean
+    }
 export interface IrCall extends Call {
   fullVisualization?: HumanizerVisualization[]
   warnings?: HumanizerWarning[]

--- a/src/libs/humanizer/modules/Across/across.test.ts
+++ b/src/libs/humanizer/modules/Across/across.test.ts
@@ -4,7 +4,15 @@ import humanizerInfo from '../../../../consts/humanizer/humanizerInfo.json'
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerMeta } from '../../interfaces'
 import { compareHumanizerVisualizations } from '../../testHelpers'
-import { getAction, getChain, getDeadline, getLabel, getRecipientText, getToken } from '../../utils'
+import {
+  getAction,
+  getChain,
+  getDeadline,
+  getLabel,
+  getRecipientText,
+  getToken,
+  getTokenWithChain
+} from '../../utils'
 import AcrossModule from '.'
 
 const transactions = [
@@ -57,7 +65,7 @@ describe('Across', () => {
         getAction('Bridge'),
         getToken('0x3c499c542cef5e3811e1192ce70d8cc03d5c3359', 130592n),
         getLabel('for'),
-        getToken('0xaf88d065e77c8cC2239327C5EDb3A432268e5831', 107647n),
+        getTokenWithChain('0xaf88d065e77c8cC2239327C5EDb3A432268e5831', 107647n, ARBITRUM_CHAIN_ID),
         getLabel('to'),
         getChain(ARBITRUM_CHAIN_ID),
         getDeadline(1718657594n)

--- a/src/libs/humanizer/modules/Across/index.ts
+++ b/src/libs/humanizer/modules/Across/index.ts
@@ -3,7 +3,15 @@ import { Interface } from 'ethers'
 import { AccountOp } from '../../../accountOp/accountOp'
 import { Across } from '../../const/abis'
 import { HumanizerCallModule, IrCall } from '../../interfaces'
-import { getAction, getChain, getDeadline, getLabel, getRecipientText, getToken } from '../../utils'
+import {
+  getAction,
+  getChain,
+  getDeadline,
+  getLabel,
+  getRecipientText,
+  getToken,
+  getTokenWithChain
+} from '../../utils'
 
 const AcrossModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[]) => {
   const iface = new Interface(Across)
@@ -24,7 +32,7 @@ const AcrossModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[]) =>
         getAction('Bridge'),
         getToken(inputToken, inputAmount),
         getLabel('for'),
-        getToken(outputToken, outputAmount),
+        getTokenWithChain(outputToken, outputAmount, destinationChainId),
         getLabel('to'),
         getChain(destinationChainId),
         getDeadline(fillDeadline),

--- a/src/libs/humanizer/modules/Socket/socket.test.ts
+++ b/src/libs/humanizer/modules/Socket/socket.test.ts
@@ -2,7 +2,14 @@ import humanizerInfo from '../../../../consts/humanizer/humanizerInfo.json'
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerMeta } from '../../interfaces'
 import { compareHumanizerVisualizations } from '../../testHelpers'
-import { getAction, getChain, getDeadline, getLabel, getToken } from '../../utils'
+import {
+  getAction,
+  getChain,
+  getDeadline,
+  getLabel,
+  getToken,
+  getTokenWithChain
+} from '../../utils'
 import AcrossModule from '../Across'
 import { SocketModule } from '.'
 
@@ -44,7 +51,7 @@ describe('socket', () => {
         getAction('Bridge'),
         getToken('0x4200000000000000000000000000000000000042', 2008021737164118026n),
         getLabel('to'),
-        getToken('0x0b2c639c533813f4aa9d7837caf62653d097ff85', 3094288n),
+        getTokenWithChain('0x0b2c639c533813f4aa9d7837caf62653d097ff85', 3094288n, 137n),
         getLabel('on'),
         getChain(137n),
         getDeadline(1720088255n)

--- a/src/libs/humanizer/modules/Socket/socketModules.ts
+++ b/src/libs/humanizer/modules/Socket/socketModules.ts
@@ -12,7 +12,8 @@ import {
   getDeadline,
   getLabel,
   getRecipientText,
-  getToken
+  getToken,
+  getTokenWithChain
 } from '../../utils'
 
 // @TODO check all additional data provided
@@ -58,7 +59,7 @@ export const SocketModule: HumanizerCallModule = (accountOp: AccountOp, irCalls:
             getAction('Bridge'),
             getToken(eToNative(fromToken), amount),
             getLabel('to'),
-            getToken(eToNative(toToken), outputAmount),
+            getTokenWithChain(eToNative(toToken), outputAmount, dstChain),
             getLabel('on'),
             getChain(dstChain),
             getDeadline(quoteAndDeadlineTimeStamps[0]),
@@ -72,7 +73,7 @@ export const SocketModule: HumanizerCallModule = (accountOp: AccountOp, irCalls:
           getAction('Bridge'),
           getLabel('undetected token'),
           getLabel('to'),
-          getToken(eToNative(outputToken), outputAmount),
+          getTokenWithChain(eToNative(outputToken), outputAmount, dstChain),
           getLabel('on'),
           getChain(dstChain),
           getDeadline(quoteAndDeadlineTimeStamps[0]),
@@ -104,7 +105,7 @@ export const SocketModule: HumanizerCallModule = (accountOp: AccountOp, irCalls:
             getAction('Bridge'),
             getToken(ZeroAddress, amount),
             getLabel('to'),
-            getToken(eToNative(outputToken), outputAmount),
+            getTokenWithChain(eToNative(outputToken), outputAmount, chainId),
             getLabel('on'),
             getChain(chainId),
             getDeadline(quoteAndDeadlineTimeStamps[0]),
@@ -158,7 +159,7 @@ export const SocketModule: HumanizerCallModule = (accountOp: AccountOp, irCalls:
           getAction('Bridge'),
           getToken(eToNative(inputToken), amount),
           getLabel('to'),
-          getToken(eToNative(outputToken), outputAmount),
+          getTokenWithChain(eToNative(outputToken), outputAmount, chainId),
           getLabel('on'),
           getChain(chainId),
           ...getRecipientText(sender, receiver)
@@ -212,7 +213,11 @@ export const SocketModule: HumanizerCallModule = (accountOp: AccountOp, irCalls:
           getAction('Bridge'),
           getToken(eToNative(tokenOut), amount),
           getLabel('to'),
-          getToken(eToNative(destinationQuery.tokenOut), destinationQuery.minAmountOut),
+          getTokenWithChain(
+            eToNative(destinationQuery.tokenOut),
+            destinationQuery.minAmountOut,
+            toChainId
+          ),
           getLabel('on'),
           getChain(toChainId),
           getDeadline(deadline),
@@ -232,7 +237,7 @@ export const SocketModule: HumanizerCallModule = (accountOp: AccountOp, irCalls:
           getAction('Bridge'),
           getToken(eToNative(token), amount),
           getLabel('to'),
-          getToken(eToNative(token), amount),
+          getTokenWithChain(eToNative(token), amount, chainId),
           getLabel('on'),
           getChain(chainId),
           ...getRecipientText(accountOp.accountAddr, recipient)
@@ -403,8 +408,14 @@ export const SocketModule: HumanizerCallModule = (accountOp: AccountOp, irCalls:
             getAction('Bridge'),
             getToken(eToNative(fromToken), amount),
             getLabel('to'),
-            getToken(eToNative(toToken), outAmount),
-            ...(chainId ? [getLabel('on'), getChain(chainId)] : []),
+
+            ...(chainId
+              ? [
+                  getTokenWithChain(eToNative(toToken), outAmount, chainId),
+                  getLabel('on'),
+                  getChain(chainId)
+                ]
+              : [getToken(eToNative(toToken), outAmount)]),
             ...getRecipientText(accountOp.accountAddr, receiverAddress)
           ].filter((x) => x)
         }

--- a/src/libs/humanizer/utils.ts
+++ b/src/libs/humanizer/utils.ts
@@ -41,7 +41,8 @@ export function getAddressVisualization(_address: string): HumanizerVisualizatio
 export function getToken(
   _address: string,
   amount: bigint,
-  isHidden?: boolean
+  isHidden?: boolean,
+  chainId?: bigint
 ): HumanizerVisualization {
   const address = _address.toLowerCase()
   return {
@@ -49,8 +50,16 @@ export function getToken(
     address,
     value: BigInt(amount),
     id: randomId(),
-    isHidden
+    isHidden,
+    chainId
   }
+}
+export function getTokenWithChain(
+  address: string,
+  amount: bigint,
+  chainId?: bigint
+): HumanizerVisualization {
+  return getToken(address, amount, undefined, chainId)
 }
 
 export function getChain(chainId: bigint): HumanizerVisualization {


### PR DESCRIPTION
The goal is to be aware that a token explorer link should lead to a network that is not the network we are signing on. 

The only use case I can think of is bridging