### PR TITLE
Config / Enchance Ledger error handling for corner cases

### DIFF
--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -477,7 +477,7 @@ export class AccountAdderController extends EventEmitter {
       }
     } catch (e: any) {
       this.emitError({
-        message: 'Retrieving accounts was canceled or failed.',
+        message: e?.message,
         error: e?.message || 'accountAdder: failed to derive accounts',
         level: 'major'
       })

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -648,7 +648,7 @@ export class MainController extends EventEmitter {
         throw new EmittableError({ message, level: 'major', error: new Error(message) })
       }
 
-      const keyIterator = new LedgerKeyIterator({ walletSDK: ledgerCtrl.walletSDK })
+      const keyIterator = new LedgerKeyIterator({ controller: ledgerCtrl })
       this.accountAdder.init({
         keyIterator,
         hdPathTemplate: BIP44_LEDGER_DERIVATION_TEMPLATE

--- a/src/interfaces/keyIterator.ts
+++ b/src/interfaces/keyIterator.ts
@@ -1,14 +1,14 @@
 import { HD_PATH_TEMPLATE_TYPE } from '../consts/derivation'
 import { SelectedAccountForImport } from './account'
-import { Key } from './keystore'
+import { ExternalSignerController, Key } from './keystore'
 
 export interface KeyIterator {
   type: Key['type']
   subType?: 'seed' | 'private-key'
   /** The wallet native SDK instance, if any exists */
   walletSDK?: any
-  /** The wallet controller, for the hardware wallets only */
-  controller?: any
+  /** Needed for the hardware wallets only */
+  controller?: ExternalSignerController
   /** Retrieves the the public addresses (accounts) from specific indexes */
   retrieve: (
     fromToArr: { from: number; to: number }[],

--- a/src/interfaces/keyIterator.ts
+++ b/src/interfaces/keyIterator.ts
@@ -7,6 +7,8 @@ export interface KeyIterator {
   subType?: 'seed' | 'private-key'
   /** The wallet native SDK instance, if any exists */
   walletSDK?: any
+  /** The wallet controller, for the hardware wallets only */
+  controller?: any
   /** Retrieves the the public addresses (accounts) from specific indexes */
   retrieve: (
     fromToArr: { from: number; to: number }[],

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -34,6 +34,7 @@ export interface ExternalSignerController {
   cleanUp: () => void // Trezor and Ledger specific
   isInitiated?: boolean // Trezor specific
   initialLoadPromise?: Promise<void> // Trezor specific
+  retrieveAddresses: (paths: string[]) => Promise<string[]> // Ledger specific
   // TODO: Refine the rest of the props
   isWebHID?: boolean // Ledger specific
   transport?: any // Ledger specific

--- a/src/libs/ledger/ledger.ts
+++ b/src/libs/ledger/ledger.ts
@@ -27,5 +27,5 @@ export const normalizeLedgerMessage = (error?: string): string => {
     return 'Rejected by your Ledger device.'
   }
 
-  return error
+  return `Could not connect to your Ledger device. Please close any other apps that may be trying to access your Ledger device (including wallet apps installed on your computer and web apps). Device error: ${error}`
 }

--- a/src/libs/ledger/ledger.ts
+++ b/src/libs/ledger/ledger.ts
@@ -27,5 +27,8 @@ export const normalizeLedgerMessage = (error?: string): string => {
     return 'Rejected by your Ledger device.'
   }
 
+  // Indicates a custom timeout error, no need to normalize
+  if (error.includes('Could not connect to your Ledger device for an extended period')) return error
+
   return `Could not connect to your Ledger device. Please close any other apps that may be accessing your Ledger device (including wallet apps on your computer and web apps). Ensure your Ledger is responsive. Unplug and plug it again. Device error: ${error}`
 }

--- a/src/libs/ledger/ledger.ts
+++ b/src/libs/ledger/ledger.ts
@@ -27,24 +27,5 @@ export const normalizeLedgerMessage = (error?: string): string => {
     return 'Rejected by your Ledger device.'
   }
 
-  return `Could not connect to your Ledger device. Please close any other apps that may be accessing your Ledger device (including wallet apps on your computer and web apps). Ensure your Ledger device is connected and responsive. Device error: ${error}`
-}
-
-/**
- * Handles the scenario where Ledger device hangs indefinitely during an
- * operation. Happens in some cases when the Ledger device gets connected to
- * Ambire, then another app is accessing the Ledger device and then user comes
- * back to Ambire (without unplug-plugging the Ledger).
- */
-const TIMEOUT_FOR_LEDGER_OPERATION = 5000
-export const withLedgerTimeoutProtection = async <T>(operation: () => Promise<T>): Promise<T> => {
-  const timeout = new Promise<never>((_, reject) => {
-    setTimeout(() => {
-      const message =
-        'Could not connect to your Ledger device for an extended period. Please close any other apps that may be accessing your Ledger device (including wallet apps on your computer and web apps). Ensure your Ledger device is connected and responsive.'
-      reject(new Error(message))
-    }, TIMEOUT_FOR_LEDGER_OPERATION)
-  })
-
-  return Promise.race([operation(), timeout])
+  return `Could not connect to your Ledger device. Please close any other apps that may be accessing your Ledger device (including wallet apps on your computer and web apps). Ensure your Ledger is responsive. Unplug and plug it again. Device error: ${error}`
 }


### PR DESCRIPTION
Tweaks a few things around the Ledger error handling:

- Add: When Ledger throws unexpected error, include a fallback note what user can do to resolve it (because the errors incoming from the device are very vague like: "invalid channel")
- Change: LedgerKeyIterator now uses the LedgerController (instead of directly calling Ledger SDK methods)
- Change: Account Adder error emit now contains the actual error message (instead of a generic one)
