### PR TITLE
Bug / Transaction (call) can't be deleted from a batch

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1140,7 +1140,7 @@ export class MainController extends EventEmitter {
       const account = this.accounts.accounts.find((x) => x.addr === meta.accountAddr)!
       const accountState = this.accounts.accountStates[meta.accountAddr][meta.networkId]
 
-      if (account.creation) {
+      if (isSmartAccount(account)) {
         const network = this.networks.networks.find((n) => n.id === meta.networkId)!
 
         // find me the accountOp for the network if any, it's always 1 for SA
@@ -1188,7 +1188,7 @@ export class MainController extends EventEmitter {
         this.actions.addOrUpdateAction(accountOpAction, withPriority, executionType)
         if (this.signAccountOp) {
           if (this.signAccountOp.fromActionId === accountOpAction.id) {
-            this.signAccountOp.update({ accountOp: accountOpAction.accountOp })
+            this.signAccountOp.update({ calls: accountOpAction.accountOp.calls })
             this.estimateSignAccountOp()
           }
         } else {
@@ -1260,7 +1260,7 @@ export class MainController extends EventEmitter {
           `batchCallsFromUserRequests: tried to run for non-existent account ${meta.accountAddr}`
         )
 
-      if (account.creation) {
+      if (isSmartAccount(account)) {
         const accountOpIndex = this.actions.actionsQueue.findIndex(
           (a) => a.type === 'accountOp' && a.id === `${meta.accountAddr}-${meta.networkId}`
         )
@@ -1282,7 +1282,7 @@ export class MainController extends EventEmitter {
           this.actions.addOrUpdateAction(accountOpAction)
 
           if (this.signAccountOp && this.signAccountOp.fromActionId === accountOpAction.id) {
-            this.signAccountOp.update({ accountOp: accountOpAction.accountOp, estimation: null })
+            this.signAccountOp.update({ calls: accountOpAction.accountOp.calls, estimation: null })
             this.estimateSignAccountOp()
           }
         } else {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -397,13 +397,12 @@ export class SignAccountOpController extends EventEmitter {
     speed,
     signingKeyAddr,
     signingKeyType,
-    accountOp,
+    calls,
     gasUsedTooHighAgreed,
     rbfAccountOps,
     bundlerGasPrices,
     blockGasLimit
   }: {
-    accountOp?: AccountOp
     gasPrices?: GasRecommendation[]
     estimation?: EstimateResult | null
     feeToken?: TokenResult
@@ -411,6 +410,7 @@ export class SignAccountOpController extends EventEmitter {
     speed?: FeeSpeed
     signingKeyAddr?: Key['addr']
     signingKeyType?: Key['type']
+    calls?: AccountOp['calls']
     gasUsedTooHighAgreed?: boolean
     rbfAccountOps?: { [key: string]: SubmittedAccountOp | null }
     bundlerGasPrices?: BundlerGasPrice
@@ -427,13 +427,7 @@ export class SignAccountOpController extends EventEmitter {
       return
     }
 
-    const shouldUpdateAccountOp =
-      accountOp &&
-      accountOp.networkId === this.accountOp.networkId &&
-      accountOp.accountAddr === this.accountOp.accountAddr
-    if (shouldUpdateAccountOp) {
-      this.accountOp = { ...this.accountOp, ...accountOp }
-    }
+    if (Array.isArray(calls)) this.accountOp.calls = calls
 
     if (blockGasLimit) this.#blockGasLimit = blockGasLimit
 
@@ -490,7 +484,7 @@ export class SignAccountOpController extends EventEmitter {
 
     // calculate the fee speeds if either there are no feeSpeeds
     // or any of properties for update is requested
-    if (!Object.keys(this.feeSpeeds).length || accountOp || gasPrices || estimation) {
+    if (!Object.keys(this.feeSpeeds).length || Array.isArray(calls) || gasPrices || estimation) {
       this.#updateFeeSpeeds()
     }
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -480,6 +480,12 @@ export class SignAccountOpController extends EventEmitter {
       this.estimation.erc4337GasLimits.gasPrice = bundlerGasPrices
     }
 
+    const shouldUpdateAccountOpCalls =
+      accountOp && accountOp.calls.length !== this.accountOp.calls.length
+    if (shouldUpdateAccountOpCalls) {
+      this.accountOp.calls = accountOp.calls
+    }
+
     // calculate the fee speeds if either there are no feeSpeeds
     // or any of properties for update is requested
     if (!Object.keys(this.feeSpeeds).length || accountOp || gasPrices || estimation) {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -427,6 +427,14 @@ export class SignAccountOpController extends EventEmitter {
       return
     }
 
+    const shouldUpdateAccountOp =
+      accountOp &&
+      accountOp.networkId === this.accountOp.networkId &&
+      accountOp.accountAddr === this.accountOp.accountAddr
+    if (shouldUpdateAccountOp) {
+      this.accountOp = { ...this.accountOp, ...accountOp }
+    }
+
     if (blockGasLimit) this.#blockGasLimit = blockGasLimit
 
     if (gasPrices) this.gasPrices = gasPrices
@@ -478,12 +486,6 @@ export class SignAccountOpController extends EventEmitter {
     // update the bundler gas prices
     if (this.estimation?.erc4337GasLimits && bundlerGasPrices) {
       this.estimation.erc4337GasLimits.gasPrice = bundlerGasPrices
-    }
-
-    const shouldUpdateAccountOpCalls =
-      accountOp && accountOp.calls.length !== this.accountOp.calls.length
-    if (shouldUpdateAccountOpCalls) {
-      this.accountOp.calls = accountOp.calls
     }
 
     // calculate the fee speeds if either there are no feeSpeeds


### PR DESCRIPTION
The `update` method of the SingAccountOp controller was not handling the case when an account op with updated (deleted) calls was passed.

Moreover, this PR refactors the other use-case where the full `accountIOp` got passed (which should not be the case), because this would reset other props that could cause potential bugs).

Resolves https://github.com/AmbireTech/ambire-app/issues/2875