### PR TITLE
Fix: RBF in history on ethereum

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -388,8 +388,6 @@ export class ActivityController extends EventEmitter {
               // if there's no receipt, confirm there's a txn
               // if there's no txn and 15 minutes have passed, declare it a failure
               const txn = await provider.getTransaction(txnId)
-              console.log('the found txn')
-              console.log(txn)
               if (!txn) declareStuckIfQuaterPassed(accountOp)
               else return
             } catch {

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -388,8 +388,8 @@ export class ActivityController extends EventEmitter {
               // if there's no receipt, confirm there's a txn
               // if there's no txn and 15 minutes have passed, declare it a failure
               const txn = await provider.getTransaction(txnId)
-              if (!txn) declareStuckIfQuaterPassed(accountOp)
-              else return
+              if (txn) return
+              declareStuckIfQuaterPassed(accountOp)
             } catch {
               this.emitError({
                 level: 'silent',

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -388,7 +388,10 @@ export class ActivityController extends EventEmitter {
               // if there's no receipt, confirm there's a txn
               // if there's no txn and 15 minutes have passed, declare it a failure
               const txn = await provider.getTransaction(txnId)
+              console.log('the found txn')
+              console.log(txn)
               if (!txn) declareStuckIfQuaterPassed(accountOp)
+              else return
             } catch {
               this.emitError({
                 level: 'silent',


### PR DESCRIPTION
Fix: when broadcasting slow on ethereum, the pending state jumps ahead and make the current pending txn RBFed while it should not. So if the transaction is found but it's just pending, do not make it RBFed