### PR TITLE
Fix / Benzin Action Removal

### DIFF
--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -141,10 +141,9 @@ export class ActionsController extends EventEmitter {
     withPriority?: boolean,
     executionType: 'queue' | 'open' = 'open'
   ) {
-    if (withPriority) {
-      // remove the benzin action if a new actions is added
-      this.actionsQueue = this.actionsQueue.filter((a) => a.type !== 'benzin')
-    }
+    // remove the benzin action if a new actions is added
+    this.actionsQueue = this.actionsQueue.filter((a) => a.type !== 'benzin')
+
     const actionIndex = this.actionsQueue.findIndex((a) => a.id === newAction.id)
     if (actionIndex !== -1) {
       this.actionsQueue[actionIndex] = newAction


### PR DESCRIPTION
* Several users reported that the Benzin screen wasn’t hiding when a new transaction was added, specifically when the action needed to be queued. This happened when a new transaction was batched and added to an existing accountOp action. Fixed this by removing the logic that prevents the Benzin action from being removed after adding an action with executionType = 'queue'. Now, regardless of the action type, the Benzin action will always be removed as expected.