### PR TITLE
UX/ Reduce RPC error banners

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -588,6 +588,7 @@ export class MainController extends EventEmitter {
 
     this.signAccountOp = new SignAccountOpController(
       this.accounts,
+      this.providers,
       this.keystore,
       this.portfolio,
       this.#externalSignerControllers,
@@ -963,7 +964,12 @@ export class MainController extends EventEmitter {
       // However, even if we don't trigger an update here, it's not a big problem,
       // as the account state will be updated anyway, and its update will be very recent.
       !isUpdatingAccount && this.selectedAccount.account?.addr
-        ? this.accounts.updateAccountState(this.selectedAccount.account.addr, 'pending')
+        ? this.accounts.updateAccountState(
+            this.selectedAccount.account.addr,
+            'pending',
+            undefined,
+            true
+          )
         : Promise.resolve(),
       // `updateSelectedAccountPortfolio` doesn't rely on `withStatus` validation internally,
       // as the PortfolioController already exposes flags that are highly sufficient for the UX.

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -322,12 +322,20 @@ export class SelectedAccountController extends EventEmitter {
   }
 
   #updatePortfolioBanners(skipUpdate?: boolean) {
-    if (!this.account || !this.#networks || !this.#providers || !this.#portfolio) return
+    if (
+      !this.account ||
+      !this.#networks ||
+      !this.#providers ||
+      !this.#portfolio ||
+      this.#accounts.areAccountStatesLoading
+    )
+      return
 
     const networksWithFailedRPCBanners = getNetworksWithFailedRPCBanners({
       providers: this.#providers.providers,
       networks: this.#networks.networks,
-      networksWithAssets: this.#portfolio.getNetworksWithAssets(this.account.addr)
+      networksWithAssets: this.#portfolio.getNetworksWithAssets(this.account.addr),
+      accountState: this.#accounts.accountStates[this.account.addr]
     })
 
     const errorBanners = getNetworksWithPortfolioErrorBanners({

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -454,6 +454,7 @@ const init = async (
   const callRelayer = relayerCall.bind({ url: '', fetch })
   const controller = new SignAccountOpController(
     accountsCtrl,
+    providersCtrl,
     keystore,
     portfolio,
     {},

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -59,6 +59,7 @@ import { AccountOpAction } from '../actions/actions'
 import EventEmitter from '../eventEmitter/eventEmitter'
 import { KeystoreController } from '../keystore/keystore'
 import { PortfolioController } from '../portfolio/portfolio'
+import { ProvidersController } from '../providers/providers'
 import {
   getFeeSpeedIdentifier,
   getFeeTokenPriceUnavailableWarning,
@@ -114,6 +115,8 @@ export class SignAccountOpController extends EventEmitter {
   #accounts: AccountsController
 
   #keystore: KeystoreController
+
+  #providers: ProvidersController
 
   #portfolio: PortfolioController
 
@@ -175,6 +178,7 @@ export class SignAccountOpController extends EventEmitter {
 
   constructor(
     accounts: AccountsController,
+    providers: ProvidersController,
     keystore: KeystoreController,
     portfolio: PortfolioController,
     externalSignerControllers: ExternalSignerControllers,
@@ -189,6 +193,7 @@ export class SignAccountOpController extends EventEmitter {
     super()
 
     this.#accounts = accounts
+    this.#providers = providers
     this.#keystore = keystore
     this.#portfolio = portfolio
     this.#externalSignerControllers = externalSignerControllers

--- a/src/interfaces/account.ts
+++ b/src/interfaces/account.ts
@@ -43,6 +43,7 @@ export interface AccountOnchainState {
   isErc4337Nonce: boolean
   isV2: boolean
   currentBlock: bigint
+  updatedAt: number
 }
 
 export type AccountStates = {

--- a/src/libs/accountState/accountState.ts
+++ b/src/libs/accountState/accountState.ts
@@ -82,7 +82,8 @@ export async function getAccountState(
       ),
       currentBlock: accResult.currentBlock,
       deployError:
-        accounts[index].associatedKeys.length > 0 && accResult.associatedKeyPrivileges.length === 0
+        accounts[index].associatedKeys.length > 0 && accResult.associatedKeyPrivileges.length === 0,
+      updatedAt: Date.now()
     }
 
     return res

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -1,4 +1,4 @@
-import { Account } from '../../interfaces/account'
+import { Account, AccountStates } from '../../interfaces/account'
 import { AccountOpAction, Action as ActionFromActionsQueue } from '../../interfaces/actions'
 // eslint-disable-next-line import/no-cycle
 import { Action, Banner } from '../../interfaces/banner'
@@ -327,14 +327,16 @@ export const getKeySyncBanner = (addr: string, email: string, keys: string[]) =>
 export const getNetworksWithFailedRPCBanners = ({
   providers,
   networks,
-  networksWithAssets
+  networksWithAssets,
+  accountState
 }: {
   providers: RPCProviders
   networks: Network[]
   networksWithAssets: NetworkId[]
+  accountState: AccountStates[string]
 }): Banner[] => {
   const banners: Banner[] = []
-  const networkIds = getNetworksWithFailedRPC({ providers }).filter((networkId) =>
+  const networkIds = getNetworksWithFailedRPC({ providers, accountState }).filter((networkId) =>
     networksWithAssets.includes(networkId)
   )
 

--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -14,7 +14,12 @@ const BROADCAST_OR_ESTIMATION_ERRORS: ErrorHumanizerError[] = [
       'the RPC provider does not support the requested operation. Please check your RPC settings or contact the dApp team.'
   },
   {
-    reasons: [RPC_HARDCODED_ERRORS.rpcTimeout, 'Unable to connect to provider'],
+    reasons: [
+      RPC_HARDCODED_ERRORS.rpcTimeout,
+      'Unable to connect to provider',
+      'SERVER_ERROR',
+      'NETWORK_ERROR'
+    ],
     message:
       'of a problem with the RPC on this network. Please try again later, change the RPC or contact support for assistance.'
   },

--- a/src/libs/networks/networks.ts
+++ b/src/libs/networks/networks.ts
@@ -74,10 +74,10 @@ export const getNetworksWithFailedRPC = ({
     if (isProviderWorking) return false
     if (!accountState || !accountState[networkId]) return true
 
-    const FIVE_MINUTES = 1000 * 60 * 5
+    const EIGHT_MINUTES = 1000 * 60 * 8
     const lastUpdate = accountState[networkId]?.updatedAt || 0
 
-    return Date.now() - lastUpdate > FIVE_MINUTES
+    return Date.now() - lastUpdate > EIGHT_MINUTES
   })
 }
 


### PR DESCRIPTION
## The problem
Account states are updated every 5 minutes automatically and on manual refresh on the dashboard. When the user is simply browsing on his laptop, the account state update fails in the background and the user decides to open his wallet to check how his portfolio is going he will see an RPC error banner, even if there was a successful update 5 minutes ago.
## The solution
Save an update timestamp and compare it before displaying an RPC error banner. If the last update is from > 8 minutes ago, an error banner is displayed. Also, the banner is displayed immediately in case of a manual refresh on the dashboard as a bad RPC means that there will be portfolio and defi positions banners, which must be replaced with a single RPC error banner for better UX. 

Closes https://github.com/AmbireTech/ambire-app/issues/3105