### PR TITLE
Disable gas usage of xWallet if not on gasTank network

### DIFF
--- a/src/consts/gasTankFeeTokens.ts
+++ b/src/consts/gasTankFeeTokens.ts
@@ -171,7 +171,7 @@ export default [
     address: '0x47Cd7E91C3CBaAF266369fe8518345fc4FC12935',
     disableGasTankDeposit: true,
     // disable if not in gas tank
-    disableGasUsage: true,
+    disableAsFeeToken: true,
     symbol: 'xwallet',
     networkId: 'ethereum',
     decimals: 18,

--- a/src/consts/gasTankFeeTokens.ts
+++ b/src/consts/gasTankFeeTokens.ts
@@ -170,7 +170,7 @@ export default [
   {
     address: '0x47Cd7E91C3CBaAF266369fe8518345fc4FC12935',
     disableGasTankDeposit: true,
-    disableGasTankUsage: true,
+    disableGasUsage: true,
     symbol: 'xwallet',
     networkId: 'ethereum',
     decimals: 18,

--- a/src/consts/gasTankFeeTokens.ts
+++ b/src/consts/gasTankFeeTokens.ts
@@ -170,6 +170,7 @@ export default [
   {
     address: '0x47Cd7E91C3CBaAF266369fe8518345fc4FC12935',
     disableGasTankDeposit: true,
+    // disable if not in gas tank
     disableGasUsage: true,
     symbol: 'xwallet',
     networkId: 'ethereum',

--- a/src/consts/gasTankFeeTokens.ts
+++ b/src/consts/gasTankFeeTokens.ts
@@ -170,6 +170,7 @@ export default [
   {
     address: '0x47Cd7E91C3CBaAF266369fe8518345fc4FC12935',
     disableGasTankDeposit: true,
+    disableGasTankUsage: true,
     symbol: 'xwallet',
     networkId: 'ethereum',
     decimals: 18,

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -57,6 +57,7 @@ export function getFlags(
   const canTopUpGasTank = foundFeeToken && !foundFeeToken?.disableGasTankDeposit
   const isFeeToken =
     address === ZeroAddress ||
+    // disable if not in gas tank
     (foundFeeToken && !foundFeeToken.disableGasUsage) ||
     tokenNetwork === 'gasTank'
 

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -57,7 +57,7 @@ export function getFlags(
   const canTopUpGasTank = foundFeeToken && !foundFeeToken?.disableGasTankDeposit
   const isFeeToken =
     address === ZeroAddress ||
-    (foundFeeToken && !foundFeeToken.disableGasTankUsage) ||
+    (foundFeeToken && !foundFeeToken.disableGasUsage) ||
     tokenNetwork === 'gasTank'
 
   return {

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -55,7 +55,10 @@ export function getFlags(
   )
 
   const canTopUpGasTank = foundFeeToken && !foundFeeToken?.disableGasTankDeposit
-  const isFeeToken = address === ZeroAddress || !!foundFeeToken
+  const isFeeToken =
+    address === ZeroAddress ||
+    (foundFeeToken && !foundFeeToken.disableGasTankUsage) ||
+    tokenNetwork === 'gasTank'
 
   return {
     onGasTank,

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -59,7 +59,7 @@ export function getFlags(
     address === ZeroAddress ||
     // disable if not in gas tank
     (foundFeeToken && !foundFeeToken.disableGasUsage) ||
-    tokenNetwork === 'gasTank'
+    networkId === 'gasTank'
 
   return {
     onGasTank,

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -58,7 +58,7 @@ export function getFlags(
   const isFeeToken =
     address === ZeroAddress ||
     // disable if not in gas tank
-    (foundFeeToken && !foundFeeToken.disableGasUsage) ||
+    (foundFeeToken && !foundFeeToken.disableAsFeeToken) ||
     networkId === 'gasTank'
 
   return {


### PR DESCRIPTION
User should not be able to pay gas with xWallet on ethereum that is not in the gas tank