### PR TITLE
Bug / Race that prevents storing a signed message in the Activity controller

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -611,15 +611,13 @@ export class MainController extends EventEmitter {
       this.actions.addOrUpdateAction(accountOpAction, true)
     }
 
+    await this.activity.addSignedMessage(signedMessage, signedMessage.accountAddr)
     await this.resolveUserRequest({ hash: signedMessage.signature }, signedMessage.fromActionId)
+
     await this.#notificationManager.create({
       title: 'Done!',
       message: 'The Message was successfully signed.'
     })
-
-    // TODO: In the rare case when this might error, the user won't be notified,
-    // since `this.resolveUserRequest` closes the action window.
-    await this.activity.addSignedMessage(signedMessage, signedMessage.accountAddr)
   }
 
   async #handleAccountAdderInitLedger(


### PR DESCRIPTION
Upon successful sign, the user request was resolved BEFORE the just signed message is stored in the Activity controller.

That caused a race, because upon user request completion, the Sign Message action window gets closed, which triggers resetting the Activity controller. So by the time the sign message logic proceeds further to storing the signed message, the Activity controller gets reset.