### PR TITLE
Enhancement/ Don't ask for entry point authorization if already signed

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1181,8 +1181,6 @@ export class MainController extends EventEmitter {
             a.accountOp.networkId === network.id
         ) as AccountOpAction | undefined
 
-        const hasAuthorized = !!currentAccountOpAction?.accountOp?.meta?.entryPointAuthorization
-
         this.activity.setFilters({
           account: account.addr,
           network: network.id
@@ -1192,10 +1190,11 @@ export class MainController extends EventEmitter {
             message.fromActionId === ENTRY_POINT_AUTHORIZATION_REQUEST_ID &&
             message.networkId === network.id
         )
-        if (
-          shouldAskForEntryPointAuthorization(network, account, accountState, hasAuthorized) &&
-          !entryPointAuthorizationMessageFromHistory
-        ) {
+        const hasAuthorized =
+          !!currentAccountOpAction?.accountOp?.meta?.entryPointAuthorization ||
+          !!entryPointAuthorizationMessageFromHistory
+
+        if (shouldAskForEntryPointAuthorization(network, account, accountState, hasAuthorized)) {
           await this.addEntryPointAuthorization(req, network, accountState, executionType)
           this.emitUpdate()
           return

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1188,7 +1188,9 @@ export class MainController extends EventEmitter {
           network: network.id
         })
         const entryPointAuthorizationMessageFromHistory = this.activity.signedMessages?.items.find(
-          (message) => message.fromActionId === ENTRY_POINT_AUTHORIZATION_REQUEST_ID
+          (message) =>
+            message.fromActionId === ENTRY_POINT_AUTHORIZATION_REQUEST_ID &&
+            message.networkId === network.id
         )
         if (
           shouldAskForEntryPointAuthorization(network, account, accountState, hasAuthorized) &&

--- a/src/libs/main/main.ts
+++ b/src/libs/main/main.ts
@@ -7,6 +7,7 @@ import { isSmartAccount } from '../account/account'
 import { AccountOp } from '../accountOp/accountOp'
 import { Call as AccountOpCall } from '../accountOp/types'
 import { getAccountOpsByNetwork } from '../actions/actions'
+import { adjustEntryPointAuthorization } from '../signMessage/signMessage'
 
 export const batchCallsFromUserRequests = ({
   accountAddr,
@@ -34,13 +35,15 @@ export const makeSmartAccountOpAction = ({
   networkId,
   nonce,
   actionsQueue,
-  userRequests
+  userRequests,
+  entryPointAuthorizationSignature
 }: {
   account: Account
   networkId: string
   nonce: bigint | null
   actionsQueue: Action[]
   userRequests: UserRequest[]
+  entryPointAuthorizationSignature?: string
 }): AccountOpAction => {
   const accountOpAction = actionsQueue.find(
     (a) => a.type === 'accountOp' && a.id === `${account.addr}-${networkId}`
@@ -59,7 +62,7 @@ export const makeSmartAccountOpAction = ({
     return accountOpAction
   }
 
-  const accountOp = {
+  const accountOp: AccountOpAction['accountOp'] = {
     accountAddr: account.addr,
     networkId,
     signingKeyAddr: null,
@@ -75,6 +78,13 @@ export const makeSmartAccountOpAction = ({
       userRequests
     })
   }
+
+  if (entryPointAuthorizationSignature) {
+    accountOp.meta = {
+      entryPointAuthorization: adjustEntryPointAuthorization(entryPointAuthorizationSignature)
+    }
+  }
+
   return {
     id: `${account.addr}-${networkId}`, // SA accountOpAction id
     type: 'accountOp',


### PR DESCRIPTION
If entry point authorization is needed first check in history if one is already signed. If it is pass the signature to the account op.

Closes https://github.com/AmbireTech/ambire-app/issues/2426