### PR TITLE
fix / Get Dapps

### DIFF
--- a/src/controllers/dapps/dapps.ts
+++ b/src/controllers/dapps/dapps.ts
@@ -49,7 +49,7 @@ export class DappsController extends EventEmitter {
     )
 
     return [...this.#dapps, ...predefinedDappsParsed].reduce((acc: Dapp[], curr: Dapp): Dapp[] => {
-      if (!acc.some(({ name }) => name === curr.name)) return [...acc, curr]
+      if (!acc.some(({ url }) => url === curr.url)) return [...acc, curr]
       return acc
     }, [])
   }


### PR DESCRIPTION
* There was an issue in the dApps getter where predefinedDapps and customDapps were improperly reduced into a final list. As a result, some custom dApps were excluded from the final dApps list, leading to connection problems with these missing dApps