### PR TITLE
Bug/ Account state not updated before estimation

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1538,10 +1538,11 @@ export class MainController extends EventEmitter {
         this.signAccountOp?.accountOp
       )
 
-      const [, estimation] = await Promise.all([
+      const [, , estimation] = await Promise.all([
         // NOTE: we are not emitting an update here because the portfolio controller will do that
         // NOTE: the portfolio controller has it's own logic of constructing/caching providers, this is intentional, as
         // it may have different needs
+        this.accounts.updateAccountState(localAccountOp.accountAddr, 'pending', [network.id]),
         this.portfolio.updateSelectedAccount(
           localAccountOp.accountAddr,
           network,


### PR DESCRIPTION
## How to test:
- Open two extension instances
- Add the same account in both instances
- Make a transaction from instance (A)
- Immediately try to make a transaction from instance (B)
- Both transactions should be signed with no problems