### PR TITLE
Proposal: change state override detection

### DIFF
--- a/src/libs/deployless/simulateDeployCall.ts
+++ b/src/libs/deployless/simulateDeployCall.ts
@@ -12,7 +12,7 @@ import { DeploylessMode, fromDescriptor } from './deployless'
 // on the given network
 export async function getSASupport(
   provider: JsonRpcProvider
-): Promise<{ addressMatches: boolean; supportsStateOverride: boolean }> {
+): Promise<{ addressMatches: boolean }> {
   const smartAccount = await getSmartAccount(
     [
       {
@@ -31,7 +31,6 @@ export async function getSASupport(
     mode: DeploylessMode.StateOverride
   }
   const deployless = fromDescriptor(provider, AmbireFactory, true)
-  let supportsStateOverride = true
   const result = await deployless
     .call(
       'deployAndExecute',
@@ -50,12 +49,10 @@ export async function getSASupport(
 
       // if there's an error, return the zero address indicating that
       // our smart accounts will most likely not work on this chain
-      supportsStateOverride = false
       return [ZeroAddress]
     })
 
   return {
-    addressMatches: result[0] === smartAccount.addr,
-    supportsStateOverride
+    addressMatches: result[0] === smartAccount.addr
   }
 }

--- a/src/libs/deployless/supportsStateOverride.ts
+++ b/src/libs/deployless/supportsStateOverride.ts
@@ -1,0 +1,42 @@
+import { JsonRpcProvider, ZeroAddress } from 'ethers'
+
+import Estimation from '../../../contracts/compiled/Estimation.json'
+import { FEE_COLLECTOR } from '../../consts/addresses'
+import { getEOAEstimationStateOverride } from '../estimate/estimateEOA'
+import { EOA_SIMULATION_NONCE } from '../portfolio/getOnchainBalances'
+import { Deployless, DeploylessMode } from './deployless'
+
+export async function doesItSupportStateOverride(provider: JsonRpcProvider) {
+  const estimator = new Deployless(provider, Estimation.abi, Estimation.bin, Estimation.binRuntime)
+
+  // try to write to the state in deployless mode
+  const accAddr = '0xc1e7354c7d11d95BDa4adf2A3Fd8984E1ddE7aCc'
+  const result = await estimator
+    .call(
+      'estimateEoa',
+      [
+        accAddr,
+        [
+          accAddr,
+          EOA_SIMULATION_NONCE,
+          [['0x3e2D734349654166a2Ad92CaB2437A76a70B650a', 1n, '0x']],
+          '0x'
+        ],
+        '0x',
+        [accAddr],
+        FEE_COLLECTOR,
+        ZeroAddress
+      ],
+      {
+        from: '0x0000000000000000000000000000000000000001',
+        blockTag: 'latest',
+        mode: DeploylessMode.StateOverride,
+        stateToOverride: getEOAEstimationStateOverride(accAddr)
+      }
+    )
+    .catch(() => {
+      return 'not working'
+    })
+
+  return result !== 'not working'
+}

--- a/src/libs/estimate/estimateEOA.ts
+++ b/src/libs/estimate/estimateEOA.ts
@@ -19,7 +19,7 @@ const abiCoder = new AbiCoder()
 
 // this is the state override we use for the EOA when
 // estimating through Estimation.sol
-function getEOAEstimationStateOverride(accountAddr: string) {
+export function getEOAEstimationStateOverride(accountAddr: string) {
   return {
     [accountAddr]: {
       code: AmbireAccount.binRuntime,


### PR DESCRIPTION
Dedicate a special function for checking state override that tries to do an `estimateEOA` - if it fails, we mark the chain as unsupported for state override as it doesn't do it properly.

Problem: Moonbeam doesn't work.  
Moonbeam doesn't work as it supports state override but not fully. Simple state override like putting code to an EVM address works, but putting the Ambire code on an EOA and calling execute() on it doesn't. So both simulations + estimation doesn't work. And the worst of all is that the EOA estimation gets bricked and the user cannot broadcast.