### PR TITLE
Change: base fee calculations

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -142,7 +142,8 @@ const networks: Network[] = [
     hasSingleton: true,
     features: [],
     feeOptions: {
-      is1559: true
+      is1559: true,
+      minBaseFeeEqualToLastBlock: true
     },
     predefined: true,
     wrappedAddr: '0x4200000000000000000000000000000000000006'

--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -106,7 +106,8 @@ export class NetworksController extends EventEmitter {
     predefinedNetworks.forEach((n) => {
       this.#networks[n.id] = {
         ...n, // add the latest structure of the predefined network to include the new props that are not in storage yet
-        ...(this.#networks[n.id] || {}) // override with stored props
+        ...(this.#networks[n.id] || {}), // override with stored props
+        feeOptions: n.feeOptions // feeOptions should take predefined priority
       }
     })
     // without await to avoid performance impact on load

--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -12,6 +12,9 @@ interface FeeOptions {
   elasticityMultiplier?: bigint
   baseFeeMaxChangeDenominator?: bigint
   feeIncrease?: bigint // should we increase the relayer fee in %
+  // transactions on Base get stuck on slow as we lower the baseFee a lot
+  // so we make the minBaseFee the same as the last block one
+  minBaseFeeEqualToLastBlock?: boolean
 }
 
 export interface NetworkInfo {

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -69,6 +69,27 @@ function average(data: bigint[]): bigint {
   return data.reduce((a, b) => a + b, 0n) / BigInt(data.length)
 }
 
+function getNetworkMinBaseFee(network: Network, lastBlock: Block): bigint {
+  // if we have a minBaseFee set in our config, use it
+  if (network.feeOptions.minBaseFee) return network.feeOptions.minBaseFee
+
+  // if we don't have a config, we return 0
+  console.log(network.feeOptions)
+  if (network.predefined && !network.feeOptions.minBaseFeeEqualToLastBlock) return 0n
+
+  // if it's a custom network and it has EIP-1559, set the minimum
+  // to the lastBlock's baseFeePerGas. Every chain is free to tweak
+  // its EIP-1559 implementation as it deems fit. Therefore, we have no
+  // guarantee the 12.5% block base fee reduction will actually happen.
+  // if it doesn't and we reduce the baseFee with our calculations,
+  // most often than not the transaction will just get stuck.
+  //
+  // Transaction fees are no longer an issue on L2s.
+  // Having the user spend a fraction of the cent more is way better
+  // than having his txns constantly getting stuck
+  return lastBlock.baseFeePerGas ?? 0n
+}
+
 // if there's an RPC issue, try refetching the block at least
 // 5 times before declaring a failure
 async function refetchBlock(
@@ -137,9 +158,8 @@ export async function getGasPriceRecommendations(
     }
 
     // if the estimated fee is below the chain minimum, set it to the min
-    if (network.feeOptions.minBaseFee && expectedBaseFee < network.feeOptions.minBaseFee) {
-      expectedBaseFee = network.feeOptions.minBaseFee
-    }
+    const minBaseFee = getNetworkMinBaseFee(network, lastBlock)
+    if (expectedBaseFee < minBaseFee) expectedBaseFee = minBaseFee
 
     const tips = filterOutliers(txns.map((x) => x.maxPriorityFeePerGas!).filter((x) => x > 0))
     const fee: Gas1559Recommendation[] = []

--- a/src/libs/gasPrice/gasPrice.ts
+++ b/src/libs/gasPrice/gasPrice.ts
@@ -74,7 +74,6 @@ function getNetworkMinBaseFee(network: Network, lastBlock: Block): bigint {
   if (network.feeOptions.minBaseFee) return network.feeOptions.minBaseFee
 
   // if we don't have a config, we return 0
-  console.log(network.feeOptions)
   if (network.predefined && !network.feeOptions.minBaseFeeEqualToLastBlock) return 0n
 
   // if it's a custom network and it has EIP-1559, set the minimum


### PR DESCRIPTION
On custom chains, make the `baseFee` the same as the last block base fee for slow calculations; hardcode it so for Base in the network config.

Sadly, a lot of chains do not follow the rules of EIP-1559 and in doing so, our aggresive reduction of about 12.5% of the baseFee when the block is considered almost empty makes it so slow speed transactions get stuck on custom networks and Base. This PR targets that and in doing so, enhances the user experience as paying a fraction of the cent more is better than having your transaction stuck and wondering what to do.