### PR TITLE
Enhancement/ Display a portfolio critical error banner if velcro doesn't work

### DIFF
--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -252,6 +252,8 @@ export const getNetworksWithPortfolioErrorBanners = ({
       portfolioForNetwork?.errors.forEach((err: any) => {
         if (err?.name === PORTFOLIO_LIB_ERROR_NAMES.PriceFetchError) {
           networkNamesWithPriceFetchError.push(networkName as string)
+        } else if (err?.name === PORTFOLIO_LIB_ERROR_NAMES.HintsError) {
+          networkNamesWithCriticalError.push(networkName as string)
         }
       })
     })


### PR DESCRIPTION
We can't be sure if the user sees all tokens and NFTs if the call to velcro fails.
![image](https://github.com/user-attachments/assets/ab7118dd-6450-4300-8a53-dc5509eaefba)
