### PR TITLE
Optimize / Portfolio Banners

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -808,12 +808,12 @@ describe('Portfolio Controller ', () => {
 
     expect(hasItems(controller.getLatestPortfolioState(account.addr))).toBeTruthy()
     expect(hasItems(controller.getPendingPortfolioState(account.addr))).toBeTruthy()
-    expect(controller.networksWithAssets.length).not.toEqual(0)
+    expect(controller.getNetworksWithAssets(account.addr).length).not.toEqual(0)
 
     controller.removeAccountData(account.addr)
 
     expect(hasItems(controller.getLatestPortfolioState(account.addr))).not.toBeTruthy()
     expect(hasItems(controller.getPendingPortfolioState(account.addr))).not.toBeTruthy()
-    expect(controller.networksWithAssets.length).toEqual(0)
+    expect(controller.getNetworksWithAssets(account.addr).length).toEqual(0)
   })
 })

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -7,11 +7,6 @@ import { Network, NetworkId } from '../../interfaces/network'
 import { Storage } from '../../interfaces/storage'
 import { isSmartAccount } from '../../libs/account/account'
 import { AccountOp, isAccountOpsIntentEqual } from '../../libs/accountOp/accountOp'
-// eslint-disable-next-line import/no-cycle
-import {
-  getNetworksWithFailedRPCBanners,
-  getNetworksWithPortfolioErrorBanners
-} from '../../libs/banners/banners'
 import { Portfolio } from '../../libs/portfolio'
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { CustomToken } from '../../libs/portfolio/customToken'
@@ -772,33 +767,14 @@ export class PortfolioController extends EventEmitter {
     return this.#pending[accountAddr] || {}
   }
 
-  get networksWithAssets() {
-    return [...new Set(Object.values(this.#networksWithAssetsByAccounts).flat())]
-  }
-
-  get banners() {
-    if (!this.#networks.isInitialized || !this.#providers.isInitialized) return []
-
-    const networksWithFailedRPCBanners = getNetworksWithFailedRPCBanners({
-      providers: this.#providers.providers,
-      networks: this.#networks.networks,
-      networksWithAssets: this.networksWithAssets
-    })
-    const networksWithPortfolioErrorBanners = getNetworksWithPortfolioErrorBanners({
-      networks: this.#networks.networks,
-      portfolioLatest: this.#latest,
-      providers: this.#providers.providers
-    })
-
-    return [...networksWithFailedRPCBanners, ...networksWithPortfolioErrorBanners]
+  getNetworksWithAssets(accountAddr: string) {
+    return this.#networksWithAssetsByAccounts[accountAddr] || []
   }
 
   toJSON() {
     return {
       ...this,
-      ...super.toJSON(),
-      networksWithAssets: this.networksWithAssets,
-      banners: this.banners
+      ...super.toJSON()
     }
   }
 }

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -138,10 +138,10 @@ export class SelectedAccountController extends EventEmitter {
     })
 
     this.#providers.onUpdate(() => {
-      this.#debounceFunctionCallsOnSameTick('updateDefiPositionsBanners', () =>
+      this.#debounceFunctionCallsOnSameTick('updateDefiPositionsBanners', () => {
         this.#updateDefiPositionsBanners()
-      )
-      // TODO: add portfolio banners and call updatePortfolioBanners here
+        this.#updatePortfolioBanners()
+      })
     })
 
     this.areControllersInitialized = true


### PR DESCRIPTION
* Calc banners only for the selected account in the selectedAccount ctrl instead of calculating banners for all accounts and filtering them on the FE. This reduces the amount of data to be sent to the FE on each portfolio update.
* Reduce the amount of getters in the portfolio because they are no longer needed. This is also a small performance optimization because it decreases the amount of data iterations on each portfolio update