### PR TITLE
Fix: bundler estimation fee

### DIFF
--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -130,6 +130,16 @@ export function getSignableCalls(op: AccountOp): [string, string, string][] {
   return callsToSign
 }
 
+export function getSignableCallsForBundlerEstimate(op: AccountOp): [string, string, string][] {
+  const callsToSign = getSignableCalls(op)
+  // add the fee call one more time when doing a bundler estimate
+  // this is because the feeCall during estimation is fake (approve instead
+  // of transfer, incorrect amount) and more ofteh than not, this causes
+  // a lower estimation than the real one, causing bad UX in the process
+  if (op.feeCall) callsToSign.push(callToTuple(op.feeCall))
+  return callsToSign
+}
+
 export function getSignableHash(
   addr: AccountId,
   chainId: bigint,

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -4,7 +4,7 @@ import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import { Account, AccountStates } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
 import { Bundler } from '../../services/bundlers/bundler'
-import { AccountOp, getSignableCalls } from '../accountOp/accountOp'
+import { AccountOp, getSignableCallsForBundlerEstimate } from '../accountOp/accountOp'
 import { getFeeCall } from '../calls/calls'
 import { TokenResult } from '../portfolio'
 import {
@@ -76,7 +76,9 @@ export async function bundlerEstimate(
   if (userOp.activatorCall) localOp.activatorCall = userOp.activatorCall
 
   const ambireAccount = new Interface(AmbireAccount.abi)
-  userOp.callData = ambireAccount.encodeFunctionData('executeBySender', [getSignableCalls(localOp)])
+  userOp.callData = ambireAccount.encodeFunctionData('executeBySender', [
+    getSignableCallsForBundlerEstimate(localOp)
+  ])
   userOp.signature = getSigForCalculations()
   const shouldStateOverride = !accountState.isErc4337Enabled && accountState.isDeployed
   const gasData = await Bundler.estimate(userOp, network, shouldStateOverride).catch((e: any) => {


### PR DESCRIPTION
When doing a bundler estimation, calculate the fee call twice as more often than not, one time is not bringing good enough results