### PR TITLE
Feature / Add Swap & Bridge "Receive" token by address

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -519,6 +519,21 @@ export class SwapAndBridgeController extends EventEmitter {
     this.emitUpdate()
   }
 
+  // TODO: wrap with status
+  async addToTokenByAddress(address: string) {
+    if (!this.toChainId) return
+
+    const isAlreadyPresent = this.toTokenList.some((t) => t.address === address)
+    if (isAlreadyPresent) return
+
+    const token = await this.#socketAPI.getToken({ address, chainId: this.toChainId })
+    if (!token) return
+
+    const nextTokenList = [...this.toTokenList, token]
+    this.toTokenList = sortTokenListResponse(nextTokenList, this.portfolioTokenList)
+    this.emitUpdate()
+  }
+
   async switchFromAndToTokens() {
     if (!this.isSwitchFromAndToTokensEnabled) return
     const currentFromSelectedToken = { ...this.fromSelectedToken }

--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -129,6 +129,33 @@ export class SocketAPI {
     return result.map(normalizeIncomingSocketToken)
   }
 
+  async getToken({
+    address,
+    chainId
+  }: {
+    address: string
+    chainId: number
+  }): Promise<SocketAPIToken> {
+    const params = new URLSearchParams({
+      address: address.toString(),
+      chainId: chainId.toString()
+    })
+    const url = `${this.#baseUrl}/supported/token-support?${params.toString()}`
+
+    let response = await this.#fetch(url, { headers: this.#headers })
+    const fallbackError = new Error('Failed to retrieve token information by address.')
+    if (!response.ok) throw fallbackError
+
+    response = await response.json()
+    if (!response.success) throw fallbackError
+    await this.updateHealthIfNeeded()
+
+    // TODO: Could be improved by checking the `response.result.isSupported` and
+    // displaying feedback if not. For now, assume that the token is supported.
+    // If it is actually NOT, API won't return a route for it, which is fine.
+    return normalizeIncomingSocketToken(response.result.token)
+  }
+
   async quote({
     fromChainId,
     fromTokenAddress,


### PR DESCRIPTION
Wires-up logic that allows adding Swap & Bridge "Receive" token by address. Needed, since we opted in to retrieve the shortlist of receive tokens only.