### PR TITLE
Fix / Selected Account Controller Not Updated On Preferences Change

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -149,6 +149,12 @@ export class SelectedAccountController extends EventEmitter {
   }
 
   async setAccount(account: Account | null) {
+    if (account && account.addr === this.account?.addr) {
+      this.account = account
+      this.emitUpdate()
+      return
+    }
+
     this.account = account
     this.portfolioBanners = []
     this.defiPositionsBanners = []


### PR DESCRIPTION
Change: dont reset portfolio if account is the same in order to set it when preferences are changed