### PR TITLE
Improve / Swap & Bridge Error Handling on the SignAccountOpScreen

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1764,7 +1764,11 @@ export class MainController extends EventEmitter {
       // if the signAccountOp has been deleted, don't continue as the request has already finished
       if (!this.signAccountOp) return
 
-      // add a more user-friendly error on an accountOp
+      // Basic Account (BA) has two pending actions:
+      // 1. Approval transaction
+      // 2. Actual transaction
+      // If the user tries to sign the second action before the approval, the estimation will fail.
+      // This part improves the error message for a better UX
       if (estimation && estimation.error) {
         if (!isSmartAccount(account)) {
           const userRequest = this.userRequests.find(

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1183,7 +1183,7 @@ export class MainController extends EventEmitter {
 
   rejectUserRequest(err: string, requestId: UserRequest['id']) {
     const userRequest = this.userRequests.find((r) => r.id === requestId)
-    if (!userRequest) return // TODO: emit error
+    if (!userRequest) return
 
     if (requestId === ENTRY_POINT_AUTHORIZATION_REQUEST_ID) {
       this.userRequests = this.userRequests.filter(
@@ -1196,9 +1196,20 @@ export class MainController extends EventEmitter {
       )
     }
 
+    // if the userRequest that is about to be removed is an approval request
+    // find and remove the associated pending transaction request if there is any
+    // this is valid scenario for a swap & bridge txs with a BA
+    if (userRequest.action.kind === 'calls') {
+      const acc = this.accounts.accounts.find((a) => a.addr === userRequest.meta.accountAddr)!
+
+      if (!isSmartAccount(acc) && userRequest.meta.isApproval) {
+        const txUserRequest = this.userRequests.find((r) => r.id === userRequest.meta.activeRouteId)
+        if (txUserRequest) this.removeUserRequest(txUserRequest.id)
+      }
+    }
+
     userRequest.dappPromise?.reject(ethErrors.provider.userRejectedRequest<any>(err))
     this.removeUserRequest(requestId)
-    this.emitUpdate()
   }
 
   async addUserRequest(
@@ -1549,11 +1560,7 @@ export class MainController extends EventEmitter {
     this.actions.removeAction(actionId, shouldOpenNextAction)
     // eslint-disable-next-line no-restricted-syntax
     for (const call of accountOp.calls) {
-      const uReq = this.userRequests.find((r) => r.id === call.fromUserRequestId)
-      if (uReq) {
-        uReq.dappPromise?.reject(ethErrors.provider.userRejectedRequest<any>(err))
-        this.removeUserRequest(uReq.id)
-      }
+      if (call.fromUserRequestId) this.rejectUserRequest(err, call.fromUserRequestId)
     }
 
     this.emitUpdate()
@@ -1756,6 +1763,27 @@ export class MainController extends EventEmitter {
       // @race
       // if the signAccountOp has been deleted, don't continue as the request has already finished
       if (!this.signAccountOp) return
+
+      // add a more user-friendly error on an accountOp
+      if (estimation && estimation.error) {
+        if (!isSmartAccount(account)) {
+          const userRequest = this.userRequests.find(
+            (r) => r.id === this.signAccountOp?.accountOp.calls[0].fromUserRequestId
+          )
+
+          if (userRequest && userRequest.meta.activeRouteId && !userRequest.meta.isApproval) {
+            const hasApprovalReq = this.userRequests.find(
+              (r) => r.id === `${userRequest.meta.activeRouteId}-approval`
+            )
+
+            if (hasApprovalReq) {
+              estimation.error = new Error(
+                'Unable to estimate due to a pending approval. Please sign the approval transaction first to proceed with this transaction.'
+              )
+            }
+          }
+        }
+      }
 
       if (estimation) {
         const currentNonceAhead =

--- a/src/libs/estimate/estimateEOA.ts
+++ b/src/libs/estimate/estimateEOA.ts
@@ -1,5 +1,4 @@
 import { AbiCoder, JsonRpcProvider, Provider, toBeHex, ZeroAddress } from 'ethers'
-import { TokenResult } from 'libs/portfolio'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import Estimation from '../../../contracts/compiled/Estimation.json'
@@ -9,6 +8,7 @@ import { Account, AccountStates } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
 import { AccountOp } from '../accountOp/accountOp'
 import { DeploylessMode, fromDescriptor } from '../deployless/deployless'
+import { TokenResult } from '../portfolio'
 import { EOA_SIMULATION_NONCE } from '../portfolio/getOnchainBalances'
 import { privSlot } from '../proxyDeploy/deploy'
 import { catchEstimationFailure, estimationErrorFormatted } from './errors'


### PR DESCRIPTION
* When swapping or bridging with a BA that requires approval, two transactions are queued: one for the approval and another for the actual swap or bridge. Previously, if the user attempted to select the second transaction before approving the first, the estimation error message was poorly presented. This PR enhances the error message display on the SignAccountOpScreen to improve the UX
<img width="1352" alt="Screenshot 2024-10-29 at 18 02 39" src="https://github.com/user-attachments/assets/705dedb5-6693-4daf-85da-5dd9548ac197">
<img width="1352" alt="Screenshot 2024-10-29 at 18 02 21" src="https://github.com/user-attachments/assets/1fbd09cb-ef32-4dbf-a3c9-06183ed60431">

* Remove redundant swap or bridge userRequest if the user deletes the approval request while both requests are still pending