### PR TITLE
Config / Improve a tiny bit most common swap and bridge API fail cases - unable to retrieve token list or to fetch a route

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -472,7 +472,7 @@ export class SwapAndBridgeController extends EventEmitter {
       this.emitError({
         error,
         level: 'major',
-        message: 'Unable to retrieve the token list.'
+        message: `Unable to retrieve the list of supported receive tokens. Please reload the tab to try again.`
       })
     }
     this.updateToTokenListStatus = 'INITIAL'
@@ -614,7 +614,7 @@ export class SwapAndBridgeController extends EventEmitter {
         this.emitError({
           error,
           level: 'major',
-          message: 'Failed to fetch routes for this pair.'
+          message: 'Failed to fetch a route for the selected tokens. Please try again.'
         })
       }
     }


### PR DESCRIPTION
Enhance a bit the most common cases - unable to retrieve token list or to fetch a route.