### PR TITLE
Fix: custom networks sign account op

### DIFF
--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -322,8 +322,9 @@ export class Portfolio {
       feeTokens: tokensWithPrices.filter((t) =>
         gasTankFeeTokens.find(
           (gasTankT) =>
-            gasTankT.address.toLowerCase() === t.address.toLowerCase() &&
-            gasTankT.networkId.toLowerCase() === t.networkId.toLowerCase()
+            t.address === ZeroAddress ||
+            (gasTankT.address.toLowerCase() === t.address.toLowerCase() &&
+              gasTankT.networkId.toLowerCase() === t.networkId.toLowerCase())
         )
       ),
       beforeNonce,


### PR DESCRIPTION
On custom networks the native address was not returned by the portfolio as a fee token => bug that blocks all custom networks