### PR TITLE
Change: rbf condition

### DIFF
--- a/src/controllers/activity/activity.test.ts
+++ b/src/controllers/activity/activity.test.ts
@@ -516,14 +516,46 @@ describe('Activity Controller ', () => {
           identifier: '0x0000000000000000000000000000000000000000000000000000000000000001'
         }
       } as SubmittedAccountOp
+      const accountOpCompleted = {
+        accountAddr: '0xa07D75aacEFd11b425AF7181958F0F85c312f143',
+        signingKeyAddr: '0x5Be214147EA1AE3653f289E17fE7Dc17A73AD175',
+        gasLimit: null,
+        gasFeePayment: {
+          isERC4337: false,
+          isGasTank: false,
+          paidBy: '0xa07D75aacEFd11b425AF7181958F0F85c312f143',
+          inToken: '0x0000000000000000000000000000000000000000',
+          amount: 1n,
+          simulatedGasLimit: 1n,
+          gasPrice: 1n
+        },
+        networkId: 'ethereum',
+        nonce: 225n,
+        signature: '0x0000000000000000000000005be214147ea1ae3653f289e17fe7dc17a73ad17503',
+        calls: [
+          {
+            to: '0x18Ce9CF7156584CDffad05003410C3633EFD1ad0',
+            value: BigInt(0),
+            data: '0x23b872dd000000000000000000000000b674f3fd5f43464db0448a57529eaf37f04ccea500000000000000000000000077777777789a8bbee6c64381e5e89e501fb0e4c80000000000000000000000000000000000000000000000000000000000000089'
+          }
+        ],
+        // wrong txn id, so we can simulate nullish getTransactionReceipt()
+        txnId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        status: 'success',
+        identifiedBy: {
+          type: 'Transaction',
+          identifier: '0x0000000000000000000000000000000000000000000000000000000000000001'
+        }
+      } as SubmittedAccountOp
 
       await controller.addAccountOp(accountOp)
+      await controller.addAccountOp(accountOpCompleted)
       await controller.updateAccountsOpsStatuses()
       const controllerAccountsOps = controller.accountsOps
 
       expect(controllerAccountsOps).toEqual({
-        items: [{ ...accountOp, status: 'unknown-but-past-nonce' }], // we expect unknown-but-past-nonce status here
-        itemsTotal: 1,
+        items: [accountOpCompleted, { ...accountOp, status: 'unknown-but-past-nonce' }], // we expect unknown-but-past-nonce status here
+        itemsTotal: 2,
         currentPage: 0,
         maxPages: 1
       })

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -7,11 +7,7 @@ import { Storage } from '../../interfaces/storage'
 import { Message } from '../../interfaces/userRequest'
 import { isSmartAccount } from '../../libs/account/account'
 import { AccountOpStatus } from '../../libs/accountOp/accountOp'
-import {
-  fetchTxnId,
-  isIdentifiedByUserOpHash,
-  SubmittedAccountOp
-} from '../../libs/accountOp/submittedAccountOp'
+import { fetchTxnId, SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { NetworkNonces } from '../../libs/portfolio/interfaces'
 import { getBenzinUrlParams } from '../../utils/benzin'
 import { AccountsController } from '../accounts/accounts'
@@ -384,22 +380,20 @@ export class ActivityController extends EventEmitter {
               })
             }
 
-            // fixed: we should check the account state of the one paying
-            // the fee as his nonce gets incremented:
-            // - EOA, SA by EOA: the account op holds the EOA nonce
-            // - relayer, 4337: the account op holds the SA nonce
-            const payedByState =
-              this.#accounts.accountStates[accountOp.gasFeePayment!.paidBy] &&
-              this.#accounts.accountStates[accountOp.gasFeePayment!.paidBy][accountOp.networkId]
-                ? this.#accounts.accountStates[accountOp.gasFeePayment!.paidBy][accountOp.networkId]
-                : null
-            const isUserOp = isIdentifiedByUserOpHash(accountOp.identifiedBy)
-
-            if (
-              payedByState &&
-              ((!isUserOp && payedByState.nonce > accountOp.nonce) ||
-                (isUserOp && payedByState.erc4337Nonce > accountOp.nonce))
-            ) {
+            // if there are more than 1 txns with the same nonce and payer,
+            // we can conclude this one is replaced by fee
+            const sameNonceTxns = this.#accountsOps[selectedAccount][networkId].filter(
+              (accOp) =>
+                accOp.gasFeePayment &&
+                accountOp.gasFeePayment &&
+                accOp.gasFeePayment.paidBy === accountOp.gasFeePayment.paidBy &&
+                accOp.nonce === accountOp.nonce
+            )
+            const confirmedSameNonceTxns = sameNonceTxns.find(
+              (accOp) =>
+                accOp.status === AccountOpStatus.Success || accOp.status === AccountOpStatus.Failure
+            )
+            if (sameNonceTxns.length > 1 && !!confirmedSameNonceTxns) {
               this.#accountsOps[selectedAccount][networkId][accountOpIndex].status =
                 AccountOpStatus.UnknownButPastNonce
               shouldUpdatePortfolio = true

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -387,7 +387,7 @@ export class ActivityController extends EventEmitter {
                 accOp.gasFeePayment &&
                 accountOp.gasFeePayment &&
                 accOp.gasFeePayment.paidBy === accountOp.gasFeePayment.paidBy &&
-                accOp.nonce === accountOp.nonce
+                accOp.nonce.toString() === accountOp.nonce.toString()
             )
             const confirmedSameNonceTxns = sameNonceTxns.find(
               (accOp) =>


### PR DESCRIPTION
Mark an accountOp as RBFed only if there is another accountOp that we know of with the same nonce; otherwise, let the txn be marked as stuck in mempool

Closes https://github.com/AmbireTech/ambire-app/issues/3311