### PR TITLE
Fix / V1 Signature warning broke

### DIFF
--- a/src/libs/networks/networks.ts
+++ b/src/libs/networks/networks.ts
@@ -17,7 +17,7 @@ import { getRpcProvider } from '../../services/provider'
 import { getSASupport } from '../deployless/simulateDeployCall'
 
 // bnb, fantom, metis
-const relayerAdditionalNetworks = [56n, 250n, 1088n]
+export const relayerAdditionalNetworks = [56n, 250n, 1088n]
 
 // 4337 network support
 // if it is supported on the network (hasBundlerSupport),

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -29,6 +29,7 @@ import {
   getSignableHash
 } from '../accountOp/accountOp'
 import { fromDescriptor } from '../deployless/deployless'
+import { relayerAdditionalNetworks } from '../networks/networks'
 import { getActivatorCall } from '../userOperation/userOperation'
 
 // EIP6492 signature ends in magicBytes, which ends with a 0x92,
@@ -304,6 +305,10 @@ export async function getPlainTextSignature(
       checksummedHexAddrWithout0x.slice(2)
     )
 
+    if (!network.predefined && !relayerAdditionalNetworks.includes(network.chainId)) {
+      throw new Error(`Signing messages is disallowed for v1 accounts on ${network.name}`)
+    }
+    
     if (
       isAsciiAddressInMessage ||
       isLowercaseHexAddressInMessage ||


### PR DESCRIPTION
closes: https://github.com/AmbireTech/ambire-app/issues/3143
Throw an error if v1 account is trying to sign message on unsupported network.