### PR TITLE
Feature / Force re-estimate account op upon another account op being confirmed

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -304,17 +304,20 @@ export class ActivityController extends EventEmitter {
   async updateAccountsOpsStatuses(): Promise<{
     shouldEmitUpdate: boolean
     shouldUpdatePortfolio: boolean
+    didAccountOpSucceeded: boolean
   }> {
     await this.#initialLoadPromise
 
     if (!this.#selectedAccount.account || !this.#accountsOps[this.#selectedAccount.account.addr])
-      return { shouldEmitUpdate: false, shouldUpdatePortfolio: false }
+      return { shouldEmitUpdate: false, shouldUpdatePortfolio: false, didAccountOpSucceeded: false }
 
     // This flag tracks the changes to AccountsOps statuses
     // and optimizes the number of the emitted updates and storage/state updates.
     let shouldEmitUpdate = false
 
     let shouldUpdatePortfolio = false
+
+    let didAccountOpSucceeded = false
 
     await Promise.all(
       Object.keys(this.#accountsOps[this.#selectedAccount.account.addr]).map(async (networkId) => {
@@ -372,6 +375,7 @@ export class ActivityController extends EventEmitter {
 
                 if (receipt.status) {
                   shouldUpdatePortfolio = true
+                  didAccountOpSucceeded = true
                 }
 
                 if (accountOp.isSingletonDeploy && receipt.status) {
@@ -424,7 +428,7 @@ export class ActivityController extends EventEmitter {
       this.emitUpdate()
     }
 
-    return { shouldEmitUpdate, shouldUpdatePortfolio }
+    return { shouldEmitUpdate, shouldUpdatePortfolio, didAccountOpSucceeded }
   }
 
   async addSignedMessage(signedMessage: SignedMessage, account: string) {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -806,10 +806,12 @@ export class MainController extends EventEmitter {
     this.emitUpdate()
     if (shouldUpdatePortfolio) this.updateSelectedAccountPortfolio(true)
 
-    // Handles a corner case where a BA account approves, then performs another
-    // action. If the user signs the approval and quickly opens the next
-    // transaction, the transaction may estimate before approval finalizes,
-    // resulting misleading error (unaware of the approval). No need to await.
+    // Handles a corner case - after BA signs an approval, the user may open
+    // the next transaction too soon. The new transaction could estimate before
+    // the account op with the approval gets confirmed on-chain, causing
+    // estimation errors (that's expected). But these stuck until the next
+    // scheduled re-estimate (that happens rarely). Forcing a re-estimate here
+    // updates this quicker and the user can proceed with the next transaction.
     if (didAccountOpSucceeded) this.estimateSignAccountOp()
   }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1666,6 +1666,13 @@ export class MainController extends EventEmitter {
       (r) => r.meta.activeRouteId && !r.meta.isApproval
     )
 
+    // Handles a corner case where a BA account approves, then performs another
+    // action. If the user signs the approval and quickly opens the next
+    // transaction, the transaction may estimate before approval finalizes,
+    // resulting misleading error (unaware of the approval). Do not await on
+    // purpose, not to block the `resolveAccountOpAction` completion.
+    this.estimateSignAccountOp()
+
     // Update route status immediately, so that the UI quickly reflects the change
     // eslint-disable-next-line no-restricted-syntax
     for (const r of swapAndBridgeUserRequests) {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -809,8 +809,7 @@ export class MainController extends EventEmitter {
     // Handles a corner case where a BA account approves, then performs another
     // action. If the user signs the approval and quickly opens the next
     // transaction, the transaction may estimate before approval finalizes,
-    // resulting misleading error (unaware of the approval). Do not await on
-    // purpose, not to block the `resolveAccountOpAction` completion.
+    // resulting misleading error (unaware of the approval). No need to await.
     if (didAccountOpSucceeded) this.estimateSignAccountOp()
   }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -798,7 +798,7 @@ export class MainController extends EventEmitter {
   async updateAccountsOpsStatuses() {
     await this.#initialLoadPromise
 
-    const { shouldEmitUpdate, shouldUpdatePortfolio } =
+    const { shouldEmitUpdate, shouldUpdatePortfolio, didAccountOpSucceeded } =
       await this.activity.updateAccountsOpsStatuses()
 
     if (!shouldEmitUpdate) return
@@ -811,7 +811,7 @@ export class MainController extends EventEmitter {
     // transaction, the transaction may estimate before approval finalizes,
     // resulting misleading error (unaware of the approval). Do not await on
     // purpose, not to block the `resolveAccountOpAction` completion.
-    this.estimateSignAccountOp()
+    if (didAccountOpSucceeded) this.estimateSignAccountOp()
   }
 
   // call this function after a call to the singleton has been made


### PR DESCRIPTION
Handles a corner case - after BA signs an approval, the user may open the next transaction too soon. The new transaction could estimate before the account op with the approval gets confirmed on-chain, causing estimation errors (that's expected). But these stuck until the next scheduled re-estimate (that currently happens every 60s).

Forcing a re-estimate here updates this quicker and the user can proceed with the next transaction.

https://github.com/user-attachments/assets/51c1b5ac-346b-47be-af9c-6d6ba81859d8

Might help with https://github.com/AmbireTech/ambire-app/issues/3104