### PR TITLE
Humanizer: fix recursively hidden calls inside execute calls explot

### DIFF
--- a/src/libs/humanizer/modules/embeddedAmbireOperationHumanizer/ambireOperation.test.ts
+++ b/src/libs/humanizer/modules/embeddedAmbireOperationHumanizer/ambireOperation.test.ts
@@ -15,8 +15,8 @@ const iface = new Interface([
   ...AmbireAccount,
   'function transfer(address recipient, uint256 amount)'
 ])
-describe('Legends', () => {
-  it('Linking, both invitation and no invitation', () => {
+describe('Hidden ambire operations', () => {
+  it('Ambire transactions', () => {
     const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
     const transactionsToWrap = [
       {

--- a/src/libs/humanizer/modules/embeddedAmbireOperationHumanizer/ambireOperation.test.ts
+++ b/src/libs/humanizer/modules/embeddedAmbireOperationHumanizer/ambireOperation.test.ts
@@ -6,7 +6,7 @@ import { AccountOp } from '../../../accountOp/accountOp'
 import { Call } from '../../../accountOp/types'
 import { AmbireAccount } from '../../const/abis/AmbireAccount'
 import { HumanizerMeta, IrCall } from '../../interfaces'
-import { compareHumanizerVisualizations, compareVisualizations } from '../../testHelpers'
+import { compareVisualizations } from '../../testHelpers'
 import { getAction, getAddressVisualization, getLabel } from '../../utils'
 import { embeddedAmbireOperationHumanizer } from '.'
 
@@ -107,11 +107,11 @@ describe('Hidden ambire operations', () => {
         // i+1 is just arbitrary value at the end
         expect(call.data).toBe(iface.encodeFunctionData('transfer', [ZeroAddress, i]))
       } else {
-        expect(call.fullVisualization?.length).toBe(3)
-        compareHumanizerVisualizations(
-          [call],
-          [[getAction('Execute calls'), getLabel('from'), getAddressVisualization(accountAddr2)]]
-        )
+        compareVisualizations(call.fullVisualization!, [
+          getAction('Execute calls'),
+          getLabel('from'),
+          getAddressVisualization(accountAddr2)
+        ])
       }
     })
   })


### PR DESCRIPTION
Follows: https://github.com/AmbireTech/ambire-common/pull/1194

Simply recursively unwrap calls found inside calls to ambire accounts' execute functions