### PR TITLE
Refactor/ Improve selected acc portfolio

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -34,10 +34,10 @@ import { ProvidersController } from '../providers/providers'
 export const DEFAULT_SELECTED_ACCOUNT_PORTFOLIO = {
   tokens: [],
   collections: [],
+  tokenAmounts: [],
   totalBalance: 0,
   isAllReady: false,
   networkSimulatedAccountOp: {},
-  tokenAmounts: [],
   latest: {},
   pending: {}
 }

--- a/src/interfaces/selectedAccount.ts
+++ b/src/interfaces/selectedAccount.ts
@@ -1,18 +1,33 @@
 import {
-  AccountState,
   CollectionResult as CollectionResultInterface,
   NetworkSimulatedAccountOp,
-  TokenAmount as TokenAmountInterface,
+  NetworkState,
   TokenResult as TokenResultInterface
 } from '../libs/portfolio/interfaces'
 
+/** A stripped version of the portfolio state that will be used in the UI */
+export type SelectedAccountPortfolioState = {
+  [networkId: string]:
+    | (Omit<NetworkState, 'result'> & {
+        result?: Omit<
+          NonNullable<NetworkState['result']>,
+          'tokens' | 'collections' | 'tokenErrors' | 'hintsFromExternalAPI' | 'priceCache'
+        >
+      })
+    | undefined
+}
+
+export type SelectedAccountPortfolioTokenResult = TokenResultInterface & {
+  latestAmount?: bigint
+  pendingAmount?: bigint
+}
+
 export interface SelectedAccountPortfolio {
-  tokens: TokenResultInterface[]
+  tokens: SelectedAccountPortfolioTokenResult[]
   collections: CollectionResultInterface[]
   totalBalance: number
   isAllReady: boolean
   networkSimulatedAccountOp: NetworkSimulatedAccountOp
-  tokenAmounts: TokenAmountInterface[]
-  latest: AccountState
-  pending: AccountState
+  latest: SelectedAccountPortfolioState
+  pending: SelectedAccountPortfolioState
 }

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -4,6 +4,7 @@ import { AccountOpAction, Action as ActionFromActionsQueue } from '../../interfa
 import { Action, Banner } from '../../interfaces/banner'
 import { Network, NetworkId } from '../../interfaces/network'
 import { RPCProviders } from '../../interfaces/provider'
+import { SelectedAccountPortfolioState } from '../../interfaces/selectedAccount'
 import { ActiveRoute } from '../../interfaces/swapAndBridge'
 import {
   AccountState as DefiPositionsAccountState,
@@ -11,7 +12,6 @@ import {
   NetworksWithPositions
 } from '../defiPositions/types'
 import { getNetworksWithFailedRPC } from '../networks/networks'
-import { AccountState as PortfolioAccountState } from '../portfolio/interfaces'
 import { PORTFOLIO_LIB_ERROR_NAMES } from '../portfolio/portfolio'
 import { getIsBridgeTxn, getQuoteRouteSteps } from '../swapAndBridge/swapAndBridge'
 
@@ -391,7 +391,7 @@ export const getNetworksWithPortfolioErrorBanners = ({
   providers
 }: {
   networks: Network[]
-  selectedAccountLatest: PortfolioAccountState
+  selectedAccountLatest: SelectedAccountPortfolioState
   providers: RPCProviders
 }): Banner[] => {
   const banners: Banner[] = []

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -209,13 +209,6 @@ export interface NetworkSimulatedAccountOp {
   [networkId: NetworkId]: AccountOp
 }
 
-export interface TokenAmount {
-  latestAmount: bigint
-  pendingAmount: bigint
-  address: string
-  networkId: string
-}
-
 export type PendingAmounts = {
   isPending: boolean
   pendingBalance: bigint


### PR DESCRIPTION
## Changes
### Reduce redundant data
Instead of repeating the same `tokens` and `collections` 3 times- in `latest`, `pending` and at the object's root, this PR leaves `tokens` and `collections` only at the root of the selected account portfolio structure. 
### Reduce object iterations
This PR reduces the iterations over `pendingStateSelectedAccount` from 3 to 1.
### Remove `tokenAmounts` 
`tokenAmounts` stored `latestAmount` and `pendingAmount` for each token in a separate variable. This PR attaches both properties to every token. 