### PR TITLE
Feature / Handle hidden tokens in the Swap & Bridge token lists

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -549,7 +549,14 @@ export class SwapAndBridgeController extends EventEmitter {
 
         return hasAmount && !token.flags.onGasTank && !token.flags.rewardsType
       }) || []
-    this.portfolioTokenList = sortPortfolioTokenList(tokens)
+    this.portfolioTokenList = sortPortfolioTokenList(
+      // Filtering out hidden tokens here means: 1) They won't be displayed in
+      // the "From" token list (`this.portfolioTokenList`) and 2) They won't be
+      // added to the "Receive" token list as additional tokens from portfolio,
+      // BUT 3) They will appear in the "Receive" if they are present in service
+      // provider's to token list. This is the desired behavior.
+      tokens.filter((t) => !t.isHidden)
+    )
 
     const fromSelectedTokenInNextPortfolio = this.portfolioTokenList.find(
       (t) =>


### PR DESCRIPTION
Hidden tokens 1) Won't be displayed in the "From" token list and 2) They won't be added to the "Receive" token list as additional tokens from the portfolio (example: hiding SKYA token on Base), BUT 3) They will STILL appear in the "Receive" list if they are present in service provider's to token list (example: hiding cbBTC on Base).

Resolves https://github.com/AmbireTech/ambire-app/issues/3743