### PR TITLE
[Mobile app] Fix for String Conversion in fetchAllSupplementTokenData to Prevent Function Call Failure

### DIFF
--- a/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
+++ b/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
@@ -256,6 +256,10 @@ export default function useBalanceOracleFetch({
     // there is an edge case where the 1. approve is slower
     // than the 2. stake transaction and the response from balance oracle
     // overrides the correct one
+
+    // Adding toString() check to handle cases where the id is a number.
+    // In the Hermes engine (used in React Native), this check can fail silently and prevent function execution.
+    // In contrast, in the web app (using a different JavaScript engine), it doesn't fail due to if statement coercion.
     const shouldWaitForPending =
       eligibleRequests.length === 1 && eligibleRequests[0].id.toString().includes('approve')
 

--- a/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
+++ b/src/hooks/usePortfolio/usePortfolioFetch/useBalanceOracleFetch.ts
@@ -257,7 +257,7 @@ export default function useBalanceOracleFetch({
     // than the 2. stake transaction and the response from balance oracle
     // overrides the correct one
     const shouldWaitForPending =
-      eligibleRequests.length === 1 && eligibleRequests[0].id.includes('approve')
+      eligibleRequests.length === 1 && eligibleRequests[0].id.toString().includes('approve')
 
     if (shouldWaitForPending) return
     const unsignedRequests = eligibleRequests
@@ -743,7 +743,9 @@ export default function useBalanceOracleFetch({
       .filter((token) => token.coingeckoId)
       .filter(
         (token) =>
-         !token?.price === 0 || !token?.priceUpdate || new Date().valueOf() - token.priceUpdate >= minutesToCheckForUpdate
+          !token?.price === 0 ||
+          !token?.priceUpdate ||
+          new Date().valueOf() - token.priceUpdate >= minutesToCheckForUpdate
       )
     const customTokens = constants?.customTokens?.filter((ct) => {
       const tokenToUpdate = tokens.find(


### PR DESCRIPTION
The issue this PR fixes is `fetchAllSupplementTokenData` function was not executing correctly in React Native when the id field in eligibleRequests was a number. The cause of the problem is that the `.includes()` method was being called on the id field without ensuring it was a string, which led to silent failures when id was a number.

This issue did not appear in web wallet due to differences in JavaScript engines and how they handle type coercion AND when it is in an if statement it does not fail, but returns false. React native app uses Hermes which is stricter and does not automatically handle coercion.

Due to this issue the function `fetchAllSupplementTokenData` is not being called and the simulation is not available on the dashboard from portfolio.