### PR TITLE
signAccount op error handling and warnings improvements

### DIFF
--- a/src/consts/signAccountOp/errorHandling.ts
+++ b/src/consts/signAccountOp/errorHandling.ts
@@ -1,9 +1,5 @@
 import { Warning } from '../../interfaces/signAccountOp'
 
-/** Errors that don't prevent signing */
-const NON_CRITICAL_ERRORS = {
-  feeUsdEstimation: 'Unable to estimate the transaction fee in USD.'
-}
 const ERRORS = {
   eoaInsufficientFunds: 'Insufficient funds to cover the fee.'
 }
@@ -21,4 +17,4 @@ const WARNINGS: { [key: string]: Warning } = {
 const RETRY_TO_INIT_ACCOUNT_OP_MSG =
   'Please attempt to initiate the transaction again or contact Ambire support.'
 
-export { NON_CRITICAL_ERRORS, ERRORS, WARNINGS, RETRY_TO_INIT_ACCOUNT_OP_MSG }
+export { ERRORS, WARNINGS, RETRY_TO_INIT_ACCOUNT_OP_MSG }

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1718,24 +1718,22 @@ export class MainController extends EventEmitter {
             : null
       })
 
+      // if there's an estimation error, override the pending results
+      if (estimation && estimation.error) {
+        this.portfolio.overridePendingResults(localAccountOp)
+      }
       // update the signAccountOp controller once estimation finishes;
       // this eliminates the infinite loading bug if the estimation comes slower
       if (this.signAccountOp && estimation) {
         this.signAccountOp.update({ estimation, rbfAccountOps })
       }
-
-      // if there's an estimation error, override the pending results
-      if (estimation && estimation.error) {
-        this.portfolio.overridePendingResults(localAccountOp)
-      }
     } catch (error: any) {
+      this.signAccountOp?.calculateWarnings()
       this.emitError({
         level: 'silent',
         message: 'Estimation error',
         error
       })
-    } finally {
-      this.signAccountOp?.calculateWarnings()
     }
   }
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -257,7 +257,7 @@ export class PortfolioController extends EventEmitter {
   }
 
   // make the pending results the same as the latest ones
-  async overridePendingResults(accountOp: AccountOp) {
+  overridePendingResults(accountOp: AccountOp) {
     if (
       this.pending[accountOp.accountAddr] &&
       this.pending[accountOp.accountAddr][accountOp.networkId] &&

--- a/src/controllers/signAccountOp/helper.ts
+++ b/src/controllers/signAccountOp/helper.ts
@@ -9,7 +9,7 @@ import { Price, TokenResult } from '../../libs/portfolio'
 import { getAccountPortfolioTotal } from '../../libs/portfolio/helpers'
 import { PortfolioControllerState } from '../../libs/portfolio/interfaces'
 
-export function getFeeSpeedIdentifier(
+function getFeeSpeedIdentifier(
   option: FeePaymentOption,
   accountAddr: string,
   rbfAccountOp: SubmittedAccountOp | null
@@ -25,7 +25,7 @@ export function getFeeSpeedIdentifier(
   }${rbfAccountOp ? `rbf-${option.paidBy}` : ''}`
 }
 
-export function getTokenUsdAmount(token: TokenResult, gasAmount: bigint): string {
+function getTokenUsdAmount(token: TokenResult, gasAmount: bigint): string {
   const isUsd = (price: Price) => price.baseCurrency === 'usd'
   const usdPrice = token.priceIn.find(isUsd)?.price
 
@@ -37,7 +37,7 @@ export function getTokenUsdAmount(token: TokenResult, gasAmount: bigint): string
   return formatUnits(BigInt(gasAmount) * usdPriceFormatted, 18 + token.decimals)
 }
 
-export function getSignificantBalanceDecreaseWarning(
+function getSignificantBalanceDecreaseWarning(
   latest: PortfolioControllerState,
   pending: PortfolioControllerState,
   networkId: Network['id'],
@@ -64,4 +64,25 @@ export function getSignificantBalanceDecreaseWarning(
   }
 
   return null
+}
+
+const getFeeTokenPriceUnavailableWarning = (
+  hasSpeed: boolean,
+  feeTokenHasPrice: boolean
+): Warning | null => {
+  if (!hasSpeed || feeTokenHasPrice) return null
+
+  return {
+    id: 'feeTokenPriceUnavailable',
+    title: 'Unable to estimate the transaction fee in USD.',
+    promptBeforeSign: false,
+    displayBeforeSign: true
+  }
+}
+
+export {
+  getFeeSpeedIdentifier,
+  getTokenUsdAmount,
+  getSignificantBalanceDecreaseWarning,
+  getFeeTokenPriceUnavailableWarning
 }

--- a/src/interfaces/signAccountOp.ts
+++ b/src/interfaces/signAccountOp.ts
@@ -1,7 +1,7 @@
 type Warning = {
   id: string
   title: string
-  text: string
+  text?: string
   promptBeforeSign: boolean
   displayBeforeSign: boolean
 }


### PR DESCRIPTION
## Changes:
- Delete: `NON_CRITICAL_ERRORS` concept in `signAccountOp`
- Change: `overridePendingResults` doesn't have to be async
- Change: Calculate signAccountOp warnings in `update`, instead of `estimateSignAccountOp`. Calculate them in `estimateSignAccountOp` only if there is an error
- Fix: "Unable to estimate the transaction fee in USD" wasn't visualized
- Fix: `emitUpdate` isn't called in `calculateWarnings`
## Screenshots:
![image](https://github.com/user-attachments/assets/1895a087-6426-4120-9ca6-0061f55ad71f)
