### PR TITLE
Better preVerificationGas estimation

### DIFF
--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -109,7 +109,7 @@ export async function estimate4337(
   const estimateGasOp = { ...op }
   if (shouldUsePaymaster(network)) {
     const feeToken = getFeeTokenForEstimate(feeTokens)
-    if (feeToken) estimateGasOp.feeCall = getFeeCall(feeToken, 1n)
+    if (feeToken) estimateGasOp.feeCall = getFeeCall(feeToken)
   }
   const estimations = await Promise.all([
     deploylessEstimator

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -41,7 +41,7 @@ export async function bundlerEstimate(
   const usesPaymaster = shouldUsePaymaster(network)
   if (usesPaymaster) {
     const feeToken = getFeeTokenForEstimate(feeTokens)
-    if (feeToken) localOp.feeCall = getFeeCall(feeToken, 1n)
+    if (feeToken) localOp.feeCall = getFeeCall(feeToken)
   }
   const userOp = getUserOperation(
     account,

--- a/src/libs/estimate/estimateHelpers.ts
+++ b/src/libs/estimate/estimateHelpers.ts
@@ -5,6 +5,14 @@ import { TokenResult } from '../portfolio'
 export function getFeeTokenForEstimate(feeTokens: TokenResult[]): TokenResult | null {
   if (!feeTokens.length) return null
 
+  // we prioritize the gasTank as on L2 networks, the gasTank commitment
+  // actually results in bigger preVerificationGas (ERC-4337). Low
+  // preVerificationGas will cause the paymaster to refuse the userOp
+  const gasTankToken = feeTokens.find(
+    (feeToken) => feeToken.flags.onGasTank && feeToken.amount > 0n
+  )
+  if (gasTankToken) return gasTankToken
+
   const erc20token = feeTokens.find(
     (feeToken) =>
       feeToken.address !== ZeroAddress && !feeToken.flags.onGasTank && feeToken.amount > 0n
@@ -15,10 +23,5 @@ export function getFeeTokenForEstimate(feeTokens: TokenResult[]): TokenResult | 
     (feeToken) =>
       feeToken.address === ZeroAddress && !feeToken.flags.onGasTank && feeToken.amount > 0n
   )
-  if (nativeToken) return nativeToken
-
-  const gasTankToken = feeTokens.find(
-    (feeToken) => feeToken.flags.onGasTank && feeToken.amount > 0n
-  )
-  return gasTankToken ?? null
+  return nativeToken ?? null
 }


### PR DESCRIPTION
Changes:
* when doing 4337 estimation, prioritize the gas tank commitment for the estimation as that brings a bigger `preVerificationGas` to the table. Previously, the paymaster refused the txn as we prioritized a fee token approval for ambire-app estimation which resulted in lower `preVerificationGas` compared to the gas tank commitment done on the relayer's paymaster estimation
* bigger numbers for gas tank / approvals for better `preVerificationGas`