### PR TITLE
If there's a cached txnId in the accountOp, use it

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -331,7 +331,8 @@ export class ActivityController extends EventEmitter {
               accountOp.identifiedBy,
               network,
               this.#fetch,
-              this.#callRelayer
+              this.#callRelayer,
+              accountOp
             )
             if (fetchTxnIdResult.status === 'rejected') {
               this.#accountsOps[selectedAccount][networkId][accountOpIndex].status =

--- a/src/libs/accountOp/submittedAccountOp.ts
+++ b/src/libs/accountOp/submittedAccountOp.ts
@@ -58,7 +58,8 @@ export async function fetchTxnId(
   identifiedBy: AccountOpIdentifiedBy,
   network: Network,
   fetchFn: Fetch,
-  callRelayer: Function
+  callRelayer: Function,
+  op?: AccountOp
 ): Promise<{ status: string; txnId: string | null }> {
   if (isIdentifiedByTxn(identifiedBy))
     return {
@@ -129,6 +130,11 @@ export async function fetchTxnId(
   }
 
   if (!response.data.txId) {
+    if (op && op.txnId)
+      return {
+        status: 'success',
+        txnId: op.txnId
+      }
     return {
       status: 'not_found',
       txnId: null


### PR DESCRIPTION
Usually, we make a call to the relayer to fetch the `txnId`. That's okay.

But if for some reason the relayer cannot return the `txnId` at the moment (it's not working), we can try to fetch the txn from the blockchain with the currently cached txnId