### PR TITLE
Bug/ Two `updateAccountState` calls on account import

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -253,11 +253,6 @@ export class MainController extends EventEmitter {
         const defaultSelectedAccount = getDefaultSelectedAccount(accounts)
         if (defaultSelectedAccount) {
           await this.#selectAccount(defaultSelectedAccount.addr)
-          // Don't wait for account state because:
-          // 1. The extension works perfectly fine without it
-          // 2. Some RPCs may be slow and we don't want to block the UI
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          this.accounts.updateAccountState(defaultSelectedAccount.addr)
         }
       },
       this.providers.updateProviderIsWorking.bind(this.providers)


### PR DESCRIPTION
The second call isn't needed as the `accountState` is already updated by `#selectAccount`

https://github.com/user-attachments/assets/331ce093-f530-4051-9ddc-8b3532e1ce0f

Also, the second error may be concerning
