### PR TITLE
Feature / Include all user portfolio tokens (> $0) on the selected Receive network in the Swap & Bridge "Receive" (to) tokens

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -159,10 +159,12 @@ export class SwapAndBridgeController extends EventEmitter {
 
     this.activeRoutes = await this.#storage.get('swapAndBridgeActiveRoutes', [])
 
-    this.#selectedAccount.onUpdate(() => {
+    this.#selectedAccount.onUpdate(async () => {
       if (this.#selectedAccount.portfolio.isAllReady) {
         this.isTokenListLoading = false
         this.updatePortfolioTokenList(this.#selectedAccount.portfolio.tokens)
+        // To token list includes selected account portfolio tokens, it should get an update too
+        await this.updateToTokenList(true)
       }
     })
     this.emitUpdate()

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -36,6 +36,21 @@ export const sortTokenListResponse = (
   )
 }
 
+export const convertPortfolioTokenToSocketAPIToken = (
+  portfolioToken: TokenResult,
+  chainId: number
+): SocketAPIToken => {
+  const { address, decimals, symbol } = portfolioToken
+  // Although name and symbol will be the same, it's better than having "No name" in the UI (valid use-case)
+  const name = symbol
+  // Fine for not having both icon props, because this would fallback to the
+  // icon discovery method used for the portfolio tokens
+  const icon = ''
+  const logoURI = ''
+
+  return { address, chainId, decimals, symbol, name, icon, logoURI }
+}
+
 const getQuoteRouteSteps = (userTxs: SocketAPIUserTx[]) => {
   return userTxs.reduce((stepsAcc: SocketAPIStep[], tx) => {
     if (tx.userTxType === 'fund-movr') {

--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -100,7 +100,9 @@ export class SocketAPI {
     const url = `${this.#baseUrl}/token-lists/to-token-list?${params.toString()}`
 
     let response = await this.#fetch(url, { headers: this.#headers })
-    const fallbackError = new Error('Failed to fetch to token list') // TODO: improve wording
+    const fallbackError = new Error(
+      'Unable to retrieve the list of supported receive tokens. Please reload the tab to try again.'
+    )
     if (!response.ok) throw fallbackError
 
     response = await response.json()


### PR DESCRIPTION
In the Swap & Bridge "receive" (to) tokens, we now add all additional unique user portfolio tokens (on the selected Receive network) without checking against the Socket API if they are supported (GET `/v2/supported/token-support`) because

1) There’s no batch check, need to check 1 by 1 which may result many API calls for larger account portfolios and

2) The worst thing that can happen if token is not supported is to result no route found (which is kind of fine).

    <img width="714" alt="Screenshot 2024-11-25 at 13 27 37" src="https://github.com/user-attachments/assets/4a9d53d3-6707-4458-8690-5f6475a52c7c">

Part of https://github.com/AmbireTech/ambire-app/issues/3163