### PR TITLE
Feature: more aggressive tips

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -601,10 +601,13 @@ export class SignAccountOpController extends EventEmitter {
     gasPropertyName: 'gasPrice' | 'maxPriorityFeePerGas',
     prevSpeed: SpeedCalc | null
   ): bigint {
+    // ape speed gets 50% increase
+    const divider = prevSpeed && prevSpeed.type === FeeSpeed.Ape ? 2n : 8n
+
     // when doing an RBF, make sure the min gas for the current speed
     // is at least 12% bigger than the previous speed
     const prevSpeedGas = prevSpeed ? prevSpeed[gasPropertyName] : undefined
-    const prevSpeedGasIncreased = prevSpeedGas ? prevSpeedGas + prevSpeedGas / 8n : 0n
+    const prevSpeedGasIncreased = prevSpeedGas ? prevSpeedGas + prevSpeedGas / divider : 0n
     const min = prevSpeedGasIncreased > calculatedGas ? prevSpeedGasIncreased : calculatedGas
 
     // if there was an error on the signed account op with a
@@ -612,7 +615,7 @@ export class SignAccountOpController extends EventEmitter {
     // IF the new estimation is not actually higher
     if (this.replacementFeeLow && this.signedAccountOp && this.signedAccountOp.gasFeePayment) {
       const prevGas = this.signedAccountOp.gasFeePayment[gasPropertyName] ?? undefined
-      const bumpFees = prevGas ? prevGas + prevGas / 8n + prevGas / 100n : 0n
+      const bumpFees = prevGas ? prevGas + prevGas / divider + prevGas / 100n : 0n
       return min > bumpFees ? min : bumpFees
     }
 
@@ -624,7 +627,7 @@ export class SignAccountOpController extends EventEmitter {
     // increase by a minimum of 13% the last broadcast txn and use that
     // or use the current gas estimation if it's more
     const rbfGas = rbfOp.gasFeePayment[gasPropertyName] ?? 0n
-    const lastTxnGasPriceIncreased = rbfGas + rbfGas / 8n + rbfGas / 100n
+    const lastTxnGasPriceIncreased = rbfGas + rbfGas / divider + rbfGas / 100n
     return min > lastTxnGasPriceIncreased ? min : lastTxnGasPriceIncreased
   }
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -602,7 +602,7 @@ export class SignAccountOpController extends EventEmitter {
     prevSpeed: SpeedCalc | null
   ): bigint {
     // ape speed gets 50% increase
-    const divider = prevSpeed && prevSpeed.type === FeeSpeed.Ape ? 2n : 8n
+    const divider = prevSpeed && prevSpeed.type === FeeSpeed.Fast ? 2n : 8n
 
     // when doing an RBF, make sure the min gas for the current speed
     // is at least 12% bigger than the previous speed

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -147,16 +147,19 @@ export async function getGasPriceRecommendations(
       const baseFee = expectedBaseFee + (expectedBaseFee * baseFeeAddBps) / 10000n
       let maxPriorityFeePerGas = average(nthGroup(tips, i, speeds.length))
 
-      // set a bare minimum of 200n for maxPriorityFeePerGas
-      maxPriorityFeePerGas = maxPriorityFeePerGas >= 200n ? maxPriorityFeePerGas : 200n
+      // set a bare minimum of 100000n for maxPriorityFeePerGas
+      maxPriorityFeePerGas = maxPriorityFeePerGas >= 100000n ? maxPriorityFeePerGas : 100000n
 
       // compare the maxPriorityFeePerGas with the previous speed
       // if it's not at least 12% bigger, then replace the calculated one
       // with at least 12% bigger maxPriorityFeePerGas.
       // This is most impactufull on L2s where txns get stuck for low maxPriorityFeePerGas
+      //
+      // if the speed is ape, make it 50% more
       const prevSpeed = fee.length ? fee[i - 1].maxPriorityFeePerGas : null
       if (prevSpeed) {
-        const min = prevSpeed + prevSpeed / 8n
+        const divider = name === 'ape' ? 2n : 8n
+        const min = prevSpeed + prevSpeed / divider
         if (maxPriorityFeePerGas < min) maxPriorityFeePerGas = min
       }
 

--- a/src/libs/gasPrice/tests/1559Network.test.ts
+++ b/src/libs/gasPrice/tests/1559Network.test.ts
@@ -133,25 +133,25 @@ describe('1559 Network gas price tests', () => {
   test('should return the lowest maxPriorityFeePerGas for a block with less than 4 txns', async () => {
     const params = {
       transactions: [
-        { maxPriorityFeePerGas: 300n },
-        { maxPriorityFeePerGas: 252n },
-        { maxPriorityFeePerGas: 252n }
+        { maxPriorityFeePerGas: 101000n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n }
       ]
     }
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const expectations = {
       slow: {
-        maxPriorityFeePerGas: 252n
+        maxPriorityFeePerGas: 100100n
       },
       medium: {
-        maxPriorityFeePerGas: 283n // 12% more
+        maxPriorityFeePerGas: 112612n // 12% more
       },
       fast: {
-        maxPriorityFeePerGas: 318n // 12% more
+        maxPriorityFeePerGas: 126688n // 12% more
       },
       ape: {
-        maxPriorityFeePerGas: 357n // 12% more
+        maxPriorityFeePerGas: 190032n // 12% more
       }
     }
     const slow: any = gasPrice[0]
@@ -170,81 +170,81 @@ describe('1559 Network gas price tests', () => {
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const slow: any = gasPrice[0]
-    expect(slow.maxPriorityFeePerGas).toBe(200n)
+    expect(slow.maxPriorityFeePerGas).toBe(100000n)
     const medium: any = gasPrice[1]
-    expect(medium.maxPriorityFeePerGas).toBe(225n)
+    expect(medium.maxPriorityFeePerGas).toBe(112500n)
     const fast: any = gasPrice[2]
-    expect(fast.maxPriorityFeePerGas).toBe(253n)
+    expect(fast.maxPriorityFeePerGas).toBe(126562n)
     const ape: any = gasPrice[3]
-    expect(ape.maxPriorityFeePerGas).toBe(284n)
+    expect(ape.maxPriorityFeePerGas).toBe(189843n)
   })
   test('should remove an outlier from a group of 17, making the group 16, and calculate average at a step of 4, disregarding none', async () => {
     const params = {
       transactions: [
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 250n },
-        { maxPriorityFeePerGas: 250n },
-        { maxPriorityFeePerGas: 300n },
-        { maxPriorityFeePerGas: 400n },
-        { maxPriorityFeePerGas: 400n },
-        { maxPriorityFeePerGas: 1000000n } // removed as an outlier
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100100n },
+        { maxPriorityFeePerGas: 100500n },
+        { maxPriorityFeePerGas: 100500n },
+        { maxPriorityFeePerGas: 103000n },
+        { maxPriorityFeePerGas: 104000n },
+        { maxPriorityFeePerGas: 104000n },
+        { maxPriorityFeePerGas: 100000000000n } // removed as an outlier
       ]
     }
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const slow: any = gasPrice[0]
-    expect(slow.maxPriorityFeePerGas).toBe(210n)
+    expect(slow.maxPriorityFeePerGas).toBe(100100n)
     const medium: any = gasPrice[1]
-    expect(medium.maxPriorityFeePerGas).toBe(236n)
+    expect(medium.maxPriorityFeePerGas).toBe(112612n)
     const fast: any = gasPrice[2]
-    expect(fast.maxPriorityFeePerGas).toBe(265n)
+    expect(fast.maxPriorityFeePerGas).toBe(126688n)
     const ape: any = gasPrice[3]
-    expect(ape.maxPriorityFeePerGas).toBe(337n)
+    expect(ape.maxPriorityFeePerGas).toBe(190032n)
   })
   test('should remove outliers from a group of 19, making the group 15, and return an average for each speed at a step of 3 for slow, medium and fast, and an avg of the remaining 6 for ape', async () => {
     const params = {
       transactions: [
         { maxPriorityFeePerGas: 1n }, // removed as an outlier
         { maxPriorityFeePerGas: 1n }, // removed as an outlier
-        { maxPriorityFeePerGas: 200n },
-        { maxPriorityFeePerGas: 200n },
-        { maxPriorityFeePerGas: 200n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 210n },
-        { maxPriorityFeePerGas: 220n },
-        { maxPriorityFeePerGas: 220n },
-        { maxPriorityFeePerGas: 220n },
-        { maxPriorityFeePerGas: 250n },
-        { maxPriorityFeePerGas: 250n },
-        { maxPriorityFeePerGas: 10000n }, // removed as an outlier
-        { maxPriorityFeePerGas: 20000n } // removed as an outlier
+        { maxPriorityFeePerGas: 100200n },
+        { maxPriorityFeePerGas: 100200n },
+        { maxPriorityFeePerGas: 100200n },
+        { maxPriorityFeePerGas: 100210n },
+        { maxPriorityFeePerGas: 100210n },
+        { maxPriorityFeePerGas: 100210n },
+        { maxPriorityFeePerGas: 100210n },
+        { maxPriorityFeePerGas: 100210n },
+        { maxPriorityFeePerGas: 100210n },
+        { maxPriorityFeePerGas: 100210n },
+        { maxPriorityFeePerGas: 100220n },
+        { maxPriorityFeePerGas: 100220n },
+        { maxPriorityFeePerGas: 100220n },
+        { maxPriorityFeePerGas: 100250n },
+        { maxPriorityFeePerGas: 100250n },
+        { maxPriorityFeePerGas: 10000000000n }, // removed as an outlier
+        { maxPriorityFeePerGas: 20000000000n } // removed as an outlier
       ]
     }
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const slow: any = gasPrice[0]
-    expect(slow.maxPriorityFeePerGas).toBe(200n)
+    expect(slow.maxPriorityFeePerGas).toBe(100200n)
     const medium: any = gasPrice[1]
-    expect(medium.maxPriorityFeePerGas).toBe(225n)
+    expect(medium.maxPriorityFeePerGas).toBe(112725n)
     const fast: any = gasPrice[2]
-    expect(fast.maxPriorityFeePerGas).toBe(253n)
+    expect(fast.maxPriorityFeePerGas).toBe(126815n)
     const ape: any = gasPrice[3]
-    expect(ape.maxPriorityFeePerGas).toBe(284n)
+    expect(ape.maxPriorityFeePerGas).toBe(190222n)
   })
   test('should remove 0s from maxPriorityFeePerGas but should keep 1s because they are not outliers, and should calculate an average of every group of 4 for slow, medium and fast, and an average of the remaining 5 for ape', async () => {
     const params = {
@@ -252,36 +252,36 @@ describe('1559 Network gas price tests', () => {
         { maxPriorityFeePerGas: 0n }, // removed because no 0s are allowed
         { maxPriorityFeePerGas: 0n }, // removed because no 0s are allowed
         { maxPriorityFeePerGas: 0n }, // removed because no 0s are allowed
-        { maxPriorityFeePerGas: 201n },
-        { maxPriorityFeePerGas: 201n },
-        { maxPriorityFeePerGas: 240n },
-        { maxPriorityFeePerGas: 240n },
-        { maxPriorityFeePerGas: 245n },
-        { maxPriorityFeePerGas: 250n },
-        { maxPriorityFeePerGas: 250n },
-        { maxPriorityFeePerGas: 250n },
-        { maxPriorityFeePerGas: 255n },
-        { maxPriorityFeePerGas: 255n },
-        { maxPriorityFeePerGas: 255n },
-        { maxPriorityFeePerGas: 255n },
-        { maxPriorityFeePerGas: 270n },
-        { maxPriorityFeePerGas: 270n },
-        { maxPriorityFeePerGas: 272n },
-        { maxPriorityFeePerGas: 285n },
-        { maxPriorityFeePerGas: 285n },
-        { maxPriorityFeePerGas: 2500n }, // removed as an outlier
-        { maxPriorityFeePerGas: 2500n } // removed as an outlier
+        { maxPriorityFeePerGas: 100201n },
+        { maxPriorityFeePerGas: 100201n },
+        { maxPriorityFeePerGas: 100240n },
+        { maxPriorityFeePerGas: 100240n },
+        { maxPriorityFeePerGas: 100245n },
+        { maxPriorityFeePerGas: 100250n },
+        { maxPriorityFeePerGas: 100250n },
+        { maxPriorityFeePerGas: 100250n },
+        { maxPriorityFeePerGas: 100255n },
+        { maxPriorityFeePerGas: 100255n },
+        { maxPriorityFeePerGas: 100255n },
+        { maxPriorityFeePerGas: 100255n },
+        { maxPriorityFeePerGas: 100270n },
+        { maxPriorityFeePerGas: 100270n },
+        { maxPriorityFeePerGas: 100272n },
+        { maxPriorityFeePerGas: 100285n },
+        { maxPriorityFeePerGas: 100285n },
+        { maxPriorityFeePerGas: 10028500n }, // removed as an outlier
+        { maxPriorityFeePerGas: 10128500 } // removed as an outlier
       ]
     }
     const provider = MockProvider.init(params)
     const gasPrice = await getGasPriceRecommendations(provider, network)
     const slow: any = gasPrice[0]
-    expect(slow.maxPriorityFeePerGas).toBe(220n)
+    expect(slow.maxPriorityFeePerGas).toBe(100220n)
     const medium: any = gasPrice[1]
-    expect(medium.maxPriorityFeePerGas).toBe(248n)
+    expect(medium.maxPriorityFeePerGas).toBe(112747n)
     const fast: any = gasPrice[2]
-    expect(fast.maxPriorityFeePerGas).toBe(279n)
+    expect(fast.maxPriorityFeePerGas).toBe(126840n)
     const ape: any = gasPrice[3]
-    expect(ape.maxPriorityFeePerGas).toBe(313n)
+    expect(ape.maxPriorityFeePerGas).toBe(190260n)
   })
 })


### PR DESCRIPTION
Changes:
* make the min tip 100k on eip-1559 networks as having the tip set close to 0 makes the transaction stuck-able. This can happen more often than not on chains with lower traction
* make ape speed increase the tip from fast by 50% to make it really impactful and with a bigger chance of the transaction succeeding