### PR TITLE
no default token to cover fee display error

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -37,7 +37,7 @@ const providers = Object.fromEntries(
   networks.map((network) => [network.id, getRpcProvider(network.rpcUrls, network.chainId)])
 )
 
-// global.structuredClone = structuredClone as any
+global.structuredClone = structuredClone as any
 
 const createAccountOp = (
   account: Account,

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -37,7 +37,7 @@ const providers = Object.fromEntries(
   networks.map((network) => [network.id, getRpcProvider(network.rpcUrls, network.chainId)])
 )
 
-global.structuredClone = structuredClone as any
+// global.structuredClone = structuredClone as any
 
 const createAccountOp = (
   account: Account,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -289,9 +289,9 @@ export class SignAccountOpController extends EventEmitter {
     }
 
     if (
-      this.selectedOption &&
-      this.accountOp.gasFeePayment &&
-      this.selectedOption.availableAmount < this.accountOp.gasFeePayment.amount
+      !this.selectedOption ||
+      (this.accountOp.gasFeePayment &&
+        this.selectedOption.availableAmount < this.accountOp.gasFeePayment.amount)
     ) {
       // show a different error message depending on whether SA/EOA
       errors.push(

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -258,9 +258,6 @@ export class SignAccountOpController extends EventEmitter {
       errors.push(this.estimation.error.message)
     }
 
-    const availableFeeOptions = this.availableFeeOptions
-    if (!availableFeeOptions.length) errors.push(CRITICAL_ERRORS.eoaInsufficientFunds)
-
     // This error should not happen, as in the update method we are always setting a default signer.
     // It may occur, only if there are no available signer.
     if (!this.accountOp.signingKeyType || !this.accountOp.signingKeyAddr)


### PR DESCRIPTION
If the account does not have a token that can cover the fee we need to display an error