### PR TITLE
Fix/ Update networksWithAccountStateError on `main.removeNetwork` (accountAdder)

### DIFF
--- a/src/controllers/accountAdder/accountAdder.ts
+++ b/src/controllers/accountAdder/accountAdder.ts
@@ -676,6 +676,11 @@ export class AccountAdderController extends EventEmitter {
     this.emitUpdate()
   }
 
+  removeNetworkData(id: Network['id']) {
+    this.networksWithAccountStateError = this.networksWithAccountStateError.filter((x) => x !== id)
+    this.emitUpdate()
+  }
+
   async #deriveAccounts(): Promise<DerivedAccount[]> {
     // Should never happen, because before the #deriveAccounts method gets
     // called - there is a check if the #keyIterator exists.

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1654,6 +1654,7 @@ export class MainController extends EventEmitter {
     await this.networks.removeNetwork(id)
     this.portfolio.removeNetworkData(id)
     this.defiPositions.removeNetworkData(id)
+    this.accountAdder.removeNetworkData(id)
   }
 
   async resolveAccountOpAction(data: any, actionId: AccountOpAction['id']) {


### PR DESCRIPTION
## How to reproduce:
- Add a network with a shitty RPC
- Open the account adder
- Make sure you see a warning
- With the account adder open, open network settings in a new tab
- Remove the problematic networks and expect the warning to go away


Closes https://github.com/AmbireTech/ambire-app/issues/3591