### PR TITLE
Fix/ Bug fixes in multiple controllers and UX improvements

### DIFF
--- a/src/controllers/defiPositions/defiPositions.ts
+++ b/src/controllers/defiPositions/defiPositions.ts
@@ -45,32 +45,6 @@ export class DefiPositionsController extends EventEmitter {
     this.#networks = networks
   }
 
-  #prepareState(accountAddr: string) {
-    if (!this.#state[accountAddr]) {
-      this.#state[accountAddr] = this.#networks.networks.reduce(
-        (acc, n) => ({
-          ...acc,
-          [n.id]: { isLoading: true, positionsByProvider: [] }
-        }),
-        this.#state[accountAddr]
-      )
-
-      this.emitUpdate()
-      return
-    }
-
-    this.#networks.networks.forEach((n) => {
-      const wasNetworkAddedAfterInitialLoad = !this.#state[accountAddr][n.id]
-
-      if (wasNetworkAddedAfterInitialLoad) {
-        this.#state[accountAddr][n.id] = { isLoading: true, positionsByProvider: [] }
-      } else {
-        this.#state[accountAddr][n.id].isLoading = true
-      }
-    })
-    this.emitUpdate()
-  }
-
   #setProviderError(
     accountAddr: string,
     networkId: string,
@@ -101,21 +75,34 @@ export class DefiPositionsController extends EventEmitter {
     if (!this.#selectedAccount.account) return
 
     const selectedAccountAddr = this.#selectedAccount.account.addr
-    this.#prepareState(selectedAccountAddr)
-
     const networksToUpdate = networkId
       ? this.#networks.networks.filter((n) => n.id === networkId)
       : this.#networks.networks
 
+    if (!this.#state[selectedAccountAddr]) {
+      this.#state[selectedAccountAddr] = {}
+    }
+
     await Promise.all(
       networksToUpdate.map(async (n) => {
+        if (!this.#state[selectedAccountAddr][n.id]) {
+          this.#state[selectedAccountAddr][n.id] = {
+            isLoading: false,
+            positionsByProvider: [],
+            updatedAt: undefined
+          }
+        }
+
         if (this.#getCanSkipUpdate(selectedAccountAddr, n.id)) {
           // Emit an update so that the current account data getter is updated
           this.emitUpdate()
           return
         }
-        const networkState = this.#state[selectedAccountAddr][n.id]
 
+        this.#state[selectedAccountAddr][n.id].isLoading = true
+        this.emitUpdate()
+
+        const networkState = this.#state[selectedAccountAddr][n.id]
         // Reset provider errors before updating
         networkState.providerErrors = []
         networkState.error = undefined

--- a/src/controllers/defiPositions/defiPositions.ts
+++ b/src/controllers/defiPositions/defiPositions.ts
@@ -87,9 +87,7 @@ export class DefiPositionsController extends EventEmitter {
   #getCanSkipUpdate(accountAddr: string, networkId: string) {
     const networkState = this.#state[accountAddr][networkId]
 
-    if (networkState.isLoading) return false
-    if (networkState.error) return false
-    if (networkState.providerErrors?.length) return false
+    if (networkState.error || networkState.providerErrors?.length) return false
     if (networkState.updatedAt && Date.now() - networkState.updatedAt < this.#minUpdateInterval)
       return true
 

--- a/src/controllers/defiPositions/defiPositions.ts
+++ b/src/controllers/defiPositions/defiPositions.ts
@@ -65,10 +65,10 @@ export class DefiPositionsController extends EventEmitter {
     const networkState = this.#state[accountAddr][networkId]
 
     if (networkState.error || networkState.providerErrors?.length) return false
-    if (networkState.updatedAt && Date.now() - networkState.updatedAt < this.#minUpdateInterval)
-      return true
+    const isWithinMinUpdateInterval =
+      networkState.updatedAt && Date.now() - networkState.updatedAt < this.#minUpdateInterval
 
-    return false
+    return isWithinMinUpdateInterval || networkState.isLoading
   }
 
   async updatePositions(networkId?: NetworkId) {

--- a/src/controllers/defiPositions/defiPositions.ts
+++ b/src/controllers/defiPositions/defiPositions.ts
@@ -59,10 +59,13 @@ export class DefiPositionsController extends EventEmitter {
       return
     }
 
-    // Init state for missing networks
     this.#networks.networks.forEach((n) => {
-      if (!this.#state[accountAddr][n.id]) {
+      const wasNetworkAddedAfterInitialLoad = !this.#state[accountAddr][n.id]
+
+      if (wasNetworkAddedAfterInitialLoad) {
         this.#state[accountAddr][n.id] = { isLoading: true, positionsByProvider: [] }
+      } else {
+        this.#state[accountAddr][n.id].isLoading = true
       }
     })
     this.emitUpdate()

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -433,11 +433,12 @@ export class MainController extends EventEmitter {
     this.swapAndBridge.onAccountChange()
     await this.addressBook.forceEmitUpdate()
     this.dapps.broadcastDappSessionEvent('accountsChanged', [toAccountAddr])
-    // Purposefully not awaiting as if the user is switching accounts, we don't want to block
-    // the UI for the account state and portfolio to be updated
-    this.updateSelectedAccountPortfolio()
-    this.defiPositions.updatePositions()
-    this.accounts.updateAccountState(toAccountAddr)
+    // Run these in parallel
+    await Promise.allSettled([
+      this.accounts.updateAccountState(toAccountAddr),
+      this.updateSelectedAccountPortfolio(),
+      this.defiPositions.updatePositions()
+    ])
 
     this.emitUpdate()
   }

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -427,15 +427,17 @@ export class MainController extends EventEmitter {
     }
     this.selectedAccount.setAccount(accountToSelect)
     this.activity.init()
-    await this.updateSelectedAccountPortfolio()
-    await this.defiPositions.updatePositions()
     // forceEmitUpdate to update the getters in the FE state of the ctrl
     await this.forceEmitUpdate()
     await this.actions.forceEmitUpdate()
-    await this.swapAndBridge.forceEmitUpdate()
+    this.swapAndBridge.onAccountChange()
     await this.addressBook.forceEmitUpdate()
     this.dapps.broadcastDappSessionEvent('accountsChanged', [toAccountAddr])
-    await this.accounts.updateAccountState(toAccountAddr)
+    // Purposefully not awaiting as if the user is switching accounts, we don't want to block
+    // the UI for the account state and portfolio to be updated
+    this.updateSelectedAccountPortfolio()
+    this.defiPositions.updatePositions()
+    this.accounts.updateAccountState(toAccountAddr)
 
     this.emitUpdate()
   }
@@ -942,8 +944,7 @@ export class MainController extends EventEmitter {
       this.signAccountOp?.accountOp
     )
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.portfolio.updateSelectedAccount(
+    await this.portfolio.updateSelectedAccount(
       this.selectedAccount.account.addr,
       network,
       accountOpsToBeSimulatedByNetwork,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -427,18 +427,18 @@ export class MainController extends EventEmitter {
     }
     this.selectedAccount.setAccount(accountToSelect)
     this.activity.init()
+    this.swapAndBridge.onAccountChange()
+    this.dapps.broadcastDappSessionEvent('accountsChanged', [toAccountAddr])
     // forceEmitUpdate to update the getters in the FE state of the ctrl
     await this.forceEmitUpdate()
     await this.actions.forceEmitUpdate()
-    this.swapAndBridge.onAccountChange()
     await this.addressBook.forceEmitUpdate()
-    this.dapps.broadcastDappSessionEvent('accountsChanged', [toAccountAddr])
-    // Run these in parallel
-    await Promise.allSettled([
-      this.accounts.updateAccountState(toAccountAddr),
-      this.updateSelectedAccountPortfolio(),
-      this.defiPositions.updatePositions()
-    ])
+    // Don't await these as they are not critical for the account selection
+    // and if the user decides to quickly change to another account withStatus
+    // will block the UI until these are resolved.
+    this.accounts.updateAccountState(toAccountAddr)
+    this.updateSelectedAccountPortfolio()
+    this.defiPositions.updatePositions()
 
     this.emitUpdate()
   }

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -201,9 +201,9 @@ export class PortfolioController extends EventEmitter {
 
     const accountState = state[accountId]
 
-    // Init state for missing networks
     this.#networks.networks.forEach((network) => {
-      if (!accountState[network.id]) {
+      const wasNetworkAddedAfterInitialLoad = !accountState[network.id]
+      if (wasNetworkAddedAfterInitialLoad) {
         accountState[network.id] = { isReady: false, isLoading: true, errors: [] }
       } else {
         accountState[network.id]!.isLoading = true

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -122,25 +122,24 @@ export class SelectedAccountController extends EventEmitter {
     this.#portfolio.onUpdate(async () => {
       this.#debounceFunctionCallsOnSameTick('updateSelectedAccountPortfolio', () => {
         this.#updateSelectedAccountPortfolio()
-        this.#updatePortfolioBanners()
       })
     }, 'selectedAccount')
 
     this.#defiPositions.onUpdate(() => {
-      this.#debounceFunctionCallsOnSameTick('updateSelectedAccountPortfolio', () => {
-        this.#updateSelectedAccountPortfolio()
-        this.#updatePortfolioBanners()
-      })
       this.#debounceFunctionCallsOnSameTick('updateSelectedAccountDefiPositions', () => {
         this.#updateSelectedAccountDefiPositions()
-        this.#updateDefiPositionsBanners()
+
+        if (!this.areDefiPositionsLoading) {
+          this.#updateDefiPositionsBanners()
+          this.#updateSelectedAccountPortfolio()
+        }
       })
     })
 
     this.#providers.onUpdate(() => {
       this.#debounceFunctionCallsOnSameTick('updateDefiPositionsBanners', () => {
-        this.#updateDefiPositionsBanners()
         this.#updatePortfolioBanners()
+        this.#updateDefiPositionsBanners()
       })
     })
 
@@ -151,6 +150,8 @@ export class SelectedAccountController extends EventEmitter {
 
   async setAccount(account: Account | null) {
     this.account = account
+    this.portfolioBanners = []
+    this.defiPositionsBanners = []
     this.resetSelectedAccountPortfolio(true)
 
     if (!account) {
@@ -209,6 +210,10 @@ export class SelectedAccountController extends EventEmitter {
 
     if (!this.portfolioStartedLoadingAtTimestamp && !newSelectedAccountPortfolio.isAllReady) {
       this.portfolioStartedLoadingAtTimestamp = Date.now()
+    }
+
+    if (newSelectedAccountPortfolio.isAllReady) {
+      this.#updatePortfolioBanners(true)
     }
 
     if (
@@ -302,7 +307,7 @@ export class SelectedAccountController extends EventEmitter {
 
     const errorBanners = getNetworksWithPortfolioErrorBanners({
       networks: this.#networks.networks,
-      selectedAccountLatest: this.#portfolio.getLatestPortfolioState(this.account.addr),
+      selectedAccountLatest: this.portfolio.latest,
       providers: this.#providers.providers
     })
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -112,6 +112,8 @@ export class SwapAndBridgeController extends EventEmitter {
 
   portfolioTokenList: TokenResult[] = []
 
+  isTokenListLoading: boolean = false
+
   toTokenList: SocketAPIToken[] = []
 
   routePriority: 'output' | 'time' = 'output'
@@ -151,6 +153,7 @@ export class SwapAndBridgeController extends EventEmitter {
 
     this.#selectedAccount.onUpdate(() => {
       if (this.#selectedAccount.portfolio.isAllReady) {
+        this.isTokenListLoading = false
         this.updatePortfolioTokenList(this.#selectedAccount.portfolio.tokens)
       }
     })
@@ -805,6 +808,13 @@ export class SwapAndBridgeController extends EventEmitter {
 
   removeActiveRoute(activeRouteId: SocketAPISendTransactionRequest['activeRouteId']) {
     this.activeRoutes = this.activeRoutes.filter((r) => r.activeRouteId !== activeRouteId)
+
+    this.emitUpdate()
+  }
+
+  onAccountChange() {
+    this.portfolioTokenList = []
+    this.isTokenListLoading = true
 
     this.emitUpdate()
   }

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -150,7 +150,9 @@ export class SwapAndBridgeController extends EventEmitter {
     this.activeRoutes = await this.#storage.get('swapAndBridgeActiveRoutes', [])
 
     this.#selectedAccount.onUpdate(() => {
-      this.updatePortfolioTokenList(this.#selectedAccount.portfolio.tokens)
+      if (this.#selectedAccount.portfolio.isAllReady) {
+        this.updatePortfolioTokenList(this.#selectedAccount.portfolio.tokens)
+      }
     })
     this.emitUpdate()
   }


### PR DESCRIPTION
## Changes:
- Add: `portfolioAdditional` `minUpdateInterval` check
- Fix: Account select screen bricks after changing from an account to Vitalik and then to another account
- Fix: `portfolio` network state not set back to loading on update
- Fix: `swapAndBridge` emits an unnecessary amount of updates on `selectedAccount` updates
- Fix: `swapAndBridge` displays `No tokens` on account change (no loading state)
- Fix: old `portfolio` and `defiPositions` banners are displayed for a few seconds after changing the selected account
- Fix: networks with errors in `portfolio` and `defiPositions` banners were updated one by one after a network goes from `isLoading` true -> false
- Refactor: got rid of `#prepareState` in `portfolio` and `defiPositions` because of the added complexity and the fact that it's really easy to miss errors. Also, if `isLoading` is set to true by `prepareState` we can't skip updates if `isLoading=true` because `isLoading` will always be true