### PR TITLE
Refactor/ Reduce get account state calls

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -210,7 +210,11 @@ export class AccountsController extends EventEmitter {
     const defaultSelectedAccount = getDefaultSelectedAccount(accounts)
     if (defaultSelectedAccount) {
       await this.#selectAccount(defaultSelectedAccount.addr)
-      await this.updateAccountState(defaultSelectedAccount.addr)
+      // Don't wait for account state because:
+      // 1. The extension works perfectly fine without it
+      // 2. Some RPCs may be slow and we don't want to block the UI
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.updateAccountState(defaultSelectedAccount.addr)
     }
 
     this.emitUpdate()

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -96,18 +96,23 @@ export class AccountsController extends EventEmitter {
       this.emitUpdate()
       return
     }
-    // TODO: error handling, trying to switch to account that does not exist
-    if (!this.accounts.find((acc) => acc.addr === toAccountAddr)) return
+    if (!this.accounts.find((acc) => acc.addr === toAccountAddr)) {
+      console.error(`Account with address ${toAccountAddr} does not exist`)
+      return
+    }
     this.selectedAccount = toAccountAddr
-    await this.#storage.set('selectedAccount', toAccountAddr)
     this.#onSelectAccount(toAccountAddr)
+    await this.updateAccountState(toAccountAddr)
+    await this.#storage.set('selectedAccount', toAccountAddr)
 
     this.emitUpdate()
   }
 
   async updateAccountStates(blockTag: string | number = 'latest', networks: NetworkId[] = []) {
-    await this.withStatus('updateAccountStates', async () =>
-      this.#updateAccountStates(this.accounts, blockTag, networks)
+    await this.withStatus(
+      'updateAccountStates',
+      async () => this.#updateAccountStates(this.accounts, blockTag, networks),
+      true
     )
   }
 
@@ -120,8 +125,10 @@ export class AccountsController extends EventEmitter {
 
     if (!accountData) return
 
-    await this.withStatus('updateAccountState', async () =>
-      this.#updateAccountStates([accountData], blockTag, networks)
+    await this.withStatus(
+      'updateAccountState',
+      async () => this.#updateAccountStates([accountData], blockTag, networks),
+      true
     )
   }
 
@@ -203,9 +210,8 @@ export class AccountsController extends EventEmitter {
     const defaultSelectedAccount = getDefaultSelectedAccount(accounts)
     if (defaultSelectedAccount) {
       await this.#selectAccount(defaultSelectedAccount.addr)
+      await this.updateAccountState(defaultSelectedAccount.addr)
     }
-
-    await this.updateAccountStates()
 
     this.emitUpdate()
   }

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -69,8 +69,6 @@ const getTokens = async () => {
   const ethAccPortfolio = await ethPortfolio.get(PLACEHOLDER_SELECTED_ACCOUNT.addr)
   const polygonAccPortfolio = await polygonPortfolio.get(PLACEHOLDER_SELECTED_ACCOUNT.addr)
 
-  console.log('ethAccPortfolio', ethAccPortfolio)
-  console.log('polygonAccPortfolio', polygonAccPortfolio)
   return [...ethAccPortfolio.tokens, ...polygonAccPortfolio.tokens]
 }
 


### PR DESCRIPTION
Fetch only the state of newly imported accounts, instead of fetching the account state of all accounts when new accounts are imported. 

## Other changes:
- Fetch account state on account select
- Allow concurrent actions

Closes https://github.com/AmbireTech/ambire-app/issues/2952