### PR TITLE
Enhancement/ Nft already minted human readable error

### DIFF
--- a/src/libs/errorDecoder/handlers/revert.ts
+++ b/src/libs/errorDecoder/handlers/revert.ts
@@ -4,8 +4,6 @@ import { AbiCoder, ErrorFragment } from 'ethers'
 import { ERROR_PREFIX } from '../constants'
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 
-const PREFIXES_TO_REMOVE = ['ERC20: ']
-
 class RevertErrorHandler implements ErrorHandler {
   public matches(data: string): boolean {
     return data?.startsWith(ERROR_PREFIX)
@@ -18,15 +16,10 @@ class RevertErrorHandler implements ErrorHandler {
       const fragment = ErrorFragment.from('Error(string)')
       const args = abi.decode(fragment.inputs, `0x${encodedReason}`)
       const reason = args[0] as string
-      let formattedReason = reason
-
-      PREFIXES_TO_REMOVE.forEach((prefix) => {
-        formattedReason = formattedReason.replace(prefix, '')
-      })
 
       return {
         type: ErrorType.RevertError,
-        reason: formattedReason,
+        reason,
         data
       }
     } catch (e) {

--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -99,7 +99,7 @@ const ESTIMATION_ERRORS: ErrorHumanizerError[] = [
     message: 'this dApp does not support Smart Account wallets. Use a Basic Account (EOA) instead.'
   },
   {
-    reasons: ['token already minted'],
+    reasons: ['ERC721: token already minted'],
     message:
       'the NFT you are trying to mint is already minted. This can also happen if you have batched multiple mint transactions for the same NFT.'
   }

--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -96,8 +96,12 @@ const ESTIMATION_ERRORS: ErrorHumanizerError[] = [
       'contracts allowed',
       'ontract is not allowed'
     ],
+    message: 'this dApp does not support Smart Account wallets. Use a Basic Account (EOA) instead.'
+  },
+  {
+    reasons: ['token already minted'],
     message:
-      'this dApp does not support Smart Account wallets. Please use a Basic Account (EOA) to interact with this dApp.'
+      'the NFT you are trying to mint is already minted. This can also happen if you have batched multiple mint transactions for the same NFT.'
   }
 ]
 


### PR DESCRIPTION
## Changes:
- Don't remove ERC20: prefix from errors. That was needed before as we were doing strict comparisons and the prefix was returned arbitrarily 
- Humanize NFT already minted

![image](https://github.com/user-attachments/assets/fd87721a-0991-4cfe-b22b-a5282c6fcb4c)
