### PR TITLE
Disable estimateGas for smart accounts on ethereum

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -20,7 +20,8 @@ const networks: Network[] = [
     features: [],
     feeOptions: { is1559: true },
     predefined: true,
-    wrappedAddr: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+    wrappedAddr: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    disableEstimateGas: true
   },
   {
     id: 'polygon',

--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -72,6 +72,7 @@ export interface Network {
   wrappedAddr?: string
   blockGasLimit?: bigint
   oldNativeAssetSymbols?: string[]
+  disableEstimateGas?: boolean
 }
 
 export interface AddNetworkRequestParams {

--- a/src/libs/estimate/estimateGas.ts
+++ b/src/libs/estimate/estimateGas.ts
@@ -17,6 +17,8 @@ export async function estimateGas(
   accountState: AccountOnchainState,
   network: Network
 ): Promise<bigint> {
+  if (network.disableEstimateGas) return 0n
+
   if (!account.creation) throw new Error('Use this estimation only for smart accounts')
 
   const saAbi = new Interface(AmbireAccount.abi)


### PR DESCRIPTION
Disable estimateGas for smart accounts on ethereum. There are the differences that we achieve by doing this.  
From:  
![Screenshot from 2024-10-07 09-30-04](https://github.com/user-attachments/assets/58347ad0-8762-4d34-8099-4e9558459965)
To:  
![Screenshot from 2024-10-07 09-29-40](https://github.com/user-attachments/assets/e6daa305-fb85-423c-b539-a48fbfb92934)
