### PR TITLE
Optimization / Make DefiPositionsController State Private in MainController

### DIFF
--- a/src/controllers/defiPositions/defiPositions.ts
+++ b/src/controllers/defiPositions/defiPositions.ts
@@ -1,7 +1,5 @@
 import { Fetch } from '../../interfaces/fetch'
 import { NetworkId } from '../../interfaces/network'
-// eslint-disable-next-line import/no-cycle
-import { getNetworksWithDeFiPositionsErrorBanners } from '../../libs/banners/banners'
 import { getAssetValue } from '../../libs/defiPositions/helpers'
 import { getAAVEPositions, getUniV3Positions } from '../../libs/defiPositions/providers'
 import {
@@ -252,23 +250,10 @@ export class DefiPositionsController extends EventEmitter {
     }
   }
 
-  get banners() {
-    if (!this.#selectedAccount.account) return []
-
-    const errorBanners = getNetworksWithDeFiPositionsErrorBanners({
-      networks: this.#networks.networks,
-      currentAccountState: this.state[this.#selectedAccount.account.addr],
-      providers: this.#providers.providers
-    })
-
-    return errorBanners
-  }
-
   toJSON() {
     return {
       ...this,
-      ...super.toJSON(),
-      banners: this.banners
+      ...super.toJSON()
     }
   }
 }

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -146,7 +146,7 @@ export class MainController extends EventEmitter {
 
   portfolio: PortfolioController
 
-  defiPositions: DefiPositionsController
+  #defiPositions: DefiPositionsController
 
   dapps: DappsController
 
@@ -234,7 +234,7 @@ export class MainController extends EventEmitter {
         this.providers.setProvider(network)
         await this.accounts.updateAccountStates('latest', [network.id])
         await this.updateSelectedAccountPortfolio(true)
-        await this.defiPositions.updatePositions(network.id)
+        await this.#defiPositions.updatePositions(network.id)
       },
       (networkId: NetworkId) => {
         this.providers.removeProvider(networkId)
@@ -271,7 +271,7 @@ export class MainController extends EventEmitter {
       relayerUrl,
       velcroUrl
     )
-    this.defiPositions = new DefiPositionsController({
+    this.#defiPositions = new DefiPositionsController({
       fetch: this.fetch,
       selectedAccount: this.selectedAccount,
       networks: this.networks,
@@ -313,7 +313,7 @@ export class MainController extends EventEmitter {
     })
     this.selectedAccount.initControllers({
       portfolio: this.portfolio,
-      defiPositions: this.defiPositions,
+      defiPositions: this.#defiPositions,
       actions: this.actions
     })
     this.swapAndBridge = new SwapAndBridgeController({
@@ -355,7 +355,7 @@ export class MainController extends EventEmitter {
     // TODO: We agreed to always fetch the latest and pending states.
     // To achieve this, we need to refactor how we use forceUpdate to obtain pending state updates.
     this.updateSelectedAccountPortfolio(true)
-    this.defiPositions.updatePositions()
+    this.#defiPositions.updatePositions()
     /**
      * Listener that gets triggered as a finalization step of adding new
      * accounts via the AccountAdder controller flow.
@@ -426,7 +426,7 @@ export class MainController extends EventEmitter {
     // TODO: We agreed to always fetch the latest and pending states.
     // To achieve this, we need to refactor how we use forceUpdate to obtain pending state updates.
     await this.updateSelectedAccountPortfolio(true)
-    await this.defiPositions.updatePositions()
+    await this.#defiPositions.updatePositions()
     // forceEmitUpdate to update the getters in the FE state of the ctrl
     await this.forceEmitUpdate()
     await this.actions.forceEmitUpdate()
@@ -917,7 +917,7 @@ export class MainController extends EventEmitter {
       // Additionally, if we trigger the portfolio update twice (i.e., running a long-living interval + force update from the Dashboard),
       // there won't be any error thrown, as all portfolio updates are queued and they don't use the `withStatus` helper.
       this.updateSelectedAccountPortfolio(true),
-      this.defiPositions.updatePositions()
+      this.#defiPositions.updatePositions()
     ])
   }
 
@@ -1544,7 +1544,7 @@ export class MainController extends EventEmitter {
   async removeNetwork(id: NetworkId) {
     await this.networks.removeNetwork(id)
     await this.updateSelectedAccountPortfolio(true)
-    await this.defiPositions.updatePositions()
+    await this.#defiPositions.updatePositions()
   }
 
   async resolveAccountOpAction(data: any, actionId: AccountOpAction['id']) {

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -137,7 +137,9 @@ describe('SelectedAccount Controller', () => {
     await selectedAccountCtrl.initControllers({
       portfolio: portfolioCtrl,
       defiPositions: defiPositionsCtrl,
-      actions: actionsCtrl
+      actions: actionsCtrl,
+      networks: networksCtrl,
+      providers: providersCtrl
     })
     expect(selectedAccountCtrl.areControllersInitialized).toEqual(true)
   })


### PR DESCRIPTION
* made defiPositions private in the MainController
* impl defiPositionsBanners in selectedAccount
* removed defiPositions.banners because these banners were specific for the selectedAccount only

**By keeping the defiPositions state private and not sending it to the FE, we ensure optimal performance even with multiple heavy accounts added to the wallet**