### PR TITLE
Fix / Active Route Never Gets Resolved

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1675,6 +1675,9 @@ export class MainController extends EventEmitter {
         walletSendCallsUserReq.dappPromise?.resolve({
           hash: `${identifiedBy.type}:${identifiedBy.identifier}`
         })
+
+        this.swapAndBridge.forceCompleteActiveRouteIfNeeded(walletSendCallsUserReq.id as number)
+
         // eslint-disable-next-line no-await-in-loop
         this.removeUserRequest(walletSendCallsUserReq.id, { shouldRemoveSwapAndBridgeRoute: false })
       }
@@ -1717,6 +1720,8 @@ export class MainController extends EventEmitter {
             })
           )
         }
+
+        this.swapAndBridge.forceCompleteActiveRouteIfNeeded(uReq.id as number)
         // eslint-disable-next-line no-await-in-loop
         this.removeUserRequest(uReq.id, { shouldRemoveSwapAndBridgeRoute: false })
       }

--- a/src/interfaces/swapAndBridge.ts
+++ b/src/interfaces/swapAndBridge.ts
@@ -182,6 +182,7 @@ export type ActiveRoute = {
     updatedAt: string
     routeStatus: string
     fromChainId: number
+    toChainId: number
     currentUserTxIndex: number
     transactionData: { txHash: string }[] | null
     userAddress: string


### PR DESCRIPTION
forcefully set the routeStatus to 'completed' after a successful broadcast in these cases:
* when we are sure that the route is a swap only one
* when it is a bridge route and when we just signed and broadcasted the final transaction that is of type: 'swap'

this will help to finalize the active routes in case where getRouteStatus from SocketAPI fails