### PR TITLE
Config / CoinGecko helpers for token details retrieval

### DIFF
--- a/src/consts/coingecko.ts
+++ b/src/consts/coingecko.ts
@@ -45,5 +45,5 @@ export function getCoinGeckoTokenApiUrl({
   if (tokenAddr === ZeroAddress) return `${COINGECKO_API_BASE_URL}${geckoNativeCoinId}`
 
   const geckoTokenAddress = geckoTokenAddressMapper(tokenAddr)
-  return `${COINGECKO_API_BASE_URL}${geckoChainId}/contact/${geckoTokenAddress}`
+  return `${COINGECKO_API_BASE_URL}${geckoChainId}/contract/${geckoTokenAddress}`
 }

--- a/src/consts/coingecko.ts
+++ b/src/consts/coingecko.ts
@@ -3,6 +3,8 @@ import { ZeroAddress } from 'ethers'
 import { Network } from '../interfaces/network'
 import { WALLET_STAKING_ADDR, WALLET_TOKEN } from './addresses'
 
+const COINGECKO_API_BASE_URL = 'https://api.coingecko.com/api/v3/coins/'
+
 // @TODO some form of a constants list
 export function geckoIdMapper(address: string, network: Network): string | null {
   if (address === ZeroAddress) return network.nativeAssetId
@@ -24,20 +26,23 @@ export function geckoTokenAddressMapper(address: string) {
   return address
 }
 
-const COINGECKO_COINS_API_URL = 'https://api.coingecko.com/api/v3/coins/'
-
-export function getGeckoTokenCoinsApiUrl(tokenAddress: string, geckoNetworkId: string) {
+/**
+ * Constructs the CoinGecko API URL for a given token address and network ID.
+ * Handles special cases where the CoinGecko API does not correctly handle
+ * certain tokens like native tokens on some networks.
+ */
+export function getCoinGeckoTokenApiUrl(tokenAddress: string, geckoNetworkId: string) {
   // Exception because the CoinGecko API doesn't handle these cases correctly.
   // Alias them to the ETH on Ethereum URL, so a valid URL is returned.
   const isNativeTokenOnNetworksThatHaveEthAsNative =
     tokenAddress === ZeroAddress &&
     ['optimistic-ethereum', 'base', 'arbitrum-one'].includes(geckoNetworkId)
-  if (isNativeTokenOnNetworksThatHaveEthAsNative) return `${COINGECKO_COINS_API_URL}ethereum`
+  if (isNativeTokenOnNetworksThatHaveEthAsNative) return `${COINGECKO_API_BASE_URL}ethereum`
 
   // CoinGecko does not handle native assets (ETH, MATIC, BNB...) via the /contract endpoint.
   // Instead, native assets are identified by the `geckoNetworkId` directly.
-  if (tokenAddress === ZeroAddress) return `${COINGECKO_COINS_API_URL}${geckoNetworkId}`
+  if (tokenAddress === ZeroAddress) return `${COINGECKO_API_BASE_URL}${geckoNetworkId}`
 
   const geckoTokenAddress = geckoTokenAddressMapper(tokenAddress)
-  return `${COINGECKO_COINS_API_URL}${geckoNetworkId}/contact/${geckoTokenAddress}`
+  return `${COINGECKO_API_BASE_URL}${geckoNetworkId}/contact/${geckoTokenAddress}`
 }

--- a/src/consts/coingecko.ts
+++ b/src/consts/coingecko.ts
@@ -1,6 +1,7 @@
 import { ZeroAddress } from 'ethers'
 
 import { Network } from '../interfaces/network'
+import { WALLET_STAKING_ADDR, WALLET_TOKEN } from './addresses'
 
 // @TODO some form of a constants list
 export function geckoIdMapper(address: string, network: Network): string | null {
@@ -10,4 +11,15 @@ export function geckoIdMapper(address: string, network: Network): string | null 
   if (address === '0x4da27a545c0c5B758a6BA100e3a049001de870f5') return 'aave'
 
   return null
+}
+
+/**
+ * Maps specific token addresses to alternative addresses if they are missing on
+ * CoinGecko (so that they are aliased to existing tokens).
+ */
+export function geckoTokenAddressMapper(address: string) {
+  // xWALLET is missing on CoinGecko, so alias it to WALLET token (that exists on CoinGecko)
+  if (address === WALLET_STAKING_ADDR) return WALLET_TOKEN
+
+  return address
 }

--- a/src/consts/coingecko.ts
+++ b/src/consts/coingecko.ts
@@ -4,6 +4,7 @@ import { Network } from '../interfaces/network'
 import { WALLET_STAKING_ADDR, WALLET_TOKEN } from './addresses'
 
 const COINGECKO_API_BASE_URL = 'https://api.coingecko.com/api/v3/coins/'
+const COINGECKO_BASE_URL = 'https://www.coingecko.com/en/coins/'
 
 // @TODO some form of a constants list
 export function geckoIdMapper(address: string, network: Network): string | null {
@@ -47,3 +48,6 @@ export function getCoinGeckoTokenApiUrl({
   const geckoTokenAddress = geckoTokenAddressMapper(tokenAddr)
   return `${COINGECKO_API_BASE_URL}${geckoChainId}/contract/${geckoTokenAddress}`
 }
+
+/** Constructs the CoinGecko URL for a given token slug. */
+export const getCoinGeckoTokenUrl = (slug: string) => `${COINGECKO_BASE_URL}${slug}`

--- a/src/consts/coingecko.ts
+++ b/src/consts/coingecko.ts
@@ -28,21 +28,22 @@ export function geckoTokenAddressMapper(address: string) {
 
 /**
  * Constructs the CoinGecko API URL for a given token address and network ID.
- * Handles special cases where the CoinGecko API does not correctly handle
- * certain tokens like native tokens on some networks.
+ * Handles special cases where the CoinGecko API handles differently certain
+ * tokens like the native tokens.
  */
-export function getCoinGeckoTokenApiUrl(tokenAddress: string, geckoNetworkId: string) {
-  // Exception because the CoinGecko API doesn't handle these cases correctly.
-  // Alias them to the ETH on Ethereum URL, so a valid URL is returned.
-  const isNativeTokenOnNetworksThatHaveEthAsNative =
-    tokenAddress === ZeroAddress &&
-    ['optimistic-ethereum', 'base', 'arbitrum-one'].includes(geckoNetworkId)
-  if (isNativeTokenOnNetworksThatHaveEthAsNative) return `${COINGECKO_API_BASE_URL}ethereum`
-
+export function getCoinGeckoTokenApiUrl({
+  tokenAddr,
+  geckoChainId,
+  geckoNativeCoinId
+}: {
+  tokenAddr: string
+  geckoChainId: string
+  geckoNativeCoinId: string
+}) {
   // CoinGecko does not handle native assets (ETH, MATIC, BNB...) via the /contract endpoint.
-  // Instead, native assets are identified by the `geckoNetworkId` directly.
-  if (tokenAddress === ZeroAddress) return `${COINGECKO_API_BASE_URL}${geckoNetworkId}`
+  // Instead, native assets are identified by URL with the `nativeAssetId` directly.
+  if (tokenAddr === ZeroAddress) return `${COINGECKO_API_BASE_URL}${geckoNativeCoinId}`
 
-  const geckoTokenAddress = geckoTokenAddressMapper(tokenAddress)
-  return `${COINGECKO_API_BASE_URL}${geckoNetworkId}/contact/${geckoTokenAddress}`
+  const geckoTokenAddress = geckoTokenAddressMapper(tokenAddr)
+  return `${COINGECKO_API_BASE_URL}${geckoChainId}/contact/${geckoTokenAddress}`
 }

--- a/src/consts/coingecko.ts
+++ b/src/consts/coingecko.ts
@@ -23,3 +23,21 @@ export function geckoTokenAddressMapper(address: string) {
 
   return address
 }
+
+const COINGECKO_COINS_API_URL = 'https://api.coingecko.com/api/v3/coins/'
+
+export function getGeckoTokenCoinsApiUrl(tokenAddress: string, geckoNetworkId: string) {
+  // Exception because the CoinGecko API doesn't handle these cases correctly.
+  // Alias them to the ETH on Ethereum URL, so a valid URL is returned.
+  const isNativeTokenOnNetworksThatHaveEthAsNative =
+    tokenAddress === ZeroAddress &&
+    ['optimistic-ethereum', 'base', 'arbitrum-one'].includes(geckoNetworkId)
+  if (isNativeTokenOnNetworksThatHaveEthAsNative) return `${COINGECKO_COINS_API_URL}ethereum`
+
+  // CoinGecko does not handle native assets (ETH, MATIC, BNB...) via the /contract endpoint.
+  // Instead, native assets are identified by the `geckoNetworkId` directly.
+  if (tokenAddress === ZeroAddress) return `${COINGECKO_COINS_API_URL}${geckoNetworkId}`
+
+  const geckoTokenAddress = geckoTokenAddressMapper(tokenAddress)
+  return `${COINGECKO_COINS_API_URL}${geckoNetworkId}/contact/${geckoTokenAddress}`
+}


### PR DESCRIPTION
Adds helpers for CoinGecko token retrieval:

- Added: `geckoTokenAddressMapper`, maps specific token addresses to alternative addresses if they are missing on CoinGecko (so that they are aliased to existing tokens), example: xWALLET (missing on CoinGecko) to WALLET
- Added: `getCoinGeckoTokenApiUrl`,  constructs the CoinGecko API URL for a given token address and network ID. Handles special cases where the CoinGecko API handles differently certain tokens like the native tokens.
- Added: `getCoinGeckoTokenUrl`, constructs the CoinGecko URL for a given token slug.