### PR TITLE
Config / Normalize all incoming and outgoing Socket API tokens

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1,4 +1,4 @@
-import { formatUnits, getAddress, parseUnits } from 'ethers'
+import { formatUnits, parseUnits } from 'ethers'
 
 import { Storage } from '../../interfaces/storage'
 import {
@@ -13,7 +13,7 @@ import { getTokenAmount } from '../../libs/portfolio/helpers'
 import { getQuoteRouteSteps, sortTokenListResponse } from '../../libs/swapAndBridge/swapAndBridge'
 import { getSanitizedAmount } from '../../libs/transfer/amount'
 import { formatNativeTokenAddressIfNeeded } from '../../services/address'
-import { normalizeNativeTokenAddressIfNeeded, SocketAPI } from '../../services/socket/api'
+import { SocketAPI } from '../../services/socket/api'
 import { validateSendTransferAmount } from '../../services/validations/validate'
 import { convertTokenPriceToBigInt } from '../../utils/numbers/formatters'
 import { AccountsController } from '../accounts/accounts'
@@ -196,8 +196,7 @@ export class SwapAndBridgeController extends EventEmitter {
 
     return !!this.portfolioTokenList.find(
       (token: TokenResult) =>
-        getAddress(normalizeNativeTokenAddressIfNeeded(token.address)) ===
-          getAddress(normalizeNativeTokenAddressIfNeeded(this.toSelectedToken!.address)) &&
+        token.address === this.toSelectedToken!.address &&
         token.networkId === toSelectedTokenNetwork.id
     )
   }
@@ -401,11 +400,7 @@ export class SwapAndBridgeController extends EventEmitter {
 
         if (!this.toSelectedToken) {
           if (addressToSelect) {
-            const token = this.toTokenList.find(
-              (t) =>
-                getAddress(normalizeNativeTokenAddressIfNeeded(t.address)) ===
-                getAddress(normalizeNativeTokenAddressIfNeeded(addressToSelect))
-            )
+            const token = this.toTokenList.find((t) => t.address === addressToSelect)
             if (token) {
               this.updateForm({ toSelectedToken: token })
               this.emitUpdate()
@@ -431,8 +426,7 @@ export class SwapAndBridgeController extends EventEmitter {
     )!
     this.fromSelectedToken = this.portfolioTokenList.find(
       (token: TokenResult) =>
-        getAddress(normalizeNativeTokenAddressIfNeeded(token.address)) ===
-          getAddress(normalizeNativeTokenAddressIfNeeded(this.toSelectedToken!.address)) &&
+        token.address === this.toSelectedToken!.address &&
         token.networkId === toSelectedTokenNetwork.id
     )!
     // Reverses the from and to chain ids, since their format is the same

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -13,7 +13,6 @@ import {
 } from '../../interfaces/swapAndBridge'
 import { SignUserRequest } from '../../interfaces/userRequest'
 import { formatNativeTokenAddressIfNeeded } from '../../services/address'
-import { normalizeNativeTokenAddressIfNeeded } from '../../services/socket/api'
 import { isSmartAccount } from '../account/account'
 import { Call } from '../accountOp/types'
 import { TokenResult } from '../portfolio'
@@ -22,22 +21,14 @@ export const sortTokenListResponse = (
   tokenListResponse: SocketAPIToken[],
   accountPortfolioTokenList: TokenResult[]
 ) => {
-  const normalizedPortfolioTokenList = accountPortfolioTokenList.map((t) => ({
-    ...t,
-    address: normalizeNativeTokenAddressIfNeeded(
-      // incoming token addresses from Socket (to compare against) are lowercased
-      t.address.toLowerCase()
-    )
-  }))
-
   return (
     tokenListResponse
       // Alphabetically, by project name (not token symbol)
       .sort((a: SocketAPIToken, b: SocketAPIToken) => a.name?.localeCompare(b?.name))
       // Sort fist the tokens that exist in the account portfolio
       .sort((a: SocketAPIToken, b: SocketAPIToken) => {
-        const aInPortfolio = normalizedPortfolioTokenList.some((t) => t.address === a.address)
-        const bInPortfolio = normalizedPortfolioTokenList.some((t) => t.address === b.address)
+        const aInPortfolio = accountPortfolioTokenList.some((t) => t.address === a.address)
+        const bInPortfolio = accountPortfolioTokenList.some((t) => t.address === b.address)
 
         if (aInPortfolio && !bInPortfolio) return -1
         if (!aInPortfolio && bInPortfolio) return 1

--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -9,6 +9,7 @@ import {
 import {
   AMBIRE_FEE_TAKER_ADDRESSES,
   ETH_ON_OPTIMISM_LEGACY_ADDRESS,
+  FEE_PERCENT,
   NULL_ADDRESS,
   ZERO_ADDRESS
 } from './constants'
@@ -139,8 +140,9 @@ export class SocketAPI {
       toTokenAddress: normalizeOutgoingSocketTokenAddress(toTokenAddress),
       fromAmount: fromAmount.toString(),
       userAddress,
-      // TODO: Figure out why passing this prop is causing error 500 in the API
-      // feeTakerAddress: normalizeOutgoingSocketTokenAddress(AMBIRE_FEE_TAKER_ADDRESSES[fromChainId]),
+      // TODO: Enable when needed
+      // feeTakerAddress: AMBIRE_FEE_TAKER_ADDRESSES[fromChainId],
+      // feePercent: FEE_PERCENT.toString(),
       isContractCall: isSmartAccount.toString(), // only get quotes with that are compatible with contracts
       sort,
       singleTxOnly: 'false',

--- a/src/services/socket/constants.ts
+++ b/src/services/socket/constants.ts
@@ -5,6 +5,12 @@ export const NULL_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 
 export const ETH_ON_OPTIMISM_LEGACY_ADDRESS = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000'
 
+/**
+ * The % of fee to be cut from the source input token amount.
+ * Can be up to three decimal places and cannot be more than 5%.
+ */
+export const FEE_PERCENT = 0.001
+
 export const AMBIRE_FEE_TAKER_ADDRESSES: { [chainId: number]: string } = {
   324: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
   1101: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',

--- a/src/services/socket/constants.ts
+++ b/src/services/socket/constants.ts
@@ -1,9 +1,9 @@
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
-export const L2_ZERO_ADDRESS = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000'
-
-// Yes, this is a real address. It's similar to the zero address. It's just a fancy
-// looking address that nobody knows the private key of. Some people use it to burn funds.
+// Some services (like Socket) use the null token address to represent the
+// native token as the ZERO_ADDRESS is not standard for it.
 export const NULL_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+
+export const ETH_ON_OPTIMISM_LEGACY_ADDRESS = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000'
 
 export const AMBIRE_FEE_TAKER_ADDRESSES: { [chainId: number]: string } = {
   324: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',


### PR DESCRIPTION
Handles 3 specifics found while working with the Socket API:

- Incoming token addresses from Socket are all lowercased (while we internally use only check-summed addresses). Outgoing token addresses should be all lowercase, Socket API works only with all lowercased addresses, otherwise, it fires status 500 (bad request)
- Socket API uses the null address (instead of the zero address) to represent a native token address
- On the Optimism network, there are two ETH tokens, we strip out the legacy one until Socket updates its API response.