### PR TITLE
Re-estimate on paymaster error

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -465,7 +465,10 @@ export class MainController extends EventEmitter {
       accountOp,
       this.#storage,
       this.fetch,
-      this.callRelayer
+      this.callRelayer,
+      () => {
+        this.estimateSignAccountOp()
+      }
     )
 
     this.emitUpdate()

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -437,7 +437,8 @@ const init = async (
     op,
     storage,
     fetch,
-    callRelayer
+    callRelayer,
+    () => {}
   )
 
   return { controller, prices, estimation }

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -157,6 +157,8 @@ export class SignAccountOpController extends EventEmitter {
 
   #callRelayer: Function
 
+  #reEstimate: Function
+
   rbfAccountOps: { [key: string]: SubmittedAccountOp | null }
 
   signedAccountOp: AccountOp | null
@@ -177,7 +179,8 @@ export class SignAccountOpController extends EventEmitter {
     accountOp: AccountOp,
     storage: Storage,
     fetch: Fetch,
-    callRelayer: Function
+    callRelayer: Function,
+    reEstimate: Function
   ) {
     super()
 
@@ -193,6 +196,7 @@ export class SignAccountOpController extends EventEmitter {
     this.#storage = storage
     this.#fetch = fetch
     this.#callRelayer = callRelayer
+    this.#reEstimate = reEstimate
 
     this.#humanizeAccountOp()
     this.gasUsedTooHigh = false
@@ -1225,6 +1229,7 @@ export class SignAccountOpController extends EventEmitter {
             })
             this.status = { type: SigningStatus.ReadyToSign }
             this.emitUpdate()
+            this.#reEstimate()
             return Promise.reject(this.status)
           }
         }


### PR DESCRIPTION
Sometimes the estimation from the paymaster fails because of changed on-chain conditions; if that is the case, we have to re-estimate, or we end up in a situation where the user has to wait for a re-estimation on the FE to see the broken estimation