### PR TITLE
Bug / Swap & Bridge normalize incoming Socket tokens in (active) routes

### DIFF
--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -345,7 +345,14 @@ export class SocketAPI {
       userTxs: response.result.userTxs.map((userTx) => ({
         ...userTx,
         fromAsset: userTx.fromAsset ? normalizeIncomingSocketToken(userTx.fromAsset) : undefined,
-        toAsset: normalizeIncomingSocketToken(userTx.toAsset)
+        toAsset: normalizeIncomingSocketToken(userTx.toAsset),
+        steps: userTx.steps
+          ? userTx.steps.map((step) => ({
+              ...step,
+              fromAsset: normalizeIncomingSocketToken(step.fromAsset),
+              toAsset: normalizeIncomingSocketToken(step.toAsset)
+            }))
+          : undefined
       }))
     }
   }


### PR DESCRIPTION
Not normalizing incoming Socket tokens in (active) routes was causing troubles for the parts that expect normalized addresses like the token icons logic. Resolves https://github.com/AmbireTech/ambire-app/issues/3725

TODO: Test various scenarios and maybe add types for the route/active-routes res?