### PR TITLE
Feature: better maxPriorityFeePerGas estimation

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -63,8 +63,7 @@ const networks: Network[] = [
     feeOptions: {
       is1559: true,
       elasticityMultiplier: 6n,
-      baseFeeMaxChangeDenominator: 50n,
-      maxPriorityFee: 100n
+      baseFeeMaxChangeDenominator: 50n
     },
     isOptimistic: true,
     predefined: true,
@@ -117,8 +116,7 @@ const networks: Network[] = [
     features: [],
     feeOptions: {
       is1559: true,
-      minBaseFee: 100000000n, // 1 gwei
-      maxPriorityFee: 100n
+      minBaseFee: 100000000n // 1 gwei
     },
     predefined: true,
     wrappedAddr: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -590,25 +590,16 @@ export class SignAccountOpController extends EventEmitter {
   ): bigint {
     // when doing an RBF, make sure the min gas for the current speed
     // is at least 12% bigger than the previous speed
-    const prevSpeedGas =
-      prevSpeed && prevSpeed[gasPropertyName]
-        ? prevSpeed[gasPropertyName] + prevSpeed[gasPropertyName] / 8n
-        : 0n
-    const min = prevSpeedGas > calculatedGas ? prevSpeedGas : calculatedGas
+    const prevSpeedGas = prevSpeed ? prevSpeed[gasPropertyName] : undefined
+    const prevSpeedGasIncreased = prevSpeedGas ? prevSpeedGas + prevSpeedGas / 8n : 0n
+    const min = prevSpeedGasIncreased > calculatedGas ? prevSpeedGasIncreased : calculatedGas
 
     // if there was an error on the signed account op with a
     // replacement fee too low, we increase by 13% the signed account op
     // IF the new estimation is not actually higher
-    if (
-      this.replacementFeeLow &&
-      this.signedAccountOp &&
-      this.signedAccountOp.gasFeePayment &&
-      this.signedAccountOp.gasFeePayment[gasPropertyName]
-    ) {
-      const bumpFees =
-        this.signedAccountOp.gasFeePayment[gasPropertyName] +
-        this.signedAccountOp.gasFeePayment[gasPropertyName] / 8n +
-        this.signedAccountOp.gasFeePayment[gasPropertyName] / 100n
+    if (this.replacementFeeLow && this.signedAccountOp && this.signedAccountOp.gasFeePayment) {
+      const prevGas = this.signedAccountOp.gasFeePayment[gasPropertyName] ?? undefined
+      const bumpFees = prevGas ? prevGas + prevGas / 8n + prevGas / 100n : 0n
       return min > bumpFees ? min : bumpFees
     }
 
@@ -619,10 +610,8 @@ export class SignAccountOpController extends EventEmitter {
 
     // increase by a minimum of 13% the last broadcast txn and use that
     // or use the current gas estimation if it's more
-    const lastTxnGasPriceIncreased =
-      rbfOp.gasFeePayment[gasPropertyName] +
-      rbfOp.gasFeePayment[gasPropertyName] / 8n +
-      rbfOp.gasFeePayment[gasPropertyName] / 100n
+    const rbfGas = rbfOp.gasFeePayment[gasPropertyName] ?? 0n
+    const lastTxnGasPriceIncreased = rbfGas + rbfGas / 8n + rbfGas / 100n
     return min > lastTxnGasPriceIncreased ? min : lastTxnGasPriceIncreased
   }
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -714,9 +714,6 @@ export class SignAccountOpController extends EventEmitter {
               )
             : undefined
 
-        console.log('max priority')
-        console.log(maxPriorityFeePerGas)
-
         const gasPrice =
           'maxPriorityFeePerGas' in gasRecommendation
             ? (gasRecommendation as Gas1559Recommendation).baseFeePerGas + maxPriorityFeePerGas!

--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -12,7 +12,6 @@ interface FeeOptions {
   elasticityMultiplier?: bigint
   baseFeeMaxChangeDenominator?: bigint
   feeIncrease?: bigint // should we increase the relayer fee in %
-  maxPriorityFee?: bigint
 }
 
 export interface NetworkInfo {

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -142,10 +142,12 @@ export async function getGasPriceRecommendations(
     }
 
     const tips = filterOutliers(txns.map((x) => x.maxPriorityFeePerGas!).filter((x) => x > 0))
+    console.log(tips)
     const fee: Gas1559Recommendation[] = []
     speeds.forEach(({ name, baseFeeAddBps }, i) => {
       const baseFee = expectedBaseFee + (expectedBaseFee * baseFeeAddBps) / 10000n
       let maxPriorityFeePerGas = average(nthGroup(tips, i, speeds.length))
+      console.log(maxPriorityFeePerGas)
 
       // set a bare minimum of 200n for maxPriorityFeePerGas
       maxPriorityFeePerGas = maxPriorityFeePerGas >= 200n ? maxPriorityFeePerGas : 200n

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -142,21 +142,31 @@ export async function getGasPriceRecommendations(
     }
 
     const tips = filterOutliers(txns.map((x) => x.maxPriorityFeePerGas!).filter((x) => x > 0))
-    return speeds.map(({ name, baseFeeAddBps }, i) => {
+    const fee: Gas1559Recommendation[] = []
+    speeds.forEach(({ name, baseFeeAddBps }, i) => {
       const baseFee = expectedBaseFee + (expectedBaseFee * baseFeeAddBps) / 10000n
+      let maxPriorityFeePerGas = average(nthGroup(tips, i, speeds.length))
 
-      // maxPriorityFeePerGas is important for networks with longer block time
-      // like Ethereum (12s) but not at all for L2s with instant block creation.
-      // For L2s we hardcode the maxPriorityFee to 100n
-      const maxPriorityFeePerGas =
-        network.feeOptions.maxPriorityFee ?? average(nthGroup(tips, i, speeds.length))
+      // set a bare minimum of 200n for maxPriorityFeePerGas
+      maxPriorityFeePerGas = maxPriorityFeePerGas >= 200n ? maxPriorityFeePerGas : 200n
 
-      return {
+      // compare the maxPriorityFeePerGas with the previous speed
+      // if it's not at least 12% bigger, then replace the calculated one
+      // with at least 12% bigger maxPriorityFeePerGas.
+      // This is most impactufull on L2s where txns get stuck for low maxPriorityFeePerGas
+      const prevSpeed = fee.length ? fee[i - 1].maxPriorityFeePerGas : null
+      if (prevSpeed) {
+        const min = prevSpeed + prevSpeed / 8n
+        if (maxPriorityFeePerGas < min) maxPriorityFeePerGas = min
+      }
+
+      fee.push({
         name,
         baseFeePerGas: baseFee,
         maxPriorityFeePerGas
-      }
+      })
     })
+    return fee
   }
   const prices = filterOutliers(txns.map((x) => x.gasPrice!).filter((x) => x > 0))
   return speeds.map(({ name }, i) => ({

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -142,12 +142,10 @@ export async function getGasPriceRecommendations(
     }
 
     const tips = filterOutliers(txns.map((x) => x.maxPriorityFeePerGas!).filter((x) => x > 0))
-    console.log(tips)
     const fee: Gas1559Recommendation[] = []
     speeds.forEach(({ name, baseFeeAddBps }, i) => {
       const baseFee = expectedBaseFee + (expectedBaseFee * baseFeeAddBps) / 10000n
       let maxPriorityFeePerGas = average(nthGroup(tips, i, speeds.length))
-      console.log(maxPriorityFeePerGas)
 
       // set a bare minimum of 200n for maxPriorityFeePerGas
       maxPriorityFeePerGas = maxPriorityFeePerGas >= 200n ? maxPriorityFeePerGas : 200n

--- a/src/libs/gasPrice/tests/1559Network.test.ts
+++ b/src/libs/gasPrice/tests/1559Network.test.ts
@@ -133,25 +133,25 @@ describe('1559 Network gas price tests', () => {
   test('should return the lowest maxPriorityFeePerGas for a block with less than 4 txns', async () => {
     const params = {
       transactions: [
-        { maxPriorityFeePerGas: 100n },
-        { maxPriorityFeePerGas: 98n },
-        { maxPriorityFeePerGas: 99n }
+        { maxPriorityFeePerGas: 300n },
+        { maxPriorityFeePerGas: 252n },
+        { maxPriorityFeePerGas: 252n }
       ]
     }
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const expectations = {
       slow: {
-        maxPriorityFeePerGas: 98n
+        maxPriorityFeePerGas: 252n
       },
       medium: {
-        maxPriorityFeePerGas: 98n
+        maxPriorityFeePerGas: 283n // 12% more
       },
       fast: {
-        maxPriorityFeePerGas: 98n
+        maxPriorityFeePerGas: 318n // 12% more
       },
       ape: {
-        maxPriorityFeePerGas: 98n
+        maxPriorityFeePerGas: 357n // 12% more
       }
     }
     const slow: any = gasPrice[0]
@@ -163,74 +163,74 @@ describe('1559 Network gas price tests', () => {
     const ape: any = gasPrice[3]
     expect(ape.maxPriorityFeePerGas).toBe(expectations.ape.maxPriorityFeePerGas)
   })
-  test('makes a maxPriorityFeePerGas prediction with an empty block and returns 0n for maxPriorityFeePerGas', async () => {
+  test('makes a maxPriorityFeePerGas prediction with an empty block and returns 200n for slow as that is the minimum but 12% more for each after', async () => {
     const params = {
       transactions: []
     }
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const slow: any = gasPrice[0]
-    expect(slow.maxPriorityFeePerGas).toBe(0n)
+    expect(slow.maxPriorityFeePerGas).toBe(200n)
     const medium: any = gasPrice[1]
-    expect(medium.maxPriorityFeePerGas).toBe(0n)
+    expect(medium.maxPriorityFeePerGas).toBe(225n)
     const fast: any = gasPrice[2]
-    expect(fast.maxPriorityFeePerGas).toBe(0n)
+    expect(fast.maxPriorityFeePerGas).toBe(253n)
     const ape: any = gasPrice[3]
-    expect(ape.maxPriorityFeePerGas).toBe(0n)
+    expect(ape.maxPriorityFeePerGas).toBe(284n)
   })
   test('should remove an outlier from a group of 17, making the group 16, and calculate average at a step of 4, disregarding none', async () => {
     const params = {
       transactions: [
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 10n },
-        { maxPriorityFeePerGas: 50n },
-        { maxPriorityFeePerGas: 50n },
-        { maxPriorityFeePerGas: 50n },
-        { maxPriorityFeePerGas: 100n },
-        { maxPriorityFeePerGas: 100n },
-        { maxPriorityFeePerGas: 10000n } // removed as an outlier
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 250n },
+        { maxPriorityFeePerGas: 250n },
+        { maxPriorityFeePerGas: 300n },
+        { maxPriorityFeePerGas: 400n },
+        { maxPriorityFeePerGas: 400n },
+        { maxPriorityFeePerGas: 1000000n } // removed as an outlier
       ]
     }
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const slow: any = gasPrice[0]
-    expect(slow.maxPriorityFeePerGas).toBe(10n)
+    expect(slow.maxPriorityFeePerGas).toBe(210n)
     const medium: any = gasPrice[1]
-    expect(medium.maxPriorityFeePerGas).toBe(10n)
+    expect(medium.maxPriorityFeePerGas).toBe(236n)
     const fast: any = gasPrice[2]
-    expect(fast.maxPriorityFeePerGas).toBe(20n)
+    expect(fast.maxPriorityFeePerGas).toBe(265n)
     const ape: any = gasPrice[3]
-    expect(ape.maxPriorityFeePerGas).toBe(75n)
+    expect(ape.maxPriorityFeePerGas).toBe(337n)
   })
   test('should remove outliers from a group of 19, making the group 15, and return an average for each speed at a step of 3 for slow, medium and fast, and an avg of the remaining 6 for ape', async () => {
     const params = {
       transactions: [
         { maxPriorityFeePerGas: 1n }, // removed as an outlier
         { maxPriorityFeePerGas: 1n }, // removed as an outlier
-        { maxPriorityFeePerGas: 100n },
-        { maxPriorityFeePerGas: 100n },
-        { maxPriorityFeePerGas: 100n },
-        { maxPriorityFeePerGas: 110n },
-        { maxPriorityFeePerGas: 110n },
-        { maxPriorityFeePerGas: 110n },
-        { maxPriorityFeePerGas: 110n },
-        { maxPriorityFeePerGas: 110n },
-        { maxPriorityFeePerGas: 110n },
-        { maxPriorityFeePerGas: 110n },
-        { maxPriorityFeePerGas: 120n },
-        { maxPriorityFeePerGas: 120n },
-        { maxPriorityFeePerGas: 120n },
-        { maxPriorityFeePerGas: 150n },
-        { maxPriorityFeePerGas: 150n },
+        { maxPriorityFeePerGas: 200n },
+        { maxPriorityFeePerGas: 200n },
+        { maxPriorityFeePerGas: 200n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 210n },
+        { maxPriorityFeePerGas: 220n },
+        { maxPriorityFeePerGas: 220n },
+        { maxPriorityFeePerGas: 220n },
+        { maxPriorityFeePerGas: 250n },
+        { maxPriorityFeePerGas: 250n },
         { maxPriorityFeePerGas: 10000n }, // removed as an outlier
         { maxPriorityFeePerGas: 20000n } // removed as an outlier
       ]
@@ -238,13 +238,13 @@ describe('1559 Network gas price tests', () => {
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const slow: any = gasPrice[0]
-    expect(slow.maxPriorityFeePerGas).toBe(100n)
+    expect(slow.maxPriorityFeePerGas).toBe(200n)
     const medium: any = gasPrice[1]
-    expect(medium.maxPriorityFeePerGas).toBe(110n)
+    expect(medium.maxPriorityFeePerGas).toBe(225n)
     const fast: any = gasPrice[2]
-    expect(fast.maxPriorityFeePerGas).toBe(110n)
+    expect(fast.maxPriorityFeePerGas).toBe(253n)
     const ape: any = gasPrice[3]
-    expect(ape.maxPriorityFeePerGas).toBe(128n)
+    expect(ape.maxPriorityFeePerGas).toBe(284n)
   })
   test('should remove 0s from maxPriorityFeePerGas but should keep 1s because they are not outliers, and should calculate an average of every group of 4 for slow, medium and fast, and an average of the remaining 5 for ape', async () => {
     const params = {
@@ -252,36 +252,36 @@ describe('1559 Network gas price tests', () => {
         { maxPriorityFeePerGas: 0n }, // removed because no 0s are allowed
         { maxPriorityFeePerGas: 0n }, // removed because no 0s are allowed
         { maxPriorityFeePerGas: 0n }, // removed because no 0s are allowed
-        { maxPriorityFeePerGas: 1n },
-        { maxPriorityFeePerGas: 1n },
-        { maxPriorityFeePerGas: 40n },
-        { maxPriorityFeePerGas: 40n },
-        { maxPriorityFeePerGas: 45n },
-        { maxPriorityFeePerGas: 50n },
-        { maxPriorityFeePerGas: 50n },
-        { maxPriorityFeePerGas: 50n },
-        { maxPriorityFeePerGas: 55n },
-        { maxPriorityFeePerGas: 55n },
-        { maxPriorityFeePerGas: 55n },
-        { maxPriorityFeePerGas: 55n },
-        { maxPriorityFeePerGas: 70n },
-        { maxPriorityFeePerGas: 70n },
-        { maxPriorityFeePerGas: 72n },
-        { maxPriorityFeePerGas: 85n },
-        { maxPriorityFeePerGas: 85n },
-        { maxPriorityFeePerGas: 500n }, // removed as an outlier
-        { maxPriorityFeePerGas: 500n } // removed as an outlier
+        { maxPriorityFeePerGas: 201n },
+        { maxPriorityFeePerGas: 201n },
+        { maxPriorityFeePerGas: 240n },
+        { maxPriorityFeePerGas: 240n },
+        { maxPriorityFeePerGas: 245n },
+        { maxPriorityFeePerGas: 250n },
+        { maxPriorityFeePerGas: 250n },
+        { maxPriorityFeePerGas: 250n },
+        { maxPriorityFeePerGas: 255n },
+        { maxPriorityFeePerGas: 255n },
+        { maxPriorityFeePerGas: 255n },
+        { maxPriorityFeePerGas: 255n },
+        { maxPriorityFeePerGas: 270n },
+        { maxPriorityFeePerGas: 270n },
+        { maxPriorityFeePerGas: 272n },
+        { maxPriorityFeePerGas: 285n },
+        { maxPriorityFeePerGas: 285n },
+        { maxPriorityFeePerGas: 2500n }, // removed as an outlier
+        { maxPriorityFeePerGas: 2500n } // removed as an outlier
       ]
     }
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const slow: any = gasPrice[0]
-    expect(slow.maxPriorityFeePerGas).toBe(20n)
+    expect(slow.maxPriorityFeePerGas).toBe(220n)
     const medium: any = gasPrice[1]
-    expect(medium.maxPriorityFeePerGas).toBe(48n)
+    expect(medium.maxPriorityFeePerGas).toBe(248n)
     const fast: any = gasPrice[2]
-    expect(fast.maxPriorityFeePerGas).toBe(55n)
+    expect(fast.maxPriorityFeePerGas).toBe(279n)
     const ape: any = gasPrice[3]
-    expect(ape.maxPriorityFeePerGas).toBe(76n)
+    expect(ape.maxPriorityFeePerGas).toBe(313n)
   })
 })


### PR DESCRIPTION
Change log:
* make the min for maxPriorityFeePerGas 200n
* make the maxPriorityFeePerGas for each speed at least 12% bigger than the previous one
* when doing RBF, increase the maxPriorityFeePerGas instead of the total gas price (if eip-1559)