### PR TITLE
Fix: infinite estimation

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1829,7 +1829,9 @@ export class MainController extends EventEmitter {
           isSmartAccount(account) &&
           !network.erc4337.enabled &&
           lastTxn &&
-          localAccountOp.nonce === lastTxn.nonce
+          localAccountOp.nonce === lastTxn.nonce &&
+          lastTxn.success &&
+          lastTxn.status === AccountOpStatus.Success
 
         if (hasNonceDiscrepancy || SAHasOldNonceOnARelayerNetwork) {
           this.accounts


### PR DESCRIPTION
Fix: if the last txn on a network fails and the nonce does not move, we enter infinite estimation; this is fixed by making sure we're comparing the nonce to a previusly successful transaction