### PR TITLE
Fix check for permit on erc20 typed message humanizer module

### DIFF
--- a/src/libs/humanizer/messageModules/erc20Module.ts
+++ b/src/libs/humanizer/messageModules/erc20Module.ts
@@ -8,11 +8,8 @@ export const erc20Module: HumanizerTypedMessageModule = (message: Message) => {
   if (
     tm.types.Permit &&
     tm.primaryType === 'Permit' &&
-    tm.message.owner &&
-    tm.message.spender &&
-    tm.message.value &&
-    tm.message.nonce &&
-    tm.message.deadline &&
+    tm.message &&
+    ['owner', 'spender', 'value', 'nonce', 'deadline'].every((i) => i in tm.message) &&
     tm.domain.verifyingContract
   ) {
     return {


### PR DESCRIPTION
in the humanizer typed message permit module we used to check if properties are present by simply evaluating them, but if, for example nonce was 0 we would consider it as absent. 

- This fixes erc20 permit typed message when nonce = 0 (on first permit for this contract)