### PR TITLE
Config / Enhance Bridge & Swap banners texts and call to actions

### DIFF
--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -69,7 +69,7 @@ export type Action =
       meta: { activeRouteId: number }
     }
   | {
-      label: 'Proceed to Next Step'
+      label: 'Proceed to Next Step' | 'Open'
       actionName: 'proceed-swap-and-bridge'
       meta: { activeRouteId: number }
     }

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -56,7 +56,7 @@ export const getSwapAndBridgeBanners = (activeRoutes: ActiveRoute[]): Banner[] =
     }
 
     if (r.routeStatus === 'ready') {
-      const isNextTnxForBridging = isBridgeTxn && r.route.currentUserTxIndex > 1
+      const isNextTnxForBridging = isBridgeTxn && r.route.currentUserTxIndex >= 1
 
       actions.push(
         {

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -35,7 +35,7 @@ const getDescription = (route: ActiveRoute, isBridgeTxn: boolean) => {
   }`
 
   const assetsText = `${steps[0].fromAsset.symbol} to ${steps[steps.length - 1].toAsset.symbol}`
-  const txnCountText = `- (Transaction ${
+  const txnCountText = `(transaction ${
     route.routeStatus === 'completed' ? route.route.totalUserTx : route.route.currentUserTxIndex + 1
   } of ${route.route.totalUserTx})`
 
@@ -56,6 +56,8 @@ export const getSwapAndBridgeBanners = (activeRoutes: ActiveRoute[]): Banner[] =
     }
 
     if (r.routeStatus === 'ready') {
+      const isNextTnxForBridging = isBridgeTxn && r.route.currentUserTxIndex > 1
+
       actions.push(
         {
           label: 'Reject',
@@ -63,7 +65,7 @@ export const getSwapAndBridgeBanners = (activeRoutes: ActiveRoute[]): Banner[] =
           meta: { activeRouteId: r.activeRouteId }
         },
         {
-          label: isBridgeTxn ? 'Proceed to Next Step' : 'Open',
+          label: isNextTnxForBridging ? 'Proceed to Next Step' : 'Open',
           actionName: 'proceed-swap-and-bridge',
           meta: { activeRouteId: r.activeRouteId }
         }

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -18,7 +18,7 @@ const getTitle = (route: ActiveRoute, isBridgeTxn: boolean) => {
   if (route.routeStatus === 'in-progress')
     return isBridgeTxn ? 'Bridge request in progress' : 'Swap request in progress'
 
-  return isBridgeTxn ? 'Bridge request waiting to be signed' : 'Swap request waiting to be signed'
+  return isBridgeTxn ? 'Bridge request awaiting signature' : 'Swap request awaiting signature'
 }
 
 const getDescription = (route: ActiveRoute, isBridgeTxn: boolean) => {

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -35,11 +35,11 @@ const getDescription = (route: ActiveRoute, isBridgeTxn: boolean) => {
   }`
 
   const assetsText = `${steps[0].fromAsset.symbol} to ${steps[steps.length - 1].toAsset.symbol}`
-  const txnCountText = `(transaction ${
+  const stepsIndexText = `(step ${
     route.routeStatus === 'completed' ? route.route.totalUserTx : route.route.currentUserTxIndex + 1
   } of ${route.route.totalUserTx})`
 
-  return `${actionText} ${assetsText}${route.route.totalUserTx > 1 ? ` ${txnCountText}` : '.'}`
+  return `${actionText} ${assetsText}${route.route.totalUserTx > 1 ? ` ${stepsIndexText}` : '.'}`
 }
 
 export const getSwapAndBridgeBanners = (activeRoutes: ActiveRoute[]): Banner[] => {

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -180,6 +180,9 @@ const buildSwapAndBridgeUserRequests = (
   return requests
 }
 
+export const getIsBridgeTxn = (userTxType: SocketAPIUserTx['userTxType']) =>
+  userTxType === 'fund-movr'
+
 export {
   getQuoteRouteSteps,
   getActiveRoutesLowestServiceTime,


### PR DESCRIPTION
Improves a bit Bridge & Swap banners so that:

- Changed: More precise titles and descriptions when swapping vs bridging (instead of common)

  <img width="602" alt="Screenshot 2024-11-04 at 15 43 12" src="https://github.com/user-attachments/assets/13ec5150-c454-4296-a8fd-6fd77ddb81fc">

- Fixed: "Proceed to next step" button only when bridging, otherwise, "Open"
- Changed: When swap is in progress, instead of the reject action (since it can't be rejected), display a got it button that closes the banner:

  <img width="604" alt="Screenshot 2024-11-04 at 15 10 42" src="https://github.com/user-attachments/assets/78a8d4bf-166e-45b1-9eb7-9d59ce84ba63">

  and
  <img width="607" alt="Screenshot 2024-11-04 at 15 10 53" src="https://github.com/user-attachments/assets/070b79d7-d8cb-4949-a8eb-a929ffa2d982">



Closes https://github.com/AmbireTech/ambire-app/issues/3149