### PR TITLE
Feature / Store (and update when needed) the HD path for the default seed

### DIFF
--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -165,85 +165,88 @@ describe('AccountAdder', () => {
     accountAdder.init({ keyIterator: null, hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE })
   })
 
-  test('should retrieve one smart account and one basic account on every slot (per page)', (done) => {
+  test('should retrieve one smart account and one basic account on every slot (per page)', async () => {
     const PAGE_SIZE = 11
-
-    let emitCounter = 0
-    const unsubscribe = accountAdder.onUpdate(() => {
-      emitCounter++
-
-      // Trigger when the accountsLoading resolves (first emit gets skipped, because it's the initial state)
-      if (emitCounter > 1 && !accountAdder.accountsLoading) {
-        // There should be one basic and one smart account on each slot, meaning
-        // there should be PAGE_SIZE * 2 accounts on the page (without the linked ones)
-        const allAccountsExceptLinked = accountAdder.accountsOnPage.filter((x) => !x.isLinked)
-        expect(allAccountsExceptLinked).toHaveLength(PAGE_SIZE * 2)
-
-        // Check the Basic Addresses retrieved
-        const basicAccountAddressesOnPage = accountAdder.accountsOnPage
-          .filter((x) => !isSmartAccount(x.account))
-          .map((x) => x.account.addr)
-        expect(basicAccountAddressesOnPage).toHaveLength(PAGE_SIZE)
-        expect(basicAccountAddressesOnPage).toEqual(key1to11BasicAccPublicAddresses)
-
-        // Check the Smart Addresses retrieved
-        const smartAccountAddressesOnPage = accountAdder.accountsOnPage.filter((x) =>
-          isSmartAccount(x.account)
-        )
-        expect(smartAccountAddressesOnPage).toHaveLength(PAGE_SIZE)
-        // TODO: Check if the calculated smart account addresses are connect
-        // expect(basicAccountAddressesOnPage).toEqual(key1to11SmartAccPublicAddresses)
-
-        // Smart account associated keys should be different than the basic
-        // account addresses, since we use derived addresses for the smart account keys
-        const noneOfTheSmartAccountsShouldHaveBasicAccountsAsAssociatedKeys =
-          smartAccountAddressesOnPage.every(
-            (x) => !x.account.associatedKeys.some((y) => basicAccountAddressesOnPage.includes(y))
-          )
-        expect(noneOfTheSmartAccountsShouldHaveBasicAccountsAsAssociatedKeys).toBeTruthy()
-
-        // Smart account associated keys should be the special derived addresses
-        const allSmartAccAssociatedKeysAddresses = smartAccountAddressesOnPage.flatMap(
-          (x) => x.account.associatedKeys
-        )
-        expect(allSmartAccAssociatedKeysAddresses).toEqual(
-          key1to11BasicAccUsedForSmartAccKeysOnlyPublicAddresses
-        )
-
-        unsubscribe()
-        done()
-      }
-    })
-
     const keyIterator = new KeyIterator(process.env.SEED)
-    accountAdder.init({
+    await accountAdder.init({
       keyIterator,
       pageSize: PAGE_SIZE,
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
     accountAdder.setPage({ page: 1 })
+
+    return new Promise((resolve) => {
+      let emitCounter = 0
+      const unsubscribe = accountAdder.onUpdate(() => {
+        emitCounter++
+
+        // Trigger when the accountsLoading resolves (first emit gets skipped, because it's the initial state)
+        if (emitCounter > 1 && !accountAdder.accountsLoading) {
+          // There should be one basic and one smart account on each slot, meaning
+          // there should be PAGE_SIZE * 2 accounts on the page (without the linked ones)
+          const allAccountsExceptLinked = accountAdder.accountsOnPage.filter((x) => !x.isLinked)
+          expect(allAccountsExceptLinked).toHaveLength(PAGE_SIZE * 2)
+
+          // Check the Basic Addresses retrieved
+          const basicAccountAddressesOnPage = accountAdder.accountsOnPage
+            .filter((x) => !isSmartAccount(x.account))
+            .map((x) => x.account.addr)
+          expect(basicAccountAddressesOnPage).toHaveLength(PAGE_SIZE)
+          expect(basicAccountAddressesOnPage).toEqual(key1to11BasicAccPublicAddresses)
+
+          // Check the Smart Addresses retrieved
+          const smartAccountAddressesOnPage = accountAdder.accountsOnPage.filter((x) =>
+            isSmartAccount(x.account)
+          )
+          expect(smartAccountAddressesOnPage).toHaveLength(PAGE_SIZE)
+          // TODO: Check if the calculated smart account addresses are connect
+          // expect(basicAccountAddressesOnPage).toEqual(key1to11SmartAccPublicAddresses)
+
+          // Smart account associated keys should be different than the basic
+          // account addresses, since we use derived addresses for the smart account keys
+          const noneOfTheSmartAccountsShouldHaveBasicAccountsAsAssociatedKeys =
+            smartAccountAddressesOnPage.every(
+              (x) => !x.account.associatedKeys.some((y) => basicAccountAddressesOnPage.includes(y))
+            )
+          expect(noneOfTheSmartAccountsShouldHaveBasicAccountsAsAssociatedKeys).toBeTruthy()
+
+          // Smart account associated keys should be the special derived addresses
+          const allSmartAccAssociatedKeysAddresses = smartAccountAddressesOnPage.flatMap(
+            (x) => x.account.associatedKeys
+          )
+          expect(allSmartAccAssociatedKeysAddresses).toEqual(
+            key1to11BasicAccUsedForSmartAccKeysOnlyPublicAddresses
+          )
+
+          unsubscribe()
+          resolve(null)
+        }
+      })
+    })
   })
 
-  test('should start the searching for linked accounts', (done) => {
-    let emitCounter = 0
-    const unsubscribe = accountAdder.onUpdate(() => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      emitCounter++
-
-      if (accountAdder.linkedAccountsLoading) {
-        expect(accountAdder.linkedAccountsLoading).toBe(true)
-        unsubscribe()
-        done()
-      }
-    })
-
+  test('should start the searching for linked accounts', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
-    accountAdder.init({
+    await accountAdder.init({
       keyIterator,
       pageSize: 4,
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
     accountAdder.setPage({ page: 1 })
+
+    return new Promise((resolve) => {
+      let emitCounter = 0
+      const unsubscribe = accountAdder.onUpdate(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        emitCounter++
+
+        if (accountAdder.linkedAccountsLoading) {
+          expect(accountAdder.linkedAccountsLoading).toBe(true)
+          unsubscribe()
+          resolve(null)
+        }
+      })
+    })
   })
 
   test('should find linked accounts', async () => {
@@ -291,243 +294,253 @@ describe('AccountAdder', () => {
     })
   })
 
-  test('should be able to select and then deselect an account', (done) => {
-    // Subscription to select an account and trigger a deselect
-    let emitCounter1 = 0
-    const unsubscribe1 = accountAdder.onUpdate(() => {
-      emitCounter1++
-
-      if (emitCounter1 === 3) {
-        accountAdder.selectAccount(basicAccount)
-      }
-
-      if (emitCounter1 === 4) {
-        const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
-        expect(selectedAccountAddr).toContain(basicAccount.addr)
-
-        accountAdder.deselectAccount(basicAccount)
-      }
-    })
-
-    // A separate subscription to check if the account got deselected
-    let emitCounter2 = 0
-    const unsubscribe2 = accountAdder.onUpdate(() => {
-      emitCounter2++
-
-      // First emit is triggered when Account Adder initializes, the second
-      // emit is triggered when the account is selected.
-      if (emitCounter2 === 5) {
-        expect(accountAdder.selectedAccounts).toHaveLength(0)
-
-        unsubscribe1()
-        unsubscribe2()
-        done()
-      }
-    })
-
+  test('should be able to select and then deselect an account', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
-    accountAdder.init({
+    await accountAdder.init({
       keyIterator,
       pageSize: 1,
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
     accountAdder.setPage({ page: 1 })
+
+    return new Promise((resolve) => {
+      // Subscription to select an account and trigger a deselect
+      let emitCounter1 = 0
+      const unsubscribe1 = accountAdder.onUpdate(() => {
+        emitCounter1++
+
+        if (emitCounter1 === 3) {
+          accountAdder.selectAccount(basicAccount)
+        }
+
+        if (emitCounter1 === 4) {
+          const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
+          expect(selectedAccountAddr).toContain(basicAccount.addr)
+
+          accountAdder.deselectAccount(basicAccount)
+        }
+      })
+
+      // A separate subscription to check if the account got deselected
+      let emitCounter2 = 0
+      const unsubscribe2 = accountAdder.onUpdate(() => {
+        emitCounter2++
+
+        // First emit is triggered when Account Adder initializes, the second
+        // emit is triggered when the account is selected.
+        if (emitCounter2 === 5) {
+          expect(accountAdder.selectedAccounts).toHaveLength(0)
+
+          unsubscribe1()
+          unsubscribe2()
+          resolve(null)
+        }
+      })
+    })
   })
 
-  test('should NOT be able to select the same account more than once', (done) => {
-    // 3 subscriptions to select the same account account again and again
-    let emitCounter1 = 0
-    const unsubscribe1 = accountAdder.onUpdate(() => {
-      emitCounter1++
-
-      if (emitCounter1 === 3) accountAdder.selectAccount(basicAccount)
-    })
-
-    let emitCounter2 = 0
-    const unsubscribe2 = accountAdder.onUpdate(() => {
-      emitCounter2++
-
-      if (emitCounter2 === 4) accountAdder.selectAccount(basicAccount)
-    })
-
-    let emitCounter3 = 0
-    const unsubscribe3 = accountAdder.onUpdate(() => {
-      emitCounter3++
-
-      if (emitCounter3 === 5) accountAdder.selectAccount(basicAccount)
-    })
-
-    // A separate subscription to check if the account got selected only once
-    let emitCounter4 = 0
-    const unsubscribe4 = accountAdder.onUpdate(() => {
-      emitCounter4++
-
-      if (emitCounter4 === 6) {
-        expect(accountAdder.selectedAccounts).toHaveLength(1)
-        const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
-        expect(selectedAccountAddr).toContain(basicAccount.addr)
-
-        unsubscribe1()
-        unsubscribe2()
-        unsubscribe3()
-        unsubscribe4()
-        done()
-      }
-    })
-
+  test('should NOT be able to select the same account more than once', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
-    accountAdder.init({
+    await accountAdder.init({
       keyIterator,
       pageSize: 1,
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
     accountAdder.setPage({ page: 1 })
+
+    return new Promise((resolve) => {
+      // 3 subscriptions to select the same account account again and again
+      let emitCounter1 = 0
+      const unsubscribe1 = accountAdder.onUpdate(() => {
+        emitCounter1++
+
+        if (emitCounter1 === 3) accountAdder.selectAccount(basicAccount)
+      })
+
+      let emitCounter2 = 0
+      const unsubscribe2 = accountAdder.onUpdate(() => {
+        emitCounter2++
+
+        if (emitCounter2 === 4) accountAdder.selectAccount(basicAccount)
+      })
+
+      let emitCounter3 = 0
+      const unsubscribe3 = accountAdder.onUpdate(() => {
+        emitCounter3++
+
+        if (emitCounter3 === 5) accountAdder.selectAccount(basicAccount)
+      })
+
+      // A separate subscription to check if the account got selected only once
+      let emitCounter4 = 0
+      const unsubscribe4 = accountAdder.onUpdate(() => {
+        emitCounter4++
+
+        if (emitCounter4 === 6) {
+          expect(accountAdder.selectedAccounts).toHaveLength(1)
+          const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
+          expect(selectedAccountAddr).toContain(basicAccount.addr)
+
+          unsubscribe1()
+          unsubscribe2()
+          unsubscribe3()
+          unsubscribe4()
+          resolve(null)
+        }
+      })
+    })
   })
 
-  test('should be able to select all the keys of a selected basic account (always one key)', (done) => {
-    // Subscription to select an account
-    let emitCounter1 = 0
-    const unsubscribe1 = accountAdder.onUpdate(() => {
-      emitCounter1++
-
-      // First - init, second - start deriving, third - deriving done
-      if (emitCounter1 === 3) {
-        accountAdder.selectAccount(basicAccount)
-      }
-    })
-
-    let emitCounter2 = 0
-    const unsubscribe2 = accountAdder.onUpdate(() => {
-      emitCounter2++
-
-      // Select account emit is triggered
-      if (emitCounter2 === 4) {
-        expect(accountAdder.selectedAccounts[0].accountKeys).toHaveLength(1)
-        const keyAddr = accountAdder.selectedAccounts[0].accountKeys[0].addr
-        const keyIndex = accountAdder.selectedAccounts[0].accountKeys[0].index
-        expect(keyAddr).toEqual(basicAccount.addr)
-        expect(keyIndex).toEqual(0)
-
-        unsubscribe1()
-        unsubscribe2()
-        done()
-      }
-    })
-
+  test('should be able to select all the keys of a selected basic account (always one key)', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
-    accountAdder.init({
+    await accountAdder.init({
       keyIterator,
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
     accountAdder.setPage({ page: 1 })
+
+    return new Promise((resolve) => {
+      // Subscription to select an account
+      let emitCounter1 = 0
+      const unsubscribe1 = accountAdder.onUpdate(() => {
+        emitCounter1++
+
+        // First - init, second - start deriving, third - deriving done
+        if (emitCounter1 === 3) {
+          accountAdder.selectAccount(basicAccount)
+        }
+      })
+
+      let emitCounter2 = 0
+      const unsubscribe2 = accountAdder.onUpdate(() => {
+        emitCounter2++
+
+        // Select account emit is triggered
+        if (emitCounter2 === 4) {
+          expect(accountAdder.selectedAccounts[0].accountKeys).toHaveLength(1)
+          const keyAddr = accountAdder.selectedAccounts[0].accountKeys[0].addr
+          const keyIndex = accountAdder.selectedAccounts[0].accountKeys[0].index
+          expect(keyAddr).toEqual(basicAccount.addr)
+          expect(keyIndex).toEqual(0)
+
+          unsubscribe1()
+          unsubscribe2()
+          resolve(null)
+        }
+      })
+    })
   })
 
-  test('should be able to select all the keys of a selected smart account (derived key)', (done) => {
-    // Subscription to select an account
-    let emitCounter1 = 0
-    const unsubscribe1 = accountAdder.onUpdate(() => {
-      emitCounter1++
-
-      // First - init, second - start deriving, third - deriving done
-      if (emitCounter1 === 3) {
-        const firstSmartAccount = accountAdder.accountsOnPage.find(
-          (x) => x.slot === 1 && isSmartAccount(x.account)
-        )
-        if (firstSmartAccount) accountAdder.selectAccount(firstSmartAccount.account)
-      }
-    })
-
-    let emitCounter2 = 0
-    const unsubscribe2 = accountAdder.onUpdate(() => {
-      emitCounter2++
-
-      // Select account emit is triggered
-      if (emitCounter2 === 4) {
-        expect(accountAdder.selectedAccounts[0].accountKeys)
-          // Might contain other keys too, but this one should be in there,
-          // since that's the derived used only for smart account key
-          .toContainEqual({
-            addr: key1to11BasicAccUsedForSmartAccKeysOnlyPublicAddresses[0],
-            index: SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET,
-            slot: 1
-          })
-
-        unsubscribe1()
-        unsubscribe2()
-        done()
-      }
-    })
-
+  test('should be able to select all the keys of a selected smart account (derived key)', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
-    accountAdder.init({
+    await accountAdder.init({
       keyIterator,
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
     accountAdder.setPage({ page: 1 })
+
+    return new Promise((resolve) => {
+      // Subscription to select an account
+      let emitCounter1 = 0
+      const unsubscribe1 = accountAdder.onUpdate(() => {
+        emitCounter1++
+
+        // First - init, second - start deriving, third - deriving done
+        if (emitCounter1 === 3) {
+          const firstSmartAccount = accountAdder.accountsOnPage.find(
+            (x) => x.slot === 1 && isSmartAccount(x.account)
+          )
+          if (firstSmartAccount) accountAdder.selectAccount(firstSmartAccount.account)
+        }
+      })
+
+      let emitCounter2 = 0
+      const unsubscribe2 = accountAdder.onUpdate(() => {
+        emitCounter2++
+
+        // Select account emit is triggered
+        if (emitCounter2 === 4) {
+          expect(accountAdder.selectedAccounts[0].accountKeys)
+            // Might contain other keys too, but this one should be in there,
+            // since that's the derived used only for smart account key
+            .toContainEqual({
+              addr: key1to11BasicAccUsedForSmartAccKeysOnlyPublicAddresses[0],
+              index: SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET,
+              slot: 1
+            })
+
+          unsubscribe1()
+          unsubscribe2()
+          resolve(null)
+        }
+      })
+    })
   })
 
-  test('should retrieve all internal keys selected 1) basic accounts and 2) smart accounts', (done) => {
-    // Subscription to select accounts
-    let emitCounter = 0
-    const unsubscribe = accountAdder.onUpdate(() => {
-      emitCounter++
-
-      // First - init, second - start deriving, third - deriving done
-      if (emitCounter === 3) {
-        accountAdder.selectAccount(basicAccount)
-        const firstSmartAccount = accountAdder.accountsOnPage.find(
-          (x) => x.slot === 1 && isSmartAccount(x.account)
-        )
-        const secondSmartAccount = accountAdder.accountsOnPage.find(
-          (x) => x.slot === 2 && isSmartAccount(x.account)
-        )
-        if (firstSmartAccount) accountAdder.selectAccount(firstSmartAccount.account)
-        if (secondSmartAccount) accountAdder.selectAccount(secondSmartAccount.account)
-
-        const internalKeys = accountAdder.retrieveInternalKeysOfSelectedAccounts()
-
-        expect(internalKeys).toHaveLength(3)
-        const firstKey = internalKeys.filter((k) => k.privateKey === key1PrivateKey)[0]
-        const secondKey = internalKeys.filter(
-          (k) => k.privateKey === key1UsedForSmartAccKeysOnlyPrivateKey
-        )[0]
-        const thirdKey = internalKeys.filter(
-          (k) => k.privateKey === key2UsedForSmartAccKeysOnlyPrivateKey
-        )[0]
-
-        expect(firstKey).toEqual(
-          expect.objectContaining({
-            privateKey: key1PrivateKey,
-            label: 'Key 1',
-            dedicatedToOneSA: false
-          })
-        )
-        expect(secondKey).toEqual(
-          expect.objectContaining({
-            privateKey: key1UsedForSmartAccKeysOnlyPrivateKey,
-            label: 'Key 1',
-            dedicatedToOneSA: true
-          })
-        )
-        expect(thirdKey).toEqual(
-          expect.objectContaining({
-            privateKey: key2UsedForSmartAccKeysOnlyPrivateKey,
-            label: 'Key 1',
-            dedicatedToOneSA: true
-          })
-        )
-
-        unsubscribe()
-        done()
-      }
-    })
-
+  test('should retrieve all internal keys selected 1) basic accounts and 2) smart accounts', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
-    accountAdder.init({
+    await accountAdder.init({
       keyIterator,
       hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
     })
     accountAdder.setPage({ page: 1 })
+
+    return new Promise((resolve) => {
+      // Subscription to select accounts
+      let emitCounter = 0
+      const unsubscribe = accountAdder.onUpdate(() => {
+        emitCounter++
+
+        // First - init, second - start deriving, third - deriving done
+        if (emitCounter === 3) {
+          accountAdder.selectAccount(basicAccount)
+          const firstSmartAccount = accountAdder.accountsOnPage.find(
+            (x) => x.slot === 1 && isSmartAccount(x.account)
+          )
+          const secondSmartAccount = accountAdder.accountsOnPage.find(
+            (x) => x.slot === 2 && isSmartAccount(x.account)
+          )
+          if (firstSmartAccount) accountAdder.selectAccount(firstSmartAccount.account)
+          if (secondSmartAccount) accountAdder.selectAccount(secondSmartAccount.account)
+
+          const internalKeys = accountAdder.retrieveInternalKeysOfSelectedAccounts()
+
+          expect(internalKeys).toHaveLength(3)
+          const firstKey = internalKeys.filter((k) => k.privateKey === key1PrivateKey)[0]
+          const secondKey = internalKeys.filter(
+            (k) => k.privateKey === key1UsedForSmartAccKeysOnlyPrivateKey
+          )[0]
+          const thirdKey = internalKeys.filter(
+            (k) => k.privateKey === key2UsedForSmartAccKeysOnlyPrivateKey
+          )[0]
+
+          expect(firstKey).toEqual(
+            expect.objectContaining({
+              privateKey: key1PrivateKey,
+              label: 'Key 1',
+              dedicatedToOneSA: false
+            })
+          )
+          expect(secondKey).toEqual(
+            expect.objectContaining({
+              privateKey: key1UsedForSmartAccKeysOnlyPrivateKey,
+              label: 'Key 1',
+              dedicatedToOneSA: true
+            })
+          )
+          expect(thirdKey).toEqual(
+            expect.objectContaining({
+              privateKey: key2UsedForSmartAccKeysOnlyPrivateKey,
+              label: 'Key 1',
+              dedicatedToOneSA: true
+            })
+          )
+
+          unsubscribe()
+          resolve(null)
+        }
+      })
+    })
   })
 
   DERIVATION_OPTIONS.forEach(({ label, value }) => {

--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -246,7 +246,7 @@ describe('AccountAdder', () => {
     accountAdder.setPage({ page: 1 })
   })
 
-  test.only('should find linked accounts', async () => {
+  test('should find linked accounts', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
     await accountAdder.init({
       keyIterator,

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -241,6 +241,13 @@ export class AccountAdderController extends EventEmitter {
     return !!this.#keyIterator?.isSeedMatching?.(defaultSeed.seed)
   }
 
+  #getInitialHdPathTemplate = async (defaultHdPathTemplate: HD_PATH_TEMPLATE_TYPE) => {
+    if (!this.isInitializedWithDefaultSeed) return defaultHdPathTemplate
+
+    const defaultSeed = await this.#keystore.getDefaultSeed()
+    return defaultSeed.hdPathTemplate || defaultHdPathTemplate
+  }
+
   async init({
     keyIterator,
     page,
@@ -261,9 +268,9 @@ export class AccountAdderController extends EventEmitter {
 
     this.page = page || DEFAULT_PAGE
     this.pageSize = pageSize || DEFAULT_PAGE_SIZE
-    this.hdPathTemplate = hdPathTemplate
-    this.isInitialized = true
     this.isInitializedWithDefaultSeed = await this.#isKeyIteratorInitializedWithTheDefaultSeed()
+    this.hdPathTemplate = await this.#getInitialHdPathTemplate(hdPathTemplate)
+    this.isInitialized = true
     this.#alreadyImportedAccountsOnControllerInit = this.#accounts.accounts
     this.shouldSearchForLinkedAccounts = shouldSearchForLinkedAccounts
     this.shouldGetAccountsUsedOnNetworks = shouldGetAccountsUsedOnNetworks

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -233,6 +233,8 @@ export class AccountAdderController extends EventEmitter {
   async #isKeyIteratorInitializedWithTheDefaultSeed() {
     if (this.#keyIterator?.subType !== 'seed') return false
 
+    if (!this.#keystore.hasKeystoreDefaultSeed) return false
+
     const defaultSeed = await this.#keystore.getDefaultSeed()
     if (!defaultSeed) return false
 

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -241,7 +241,7 @@ export class AccountAdderController extends EventEmitter {
     return !!this.#keyIterator?.isSeedMatching?.(defaultSeed.seed)
   }
 
-  #getInitialHdPathTemplate = async (defaultHdPathTemplate: HD_PATH_TEMPLATE_TYPE) => {
+  async #getInitialHdPathTemplate(defaultHdPathTemplate: HD_PATH_TEMPLATE_TYPE) {
     if (!this.isInitializedWithDefaultSeed) return defaultHdPathTemplate
 
     const defaultSeed = await this.#keystore.getDefaultSeed()

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -301,6 +301,7 @@ export class AccountAdderController extends EventEmitter {
     this.readyToAddAccounts = []
     this.readyToAddKeys = { internal: [], external: [] }
     this.isInitialized = false
+    this.isInitializedWithDefaultSeed = false
 
     this.emitUpdate()
   }

--- a/src/controllers/keystore/keystore.test.ts
+++ b/src/controllers/keystore/keystore.test.ts
@@ -504,7 +504,8 @@ describe('KeystoreController', () => {
   test('should get default seed phrase', async () => {
     expect(!!keystore.hasKeystoreDefaultSeed).toBeTruthy()
     const decryptedDefaultSeedPhrase = await keystore.getDefaultSeed()
-    expect(decryptedDefaultSeedPhrase).toEqual(process.env.SEED)
+    expect(decryptedDefaultSeedPhrase.seed).toEqual(process.env.SEED)
+    expect(decryptedDefaultSeedPhrase.hdPathTemplate).toEqual(BIP44_STANDARD_DERIVATION_TEMPLATE)
   })
 })
 

--- a/src/controllers/keystore/keystore.test.ts
+++ b/src/controllers/keystore/keystore.test.ts
@@ -495,7 +495,10 @@ describe('KeystoreController', () => {
   test('should add keystore default seed phrase', async () => {
     expect(!!keystore.hasKeystoreDefaultSeed).toBeFalsy()
     expect(keystore.isUnlocked).toBeTruthy()
-    await keystore.addSeed(process.env.SEED)
+    await keystore.addSeed({
+      seed: process.env.SEED,
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+    })
     expect(!!keystore.hasKeystoreDefaultSeed).toBeTruthy()
   })
   test('should get default seed phrase', async () => {

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -681,13 +681,15 @@ export class KeystoreController extends EventEmitter {
     if (!this.isUnlocked) throw new Error('keystore: not unlocked')
     if (!this.#keystoreSeeds.length) throw new Error('keystore: no seed phrase added yet')
 
+    const hdPathTemplate = this.#keystoreSeeds[0].hdPathTemplate
     const encryptedSeedBytes = getBytes(this.#keystoreSeeds[0].seed)
     // @ts-ignore
     const counter = new aes.Counter(this.#mainKey.iv)
     // @ts-ignore
     const aesCtr = new aes.ModeOfOperation.ctr(this.#mainKey.key, counter)
     const decryptedSeedBytes = aesCtr.decrypt(encryptedSeedBytes)
-    return new TextDecoder().decode(decryptedSeedBytes)
+    const decryptedSeed = new TextDecoder().decode(decryptedSeedBytes)
+    return { seed: decryptedSeed, hdPathTemplate }
   }
 
   async #changeKeystorePassword(newSecret: string, oldSecret?: string) {

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -37,6 +37,7 @@ import {
 import { Storage } from '../../interfaces/storage'
 import {
   getDefaultKeyLabel,
+  getShouldMigrateKeystoreSeedsWithoutHdPath,
   migrateKeyPreferencesToKeystoreKeys,
   migrateKeystoreSeedsWithoutHdPathTemplate
 } from '../../libs/keys/keys'
@@ -137,13 +138,9 @@ export class KeystoreController extends EventEmitter {
       this.keyStoreUid = keyStoreUid
 
       // keystore seeds migration
-      const shouldMigrateKeystoreSeedsWithoutHdPath =
-        this.#keystoreSeeds.length &&
-        this.#keystoreSeeds.some((seed) => !seed.hdPathTemplate) &&
-        this.#keystoreSeeds.every((seed) => typeof seed === 'string')
-      if (shouldMigrateKeystoreSeedsWithoutHdPath) {
+      if (getShouldMigrateKeystoreSeedsWithoutHdPath(keystoreSeeds)) {
         // Cast to the old type (string[]) to avoid TS errors
-        const preMigrationKeystoreSeeds = this.#keystoreSeeds as unknown as string[]
+        const preMigrationKeystoreSeeds = keystoreSeeds as unknown as string[]
         this.#keystoreSeeds = migrateKeystoreSeedsWithoutHdPathTemplate(preMigrationKeystoreSeeds)
         await this.#storage.set('keystoreSeeds', this.#keystoreSeeds)
       } else {

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -240,11 +240,11 @@ describe('Main Controller ', () => {
       isLinked: false
     }
 
-    const addAccounts = () => {
+    const addAccounts = async () => {
       const keyIterator = new KeyIterator(
         '0x574f261b776b26b1ad75a991173d0e8ca2ca1d481bd7822b2b58b2ef8a969f12'
       )
-      controller.accountAdder.init({
+      await controller.accountAdder.init({
         keyIterator,
         hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
       })
@@ -259,12 +259,12 @@ describe('Main Controller ', () => {
     // check if the controller is ready outside of the onUpdate first and add the accounts.
     if (controller.isReady && emitCounter === 0) {
       emitCounter++
-      addAccounts()
+      await addAccounts()
     }
 
-    const unsubscribe = controller.onUpdate(() => {
+    const unsubscribe = controller.onUpdate(async () => {
       emitCounter++
-      if (emitCounter === 2 && controller.isReady) addAccounts()
+      if (emitCounter === 2 && controller.isReady) await addAccounts()
 
       if (controller.statuses.onAccountAdderSuccess === 'SUCCESS') {
         expect(controller.accounts.accounts).toContainEqual({

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -232,7 +232,7 @@ describe('Main Controller ', () => {
           ]
         ],
         preferences: {
-          label: DEFAULT_ACCOUNT_LABEL,
+          label: 'Account 4', // because there are 3 in the storage before this one
           pfp: addr
         }
       },
@@ -248,7 +248,7 @@ describe('Main Controller ', () => {
         keyIterator,
         hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
       })
-      controller.accountAdder.addAccounts([accountPendingCreation]).catch(console.error)
+      await controller.accountAdder.addAccounts([accountPendingCreation]).catch(console.error)
     }
 
     let emitCounter = 0
@@ -262,17 +262,21 @@ describe('Main Controller ', () => {
       await addAccounts()
     }
 
-    const unsubscribe = controller.onUpdate(async () => {
-      emitCounter++
-      if (emitCounter === 2 && controller.isReady) await addAccounts()
+    return new Promise((resolve) => {
+      const unsubscribe = controller.onUpdate(async () => {
+        emitCounter++
+        if (emitCounter === 2 && controller.isReady) await addAccounts()
 
-      if (controller.statuses.onAccountAdderSuccess === 'SUCCESS') {
-        expect(controller.accounts.accounts).toContainEqual({
-          ...accountPendingCreation.account,
-          newlyCreated: false
-        })
-        unsubscribe()
-      }
+        if (controller.statuses.onAccountAdderSuccess === 'SUCCESS') {
+          expect(controller.accounts.accounts).toContainEqual({
+            ...accountPendingCreation.account,
+            newlyAdded: true,
+            newlyCreated: false
+          })
+          unsubscribe()
+          resolve(null)
+        }
+      })
     })
   })
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -23,6 +23,7 @@ import { Fetch } from '../../interfaces/fetch'
 import {
   ExternalSignerControllers,
   Key,
+  KeystoreSeed,
   KeystoreSignerType,
   TxnRequest
 } from '../../interfaces/keystore'
@@ -345,13 +346,13 @@ export class MainController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async importSmartAccountFromDefaultSeed(seed?: string) {
+  async importSmartAccountFromDefaultSeed(keystoreSeed?: KeystoreSeed) {
     await this.withStatus(
       'importSmartAccountFromDefaultSeed',
       async () => {
         if (this.accountAdder.isInitialized) this.accountAdder.reset()
-        if (seed && !this.keystore.hasKeystoreDefaultSeed) {
-          await this.keystore.addSeed(seed)
+        if (keystoreSeed && !this.keystore.hasKeystoreDefaultSeed) {
+          await this.keystore.addSeed(keystoreSeed)
         }
 
         const defaultSeed = await this.keystore.getDefaultSeed()

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -333,6 +333,8 @@ export class MainController extends EventEmitter {
           // skips the parallel one, if one is requested).
           await this.keystore.addKeys(this.accountAdder.readyToAddKeys.internal)
           await this.keystore.addKeysExternallyStored(this.accountAdder.readyToAddKeys.external)
+
+          // TODO: Update derivation of the default seed, if needed.
         },
         true
       )
@@ -364,7 +366,7 @@ export class MainController extends EventEmitter {
         }
 
         const keyIterator = new KeyIterator(defaultSeed.seed)
-        this.accountAdder.init({
+        await this.accountAdder.init({
           keyIterator,
           hdPathTemplate: defaultSeed.hdPathTemplate,
           pageSize: 1,
@@ -632,7 +634,7 @@ export class MainController extends EventEmitter {
       }
 
       const keyIterator = new LedgerKeyIterator({ controller: ledgerCtrl })
-      this.accountAdder.init({ keyIterator, hdPathTemplate })
+      await this.accountAdder.init({ keyIterator, hdPathTemplate })
 
       return await this.accountAdder.setPage({ page: 1 })
     } catch (error: any) {
@@ -664,7 +666,7 @@ export class MainController extends EventEmitter {
       await latticeCtrl.unlock(hdPathTemplate, undefined, true)
 
       const { walletSDK } = latticeCtrl
-      this.accountAdder.init({
+      await this.accountAdder.init({
         keyIterator: new LatticeKeyIterator({ walletSDK }),
         hdPathTemplate
       })

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -334,7 +334,12 @@ export class MainController extends EventEmitter {
           await this.keystore.addKeys(this.accountAdder.readyToAddKeys.internal)
           await this.keystore.addKeysExternallyStored(this.accountAdder.readyToAddKeys.external)
 
-          // TODO: Update derivation of the default seed, if needed.
+          // Update the default seed `hdPathTemplate` if accounts were added from
+          // the default seed, so when user opts in to "Import a new Smart Account
+          // from the default Seed Phrase" the next account is derived based
+          // on the latest `hdPathTemplate` chosen in the AccountAdder.
+          if (this.accountAdder.isInitializedWithDefaultSeed)
+            this.keystore.changeDefaultSeedHdPathTemplateIfNeeded(this.accountAdder.hdPathTemplate)
         },
         true
       )

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -366,10 +366,10 @@ export class MainController extends EventEmitter {
           })
         }
 
-        const keyIterator = new KeyIterator(defaultSeed)
+        const keyIterator = new KeyIterator(defaultSeed.seed)
         this.accountAdder.init({
           keyIterator,
-          hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+          hdPathTemplate: defaultSeed.hdPathTemplate,
           pageSize: 1,
           shouldGetAccountsUsedOnNetworks: false,
           shouldSearchForLinkedAccounts: false

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -23,7 +23,6 @@ import { Fetch } from '../../interfaces/fetch'
 import {
   ExternalSignerControllers,
   Key,
-  KeystoreSeed,
   KeystoreSignerType,
   TxnRequest
 } from '../../interfaces/keystore'
@@ -350,17 +349,16 @@ export class MainController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async importSmartAccountFromDefaultSeed(keystoreSeed?: KeystoreSeed) {
+  async importSmartAccountFromDefaultSeed(seed?: string) {
     await this.withStatus(
       'importSmartAccountFromDefaultSeed',
       async () => {
         if (this.accountAdder.isInitialized) this.accountAdder.reset()
-        if (keystoreSeed && !this.keystore.hasKeystoreDefaultSeed) {
-          await this.keystore.addSeed(keystoreSeed)
+        if (seed && !this.keystore.hasKeystoreDefaultSeed) {
+          await this.keystore.addSeed({ seed, hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE })
         }
 
         const defaultSeed = await this.keystore.getDefaultSeed()
-
         if (!defaultSeed) {
           throw new EmittableError({
             message:

--- a/src/interfaces/keyIterator.ts
+++ b/src/interfaces/keyIterator.ts
@@ -27,4 +27,6 @@ export interface KeyIterator {
     dedicatedToOneSA: boolean
     meta: null
   }[]
+  /** Checks if the seed matches the key iterator's seed (optional, for hot wallets) */
+  isSeedMatching?: (seedToCompareWith: string) => boolean
 }

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -121,6 +121,8 @@ export type ExternalKey = {
 
 export type StoredKey = (InternalKey & { privKey: string }) | (ExternalKey & { privKey: null })
 
+export type KeystoreSeed = { seed: string; hdPathTemplate: HD_PATH_TEMPLATE_TYPE }
+
 export type KeystoreSignerType = {
   new (key: Key, privateKey?: string): KeystoreSigner
 }

--- a/src/libs/keyIterator/keyIterator.ts
+++ b/src/libs/keyIterator/keyIterator.ts
@@ -178,4 +178,13 @@ export class KeyIterator implements KeyIteratorInterface {
       })
     })
   }
+
+  isSeedMatching(seedPhraseToCompareWith: string) {
+    if (!this.#seedPhrase) return false
+
+    return (
+      Mnemonic.fromPhrase(this.#seedPhrase).phrase ===
+      Mnemonic.fromPhrase(seedPhraseToCompareWith).phrase
+    )
+  }
 }

--- a/src/libs/keys/keys.ts
+++ b/src/libs/keys/keys.ts
@@ -42,7 +42,7 @@ export function migrateKeyPreferencesToKeystoreKeys(
   })
 }
 
-// As of version 4.33.0, user can change the HD path when importing a seed.
+// As of version v4.33.0, user can change the HD path when importing a seed.
 // Migration is needed because previously the HD path was not stored,
 // and the default used was `BIP44_STANDARD_DERIVATION_TEMPLATE`.
 export const getShouldMigrateKeystoreSeedsWithoutHdPath = (

--- a/src/libs/keys/keys.ts
+++ b/src/libs/keys/keys.ts
@@ -1,5 +1,4 @@
-import { BIP44_STANDARD_DERIVATION_TEMPLATE, HD_PATH_TEMPLATE_TYPE } from 'consts/derivation'
-
+import { BIP44_STANDARD_DERIVATION_TEMPLATE, HD_PATH_TEMPLATE_TYPE } from '../../consts/derivation'
 import { Key, StoredKey } from '../../interfaces/keystore'
 
 export const DEFAULT_KEY_LABEL_PATTERN = /^Key (\d+)$/

--- a/src/libs/keys/keys.ts
+++ b/src/libs/keys/keys.ts
@@ -1,5 +1,5 @@
 import { BIP44_STANDARD_DERIVATION_TEMPLATE, HD_PATH_TEMPLATE_TYPE } from '../../consts/derivation'
-import { Key, StoredKey } from '../../interfaces/keystore'
+import { Key, KeystoreSeed, StoredKey } from '../../interfaces/keystore'
 
 export const DEFAULT_KEY_LABEL_PATTERN = /^Key (\d+)$/
 export const getDefaultKeyLabel = (prevKeys: Key[], i: number) => {
@@ -45,6 +45,11 @@ export function migrateKeyPreferencesToKeystoreKeys(
 // As of version 4.33.0, user can change the HD path when importing a seed.
 // Migration is needed because previously the HD path was not stored,
 // and the default used was `BIP44_STANDARD_DERIVATION_TEMPLATE`.
+export const getShouldMigrateKeystoreSeedsWithoutHdPath = (
+  keystoreSeeds: string[] | KeystoreSeed[]
+) =>
+  // @ts-ignore TS complains, but we know that keystoreSeeds is either an array of strings or an array of objects
+  !!keystoreSeeds?.length && keystoreSeeds.every((seed) => typeof seed === 'string')
 export function migrateKeystoreSeedsWithoutHdPathTemplate(
   prevKeystoreSeeds: string[]
 ): { seed: string; hdPathTemplate: HD_PATH_TEMPLATE_TYPE }[] {

--- a/src/libs/keys/keys.ts
+++ b/src/libs/keys/keys.ts
@@ -1,3 +1,5 @@
+import { BIP44_STANDARD_DERIVATION_TEMPLATE, HD_PATH_TEMPLATE_TYPE } from 'consts/derivation'
+
 import { Key, StoredKey } from '../../interfaces/keystore'
 
 export const DEFAULT_KEY_LABEL_PATTERN = /^Key (\d+)$/
@@ -39,4 +41,16 @@ export function migrateKeyPreferencesToKeystoreKeys(
 
     return key
   })
+}
+
+// As of version 4.33.0, user can change the HD path when importing a seed.
+// Migration is needed because previously the HD path was not stored,
+// and the default used was `BIP44_STANDARD_DERIVATION_TEMPLATE`.
+export function migrateKeystoreSeedsWithoutHdPathTemplate(
+  prevKeystoreSeeds: string[]
+): { seed: string; hdPathTemplate: HD_PATH_TEMPLATE_TYPE }[] {
+  return prevKeystoreSeeds.map((seed) => ({
+    seed,
+    hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+  }))
 }

--- a/src/utils/hdPath.ts
+++ b/src/utils/hdPath.ts
@@ -12,9 +12,9 @@ export const getHDPathIndices = (hdPathTemplate: HD_PATH_TEMPLATE_TYPE, insertId
   path.forEach((_idx) => {
     const isHardened = _idx[_idx.length - 1] === "'"
     let idx = isHardened ? HARDENED_OFFSET : 0
-    // If there is an `x` in the path string, we will use it to insert our
+    // If there is an `<account>` in the path string, we will use it to insert our
     // index. This is useful for e.g. Ledger Live path. Most paths have the
-    // changing index as the last one, so having an `x` in the path isn't
+    // changing index as the last one, so having an `<account>` in the path isn't
     // usually necessary.
     if (_idx.indexOf('<account>') > -1) {
       idx += insertIdx
@@ -26,7 +26,7 @@ export const getHDPathIndices = (hdPathTemplate: HD_PATH_TEMPLATE_TYPE, insertId
     }
     indices.push(idx)
   })
-  // If this path string does not include an `x`, we just append the index
+  // If this path string does not include an `<account>`, we just append the index
   // to the end of the extracted set
   if (usedX === false) {
     indices.push(insertIdx)


### PR DESCRIPTION
Since we allow changing the HD path when importing accounts from seed, tweak a bit the case when the user imports accounts from the default seed so that:

- Added: Store the hd path chosen when initially importing accounts from the default seed (stored in the Keystore) and migrate all existing keystore seeds (without hd path) so that they have the default one we set (BIP44 Standard).
- Added: When the user opts in to "Import a new Smart Account from the default Seed Phrase" the next account is now derived based on the latest hd path chosen in the AccountAdder when the user imported the default seed.