### PR TITLE
Config / Bridge & Swap in progress banner call to action button text changed to "close" (prev "got it")

### DIFF
--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -75,7 +75,7 @@ export type Action =
       meta: { activeRouteId: number }
     }
   | {
-      label: 'Got it'
+      label: 'Got it' | 'Close'
       actionName: 'close-swap-and-bridge'
       meta: { activeRouteId: number }
     }

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -49,7 +49,7 @@ export const getSwapAndBridgeBanners = (activeRoutes: ActiveRoute[]): Banner[] =
 
     if (['in-progress', 'completed'].includes(r.routeStatus)) {
       actions.push({
-        label: 'Got it',
+        label: r.routeStatus === 'completed' ? 'Got it' : 'Close',
         actionName: 'close-swap-and-bridge',
         meta: { activeRouteId: r.activeRouteId }
       })


### PR DESCRIPTION
In addition to https://github.com/AmbireTech/ambire-common/pull/1068 , "close" intends better that clicking this button closes the notification in general (user won't see it anymore).