### PR TITLE
Enhancement/ Add previous preferences to accounts in account adder

### DIFF
--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -701,13 +701,16 @@ export class AccountAdderController extends EventEmitter {
       const slot = startIdx + (index + 1)
 
       // The derived EOA (basic) account which is the key for the smart account
-      const account = getBasicAccount(smartAccKey)
+      const account = getBasicAccount(smartAccKey, this.#accounts.accounts)
       const indexWithOffset = slot - 1 + SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
       accounts.push({ account, isLinked: false, slot, index: indexWithOffset })
 
       // Derive the Ambire (smart) account
       smartAccountsPromises.push(
-        getSmartAccount([{ addr: smartAccKey, hash: dedicatedToOneSAPriv }])
+        getSmartAccount(
+          [{ addr: smartAccKey, hash: dedicatedToOneSAPriv }],
+          this.#accounts.accounts
+        )
           .then((smartAccount) => {
             return { account: smartAccount, isLinked: false, slot, index: slot - 1 }
           })
@@ -733,7 +736,7 @@ export class AccountAdderController extends EventEmitter {
       const slot = startIdx + (index + 1)
 
       // The EOA (basic) account on this slot
-      const account = getBasicAccount(basicAccKey)
+      const account = getBasicAccount(basicAccKey, this.#accounts.accounts)
       accounts.push({ account, isLinked: false, slot, index: slot - 1 })
     }
 
@@ -886,6 +889,8 @@ export class AccountAdderController extends EventEmitter {
 
         return []
       }
+
+      const existingAccount = this.#accounts.accounts.find((acc) => acc.addr === addr)
       return [
         {
           account: {
@@ -902,8 +907,8 @@ export class AccountAdderController extends EventEmitter {
               salt
             },
             preferences: {
-              label: DEFAULT_ACCOUNT_LABEL,
-              pfp: addr
+              label: existingAccount?.preferences.label || DEFAULT_ACCOUNT_LABEL,
+              pfp: existingAccount?.preferences?.pfp || addr
             }
           },
           isLinked: true

--- a/src/libs/account/account.test.ts
+++ b/src/libs/account/account.test.ts
@@ -34,7 +34,7 @@ const basicAccount: Account = {
 describe('Account', () => {
   test('should return basic account', () => {
     expect.assertions(1)
-    const newBasicAccount = getBasicAccount(keyPublicAddress)
+    const newBasicAccount = getBasicAccount(keyPublicAddress, [])
     expect(newBasicAccount as Account).toStrictEqual(basicAccount)
   })
   test('should return smartAccount', async () => {
@@ -43,7 +43,7 @@ describe('Account', () => {
       addr: keyPublicAddress,
       hash: dedicatedToOneSAPriv
     }
-    const newSmartAccount = await getSmartAccount([priv])
+    const newSmartAccount = await getSmartAccount([priv], [])
     const bytecode = await getBytecode([priv])
     const accountNotDeployed = {
       addr: getAmbireAccountAddress(AMBIRE_ACCOUNT_FACTORY, bytecode),
@@ -179,7 +179,7 @@ describe('Account', () => {
       addr: keyPublicAddress,
       hash: dedicatedToOneSAPriv
     }
-    const smartAccount = await getSmartAccount([priv])
+    const smartAccount = await getSmartAccount([priv], [])
     const key: Key = {
       addr: basicAccount.addr,
       type: 'trezor',
@@ -240,7 +240,7 @@ describe('Account', () => {
       addr: keyPublicAddress,
       hash: dedicatedToOneSAPriv
     }
-    const smartAccountWithIncompleteAssociatedKeys = await getSmartAccount([priv])
+    const smartAccountWithIncompleteAssociatedKeys = await getSmartAccount([priv], [])
 
     const oneOfTheSmartAccountKeys: Key = {
       addr: basicAccount.addr,

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -55,22 +55,27 @@ export function getAccountDeployParams(account: Account): [string, string] {
   ]
 }
 
-export function getBasicAccount(addr: string): Account {
+export function getBasicAccount(addr: string, existingAccounts: Account[]): Account {
+  const { preferences } = existingAccounts.find((acc) => acc.addr === addr) || {}
   return {
     addr,
     associatedKeys: [addr],
     initialPrivileges: [],
     creation: null,
     preferences: {
-      label: DEFAULT_ACCOUNT_LABEL,
-      pfp: addr
+      label: preferences?.label || DEFAULT_ACCOUNT_LABEL,
+      pfp: preferences?.pfp || addr
     }
   }
 }
 
-export async function getSmartAccount(privileges: PrivLevels[]): Promise<Account> {
+export async function getSmartAccount(
+  privileges: PrivLevels[],
+  existingAccounts: Account[]
+): Promise<Account> {
   const bytecode = await getBytecode(privileges)
   const addr = getAmbireAccountAddress(AMBIRE_ACCOUNT_FACTORY, bytecode)
+  const { preferences } = existingAccounts.find((acc) => acc.addr === addr) || {}
 
   return {
     addr,
@@ -82,8 +87,8 @@ export async function getSmartAccount(privileges: PrivLevels[]): Promise<Account
       salt: toBeHex(0, 32)
     },
     preferences: {
-      label: DEFAULT_ACCOUNT_LABEL,
-      pfp: addr
+      label: preferences?.label || DEFAULT_ACCOUNT_LABEL,
+      pfp: preferences?.pfp || addr
     }
   }
 }
@@ -172,7 +177,7 @@ export async function getEmailAccount(
   )
   const { hash } = getSignerKey(validatorAddr, validatorData)
   const privileges = [{ addr: associatedKey, hash }]
-  return getSmartAccount(privileges)
+  return getSmartAccount(privileges, [])
 }
 
 export const isAmbireV1LinkedAccount = (factoryAddr?: string) =>

--- a/src/libs/deployless/simulateDeployCall.ts
+++ b/src/libs/deployless/simulateDeployCall.ts
@@ -1,4 +1,4 @@
-import { FetchRequest, JsonRpcProvider, ZeroAddress } from 'ethers'
+import { JsonRpcProvider, ZeroAddress } from 'ethers'
 
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import { AMBIRE_ACCOUNT_FACTORY, DEPLOYLESS_SIMULATION_FROM } from '../../consts/deploy'
@@ -13,12 +13,15 @@ import { DeploylessMode, fromDescriptor } from './deployless'
 export async function getSASupport(
   provider: JsonRpcProvider
 ): Promise<{ addressMatches: boolean; supportsStateOverride: boolean }> {
-  const smartAccount = await getSmartAccount([
-    {
-      addr: DEPLOYLESS_SIMULATION_FROM,
-      hash: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
-    }
-  ])
+  const smartAccount = await getSmartAccount(
+    [
+      {
+        addr: DEPLOYLESS_SIMULATION_FROM,
+        hash: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      }
+    ],
+    []
+  )
   const deploylessOptions = {
     blockTag: 'latest',
     from: DEPLOYLESS_SIMULATION_FROM,

--- a/src/libs/estimate/estimate.test.ts
+++ b/src/libs/estimate/estimate.test.ts
@@ -790,7 +790,7 @@ describe('estimate', () => {
         hash: dedicatedToOneSAPriv
       }
     ]
-    const smartAcc = await getSmartAccount(privs)
+    const smartAcc = await getSmartAccount(privs, [])
     const opOptimism: AccountOp = {
       accountAddr: smartAcc.addr,
       signingKeyAddr: smartAcc.associatedKeys[0],
@@ -840,7 +840,7 @@ describe('estimate', () => {
         hash: dedicatedToOneSAPriv
       }
     ]
-    const smartAcc = await getSmartAccount(privs)
+    const smartAcc = await getSmartAccount(privs, [])
     const opOptimism: AccountOp = {
       accountAddr: smartAcc.addr,
       signingKeyAddr: smartAcc.associatedKeys[0],
@@ -892,7 +892,7 @@ describe('estimate', () => {
       }
     ]
     const ERC20Interface = new Interface(ERC20.abi)
-    const smartAcc = await getSmartAccount(privs)
+    const smartAcc = await getSmartAccount(privs, [])
     const opOptimism: AccountOp = {
       accountAddr: smartAcc.addr,
       signingKeyAddr: smartAcc.associatedKeys[0],

--- a/src/libs/estimate/estimateBundler.test.ts
+++ b/src/libs/estimate/estimateBundler.test.ts
@@ -50,7 +50,7 @@ describe('Bundler estimation tests', () => {
           hash: dedicatedToOneSAPriv
         }
       ]
-      const smartAcc = await getSmartAccount(privs)
+      const smartAcc = await getSmartAccount(privs, [])
       const opOptimism: AccountOp = {
         accountAddr: smartAcc.addr,
         signingKeyAddr: smartAcc.associatedKeys[0],

--- a/src/services/bundlers/bundler.test.ts
+++ b/src/services/bundlers/bundler.test.ts
@@ -151,7 +151,7 @@ describe('Bundler tests', () => {
           hash: dedicatedToOneSAPriv
         }
       ]
-      const smartAcc = await getSmartAccount(privs)
+      const smartAcc = await getSmartAccount(privs, [])
 
       const opOptimism: AccountOp = {
         accountAddr: smartAcc.addr,
@@ -210,7 +210,7 @@ describe('Bundler tests', () => {
           hash: dedicatedToOneSAPriv
         }
       ]
-      const smartAcc = await getSmartAccount(privs)
+      const smartAcc = await getSmartAccount(privs, [])
       const opOptimism: AccountOp = {
         accountAddr: smartAcc.addr,
         signingKeyAddr: smartAcc.associatedKeys[0],
@@ -267,7 +267,7 @@ describe('Bundler tests', () => {
           hash: dedicatedToOneSAPriv
         }
       ]
-      const smartAcc = await getSmartAccount(privs)
+      const smartAcc = await getSmartAccount(privs, [])
       const ERC20Interface = new Interface(ERC20.abi)
       const opOptimism: AccountOp = {
         accountAddr: smartAcc.addr,
@@ -467,7 +467,7 @@ describe('Bundler tests', () => {
           hash: dedicatedToOneSAPriv
         }
       ]
-      const smartAcc = await getSmartAccount(privs)
+      const smartAcc = await getSmartAccount(privs, [])
 
       const opMantle: AccountOp = {
         accountAddr: smartAcc.addr,
@@ -518,7 +518,7 @@ describe('Bundler tests', () => {
           hash: dedicatedToOneSAPriv
         }
       ]
-      const smartAcc = await getSmartAccount(privs)
+      const smartAcc = await getSmartAccount(privs, [])
       const ERC20Interface = new Interface(ERC20.abi)
       const opMantle: AccountOp = {
         accountAddr: smartAcc.addr,


### PR DESCRIPTION
Try to find an existing account and get its preferences when creating accounts in the account adder.

Needed for https://github.com/AmbireTech/ambire-app/issues/2515