### PR TITLE
bug: significant balance decrease warning when depositing in aave

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -645,12 +645,15 @@ export class MainController extends EventEmitter {
     const learnedNewNfts = await this.portfolio.learnNfts(nfts, network.id)
     // update the portfolio only if new tokens were found through tracing
     if (learnedNewTokens || learnedNewNfts) {
-      this.portfolio.updateSelectedAccount(
-        accountOp.accountAddr,
-        network,
-        getAccountOpsForSimulation(account, this.actions.visibleActionsQueue, network, accountOp),
-        { forceUpdate: true }
-      )
+      this.portfolio
+        .updateSelectedAccount(
+          accountOp.accountAddr,
+          network,
+          getAccountOpsForSimulation(account, this.actions.visibleActionsQueue, network, accountOp),
+          { forceUpdate: true }
+        )
+        // fire an update request to refresh the warnings if any
+        .then(() => this.signAccountOp?.update({}))
     }
   }
 


### PR DESCRIPTION
When depositing to aave, the receiving token comes after the debug trace call request. During that time, a warning for a significant balance loss is shown. Even after portfolio update, it did not disappear even thoguh the simulation now shows the receiving token

Closes https://github.com/AmbireTech/ambire-app/issues/3271