### PR TITLE
Update/ Overwrite hasRelayer on #load in networks ctrl

### DIFF
--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -108,6 +108,7 @@ export class NetworksController extends EventEmitter {
         ...n, // add the latest structure of the predefined network to include the new props that are not in storage yet
         ...(this.#networks[n.id] || {}), // override with stored props
         feeOptions: n.feeOptions, // feeOptions should take predefined priority
+        hasRelayer: n.hasRelayer, // hasRelayer should take predefined priority
         nativeAssetId: n.nativeAssetId, // nativeAssetId should take predefined priority
         nativeAssetSymbol: n.nativeAssetSymbol // nativeAssetSymbol should take predefined priority
       }


### PR DESCRIPTION
If we don't overwrite the flag this bug can happen:
1. Network A isn't predefined in the extension
2. User adds network A as a custom network `hasRelayer: false` because it's a custom network
3. Network A is added to the list of predefined networks (and is supported by the relayer so `hasRelayer: true`)
4. `hasRelayer` remains false and the user can't use v1 accounts