### PR TITLE
Fix: relayer networks nonce discrepancy

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -620,6 +620,17 @@ export class ActivityController extends EventEmitter {
     return !ops.length ? null : ops.reduce((m, e) => (e.nonce > m.nonce ? e : m))
   }
 
+  getLastTxn(networkId: Network['id']): SubmittedAccountOp | null {
+    if (
+      !this.#accounts.selectedAccount ||
+      !this.#accountsOps[this.#accounts.selectedAccount] ||
+      !this.#accountsOps[this.#accounts.selectedAccount][networkId]
+    )
+      return null
+
+    return this.#accountsOps[this.#accounts.selectedAccount][networkId][0]
+  }
+
   toJSON() {
     return {
       ...this,

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -224,7 +224,7 @@ export async function estimate(
     is4337Broadcast?: boolean
   },
   blockFrom: string = '0x0000000000000000000000000000000000000001',
-  blockTag: string | number = 'latest'
+  blockTag: string | number = 'pending'
 ): Promise<EstimateResult> {
   // if EOA, delegate
   if (!isSmartAccount(account))

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -38,7 +38,7 @@ function getInnerCallFailure(estimationOp: { success: boolean; err: string }): E
   })
 }
 
-// the outcomeNonce should always be equat to the nonce in accountOp + 1
+// the outcomeNonce should always be equal to the nonce in accountOp + 1
 // that's an indication of transaction success
 function getNonceDiscrepancyFailure(op: AccountOp, outcomeNonce: number): Error | null {
   if (op.nonce !== null && op.nonce + 1n === BigInt(outcomeNonce)) return null


### PR DESCRIPTION
Fix: nonce discrepancy on relayer networks and SA by making the estimation re-estimation until it finds the correct nonce from the RPC

This is the flow:
* if the estimation finds a higher nonce than the currently set one - reestimate
* if there's a nonce discrepancy (found nonce in the estimation is LOWER than the one in account op) - reestimate. This also is a valid case when an RPC is not up-to-date and it was a bug that caused showing "nonce discrepancy..."
* if there's no nonce discrepancy but the nonce from the estimation and the account op are the same as the last broadcast txn on a relayer network with a smart account, re-estimate again until the next nonce is found

Closes [2705](https://github.com/AmbireTech/ambire-app/issues/2705)