### PR TITLE
Handle EIP-2612 with SA

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -984,10 +984,10 @@ export class MainController extends EventEmitter {
       if (!msg) {
         throw ethErrors.rpc.invalidRequest('No msg request to sign')
       }
-      const msdAddress = getAddress(msg?.[1])
+      const msgAddress = getAddress(msg?.[1])
       // TODO: if address is in this.accounts in theory the user should be able to sign
       // e.g. if an acc from the wallet is used as a signer of another wallet
-      if (getAddress(msdAddress) !== this.accounts.selectedAccount) {
+      if (msgAddress !== this.accounts.selectedAccount) {
         dappPromise.reject(
           ethErrors.provider.userRejectedRequest(
             // if updating, check https://github.com/AmbireTech/ambire-wallet/pull/1627
@@ -1014,7 +1014,7 @@ export class MainController extends EventEmitter {
         session: request.session,
         meta: {
           isSignAction: true,
-          accountAddr: msdAddress,
+          accountAddr: msgAddress,
           networkId: network.id
         },
         dappPromise
@@ -1026,10 +1026,10 @@ export class MainController extends EventEmitter {
       if (!msg) {
         throw ethErrors.rpc.invalidRequest('No msg request to sign')
       }
-      const msdAddress = getAddress(msg?.[0])
+      const msgAddress = getAddress(msg?.[0])
       // TODO: if address is in this.accounts in theory the user should be able to sign
       // e.g. if an acc from the wallet is used as a signer of another wallet
-      if (getAddress(msdAddress) !== this.accounts.selectedAccount) {
+      if (msgAddress !== this.accounts.selectedAccount) {
         dappPromise.reject(
           ethErrors.provider.userRejectedRequest(
             // if updating, check https://github.com/AmbireTech/ambire-wallet/pull/1627
@@ -1078,7 +1078,7 @@ export class MainController extends EventEmitter {
         session: request.session,
         meta: {
           isSignAction: true,
-          accountAddr: msdAddress,
+          accountAddr: msgAddress,
           networkId: network.id
         },
         dappPromise

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -209,7 +209,7 @@ export class SignMessageController extends EventEmitter {
         if (this.messageToSign.content.kind === 'typedMessage') {
           if (account.creation && this.messageToSign.content.primaryType === 'Permit') {
             throw new Error(
-              'Please, change the approval type to "Transaction" in the dApp, because signing a \'Permit\' message approval is not supported on Smart Accounts.'
+              'It looks like that this dApp doesn\'t detect Smart Account wallets, and requested incompatible approval type. Please, go back to the dApp and change the approval type to "Transaction", which is supported by Smart Account wallets.'
             )
           }
 

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -207,6 +207,12 @@ export class SignMessageController extends EventEmitter {
         }
 
         if (this.messageToSign.content.kind === 'typedMessage') {
+          if (account.creation && this.messageToSign.content.primaryType === 'Permit') {
+            throw new Error(
+              'Please, change the approval type to "Transaction" from the dApp, because signing a \'Permit\' message approval is not supported on Smart Accounts.'
+            )
+          }
+
           signature = await getEIP712Signature(
             this.messageToSign.content,
             account,

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -209,7 +209,7 @@ export class SignMessageController extends EventEmitter {
         if (this.messageToSign.content.kind === 'typedMessage') {
           if (account.creation && this.messageToSign.content.primaryType === 'Permit') {
             throw new Error(
-              'Please, change the approval type to "Transaction" from the dApp, because signing a \'Permit\' message approval is not supported on Smart Accounts.'
+              'Please, change the approval type to "Transaction" in the dApp, because signing a \'Permit\' message approval is not supported on Smart Accounts.'
             )
           }
 


### PR DESCRIPTION
Resolves: https://github.com/AmbireTech/ambire-app/issues/1531

* Impl: throw a toast error when signing an EIP-2612 Permit message with SA (inspired by the implementation in the Ambire web app)

We could reject the request with that same error before even opening the Sign Message screen. However, some dApps may not display the actual error message returned by the wallet, leading to potentially confusing behavior for the user. Therefore, we block the sign process with a toast error, allowing the user to reject the message themselves after reading the error, which improves the overall UX

<img width="1206" alt="Screenshot 2024-08-26 at 14 51 25" src="https://github.com/user-attachments/assets/5dbb73ca-f0be-4050-a28b-bd9c45143c41">
