### PR TITLE
Fix / Unable to open the popup window due to opened action window

### DIFF
--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -260,6 +260,11 @@ export class ActionsController extends EventEmitter {
     this.#windowManager.focus(this.actionWindow.id)
   }
 
+  closeActionWindow = () => {
+    if (!this.actionWindow.id) return
+    this.#windowManager.remove(this.actionWindow.id)
+  }
+
   setWindowLoaded() {
     if (!this.actionWindow.id) return
     this.actionWindow.loaded = true

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -438,6 +438,10 @@ export class MainController extends EventEmitter {
       console.error(`Account with address ${toAccountAddr} does not exist`)
       return
     }
+
+    // call closeActionWindow while still on the currently selected account to allow proper
+    // state cleanup of the controllers like actionsCtrl, signAccountOpCtrl, signMessageCtrl...
+    this.actions.closeActionWindow()
     this.selectedAccount.setAccount(accountToSelect)
     this.swapAndBridge.onAccountChange()
     this.dapps.broadcastDappSessionEvent('accountsChanged', [toAccountAddr])
@@ -451,7 +455,6 @@ export class MainController extends EventEmitter {
     this.accounts.updateAccountState(toAccountAddr)
     this.updateSelectedAccountPortfolio()
     this.defiPositions.updatePositions()
-
     this.emitUpdate()
   }
 


### PR DESCRIPTION
When the account is changed while there is a pending action like signAccountOp and when on the new account one tries to open the popup window it does not work because there is a minimized action window that can not be automatically opened because the action for the window is filtered out for the newly selected account

Steps to reproduce before the fix:
1. open swap&bridge or transfer screen and make a transaction
2. minimize the action window of the signAccountOp
3. on the swap&bridge or transfer screen press back which leads to the Dashboard screen
4. on the Dashboard switch the account
5. then try to open the extension popup or refocus the action window and reject the signAccountOp - it is not possible