### PR TITLE
Refactor / Migrate the (legacy) Account Adder tests

### DIFF
--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -171,7 +171,8 @@ describe('AccountAdder', () => {
     await accountAdder.init({
       keyIterator,
       pageSize: PAGE_SIZE,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+      shouldGetAccountsUsedOnNetworks: false
     })
     accountAdder.setPage({ page: 1 })
 
@@ -230,8 +231,10 @@ describe('AccountAdder', () => {
     await accountAdder.init({
       keyIterator,
       pageSize: 4,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+      shouldGetAccountsUsedOnNetworks: false
     })
+
     accountAdder.setPage({ page: 1 })
 
     return new Promise((resolve) => {
@@ -254,44 +257,29 @@ describe('AccountAdder', () => {
     await accountAdder.init({
       keyIterator,
       pageSize: 3,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+      shouldGetAccountsUsedOnNetworks: false
     })
-    accountAdder.setPage({ page: 1 })
+    await accountAdder.setPage({ page: 1 })
 
-    return new Promise((resolve) => {
-      let emitCounter = 0
-      const unsubscribe = accountAdder.onUpdate(() => {
-        emitCounter++
+    expect(accountAdder.linkedAccountsLoading).toBe(false)
+    const linkedAccountsOnPage = accountAdder.accountsOnPage.filter(({ isLinked }) => isLinked)
 
-        // First emit is triggered when account derivation is done, int the
-        // second emit it should start the searching for linked accounts,
-        // on the third emit there should be linked accounts fetched
-        if (emitCounter === 3) {
-          expect(accountAdder.linkedAccountsLoading).toBe(false)
-          const linkedAccountsOnPage = accountAdder.accountsOnPage.filter(
-            ({ isLinked }) => isLinked
-          )
+    const accountsOnSlot1 = linkedAccountsOnPage
+      .filter(({ slot }) => slot === 1)
+      .map(({ account }) => account.addr)
+    // This account was manually added as a signer to one of our test accounts
+    expect(accountsOnSlot1).toContain('0x740523d7876Fbb8AF246c5B307f26d4b2D2BFDA9')
 
-          const accountsOnSlot1 = linkedAccountsOnPage
-            .filter(({ slot }) => slot === 1)
-            .map(({ account }) => account.addr)
-          // This account was manually added as a signer to one of our test accounts
-          expect(accountsOnSlot1).toContain('0x740523d7876Fbb8AF246c5B307f26d4b2D2BFDA9')
-
-          const accountsOnSlot3 = linkedAccountsOnPage
-            .filter(({ slot }) => slot === 3)
-            .map(({ account }) => account.addr)
-          // These accounts was manually added as signers to our test accounts
-          expect(accountsOnSlot3).toContain('0x0ace96748e66F42EBeA22D777C2a99eA2c83D8A6')
-          expect(accountsOnSlot3).toContain('0xc583f33d502dE560dd2C60D4103043d5998A98E5')
-          expect(accountsOnSlot3).toContain('0x63caaD57Cd66A69A4c56b595E3A4a1e4EeA066d8')
-          expect(accountsOnSlot3).toContain('0x619A6a273c628891dD0994218BC0625947653AC7')
-          expect(accountsOnSlot3).toContain('0x7ab87ab041EB1c4f0d4f4d1ABD5b0973B331e2E7')
-          unsubscribe()
-          resolve(null)
-        }
-      })
-    })
+    const accountsOnSlot3 = linkedAccountsOnPage
+      .filter(({ slot }) => slot === 3)
+      .map(({ account }) => account.addr)
+    // These accounts was manually added as signers to our test accounts
+    expect(accountsOnSlot3).toContain('0x0ace96748e66F42EBeA22D777C2a99eA2c83D8A6')
+    expect(accountsOnSlot3).toContain('0xc583f33d502dE560dd2C60D4103043d5998A98E5')
+    expect(accountsOnSlot3).toContain('0x63caaD57Cd66A69A4c56b595E3A4a1e4EeA066d8')
+    expect(accountsOnSlot3).toContain('0x619A6a273c628891dD0994218BC0625947653AC7')
+    expect(accountsOnSlot3).toContain('0x7ab87ab041EB1c4f0d4f4d1ABD5b0973B331e2E7')
   })
 
   test('should be able to select and then deselect an account', async () => {
@@ -299,44 +287,18 @@ describe('AccountAdder', () => {
     await accountAdder.init({
       keyIterator,
       pageSize: 1,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+      shouldSearchForLinkedAccounts: false,
+      shouldGetAccountsUsedOnNetworks: false
     })
-    accountAdder.setPage({ page: 1 })
+    await accountAdder.setPage({ page: 1 })
 
-    return new Promise((resolve) => {
-      // Subscription to select an account and trigger a deselect
-      let emitCounter1 = 0
-      const unsubscribe1 = accountAdder.onUpdate(() => {
-        emitCounter1++
+    accountAdder.selectAccount(basicAccount)
+    const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
+    expect(selectedAccountAddr).toContain(basicAccount.addr)
 
-        if (emitCounter1 === 3) {
-          accountAdder.selectAccount(basicAccount)
-        }
-
-        if (emitCounter1 === 4) {
-          const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
-          expect(selectedAccountAddr).toContain(basicAccount.addr)
-
-          accountAdder.deselectAccount(basicAccount)
-        }
-      })
-
-      // A separate subscription to check if the account got deselected
-      let emitCounter2 = 0
-      const unsubscribe2 = accountAdder.onUpdate(() => {
-        emitCounter2++
-
-        // First emit is triggered when Account Adder initializes, the second
-        // emit is triggered when the account is selected.
-        if (emitCounter2 === 5) {
-          expect(accountAdder.selectedAccounts).toHaveLength(0)
-
-          unsubscribe1()
-          unsubscribe2()
-          resolve(null)
-        }
-      })
-    })
+    accountAdder.deselectAccount(basicAccount)
+    expect(accountAdder.selectedAccounts).toHaveLength(0)
   })
 
   test('should NOT be able to select the same account more than once', async () => {
@@ -344,210 +306,130 @@ describe('AccountAdder', () => {
     await accountAdder.init({
       keyIterator,
       pageSize: 1,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+      shouldSearchForLinkedAccounts: false,
+      shouldGetAccountsUsedOnNetworks: false
     })
-    accountAdder.setPage({ page: 1 })
+    await accountAdder.setPage({ page: 1 })
 
-    return new Promise((resolve) => {
-      // 3 subscriptions to select the same account account again and again
-      let emitCounter1 = 0
-      const unsubscribe1 = accountAdder.onUpdate(() => {
-        emitCounter1++
+    accountAdder.selectAccount(basicAccount)
+    accountAdder.selectAccount(basicAccount)
+    accountAdder.selectAccount(basicAccount)
 
-        if (emitCounter1 === 3) accountAdder.selectAccount(basicAccount)
-      })
-
-      let emitCounter2 = 0
-      const unsubscribe2 = accountAdder.onUpdate(() => {
-        emitCounter2++
-
-        if (emitCounter2 === 4) accountAdder.selectAccount(basicAccount)
-      })
-
-      let emitCounter3 = 0
-      const unsubscribe3 = accountAdder.onUpdate(() => {
-        emitCounter3++
-
-        if (emitCounter3 === 5) accountAdder.selectAccount(basicAccount)
-      })
-
-      // A separate subscription to check if the account got selected only once
-      let emitCounter4 = 0
-      const unsubscribe4 = accountAdder.onUpdate(() => {
-        emitCounter4++
-
-        if (emitCounter4 === 6) {
-          expect(accountAdder.selectedAccounts).toHaveLength(1)
-          const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
-          expect(selectedAccountAddr).toContain(basicAccount.addr)
-
-          unsubscribe1()
-          unsubscribe2()
-          unsubscribe3()
-          unsubscribe4()
-          resolve(null)
-        }
-      })
-    })
+    expect(accountAdder.selectedAccounts).toHaveLength(1)
+    const selectedAccountAddr = accountAdder.selectedAccounts.map((a) => a.account.addr)
+    expect(selectedAccountAddr).toContain(basicAccount.addr)
   })
 
   test('should be able to select all the keys of a selected basic account (always one key)', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
     await accountAdder.init({
       keyIterator,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+      shouldSearchForLinkedAccounts: false,
+      shouldGetAccountsUsedOnNetworks: false
     })
-    accountAdder.setPage({ page: 1 })
+    await accountAdder.setPage({ page: 1 })
 
-    return new Promise((resolve) => {
-      // Subscription to select an account
-      let emitCounter1 = 0
-      const unsubscribe1 = accountAdder.onUpdate(() => {
-        emitCounter1++
+    accountAdder.selectAccount(basicAccount)
 
-        // First - init, second - start deriving, third - deriving done
-        if (emitCounter1 === 3) {
-          accountAdder.selectAccount(basicAccount)
-        }
-      })
-
-      let emitCounter2 = 0
-      const unsubscribe2 = accountAdder.onUpdate(() => {
-        emitCounter2++
-
-        // Select account emit is triggered
-        if (emitCounter2 === 4) {
-          expect(accountAdder.selectedAccounts[0].accountKeys).toHaveLength(1)
-          const keyAddr = accountAdder.selectedAccounts[0].accountKeys[0].addr
-          const keyIndex = accountAdder.selectedAccounts[0].accountKeys[0].index
-          expect(keyAddr).toEqual(basicAccount.addr)
-          expect(keyIndex).toEqual(0)
-
-          unsubscribe1()
-          unsubscribe2()
-          resolve(null)
-        }
-      })
-    })
+    expect(accountAdder.selectedAccounts[0].accountKeys).toHaveLength(1)
+    const keyAddr = accountAdder.selectedAccounts[0].accountKeys[0].addr
+    const keyIndex = accountAdder.selectedAccounts[0].accountKeys[0].index
+    expect(keyAddr).toEqual(basicAccount.addr)
+    expect(keyIndex).toEqual(0)
   })
 
   test('should be able to select all the keys of a selected smart account (derived key)', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
     await accountAdder.init({
       keyIterator,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+      shouldSearchForLinkedAccounts: false,
+      shouldGetAccountsUsedOnNetworks: false
     })
-    accountAdder.setPage({ page: 1 })
+    await accountAdder.setPage({ page: 1 })
 
-    return new Promise((resolve) => {
-      // Subscription to select an account
-      let emitCounter1 = 0
-      const unsubscribe1 = accountAdder.onUpdate(() => {
-        emitCounter1++
+    const firstSmartAccount = accountAdder.accountsOnPage.find(
+      (x) => x.slot === 1 && isSmartAccount(x.account)
+    )
+    if (firstSmartAccount) accountAdder.selectAccount(firstSmartAccount.account)
 
-        // First - init, second - start deriving, third - deriving done
-        if (emitCounter1 === 3) {
-          const firstSmartAccount = accountAdder.accountsOnPage.find(
-            (x) => x.slot === 1 && isSmartAccount(x.account)
-          )
-          if (firstSmartAccount) accountAdder.selectAccount(firstSmartAccount.account)
-        }
+    expect(accountAdder.selectedAccounts[0].accountKeys)
+      // Might contain other keys too, but this one should be in there,
+      // since that's the derived used only for smart account key
+      .toContainEqual({
+        addr: key1to11BasicAccUsedForSmartAccKeysOnlyPublicAddresses[0],
+        index: SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET,
+        slot: 1
       })
-
-      let emitCounter2 = 0
-      const unsubscribe2 = accountAdder.onUpdate(() => {
-        emitCounter2++
-
-        // Select account emit is triggered
-        if (emitCounter2 === 4) {
-          expect(accountAdder.selectedAccounts[0].accountKeys)
-            // Might contain other keys too, but this one should be in there,
-            // since that's the derived used only for smart account key
-            .toContainEqual({
-              addr: key1to11BasicAccUsedForSmartAccKeysOnlyPublicAddresses[0],
-              index: SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET,
-              slot: 1
-            })
-
-          unsubscribe1()
-          unsubscribe2()
-          resolve(null)
-        }
-      })
-    })
   })
 
   test('should retrieve all internal keys selected 1) basic accounts and 2) smart accounts', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
     await accountAdder.init({
       keyIterator,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
+      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE,
+      shouldSearchForLinkedAccounts: false,
+      shouldGetAccountsUsedOnNetworks: false
     })
-    accountAdder.setPage({ page: 1 })
+    await accountAdder.setPage({ page: 1 })
 
-    return new Promise((resolve) => {
-      // Subscription to select accounts
-      let emitCounter = 0
-      const unsubscribe = accountAdder.onUpdate(() => {
-        emitCounter++
+    accountAdder.selectAccount(basicAccount)
+    const firstSmartAccount = accountAdder.accountsOnPage.find(
+      (x) => x.slot === 1 && isSmartAccount(x.account)
+    )
+    const secondSmartAccount = accountAdder.accountsOnPage.find(
+      (x) => x.slot === 2 && isSmartAccount(x.account)
+    )
+    if (firstSmartAccount) accountAdder.selectAccount(firstSmartAccount.account)
+    if (secondSmartAccount) accountAdder.selectAccount(secondSmartAccount.account)
 
-        // First - init, second - start deriving, third - deriving done
-        if (emitCounter === 3) {
-          accountAdder.selectAccount(basicAccount)
-          const firstSmartAccount = accountAdder.accountsOnPage.find(
-            (x) => x.slot === 1 && isSmartAccount(x.account)
-          )
-          const secondSmartAccount = accountAdder.accountsOnPage.find(
-            (x) => x.slot === 2 && isSmartAccount(x.account)
-          )
-          if (firstSmartAccount) accountAdder.selectAccount(firstSmartAccount.account)
-          if (secondSmartAccount) accountAdder.selectAccount(secondSmartAccount.account)
+    const internalKeys = accountAdder.retrieveInternalKeysOfSelectedAccounts()
 
-          const internalKeys = accountAdder.retrieveInternalKeysOfSelectedAccounts()
+    expect(internalKeys).toHaveLength(3)
+    const firstKey = internalKeys.filter((k) => k.privateKey === key1PrivateKey)[0]
+    const secondKey = internalKeys.filter(
+      (k) => k.privateKey === key1UsedForSmartAccKeysOnlyPrivateKey
+    )[0]
+    const thirdKey = internalKeys.filter(
+      (k) => k.privateKey === key2UsedForSmartAccKeysOnlyPrivateKey
+    )[0]
 
-          expect(internalKeys).toHaveLength(3)
-          const firstKey = internalKeys.filter((k) => k.privateKey === key1PrivateKey)[0]
-          const secondKey = internalKeys.filter(
-            (k) => k.privateKey === key1UsedForSmartAccKeysOnlyPrivateKey
-          )[0]
-          const thirdKey = internalKeys.filter(
-            (k) => k.privateKey === key2UsedForSmartAccKeysOnlyPrivateKey
-          )[0]
-
-          expect(firstKey).toEqual(
-            expect.objectContaining({
-              privateKey: key1PrivateKey,
-              label: 'Key 1',
-              dedicatedToOneSA: false
-            })
-          )
-          expect(secondKey).toEqual(
-            expect.objectContaining({
-              privateKey: key1UsedForSmartAccKeysOnlyPrivateKey,
-              label: 'Key 1',
-              dedicatedToOneSA: true
-            })
-          )
-          expect(thirdKey).toEqual(
-            expect.objectContaining({
-              privateKey: key2UsedForSmartAccKeysOnlyPrivateKey,
-              label: 'Key 1',
-              dedicatedToOneSA: true
-            })
-          )
-
-          unsubscribe()
-          resolve(null)
-        }
+    expect(firstKey).toEqual(
+      expect.objectContaining({
+        privateKey: key1PrivateKey,
+        label: 'Key 1',
+        dedicatedToOneSA: false
       })
-    })
+    )
+    expect(secondKey).toEqual(
+      expect.objectContaining({
+        privateKey: key1UsedForSmartAccKeysOnlyPrivateKey,
+        label: 'Key 1',
+        dedicatedToOneSA: true
+      })
+    )
+    expect(thirdKey).toEqual(
+      expect.objectContaining({
+        privateKey: key2UsedForSmartAccKeysOnlyPrivateKey,
+        label: 'Key 1',
+        dedicatedToOneSA: true
+      })
+    )
   })
 
   DERIVATION_OPTIONS.forEach(({ label, value }) => {
     test(`should derive correctly ${label}`, async () => {
       const keyIterator = new KeyIterator(process.env.SEED)
       const pageSize = 5
-      await accountAdder.init({ keyIterator, hdPathTemplate: value, pageSize })
+      await accountAdder.init({
+        keyIterator,
+        hdPathTemplate: value,
+        pageSize,
+        shouldSearchForLinkedAccounts: false,
+        shouldGetAccountsUsedOnNetworks: false
+      })
 
       // Checks page 1 Basic Accounts
       await accountAdder.setPage({ page: 1 })

--- a/src/controllers/accountAdder/accountAdder.test.ts
+++ b/src/controllers/accountAdder/accountAdder.test.ts
@@ -105,7 +105,7 @@ describe('AccountAdder', () => {
   beforeEach(() => {
     accountAdder = new AccountAdderController({
       accounts: accountsCtrl,
-      keystore: new KeystoreController(produceMemoryStore(), {}),
+      keystore: new KeystoreController(storage, {}),
       networks: networksCtrl,
       providers: providersCtrl,
       relayerUrl,
@@ -115,17 +115,17 @@ describe('AccountAdder', () => {
 
   test('should initialize', async () => {
     const keyIterator = new KeyIterator(process.env.SEED)
-    await accountAdder.init({
-      keyIterator,
-      hdPathTemplate: BIP44_STANDARD_DERIVATION_TEMPLATE
-    })
+    const hdPathTemplate = BIP44_STANDARD_DERIVATION_TEMPLATE
+    await accountAdder.init({ keyIterator, hdPathTemplate })
 
     expect(accountAdder.page).toEqual(DEFAULT_PAGE)
     expect(accountAdder.pageSize).toEqual(DEFAULT_PAGE_SIZE)
     expect(accountAdder.isInitialized).toBeTruthy()
     expect(accountAdder.isInitializedWithDefaultSeed).toBeFalsy()
     expect(accountAdder.selectedAccounts).toEqual([])
-    expect(accountAdder.hdPathTemplate).toEqual(BIP44_STANDARD_DERIVATION_TEMPLATE)
+    expect(accountAdder.hdPathTemplate).toEqual(hdPathTemplate)
+    expect(accountAdder.shouldGetAccountsUsedOnNetworks).toBeTruthy()
+    expect(accountAdder.shouldSearchForLinkedAccounts).toBeTruthy()
   })
 
   test('should throw if AccountAdder controller method is requested, but the controller was not initialized beforehand', (done) => {

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -419,7 +419,7 @@ export class AccountAdderController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async deselectAccount(account: Account) {
+  deselectAccount(account: Account) {
     if (!this.isInitialized) return this.#throwNotInitialized()
     if (!this.#keyIterator) return this.#throwMissingKeyIterator()
 
@@ -503,7 +503,7 @@ export class AccountAdderController extends EventEmitter {
     this.accountsLoading = false
     this.emitUpdate()
 
-    this.#findAndSetLinkedAccounts({
+    await this.#findAndSetLinkedAccounts({
       accounts: this.#derivedAccounts
         .filter(
           (acc) =>

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -306,7 +306,7 @@ export class AccountAdderController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async setHDPathTemplate({ hdPathTemplate }: { hdPathTemplate: HD_PATH_TEMPLATE_TYPE }): void {
+  async setHDPathTemplate({ hdPathTemplate }: { hdPathTemplate: HD_PATH_TEMPLATE_TYPE }) {
     this.hdPathTemplate = hdPathTemplate
 
     // Reset the currently selected accounts, because for the keys of these

--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -306,7 +306,7 @@ export class AccountAdderController extends EventEmitter {
     this.emitUpdate()
   }
 
-  setHDPathTemplate({ hdPathTemplate }: { hdPathTemplate: HD_PATH_TEMPLATE_TYPE }): void {
+  async setHDPathTemplate({ hdPathTemplate }: { hdPathTemplate: HD_PATH_TEMPLATE_TYPE }): void {
     this.hdPathTemplate = hdPathTemplate
 
     // Reset the currently selected accounts, because for the keys of these
@@ -314,7 +314,7 @@ export class AccountAdderController extends EventEmitter {
     // completes, only the latest hd path of the controller is stored.
     this.selectedAccounts = []
 
-    this.setPage({ page: DEFAULT_PAGE }) // takes the user back on the first page
+    await this.setPage({ page: DEFAULT_PAGE }) // takes the user back on the first page
   }
 
   #getAccountKeys(account: Account, accountsOnPageWithThisAcc: AccountOnPage[]) {


### PR DESCRIPTION
After the HD path changes, I noticed that the Account Adder tests were left a bit behind. So in this PR, I'm migrating them to the concept described in https://github.com/AmbireTech/ambire-app/issues/2454 , and also:

- Changed: Speed unit tests up by using the `shouldGetAccountsUsedOnNetworks` and `shouldSearchForLinkedAccounts` flags where appropriate
- Changed: Await all actions happening in the `setPage()` flow