### PR TITLE
Make estimateEOA not required

### DIFF
--- a/src/libs/estimate/estimateEOA.ts
+++ b/src/libs/estimate/estimateEOA.ts
@@ -98,7 +98,11 @@ export async function estimateEOA(
               stateToOverride: getEOAEstimationStateOverride(account.addr)
             }
           )
-          .catch(catchEstimationFailure)
+          .catch((e) => {
+            console.log('error calling estimateEoa:')
+            console.log(e)
+            return [[0n, [], {}]]
+          })
       : deploylessEstimator
           .call('getL1GasEstimation', [encodedCallData, FEE_COLLECTOR, optimisticOracle], {
             from: blockFrom,
@@ -120,8 +124,12 @@ export async function estimateEOA(
   let gasUsed = 0n
   if (!network.rpcNoStateOverride) {
     const [gasUsedEstimateGas, [[gasUsedEstimationSol, feeTokenOutcomes, l1GasEstimation]]] = result
-    feePaymentOptions[0].availableAmount = feeTokenOutcomes[0][1]
-    feePaymentOptions[0].addedNative = l1GasEstimation.fee
+    if (feeTokenOutcomes.length && feeTokenOutcomes[0].length) {
+      feePaymentOptions[0].availableAmount = feeTokenOutcomes[0][1]
+    }
+    if (l1GasEstimation && l1GasEstimation.fee) {
+      feePaymentOptions[0].addedNative = l1GasEstimation.fee
+    }
 
     // if it's a simple transfer, trust estimateGas as it should be 21K
     // if it's a contract call, trust whichever is higher


### PR DESCRIPTION
When doing estimations, if estimateEOA reverts, the user cannot continue.  
Usually, estimateEOA shouldn't revert and it doesn't revert on normal networks. But it does on Moonbeam.  
Here's another PR for making changes to state override detection that will handle this problem on Moonbeam and similar networks: https://github.com/AmbireTech/ambire-common/pull/1077

Closes https://github.com/AmbireTech/ambire-app/issues/3142