### PR TITLE
Bug / Duplicated ETH token in the Swap & Bridge receive list

### DIFF
--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -114,6 +114,12 @@ export class SocketAPI {
         (token: SocketAPIToken) => token.address !== ETH_ON_OPTIMISM_LEGACY_ADDRESS
       )
 
+    // Exception for Ethereum, duplicate ETH tokens are incoming from the API.
+    // One is with the `ZERO_ADDRESS` and one with `NULL_ADDRESS`, both for ETH.
+    // Strip out the one with the `ZERO_ADDRESS` to be consistent with the rest.
+    if (toChainId === 1)
+      result = result.filter((token: SocketAPIToken) => token.address !== ZERO_ADDRESS)
+
     return result.map(normalizeIncomingSocketToken)
   }
 


### PR DESCRIPTION
Caused by a bug in the Socket API (duplicate ETH tokens are incoming, one is with the `ZERO_ADDRESS` and one with `NULL_ADDRESS`, both for ETH). Strip out the one with the `ZERO_ADDRESS` to be consistent with the rest.

PS: Bug reported to the Socket team ✅ 