### PR TITLE
Feature / Enable DeFi Tokens Sending

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -136,7 +136,7 @@ export class SelectedAccountController extends EventEmitter {
 
   #updateSelectedAccountPortfolio(skipUpdate?: boolean) {
     if (!this.#portfolio || !this.#defiPositions || !this.account) return
-    console.log('in')
+
     const defiPositionsAccountState = this.#defiPositions.state[this.account.addr]
 
     const portfolioState = structuredClone({

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -23,6 +23,7 @@ export type TokenResult = Omit<CustomToken, 'standard'> & {
     rewardsType: 'wallet-vesting' | 'wallet-rewards' | null
     canTopUpGasTank: boolean
     isFeeToken: boolean
+    isDefiToken?: boolean
   }
 }
 

--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -57,7 +57,19 @@ export const updatePortfolioStateWithDefiPositions = (
 
             networkBalance -= tokenBalanceUSD || 0 // deduct portfolio token balance
 
-            tokens = tokens.filter((_, index) => index !== tokenInPortfolioIndex)
+            tokens = tokens.map((token, idx) => {
+              if (idx === tokenInPortfolioIndex) {
+                return {
+                  ...token,
+                  flags: {
+                    ...(token.flags || {}),
+                    isDefiToken: true
+                  }
+                } as TokenResult
+              }
+
+              return token
+            })
           }
         })
 


### PR DESCRIPTION
* Add back the defi tokens to the selectedAccount.portfolio tokens list
* add isDefiToken to token.flags for each portfolio token that is also in defiPositions

**The new flag is primarily used on the Dashboard screen to hide tokens marked with isDefiToken, favoring their listing under the DeFi tab instead. This approach keeps DeFi tokens in the portfolio (instead of filtering them out), allowing them to be used for gas payments or transferred to another address if the user wishes.**