### PR TITLE
Config / Separate call to action for "in progress" and "completed" bridge banners

### DIFF
--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -15,6 +15,8 @@ import { messageOnNewAction } from '../../libs/actions/actions'
 import { getDappActionRequestsBanners } from '../../libs/banners/banners'
 import { ENTRY_POINT_AUTHORIZATION_REQUEST_ID } from '../../libs/userOperation/userOperation'
 import EventEmitter from '../eventEmitter/eventEmitter'
+// Kind of inevitable, the AccountsController has SelectedAccountController, which has ActionsController
+// eslint-disable-next-line import/no-cycle
 import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 
 // TODO: Temporarily. Refactor imports across the codebase to ref /interfaces/actions instead.

--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -1,10 +1,15 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
 import { Account } from '../../interfaces/account'
+import {
+  AccountOpAction,
+  Action,
+  BenzinAction,
+  DappRequestAction,
+  SignMessageAction
+} from '../../interfaces/actions'
 import { NotificationManager } from '../../interfaces/notification'
-import { DappUserRequest, SignUserRequest, UserRequest } from '../../interfaces/userRequest'
 import { WindowManager } from '../../interfaces/window'
-import { AccountOp } from '../../libs/accountOp/accountOp'
 // eslint-disable-next-line import/no-cycle
 import { messageOnNewAction } from '../../libs/actions/actions'
 import { getDappActionRequestsBanners } from '../../libs/banners/banners'
@@ -12,31 +17,8 @@ import { ENTRY_POINT_AUTHORIZATION_REQUEST_ID } from '../../libs/userOperation/u
 import EventEmitter from '../eventEmitter/eventEmitter'
 import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 
-export type AccountOpAction = {
-  id: SignUserRequest['id']
-  type: 'accountOp'
-  accountOp: AccountOp
-}
-
-export type SignMessageAction = {
-  id: SignUserRequest['id']
-  type: 'signMessage'
-  userRequest: SignUserRequest
-}
-
-export type BenzinAction = {
-  id: UserRequest['id']
-  type: 'benzin'
-  userRequest: SignUserRequest
-}
-
-export type DappRequestAction = {
-  id: UserRequest['id']
-  type: 'dappRequest'
-  userRequest: DappUserRequest
-}
-
-export type Action = AccountOpAction | SignMessageAction | BenzinAction | DappRequestAction
+// TODO: Temporarily. Refactor imports across the codebase to ref /interfaces/actions instead.
+export type { Action, AccountOpAction, SignMessageAction, BenzinAction, DappRequestAction }
 
 /**
  * The ActionsController is responsible for storing the converted userRequests

--- a/src/interfaces/actions.ts
+++ b/src/interfaces/actions.ts
@@ -1,0 +1,28 @@
+import { AccountOp } from '../libs/accountOp/accountOp'
+import { DappUserRequest, SignUserRequest, UserRequest } from './userRequest'
+
+export type AccountOpAction = {
+  id: SignUserRequest['id']
+  type: 'accountOp'
+  accountOp: AccountOp
+}
+
+export type SignMessageAction = {
+  id: SignUserRequest['id']
+  type: 'signMessage'
+  userRequest: SignUserRequest
+}
+
+export type BenzinAction = {
+  id: UserRequest['id']
+  type: 'benzin'
+  userRequest: SignUserRequest
+}
+
+export type DappRequestAction = {
+  id: UserRequest['id']
+  type: 'dappRequest'
+  userRequest: DappUserRequest
+}
+
+export type Action = AccountOpAction | SignMessageAction | BenzinAction | DappRequestAction

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -75,8 +75,13 @@ export type Action =
       meta: { activeRouteId: number }
     }
   | {
-      label: 'Got it' | 'Close'
+      label: 'Close'
       actionName: 'close-bridge'
+      meta: { activeRouteId: number }
+    }
+  | {
+      label: 'Details'
+      actionName: 'open-swap-and-bridge-tab'
       meta: { activeRouteId: number }
     }
   | {

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -82,7 +82,6 @@ export type Action =
   | {
       label: 'Details'
       actionName: 'open-swap-and-bridge-tab'
-      meta: { activeRouteId: number }
     }
   | {
       label: 'Hide'

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -1,17 +1,16 @@
+// eslint-disable-next-line import/no-cycle
 import {
   AccountOpAction,
   Action as ActionFromActionsQueue
 } from '../../controllers/actions/actions'
-// eslint-disable-next-line import/no-cycle
 import { Account, AccountId } from '../../interfaces/account'
 import { Action, Banner } from '../../interfaces/banner'
 import { Network, NetworkId } from '../../interfaces/network'
 import { RPCProviders } from '../../interfaces/provider'
 import { ActiveRoute } from '../../interfaces/swapAndBridge'
-// eslint-disable-next-line import/no-cycle
-import { PortfolioControllerState } from '../../libs/portfolio/interfaces'
 import { AccountState, DeFiPositionsError } from '../defiPositions/types'
 import { getNetworksWithFailedRPC } from '../networks/networks'
+import { PortfolioControllerState } from '../portfolio/interfaces'
 import { PORTFOLIO_LIB_ERROR_NAMES } from '../portfolio/portfolio'
 import { getIsBridgeTxn, getQuoteRouteSteps } from '../swapAndBridge/swapAndBridge'
 
@@ -72,9 +71,17 @@ export const getBridgeBanners = (
     .map((r) => {
       const actions: Action[] = []
 
-      if (['in-progress', 'completed'].includes(r.routeStatus)) {
+      if (r.routeStatus === 'in-progress') {
         actions.push({
-          label: r.routeStatus === 'completed' ? 'Got it' : 'Close',
+          label: 'Details',
+          actionName: 'open-swap-and-bridge-tab',
+          meta: { activeRouteId: r.activeRouteId }
+        })
+      }
+
+      if (r.routeStatus === 'completed') {
+        actions.push({
+          label: 'Close',
           actionName: 'close-bridge',
           meta: { activeRouteId: r.activeRouteId }
         })

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -1,9 +1,5 @@
-// eslint-disable-next-line import/no-cycle
-import {
-  AccountOpAction,
-  Action as ActionFromActionsQueue
-} from '../../controllers/actions/actions'
 import { Account, AccountId } from '../../interfaces/account'
+import { AccountOpAction, Action as ActionFromActionsQueue } from '../../interfaces/actions'
 import { Action, Banner } from '../../interfaces/banner'
 import { Network, NetworkId } from '../../interfaces/network'
 import { RPCProviders } from '../../interfaces/provider'

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -70,8 +70,7 @@ export const getBridgeBanners = (
       if (r.routeStatus === 'in-progress') {
         actions.push({
           label: 'Details',
-          actionName: 'open-swap-and-bridge-tab',
-          meta: { activeRouteId: r.activeRouteId }
+          actionName: 'open-swap-and-bridge-tab'
         })
       }
 


### PR DESCRIPTION
Tackles three things:

- Changed: Separates call to action for "in progress" and "completed" bridge banners, so they can be differently handled in [#3249](https://github.com/AmbireTech/ambire-app/pull/3249)
- Fixed: Dep cycle between the ActionsController and the banners lib (by extracting the common action types in an interface.
- Changed: "Got it" to "Close" for the "completed" bridge banner.