### PR TITLE
Feature / Cache Swap & Bridge "Receive" token lists

### DIFF
--- a/src/interfaces/swapAndBridge.ts
+++ b/src/interfaces/swapAndBridge.ts
@@ -189,3 +189,7 @@ export type ActiveRoute = {
   routeStatus: 'in-progress' | 'ready' | 'completed'
   error?: string
 }
+
+type StringifiedChainId = string
+export type TokenListKey = `from-${StringifiedChainId}-to-${StringifiedChainId}`
+export type ToTokenLists = { [key: TokenListKey]: { lastFetched: number; data: SocketAPIToken[] } }


### PR DESCRIPTION
Implements a mechanism to efficiently manage and cache token lists for different chain combinations (`fromChainId` and `toChainId`). This way we can 1) quickly retrieve and update the token lists without having to fetch them repeatedly from the API and 2) Tokens added to a list by address are also cached for sometime.