### PR TITLE
Fix / Basic Account Estimation Error Due to a Pending Approval

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -304,17 +304,19 @@ export class ActivityController extends EventEmitter {
   async updateAccountsOpsStatuses(): Promise<{
     shouldEmitUpdate: boolean
     shouldUpdatePortfolio: boolean
+    updatedAccountsOps: SubmittedAccountOp[]
   }> {
     await this.#initialLoadPromise
 
     if (!this.#selectedAccount.account || !this.#accountsOps[this.#selectedAccount.account.addr])
-      return { shouldEmitUpdate: false, shouldUpdatePortfolio: false }
+      return { shouldEmitUpdate: false, shouldUpdatePortfolio: false, updatedAccountsOps: [] }
 
     // This flag tracks the changes to AccountsOps statuses
     // and optimizes the number of the emitted updates and storage/state updates.
     let shouldEmitUpdate = false
 
     let shouldUpdatePortfolio = false
+    const updatedAccountsOps: SubmittedAccountOp[] = []
 
     await Promise.all(
       Object.keys(this.#accountsOps[this.#selectedAccount.account.addr]).map(async (networkId) => {
@@ -354,10 +356,12 @@ export class ActivityController extends EventEmitter {
             if (fetchTxnIdResult.status === 'rejected') {
               this.#accountsOps[selectedAccount][networkId][accountOpIndex].status =
                 AccountOpStatus.Rejected
+              updatedAccountsOps.push(this.#accountsOps[selectedAccount][networkId][accountOpIndex])
               return
             }
             if (fetchTxnIdResult.status === 'not_found') {
               declareStuckIfQuaterPassed(accountOp)
+              updatedAccountsOps.push(this.#accountsOps[selectedAccount][networkId][accountOpIndex])
               return
             }
 
@@ -369,6 +373,9 @@ export class ActivityController extends EventEmitter {
               if (receipt) {
                 this.#accountsOps[selectedAccount][networkId][accountOpIndex].status =
                   receipt.status ? AccountOpStatus.Success : AccountOpStatus.Failure
+                updatedAccountsOps.push(
+                  this.#accountsOps[selectedAccount][networkId][accountOpIndex]
+                )
 
                 if (receipt.status) {
                   shouldUpdatePortfolio = true
@@ -411,6 +418,7 @@ export class ActivityController extends EventEmitter {
             if (sameNonceTxns.length > 1 && !!confirmedSameNonceTxns) {
               this.#accountsOps[selectedAccount][networkId][accountOpIndex].status =
                 AccountOpStatus.UnknownButPastNonce
+              updatedAccountsOps.push(this.#accountsOps[selectedAccount][networkId][accountOpIndex])
               shouldUpdatePortfolio = true
             }
           })
@@ -424,7 +432,7 @@ export class ActivityController extends EventEmitter {
       this.emitUpdate()
     }
 
-    return { shouldEmitUpdate, shouldUpdatePortfolio }
+    return { shouldEmitUpdate, shouldUpdatePortfolio, updatedAccountsOps }
   }
 
   async addSignedMessage(signedMessage: SignedMessage, account: string) {

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -343,6 +343,9 @@ export class ActivityController extends EventEmitter {
               if (aQuaterHasPassed) {
                 this.#accountsOps[selectedAccount][networkId][accountOpIndex].status =
                   AccountOpStatus.BroadcastButStuck
+                updatedAccountsOps.push(
+                  this.#accountsOps[selectedAccount][networkId][accountOpIndex]
+                )
               }
             }
 
@@ -361,7 +364,6 @@ export class ActivityController extends EventEmitter {
             }
             if (fetchTxnIdResult.status === 'not_found') {
               declareStuckIfQuaterPassed(accountOp)
-              updatedAccountsOps.push(this.#accountsOps[selectedAccount][networkId][accountOpIndex])
               return
             }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1236,7 +1236,7 @@ export class MainController extends EventEmitter {
           this.removeUserRequest(activeRoute.activeRouteId, {
             shouldRemoveSwapAndBridgeRoute: false
           })
-          this.swapAndBridge.updateActiveRoute(activeRouteId, { error: undefined })
+          this.swapAndBridge.updateActiveRoute(activeRoute.activeRouteId, { error: undefined })
           if (!isSmartAccount(this.selectedAccount.account)) {
             this.removeUserRequest(`${activeRouteId}-revoke-approval`, {
               shouldRemoveSwapAndBridgeRoute: false

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -243,11 +243,11 @@ describe('SwapAndBridge Controller', () => {
   })
   test('should update an activeRoute', async () => {
     const activeRouteId = swapAndBridgeController.activeRoutes[0].activeRouteId
-    await swapAndBridgeController.updateActiveRoute(activeRouteId, {
+    swapAndBridgeController.updateActiveRoute(activeRouteId, {
       routeStatus: 'in-progress',
       userTxHash: 'test'
     })
-    await swapAndBridgeController.updateActiveRoute(activeRouteId) // for the coverage
+    swapAndBridgeController.updateActiveRoute(activeRouteId) // for the coverage
     expect(swapAndBridgeController.activeRoutes).toHaveLength(1)
     expect(swapAndBridgeController.activeRoutes[0].routeStatus).toEqual('in-progress')
     expect(swapAndBridgeController.banners).toHaveLength(1)
@@ -256,7 +256,7 @@ describe('SwapAndBridge Controller', () => {
   test('should check for route status', async () => {
     await swapAndBridgeController.checkForNextUserTxForActiveRoutes()
     expect(swapAndBridgeController.activeRoutes[0].routeStatus).toEqual('ready')
-    await swapAndBridgeController.updateActiveRoute(
+    swapAndBridgeController.updateActiveRoute(
       swapAndBridgeController.activeRoutes[0].activeRouteId,
       {
         routeStatus: 'in-progress',

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1,10 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import { formatUnits, isAddress, parseUnits } from 'ethers'
 
-import { AccountOpStatus } from '@ambire-common/libs/accountOp/accountOp'
-import { SubmittedAccountOp } from '@ambire-common/libs/accountOp/submittedAccountOp'
-import { Call } from '@ambire-common/libs/accountOp/types'
-
 import EmittableError from '../../classes/EmittableError'
 import { Network } from '../../interfaces/network'
 import { Storage } from '../../interfaces/storage'
@@ -19,6 +15,9 @@ import {
   SocketAPIToken
 } from '../../interfaces/swapAndBridge'
 import { isSmartAccount } from '../../libs/account/account'
+import { AccountOpStatus } from '../../libs/accountOp/accountOp'
+import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
+import { Call } from '../../libs/accountOp/types'
 import { getBridgeBanners } from '../../libs/banners/banners'
 import { TokenResult } from '../../libs/portfolio'
 import { getTokenAmount } from '../../libs/portfolio/helpers'

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-cycle
-import { AccountOpAction } from '../controllers/actions/actions'
+import { AccountOpAction } from './actions'
 import { Network } from './network'
 
 export type BannerType = 'error' | 'warning' | 'info' | 'info2' | 'success'

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -1,5 +1,5 @@
-import { AccountOpAction } from 'controllers/actions/actions'
-
+// eslint-disable-next-line import/no-cycle
+import { AccountOpAction } from '../controllers/actions/actions'
 import { Network } from './network'
 
 export type BannerType = 'error' | 'warning' | 'info' | 'info2' | 'success'
@@ -7,6 +7,7 @@ export type BannerCategory =
   | 'pending-to-be-signed-acc-op'
   | 'pending-to-be-confirmed-acc-op'
   | 'bridge-in-progress'
+  | 'bridge-waiting-approval-to-resolve'
   | 'bridge-ready'
   | 'bridge-completed'
   | 'bridge-failed'

--- a/src/interfaces/swapAndBridge.ts
+++ b/src/interfaces/swapAndBridge.ts
@@ -187,7 +187,7 @@ export type ActiveRoute = {
     transactionData: { txHash: string }[] | null
     userAddress: string
   }
-  routeStatus: 'in-progress' | 'ready' | 'completed' | 'failed'
+  routeStatus: 'waiting-approval-to-resolve' | 'in-progress' | 'ready' | 'completed' | 'failed'
   error?: string
 }
 

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -1,5 +1,6 @@
 import { Account } from '../../interfaces/account'
 import { AccountOpAction, Action as ActionFromActionsQueue } from '../../interfaces/actions'
+// eslint-disable-next-line import/no-cycle
 import { Action, Banner } from '../../interfaces/banner'
 import { Network, NetworkId } from '../../interfaces/network'
 import { RPCProviders } from '../../interfaces/provider'
@@ -66,7 +67,12 @@ export const getBridgeBanners = (
     route.route.userTxs.some((t) => getIsBridgeTxn(t.userTxType))
   const isRouteTurnedIntoAccountOp = (route: ActiveRoute) => {
     return accountOpActions.some((action) => {
-      return action.accountOp.calls.some((call) => call.fromUserRequestId === route.activeRouteId)
+      return action.accountOp.calls.some(
+        (call) =>
+          call.fromUserRequestId === route.activeRouteId ||
+          call.fromUserRequestId === `${route.activeRouteId}-revoke-approval` ||
+          call.fromUserRequestId === `${route.activeRouteId}-approval`
+      )
     })
   }
 
@@ -82,7 +88,7 @@ export const getBridgeBanners = (
     .map((r) => {
       const actions: Action[] = []
 
-      if (r.routeStatus === 'in-progress') {
+      if (r.routeStatus === 'in-progress' || r.routeStatus === 'waiting-approval-to-resolve') {
         actions.push({
           label: 'Details',
           actionName: 'open-swap-and-bridge-tab'

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -188,6 +188,7 @@ const buildSwapAndBridgeUserRequests = async (
     ]
   }
   const requests: SignUserRequest[] = []
+  let shouldBuildSwapOrBridgeTx = true
   if (userTx.approvalData) {
     const erc20Interface = new Interface(ERC20.abi)
     let shouldApprove = true
@@ -247,30 +248,34 @@ const buildSwapAndBridgeUserRequests = async (
           isApproval: true
         }
       } as SignUserRequest)
+      // first build only the approval tx and then when confirmed this func will be called a second time
+      // and then only the swap or bridge tx will be created
+      shouldBuildSwapOrBridgeTx = false
     }
   }
 
-  requests.push({
-    id: userTx.activeRouteId,
-    action: {
-      kind: 'calls' as const,
-      calls: [
-        {
-          to: userTx.txTarget,
-          value: BigInt(userTx.value),
-          data: userTx.txData,
-          fromUserRequestId: userTx.activeRouteId
-        } as Call
-      ]
-    },
-    meta: {
-      isSignAction: true,
-      networkId,
-      accountAddr: account.addr,
-      activeRouteId: userTx.activeRouteId
-    }
-  } as SignUserRequest)
-
+  if (shouldBuildSwapOrBridgeTx) {
+    requests.push({
+      id: userTx.activeRouteId,
+      action: {
+        kind: 'calls' as const,
+        calls: [
+          {
+            to: userTx.txTarget,
+            value: BigInt(userTx.value),
+            data: userTx.txData,
+            fromUserRequestId: userTx.activeRouteId
+          } as Call
+        ]
+      },
+      meta: {
+        isSignAction: true,
+        networkId,
+        accountAddr: account.addr,
+        activeRouteId: userTx.activeRouteId
+      }
+    } as SignUserRequest)
+  }
   return requests
 }
 


### PR DESCRIPTION
* added: 'waiting-approval-to-resolve' routeStatus
* do not build both approval and swap or bridge tx at the same time to prevent bugs - first build the approval tx and when confirmed build the swap or bridge tx 


* Refactoring part resolves https://github.com/AmbireTech/ambire-app/issues/3542:
    * Previously, the routeStatus was updated after signing a transaction in resolveAccountOpAction within the main function. However, with smart accounts, this approach caused issues because the relayer would modify or batch the transaction with others, resulting in a different txnId. This mismatch led to errors in Socket, as the incorrect txnId was passed, preventing proper status updates for some routes indefinitely.
    * Now, all routeStatus updates for the whole lifecycle of the activeRoute occur after receiving updates in the SubmittedAccountOp from the activity controller. This logic has been consolidated into a single function, making the update process for activeRoutes more robust, less prone to errors, and easier to maintain.