### PR TITLE
Fix: allow V1 signatures for safe messages

### DIFF
--- a/src/libs/signMessage/signMessage.test.ts
+++ b/src/libs/signMessage/signMessage.test.ts
@@ -1,4 +1,4 @@
-import { Contract, hashMessage, hexlify, toUtf8Bytes, TypedDataEncoder, Wallet } from 'ethers'
+import { Contract, hashMessage, toUtf8Bytes, TypedDataEncoder, Wallet } from 'ethers'
 
 import { beforeAll, describe, expect, test } from '@jest/globals'
 

--- a/src/libs/signMessage/signMessage.test.ts
+++ b/src/libs/signMessage/signMessage.test.ts
@@ -1,4 +1,4 @@
-import { Contract, hashMessage, toUtf8Bytes, TypedDataEncoder, Wallet } from 'ethers'
+import { Contract, hashMessage, hexlify, toUtf8Bytes, TypedDataEncoder, Wallet } from 'ethers'
 
 import { beforeAll, describe, expect, test } from '@jest/globals'
 
@@ -214,7 +214,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     const accountStates = await getAccountsInfo([v1Account])
     const signer = await keystore.getSigner(v1siger.keyPublicAddress, 'internal')
 
-    const msg = `test for ${v1Account.addr}`
+    const msg = hexlify(toUtf8Bytes(`test for ${v1Account.addr}`))
     const signatureForPlainText = await getPlainTextSignature(
       msg,
       polygonNetwork,

--- a/src/libs/signMessage/signMessage.test.ts
+++ b/src/libs/signMessage/signMessage.test.ts
@@ -214,7 +214,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     const accountStates = await getAccountsInfo([v1Account])
     const signer = await keystore.getSigner(v1siger.keyPublicAddress, 'internal')
 
-    const msg = hexlify(toUtf8Bytes(`test for ${v1Account.addr}`))
+    const msg = `test for ${v1Account.addr}`
     const signatureForPlainText = await getPlainTextSignature(
       msg,
       polygonNetwork,

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -292,6 +292,7 @@ export async function getPlainTextSignature(
 
   if (!accountState.isV2) {
     const humanReadableMsg = message instanceof Uint8Array ? hexlify(message) : message
+    // issue win this if
     if (humanReadableMsg.toLowerCase().indexOf(account.addr.toLowerCase()) !== -1) {
       return wrapUnprotected(await signer.signMessage(messageHex))
     }

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -291,15 +291,23 @@ export async function getPlainTextSignature(
   }
 
   if (!accountState.isV2) {
+    const lowercaseHexAddrWithout0x = hexlify(toUtf8Bytes(account.addr.toLowerCase().slice(2)))
+    const checksummedHexAddrWithout0x = hexlify(toUtf8Bytes(account.addr.slice(2)))
+    const asciiAddrLowerCase = account.addr.toLowerCase()
     const humanReadableMsg = message instanceof Uint8Array ? hexlify(message) : message
-    // NOTE: tmp fix for allowing some plaintext signatures for V1 accounts
-    // the problem was that some signatures are passed as ascii and some are hex from the original ascii
-    const lowerCaseAddr = hexlify(toUtf8Bytes(account.addr.toLowerCase().slice(2)))
-    const checksummedCaseAddr = hexlify(toUtf8Bytes(account.addr.slice(2)))
+
+    const isAsciiAddressInMessage = humanReadableMsg.toLowerCase().includes(asciiAddrLowerCase)
+    const isLowercaseHexAddressInMessage = humanReadableMsg.includes(
+      lowercaseHexAddrWithout0x.slice(2)
+    )
+    const isChecksummedHexAddressInMessage = humanReadableMsg.includes(
+      checksummedHexAddrWithout0x.slice(2)
+    )
+
     if (
-      humanReadableMsg.toLowerCase().includes(account.addr.toLowerCase()) ||
-      humanReadableMsg.includes(lowerCaseAddr.slice(2)) ||
-      humanReadableMsg.includes(checksummedCaseAddr.slice(2))
+      isAsciiAddressInMessage ||
+      isLowercaseHexAddressInMessage ||
+      isChecksummedHexAddressInMessage
     ) {
       return wrapUnprotected(await signer.signMessage(messageHex))
     }

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -14,7 +14,6 @@ import {
   TypedDataEncoder,
   TypedDataField
 } from 'ethers'
-import { humanizeMessage } from 'libs/humanizer'
 
 import UniversalSigValidator from '../../../contracts/compiled/UniversalSigValidator.json'
 import { PERMIT_2_ADDRESS, UNISWAP_UNIVERSAL_ROUTERS } from '../../consts/addresses'


### PR DESCRIPTION
WC's airdrop requires plaintext signature
The signatures contains the address of the V1 acc, but we did not detect that correctly and we used to disallow it. This PR fixes the issue. 