### PR TITLE
add: methods to store a seed temporarily

### DIFF
--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -57,6 +57,7 @@ const STATUS_WRAPPED_METHODS = {
   unlockWithSecret: 'INITIAL',
   addSecret: 'INITIAL',
   addSeed: 'INITIAL',
+  moveTempSeedToKeystoreSeeds: 'INITIAL',
   deleteSavedSeed: 'INITIAL',
   removeSecret: 'INITIAL',
   addKeys: 'INITIAL',
@@ -474,7 +475,7 @@ export class KeystoreController extends EventEmitter {
     if (shouldUpdate) this.emitUpdate()
   }
 
-  async addTempSeedToKeystoreSeeds() {
+  async #moveTempSeedToKeystoreSeeds() {
     if (this.#mainKey === null)
       throw new EmittableError({
         message: KEYSTORE_UNEXPECTED_ERROR_MESSAGE,
@@ -507,6 +508,10 @@ export class KeystoreController extends EventEmitter {
     await this.#storage.set('keystoreSeeds', this.#keystoreSeeds)
     this.#tempSeed = null
     this.emitUpdate()
+  }
+
+  async moveTempSeedToKeystoreSeeds() {
+    await this.withStatus('moveTempSeedToKeystoreSeeds', () => this.#moveTempSeedToKeystoreSeeds())
   }
 
   async #addSeed({ seed, hdPathTemplate }: KeystoreSeed) {

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -23,6 +23,7 @@ import scrypt from 'scrypt-js'
 
 import EmittableError from '../../classes/EmittableError'
 import { HD_PATH_TEMPLATE_TYPE } from '../../consts/derivation'
+import { Banner } from '../../interfaces/banner'
 import {
   ExternalKey,
   InternalKey,
@@ -895,6 +896,26 @@ export class KeystoreController extends EventEmitter {
     return this.#tempSeed !== undefined
   }
 
+  get banners(): Banner[] {
+    if (!this.#tempSeed) return []
+
+    return [
+      {
+        id: 'tempSeed',
+        type: 'warning',
+        category: 'temp-seed-not-confirmed',
+        title: 'Please decide should the seed be stored in the extension!',
+        text: '',
+        actions: [
+          {
+            label: 'Proceed',
+            actionName: 'confirm-temp-seed'
+          }
+        ]
+      }
+    ]
+  }
+
   toJSON() {
     return {
       ...this,
@@ -903,7 +924,8 @@ export class KeystoreController extends EventEmitter {
       keys: this.keys,
       hasPasswordSecret: this.hasPasswordSecret,
       hasKeystoreSavedSeed: this.hasKeystoreSavedSeed,
-      hasKeystoreTempSeed: this.hasKeystoreTempSeed
+      hasKeystoreTempSeed: this.hasKeystoreTempSeed,
+      banners: this.banners
     }
   }
 }

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -920,7 +920,7 @@ export class KeystoreController extends EventEmitter {
   }
 
   get hasKeystoreTempSeed() {
-    return this.#tempSeed !== undefined
+    return !!this.#tempSeed
   }
 
   get banners(): Banner[] {

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -904,11 +904,11 @@ export class KeystoreController extends EventEmitter {
         id: 'tempSeed',
         type: 'warning',
         category: 'temp-seed-not-confirmed',
-        title: 'Please decide should the seed be stored in the extension!',
+        title: 'You have an unsaved imported seed',
         text: '',
         actions: [
           {
-            label: 'Proceed',
+            label: 'Check',
             actionName: 'confirm-temp-seed'
           }
         ]

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -511,6 +511,7 @@ export class KeystoreController extends EventEmitter {
   }
 
   async moveTempSeedToKeystoreSeeds() {
+    await this.#initialLoadPromise
     await this.withStatus('moveTempSeedToKeystoreSeeds', () => this.#moveTempSeedToKeystoreSeeds())
   }
 

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -201,6 +201,7 @@ export class KeystoreController extends EventEmitter {
 
   lock() {
     this.#mainKey = null
+    if (this.#tempSeed) this.deleteTempSeed(false)
     this.emitUpdate()
   }
 
@@ -468,9 +469,9 @@ export class KeystoreController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async deleteTempSeed() {
+  deleteTempSeed(shouldUpdate = true) {
     this.#tempSeed = null
-    this.emitUpdate()
+    if (shouldUpdate) this.emitUpdate()
   }
 
   async addTempSeedToKeystoreSeeds() {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -361,6 +361,8 @@ export class MainController extends EventEmitter {
           // on the latest `hdPathTemplate` chosen in the AccountAdder.
           if (this.accountAdder.isInitializedWithSavedSeed)
             this.keystore.changeSavedSeedHdPathTemplateIfNeeded(this.accountAdder.hdPathTemplate)
+          if (this.keystore.hasKeystoreTempSeed)
+            this.keystore.changeTempSeedHdPathTemplateIfNeeded(this.accountAdder.hdPathTemplate)
         },
         true
       )

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -80,6 +80,6 @@ export type Action =
       meta: { activeRouteId: number }
     }
   | {
-      label: 'Proceed'
+      label: 'Check'
       actionName: 'confirm-temp-seed'
     }

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -9,6 +9,7 @@ export type BannerCategory =
   | 'swap-and-bridge-in-progress'
   | 'swap-and-bridge-ready'
   | 'swap-and-bridge-completed'
+  | 'temp-seed-not-confirmed'
 
 export interface Banner {
   id: number | string
@@ -77,4 +78,8 @@ export type Action =
       label: 'Got it'
       actionName: 'close-swap-and-bridge'
       meta: { activeRouteId: number }
+    }
+  | {
+      label: 'Proceed'
+      actionName: 'confirm-temp-seed'
     }


### PR DESCRIPTION
Here's what we do:
* add a `#tempSeed` in the keystore
* add a method `addSeedToTemp` in the keystore that will add the seed to temp **encrypted**
* add `deleteTempSeed` - if the user declines to save the seed, we delete it from temp
* add `moveTempSeed` - if the user wants the seed stored, we move it to keystoreSeeds

The flow from account adder is as follows:
* users doesn't have a saved seed
* user imports one, we save it to temp **encryptedly**
* he adds his accounts, personalizes them, goes to final step - do you want to save the imported seed
* if he clicks yes, we store it and remove it from temp
* if he clicks no, we delete it from temp

If the user doesn't complete the login process (rage quits as account personalize), the temp seed remains in the keystore until the user locks his extension or the background process is restarted/reloaded. If the user locks his extension, we delete the temp seed. This is visible in the ambire-app PR (yet to be published)