### PR TITLE
Fix / SignAccountOp Updates While Signing or Broadcasting

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -209,9 +209,9 @@ export class MainController extends EventEmitter {
 
   #notificationManager: NotificationManager
 
-  #signAccountOpSigningPromise: null | Promise<AccountOp | void> = null
+  #signAccountOpSigningPromise?: Promise<AccountOp | void>
 
-  #signAccountOpBroadcastPromise: null | Promise<SubmittedAccountOp> = null
+  #signAccountOpBroadcastPromise?: Promise<SubmittedAccountOp>
 
   constructor({
     storage,
@@ -1422,8 +1422,8 @@ export class MainController extends EventEmitter {
         )
       }
 
-      await this.#signAccountOpSigningPromise
-      await this.#signAccountOpBroadcastPromise
+      if (this.#signAccountOpSigningPromise) await this.#signAccountOpSigningPromise
+      if (this.#signAccountOpBroadcastPromise) await this.#signAccountOpBroadcastPromise
 
       const account = this.accounts.accounts.find((x) => x.addr === meta.accountAddr)!
       const accountState = this.accounts.accountStates[meta.accountAddr][meta.networkId]

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -209,7 +209,7 @@ export class MainController extends EventEmitter {
 
   #notificationManager: NotificationManager
 
-  #signAccountOpSigningPromise?: Promise<AccountOp | void>
+  #signAccountOpSigningPromise?: Promise<AccountOp | void | null>
 
   #signAccountOpBroadcastPromise?: Promise<SubmittedAccountOp>
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -209,9 +209,9 @@ export class MainController extends EventEmitter {
 
   #notificationManager: NotificationManager
 
-  #signAccountOpSigningPromise: Promise<AccountOp | void> | null = null
+  #signAccountOpSigningPromise: null | Promise<AccountOp | void> = null
 
-  #signAccountOpBroadcastPromise: Promise<SubmittedAccountOp> | null = null
+  #signAccountOpBroadcastPromise: null | Promise<SubmittedAccountOp> = null
 
   constructor({
     storage,


### PR DESCRIPTION
prevent the signAccountOp from being replaced with another signAccountOp while the previous one is still in the signing or broadcasting process. Now the new request will await the completion of the previous signAccountOp to finish and be destroyed properly before being added as an action

resolves: https://github.com/AmbireTech/ambire-app/issues/3547