### PR TITLE
Handle / Failed to Get txnId

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1712,8 +1712,7 @@ export class MainController extends EventEmitter {
           uReq.dappPromise?.resolve({ hash: txnId })
         } else {
           uReq.dappPromise?.reject(
-            ethErrors.provider.custom({
-              code: 1001,
+            ethErrors.rpc.transactionRejected({
               message: 'Transaction rejected by the bundler'
             })
           )

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1688,20 +1688,36 @@ export class MainController extends EventEmitter {
       this.callRelayer
     )
 
-    // Follow up update with the just polled txnId (that potentially came slower)
     // eslint-disable-next-line no-restricted-syntax
     for (const r of swapAndBridgeUserRequests) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.swapAndBridge.updateActiveRoute(r.meta.activeRouteId, {
-        userTxHash: txnId
-      })
+      if (txnId) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.swapAndBridge.updateActiveRoute(r.meta.activeRouteId, {
+          userTxHash: txnId
+        })
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        await this.swapAndBridge.updateActiveRoute(r.meta.activeRouteId, {
+          routeStatus: 'failed',
+          error: 'Transaction rejected by the bundler'
+        })
+      }
     }
 
     // eslint-disable-next-line no-restricted-syntax
     for (const call of accountOp.calls) {
       const uReq = this.userRequests.find((r) => r.id === call.fromUserRequestId)
       if (uReq) {
-        uReq.dappPromise?.resolve({ hash: txnId })
+        if (txnId) {
+          uReq.dappPromise?.resolve({ hash: txnId })
+        } else {
+          uReq.dappPromise?.reject(
+            ethErrors.provider.custom({
+              code: 1001,
+              message: 'Transaction rejected by the bundler'
+            })
+          )
+        }
         // eslint-disable-next-line no-await-in-loop
         this.removeUserRequest(uReq.id, { shouldRemoveSwapAndBridgeRoute: false })
       }

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -301,8 +301,10 @@ export class SwapAndBridgeController extends EventEmitter {
       this.activeRoutes = this.activeRoutes.filter((r) => r.routeStatus !== 'completed')
       // remove activeRoutes errors from the previous session
       this.activeRoutes.forEach((r) => {
-        // eslint-disable-next-line no-param-reassign
-        delete r.error
+        if (r.routeStatus !== 'failed') {
+          // eslint-disable-next-line no-param-reassign
+          delete r.error
+        }
       })
       // update the activeRoute.route prop for the new session
       this.activeRoutes.forEach((r) => {

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -9,6 +9,7 @@ export type BannerCategory =
   | 'bridge-in-progress'
   | 'bridge-ready'
   | 'bridge-completed'
+  | 'bridge-failed'
   | 'temp-seed-not-confirmed'
   | 'old-account'
 

--- a/src/interfaces/swapAndBridge.ts
+++ b/src/interfaces/swapAndBridge.ts
@@ -186,7 +186,7 @@ export type ActiveRoute = {
     transactionData: { txHash: string }[] | null
     userAddress: string
   }
-  routeStatus: 'in-progress' | 'ready' | 'completed'
+  routeStatus: 'in-progress' | 'ready' | 'completed' | 'failed'
   error?: string
 }
 

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -73,8 +73,8 @@ export const getBridgeBanners = (
   return activeRoutes
     .filter(isBridgeTxn)
     .filter((route) => {
+      if (route.routeStatus === 'failed') return false
       if (route.routeStatus !== 'ready') return true
-
       // If the route is ready to be signed, we should display the banner only if it's not turned into an account op
       // because when it does get turned into an account op, there will be a different banner for that
       return !isRouteTurnedIntoAccountOp(route)


### PR DESCRIPTION
*  when pollTxnId fails to get the txnId:
    * instead of resolving the dappPromise, reject it with a rpc.transactionRejected
    * if the accountOp containes a swapAndBridge calls set an error to the respective activeRoutes