### PR TITLE
Fix/insufficient native report

### DIFF
--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -10,6 +10,7 @@ import { suppressConsoleBeforeEach } from '../../../test/helpers/console'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { BIP44_STANDARD_DERIVATION_TEMPLATE } from '../../consts/derivation'
+import { networks } from '../../consts/networks'
 import { SelectedAccountForImport } from '../../interfaces/account'
 import { UserRequest } from '../../interfaces/userRequest'
 import { InnerCallFailureError } from '../../libs/errorDecoder/customErrors'
@@ -432,7 +433,11 @@ describe('Main Controller ', () => {
     })
     it('Error that should be humanized by getHumanReadableBroadcastError', async () => {
       const { controllerAnyType } = prepareTest()
-      const error = new InnerCallFailureError('   transfer amount exceeds balance   ')
+      const error = new InnerCallFailureError(
+        '   transfer amount exceeds balance   ',
+        [],
+        networks.find((net) => net.id === 'base')!
+      )
 
       try {
         await controllerAnyType.throwBroadcastAccountOp({

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -2059,7 +2059,6 @@ export class MainController extends EventEmitter {
             this.emitError(e)
           },
           this.signAccountOp.bundlerSwitcher,
-          portfolioNativeValue,
           {
             is4337Broadcast: isErc4337Broadcast(
               account,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/brace-style */
 
 import { ethErrors } from 'eth-rpc-errors'
-import { getAddress, getBigInt, Interface, isAddress } from 'ethers'
+import { getAddress, getBigInt, Interface, isAddress, ZeroAddress } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
@@ -1992,6 +1992,14 @@ export class MainController extends EventEmitter {
         this.portfolio.getLatestPortfolioState(localAccountOp.accountAddr)?.gasTank?.result
           ?.tokens ?? []
 
+      // get the current native value the user has for the network or
+      // an undefined if it's not available atms
+      const portfolioNativeValue = this.portfolio
+        .getLatestPortfolioState(localAccountOp.accountAddr)
+        ?.[localAccountOp.networkId]?.result?.tokens.find(
+          (token) => token.address === ZeroAddress
+        )?.amount
+
       const feeTokens =
         [...networkFeeTokens, ...gasTankFeeTokens].filter((t) => t.flags.isFeeToken) || []
 
@@ -2051,6 +2059,7 @@ export class MainController extends EventEmitter {
             this.emitError(e)
           },
           this.signAccountOp.bundlerSwitcher,
+          portfolioNativeValue,
           {
             is4337Broadcast: isErc4337Broadcast(
               account,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/brace-style */
 
 import { ethErrors } from 'eth-rpc-errors'
-import { getAddress, getBigInt, Interface, isAddress, ZeroAddress } from 'ethers'
+import { getAddress, getBigInt, Interface, isAddress } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
@@ -1993,14 +1993,6 @@ export class MainController extends EventEmitter {
       const gasTankFeeTokens =
         this.portfolio.getLatestPortfolioState(localAccountOp.accountAddr)?.gasTank?.result
           ?.tokens ?? []
-
-      // get the current native value the user has for the network or
-      // an undefined if it's not available atms
-      const portfolioNativeValue = this.portfolio
-        .getLatestPortfolioState(localAccountOp.accountAddr)
-        ?.[localAccountOp.networkId]?.result?.tokens.find(
-          (token) => token.address === ZeroAddress
-        )?.amount
 
       const feeTokens =
         [...networkFeeTokens, ...gasTankFeeTokens].filter((t) => t.flags.isFeeToken) || []

--- a/src/libs/errorDecoder/customErrors.ts
+++ b/src/libs/errorDecoder/customErrors.ts
@@ -3,13 +3,24 @@
 import { isHexString } from 'ethers'
 
 import { BUNDLER } from '../../consts/bundlers'
+import { Network } from '../../interfaces/network'
+import { Call } from '../accountOp/types'
 
 class InnerCallFailureError extends Error {
   public data: string = ''
 
-  constructor(message: string) {
+  public calls: Call[]
+
+  public nativePortfolioValue: bigint | undefined
+
+  public network: Network
+
+  constructor(message: string, calls: Call[], network: Network, nativePortfolioValue?: bigint) {
     super(message)
     this.name = 'InnerCallFailureError'
+    this.calls = calls
+    this.network = network
+    this.nativePortfolioValue = nativePortfolioValue
     // If the message is a hex string pass it to
     // the data field so it can be used by other error handlers
     if (isHexString(message)) {

--- a/src/libs/errorDecoder/errorDecoder.test.ts
+++ b/src/libs/errorDecoder/errorDecoder.test.ts
@@ -6,8 +6,10 @@ import { describe, expect } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
 import { networks } from '../../consts/networks'
-import { MESSAGE_PREFIX } from '../errorHumanizer/estimationErrorHumanizer'
-import { humanizeEstimationOrBroadcastError } from '../errorHumanizer/humanizeCommonCases'
+import {
+  getHumanReadableEstimationError,
+  MESSAGE_PREFIX
+} from '../errorHumanizer/estimationErrorHumanizer'
 import { RELAYER_DOWN_MESSAGE, RelayerError } from '../relayerCall/relayerCall'
 import { PANIC_ERROR_PREFIX } from './constants'
 import { InnerCallFailureError, RelayerPaymasterError } from './customErrors'
@@ -371,8 +373,8 @@ describe('Error decoders work', () => {
     const error = new InnerCallFailureError('0x', [{ to: '', value: 10n, data: '0x' }], base, 9n)
     const decodedError = decodeError(error)
     expect(decodedError.reason).toBe(`Insufficient ${base.nativeAssetSymbol} for transaction calls`)
-    const humanized = humanizeEstimationOrBroadcastError(decodedError.reason, MESSAGE_PREFIX)
-    expect(humanized).toBe(`Insufficient ${base.nativeAssetSymbol} for transaction calls`)
+    const humanized = getHumanReadableEstimationError(decodedError)
+    expect(humanized.message).toBe(`Insufficient ${base.nativeAssetSymbol} for transaction calls`)
 
     const sameErrorOnAvax = new InnerCallFailureError(
       '0x',
@@ -384,14 +386,16 @@ describe('Error decoders work', () => {
     expect(decodedsameErrorOnAvax.reason).toBe(
       `Insufficient ${avalanche.nativeAssetSymbol} for transaction calls`
     )
-    const humanizedAvax = humanizeEstimationOrBroadcastError(decodedError.reason, MESSAGE_PREFIX)
-    expect(humanizedAvax).toBe(`Insufficient ${avalanche.nativeAssetSymbol} for transaction calls`)
+    const humanizedAvax = getHumanReadableEstimationError(decodedsameErrorOnAvax)
+    expect(humanizedAvax.message).toBe(
+      `Insufficient ${avalanche.nativeAssetSymbol} for transaction calls`
+    )
   })
   it('Should report transaction reverted with error unknown when error is 0x and the calls value is less or equal to the portfolio amount', async () => {
     const error = new InnerCallFailureError('0x', [{ to: '', value: 10n, data: '0x' }], base, 10n)
     const decodedError = decodeError(error)
     expect(decodedError.reason).toBe('Inner call: 0x')
-    const humanizedAvax = humanizeEstimationOrBroadcastError(decodedError.reason, MESSAGE_PREFIX)
-    expect(humanizedAvax).toBe(`${MESSAGE_PREFIX} it reverted onchain with reason unknown.`)
+    const humanizedAvax = getHumanReadableEstimationError(decodedError)
+    expect(humanizedAvax.message).toBe(`${MESSAGE_PREFIX} it reverted onchain with reason unknown.`)
   })
 })

--- a/src/libs/errorDecoder/errorDecoder.test.ts
+++ b/src/libs/errorDecoder/errorDecoder.test.ts
@@ -5,6 +5,9 @@ import { ethers } from 'hardhat'
 import { describe, expect } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
+import { networks } from '../../consts/networks'
+import { MESSAGE_PREFIX } from '../errorHumanizer/estimationErrorHumanizer'
+import { humanizeEstimationOrBroadcastError } from '../errorHumanizer/humanizeCommonCases'
 import { RELAYER_DOWN_MESSAGE, RelayerError } from '../relayerCall/relayerCall'
 import { PANIC_ERROR_PREFIX } from './constants'
 import { InnerCallFailureError, RelayerPaymasterError } from './customErrors'
@@ -14,6 +17,9 @@ import { DecodedError, ErrorType } from './types'
 
 const TEST_MESSAGE_REVERT_DATA =
   '0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c54657374206d6573736167650000000000000000000000000000000000000000'
+
+const base = networks.find((net) => net.id === 'base')!
+const avalanche = networks.find((net) => net.id === 'avalanche')!
 
 export const MockBundlerEstimationError = class extends Error {
   public constructor(public shortMessage?: string) {
@@ -155,7 +161,7 @@ describe('Error decoders work', () => {
   })
   describe('InnerCallFailureHandler', () => {
     it('Error is decoded InnerCallFailureHandler it if not panic or revert', async () => {
-      const error = new InnerCallFailureError('transfer amount exceeds balance')
+      const error = new InnerCallFailureError('transfer amount exceeds balance', [], base)
       const decodedError = decodeError(error)
 
       expect(decodedError.type).toEqual(ErrorType.InnerCallFailureError)
@@ -163,7 +169,7 @@ describe('Error decoders work', () => {
       expect(decodedError.data).toBe('transfer amount exceeds balance')
     })
     it("Error doesn't gets overwritten by Panic/Revert if it is panic or revert", async () => {
-      const error = new InnerCallFailureError(TEST_MESSAGE_REVERT_DATA)
+      const error = new InnerCallFailureError(TEST_MESSAGE_REVERT_DATA, [], base)
       const decodedError = decodeError(error)
 
       expect(decodedError.type).toEqual(ErrorType.RevertError)
@@ -340,7 +346,7 @@ describe('Error decoders work', () => {
     restore()
   })
   it('Should trim leading and trailing whitespaces from the reason', async () => {
-    const error = new InnerCallFailureError('   transfer amount exceeds balance   ')
+    const error = new InnerCallFailureError('   transfer amount exceeds balance   ', [], base)
     const decodedError = decodeError(error)
 
     expect(decodedError.reason).toBe('transfer amount exceeds balance')
@@ -360,5 +366,32 @@ describe('Error decoders work', () => {
 
     expect(decodedError.type).toEqual(ErrorType.UserRejectionError)
     expect(decodedError.reason).toBe(TRANSACTION_REJECTED_REASON)
+  })
+  it('Should report insufficient native when inner call error is 0x and the calls value is bigger than the portfolio amount', async () => {
+    const error = new InnerCallFailureError('0x', [{ to: '', value: 10n, data: '0x' }], base, 9n)
+    const decodedError = decodeError(error)
+    expect(decodedError.reason).toBe(`Insufficient ${base.nativeAssetSymbol} for transaction calls`)
+    const humanized = humanizeEstimationOrBroadcastError(decodedError.reason, MESSAGE_PREFIX)
+    expect(humanized).toBe(`Insufficient ${base.nativeAssetSymbol} for transaction calls`)
+
+    const sameErrorOnAvax = new InnerCallFailureError(
+      '0x',
+      [{ to: '', value: 10n, data: '0x' }],
+      avalanche,
+      9n
+    )
+    const decodedsameErrorOnAvax = decodeError(sameErrorOnAvax)
+    expect(decodedsameErrorOnAvax.reason).toBe(
+      `Insufficient ${avalanche.nativeAssetSymbol} for transaction calls`
+    )
+    const humanizedAvax = humanizeEstimationOrBroadcastError(decodedError.reason, MESSAGE_PREFIX)
+    expect(humanizedAvax).toBe(`Insufficient ${avalanche.nativeAssetSymbol} for transaction calls`)
+  })
+  it('Should report transaction reverted with error unknown when error is 0x and the calls value is less or equal to the portfolio amount', async () => {
+    const error = new InnerCallFailureError('0x', [{ to: '', value: 10n, data: '0x' }], base, 10n)
+    const decodedError = decodeError(error)
+    expect(decodedError.reason).toBe('Inner call: 0x')
+    const humanizedAvax = humanizeEstimationOrBroadcastError(decodedError.reason, MESSAGE_PREFIX)
+    expect(humanizedAvax).toBe(`${MESSAGE_PREFIX} it reverted onchain with reason unknown.`)
   })
 })

--- a/src/libs/errorDecoder/handlers/innerCallFailure.ts
+++ b/src/libs/errorDecoder/handlers/innerCallFailure.ts
@@ -25,7 +25,7 @@ class InnerCallFailureHandler implements ErrorHandler {
 
     // if the error is 0x but we don't have info on the portfolio value
     // because of an RPC failure or something, return error unknown
-    if (isError0x && innerCallError.nativePortfolioValue === undefined) {
+    if (innerCallError.nativePortfolioValue === undefined) {
       const reason = 'Inner call: 0x'
       return {
         type: this.type,

--- a/src/libs/errorDecoder/handlers/innerCallFailure.ts
+++ b/src/libs/errorDecoder/handlers/innerCallFailure.ts
@@ -1,16 +1,50 @@
 /* eslint-disable class-methods-use-this */
+import { InnerCallFailureError } from '../customErrors'
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 
 class InnerCallFailureHandler implements ErrorHandler {
+  type = ErrorType.InnerCallFailureError
+
   public matches(data: string, error: Error) {
     return error.name === 'InnerCallFailureError'
   }
 
   public handle(data: string, error: Error): DecodedError {
-    const reason = error.message === '0x' ? 'Inner call: 0x' : error.message
+    const innerCallError = error as InnerCallFailureError
+    const isError0x = innerCallError.message === '0x'
+
+    // if an error has been found, report it back
+    if (!isError0x) {
+      const reason = innerCallError.message
+      return {
+        type: this.type,
+        reason,
+        data: reason
+      }
+    }
+
+    // if the error is 0x but we don't have info on the portfolio value
+    // because of an RPC failure or something, return error unknown
+    if (isError0x && innerCallError.nativePortfolioValue === undefined) {
+      const reason = 'Inner call: 0x'
+      return {
+        type: this.type,
+        reason,
+        data: reason
+      }
+    }
+
+    let callsNative = 0n
+    innerCallError.calls.forEach((call) => {
+      callsNative += call.value ?? 0n
+    })
+    const isCallsNativeMoreThanPortfolio = callsNative > innerCallError.nativePortfolioValue!
+    const reason = isCallsNativeMoreThanPortfolio
+      ? `Insufficient ${innerCallError.network.nativeAssetSymbol} for transaction calls`
+      : 'Inner call: 0x'
 
     return {
-      type: ErrorType.InnerCallFailureError,
+      type: this.type,
       reason,
       data: reason
     }

--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -158,8 +158,7 @@ const ESTIMATION_ERRORS: ErrorHumanizerError[] = [
   },
   {
     reasons: ['Inner call: 0x'],
-    message:
-      'it reverted onchain. Reason might be insufficient funds in one of the transaction calls.'
+    message: 'it reverted onchain with reason unknown.'
   },
   // Rare contract errors
   {

--- a/src/libs/errorHumanizer/helpers.ts
+++ b/src/libs/errorHumanizer/helpers.ts
@@ -25,7 +25,9 @@ function getGenericMessageFromType(
     case ErrorType.UnknownError:
       return `${messagePrefix} of an unknown error.${messageSuffix}`
     case ErrorType.InnerCallFailureError:
-      return `${messagePrefix} it will revert onchain with reason unknown.${messageSuffix}`
+      return (
+        reason ?? `${messagePrefix} it will revert onchain with reason unknown.${messageSuffix}`
+      )
     // I don't think we should say anything else for this case
     case ErrorType.UserRejectionError:
       return 'Transaction rejected.'

--- a/src/libs/estimate/estimate.test.ts
+++ b/src/libs/estimate/estimate.test.ts
@@ -720,7 +720,6 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(ethereum, getSignAccountOpStatus, noStateUpdateStatuses),
-      0n,
       { calculateRefund: true }
     )
 
@@ -848,7 +847,6 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
-      0n,
       { is4337Broadcast: true }
     )
 
@@ -901,7 +899,6 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
-      0n,
       { is4337Broadcast: true }
     )
 
@@ -962,7 +959,6 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
-      0n,
       { is4337Broadcast: true }
     )
 
@@ -1003,7 +999,6 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
-      0n,
       { is4337Broadcast: true }
     )
 
@@ -1048,7 +1043,6 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
-      0n,
       { is4337Broadcast: true }
     )
 
@@ -1092,7 +1086,6 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(arbitrum, getSignAccountOpStatus, noStateUpdateStatuses),
-      0n,
       { is4337Broadcast: false }
     )
 

--- a/src/libs/estimate/estimate.test.ts
+++ b/src/libs/estimate/estimate.test.ts
@@ -720,6 +720,7 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(ethereum, getSignAccountOpStatus, noStateUpdateStatuses),
+      0n,
       { calculateRefund: true }
     )
 
@@ -847,6 +848,7 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
+      0n,
       { is4337Broadcast: true }
     )
 
@@ -899,6 +901,7 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
+      0n,
       { is4337Broadcast: true }
     )
 
@@ -961,6 +964,7 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
+      0n,
       { is4337Broadcast: true }
     )
 
@@ -1001,6 +1005,7 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
+      0n,
       { is4337Broadcast: true }
     )
 
@@ -1045,6 +1050,7 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(optimism, getSignAccountOpStatus, noStateUpdateStatuses),
+      0n,
       { is4337Broadcast: true }
     )
 
@@ -1088,6 +1094,7 @@ describe('estimate', () => {
       feeTokens,
       errorCallback,
       new BundlerSwitcher(arbitrum, getSignAccountOpStatus, noStateUpdateStatuses),
+      0n,
       { is4337Broadcast: false }
     )
 

--- a/src/libs/estimate/estimate.test.ts
+++ b/src/libs/estimate/estimate.test.ts
@@ -906,9 +906,7 @@ describe('estimate', () => {
     )
 
     expect(response.error).not.toBe(null)
-    expect(response.error?.message).toBe(
-      'The transaction will fail because it reverted onchain. Reason might be insufficient funds in one of the transaction calls.'
-    )
+    expect(response.error?.message).toBe('Insufficient ETH for transaction calls')
 
     expect(response.erc4337GasLimits).not.toBe(undefined)
     expect(BigInt(response.erc4337GasLimits!.callGasLimit)).toBeGreaterThan(0n)
@@ -1132,7 +1130,7 @@ describe('estimate', () => {
     )
     expect(response.error).not.toBe(null)
     expect(response.error?.message).toBe(
-      'The transaction will fail because it reverted onchain. Reason might be insufficient funds in one of the transaction calls.'
+      'The transaction will fail because it reverted onchain with reason unknown.'
     )
   })
 


### PR DESCRIPTION
Add an error message for insufficient native when these conditions are met:
* ambire estimation reverts with 0x (unknown error)
* all the transaction calls's value summed up is bigger than the amount the user has currently in his portfolio