### PR TITLE
Fix / Potential Issue With Duplicate Accounts

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -212,7 +212,7 @@ export class AccountsController extends EventEmitter {
   }
 
   async removeAccountData(address: Account['addr']) {
-    this.accounts = this.accounts.filter((acc) => acc.addr !== address)
+    this.accounts = getUniqueAccountsArray(this.accounts.filter((acc) => acc.addr !== address))
     if (this.selectedAccount === address) await this.#selectAccount(this.accounts[0]?.addr)
     delete this.accountStates[address]
     this.#storage.set('accounts', this.accounts)
@@ -228,14 +228,16 @@ export class AccountsController extends EventEmitter {
   }
 
   async #updateAccountPreferences(accounts: { addr: string; preferences: AccountPreferences }[]) {
-    this.accounts = this.accounts.map((acc) => {
-      const account = accounts.find((a) => a.addr === acc.addr)
-      if (!account) return acc
-      if (isAddress(account.preferences.pfp)) {
-        account.preferences.pfp = getAddress(account.preferences.pfp)
-      }
-      return { ...acc, preferences: account.preferences, newlyAdded: false }
-    })
+    this.accounts = getUniqueAccountsArray(
+      this.accounts.map((acc) => {
+        const account = accounts.find((a) => a.addr === acc.addr)
+        if (!account) return acc
+        if (isAddress(account.preferences.pfp)) {
+          account.preferences.pfp = getAddress(account.preferences.pfp)
+        }
+        return { ...acc, preferences: account.preferences, newlyAdded: false }
+      })
+    )
     await this.#storage.set('accounts', this.accounts)
     this.emitUpdate()
   }

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -212,7 +212,7 @@ export class AccountsController extends EventEmitter {
   }
 
   async removeAccountData(address: Account['addr']) {
-    this.accounts = getUniqueAccountsArray(this.accounts.filter((acc) => acc.addr !== address))
+    this.accounts = this.accounts.filter((acc) => acc.addr !== address)
     if (this.selectedAccount === address) await this.#selectAccount(this.accounts[0]?.addr)
     delete this.accountStates[address]
     this.#storage.set('accounts', this.accounts)
@@ -228,16 +228,15 @@ export class AccountsController extends EventEmitter {
   }
 
   async #updateAccountPreferences(accounts: { addr: string; preferences: AccountPreferences }[]) {
-    this.accounts = getUniqueAccountsArray(
-      this.accounts.map((acc) => {
-        const account = accounts.find((a) => a.addr === acc.addr)
-        if (!account) return acc
-        if (isAddress(account.preferences.pfp)) {
-          account.preferences.pfp = getAddress(account.preferences.pfp)
-        }
-        return { ...acc, preferences: account.preferences, newlyAdded: false }
-      })
-    )
+    this.accounts = this.accounts.map((acc) => {
+      const account = accounts.find((a) => a.addr === acc.addr)
+      if (!account) return acc
+      if (isAddress(account.preferences.pfp)) {
+        account.preferences.pfp = getAddress(account.preferences.pfp)
+      }
+      return { ...acc, preferences: account.preferences, newlyAdded: false }
+    })
+
     await this.#storage.set('accounts', this.accounts)
     this.emitUpdate()
   }

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -5,6 +5,7 @@ import { NetworkId } from '../../interfaces/network'
 import { Storage } from '../../interfaces/storage'
 import {
   getDefaultSelectedAccount,
+  getUniqueAccountsArray,
   migrateAccountPreferencesToAccounts
 } from '../../libs/account/account'
 import { getAccountState } from '../../libs/accountState/accountState'
@@ -68,11 +69,13 @@ export class AccountsController extends EventEmitter {
       this.#storage.get('accountPreferences', undefined)
     ])
     if (accountPreferences) {
-      this.accounts = migrateAccountPreferencesToAccounts(accountPreferences, accounts)
+      this.accounts = getUniqueAccountsArray(
+        migrateAccountPreferencesToAccounts(accountPreferences, accounts)
+      )
       await this.#storage.set('accounts', this.accounts)
       await this.#storage.remove('accountPreferences')
     } else {
-      this.accounts = accounts
+      this.accounts = getUniqueAccountsArray(accounts)
     }
     this.selectedAccount = selectedAccount
     // Emit an update before updating account states as the first state update may take some time
@@ -195,8 +198,8 @@ export class AccountsController extends EventEmitter {
       ...newAccountsNotAddedYet.map((a) => ({ ...a, newlyAdded: true }))
     ]
 
-    this.accounts = nextAccounts
-    await this.#storage.set('accounts', nextAccounts)
+    this.accounts = getUniqueAccountsArray(nextAccounts)
+    await this.#storage.set('accounts', this.accounts)
 
     const defaultSelectedAccount = getDefaultSelectedAccount(accounts)
     if (defaultSelectedAccount) {
@@ -210,13 +213,8 @@ export class AccountsController extends EventEmitter {
 
   async removeAccountData(address: Account['addr']) {
     this.accounts = this.accounts.filter((acc) => acc.addr !== address)
-
-    if (this.selectedAccount === address) {
-      await this.#selectAccount(this.accounts[0]?.addr)
-    }
-
+    if (this.selectedAccount === address) await this.#selectAccount(this.accounts[0]?.addr)
     delete this.accountStates[address]
-
     this.#storage.set('accounts', this.accounts)
     this.emitUpdate()
   }

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -309,3 +309,7 @@ export function migrateAccountPreferencesToAccounts(
     }
   })
 }
+
+export function getUniqueAccountsArray(accounts: Account[]) {
+  return Array.from(new Map(accounts.map((account) => [account.addr, account])).values())
+}


### PR DESCRIPTION
* Some users are encountering duplicate accounts in their storage, leading to duplicates on the FE. While the cause of these duplicates in storage is still unknown, filtering for unique accounts on AccountsController init ensures this issue no longer occurs.
* When a user adds, edits, or removes an account, the issue of duplicate accounts in storage will be automatically resolved (if such), as we filter for unique addresses with every storage.set
