### PR TITLE
Actions Fixes And Improvements

### DIFF
--- a/src/controllers/actions/actions.test.ts
+++ b/src/controllers/actions/actions.test.ts
@@ -192,7 +192,7 @@ describe('Actions Controller', () => {
       }
     })
 
-    actionsCtrl.addOrUpdateAction(updatedAction2, true)
+    actionsCtrl.addOrUpdateAction(updatedAction2, 'first')
   })
   test('should add an action with priority', (done) => {
     const req3: SignUserRequest = {
@@ -221,7 +221,7 @@ describe('Actions Controller', () => {
       }
     })
 
-    actionsCtrl.addOrUpdateAction(action3, true)
+    actionsCtrl.addOrUpdateAction(action3, 'first')
   })
   test('should have banners', () => {
     // no banner for benzin and one banner for the 2 other actions

--- a/src/controllers/actions/actions.test.ts
+++ b/src/controllers/actions/actions.test.ts
@@ -144,7 +144,7 @@ describe('Actions Controller', () => {
       emitCounter++
       if (emitCounter === 3) {
         expect(actionsCtrl.actionsQueue).toHaveLength(2)
-        expect(actionsCtrl.currentAction).toEqual(ACTION_1)
+        expect(actionsCtrl.currentAction).toEqual(ACTION_2)
         unsubscribe()
         done()
       }
@@ -185,7 +185,7 @@ describe('Actions Controller', () => {
         expect(actionsCtrl.visibleActionsQueue).toHaveLength(2)
         expect(actionsCtrl.currentAction?.id).not.toEqual(null)
         // update does not change the currently selectedAction
-        expect(actionsCtrl.currentAction?.id).not.toEqual(updatedAction2.id)
+        expect(actionsCtrl.currentAction?.id).toEqual(updatedAction2.id)
         expect(actionsCtrl.actionWindow.id).toEqual(1)
         unsubscribe()
         done()
@@ -270,19 +270,19 @@ describe('Actions Controller', () => {
     const unsubscribe = actionsCtrl.onUpdate(async () => {
       emitCounter++
       if (emitCounter === 5) {
-        expect(actionsCtrl.currentAction?.id).toEqual(2)
+        expect(actionsCtrl.currentAction?.id).toEqual(1)
         unsubscribe()
         done()
       }
       if (emitCounter === 4) {
         expect(actionsCtrl.actionWindow.id).toEqual(3)
-        actionsCtrl.setCurrentActionById(2)
+        actionsCtrl.setCurrentActionById(1)
       }
       if (emitCounter === 3) {
         expect(actionsCtrl.actionWindow.id).toEqual(2)
       }
       if (emitCounter === 2) {
-        expect(actionsCtrl.currentAction?.id).toEqual(1)
+        expect(actionsCtrl.currentAction?.id).toEqual(2)
         expect(actionsCtrl.actionsQueue).toHaveLength(2)
       }
 

--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -30,6 +30,10 @@ export type {
   DappRequestAction
 }
 
+export type ActionPosition = 'first' | 'last'
+
+export type ActionExecutionType = 'queue' | 'queue-but-open-action-window' | 'open-action-window'
+
 /**
  * The ActionsController is responsible for storing the converted userRequests
  * from the MainController into actions. After adding an action an action-window will be opened with the first action form actionsQueue
@@ -133,8 +137,8 @@ export class ActionsController extends EventEmitter {
 
   addOrUpdateAction(
     newAction: Action,
-    withPriority?: boolean,
-    executionType: 'queue' | 'open' = 'open'
+    position: ActionPosition = 'last',
+    executionType: ActionExecutionType = 'open-action-window'
   ) {
     // remove the benzin action if a new actions is added
     this.actionsQueue = this.actionsQueue.filter((a) => a.type !== 'benzin')
@@ -145,14 +149,15 @@ export class ActionsController extends EventEmitter {
     const actionIndex = this.actionsQueue.findIndex((a) => a.id === newAction.id)
     if (actionIndex !== -1) {
       this.actionsQueue[actionIndex] = newAction
-      if (executionType === 'open') {
-        this.sendNewActionMessage(newAction, 'update')
-        const currentAction = withPriority
-          ? this.visibleActionsQueue[0] || null
-          : this.currentAction ||
-            this.visibleActionsQueue.find((a) => a.id === newAction.id) ||
-            this.visibleActionsQueue[0] ||
-            null
+      if (executionType !== 'queue') {
+        let currentAction = null
+        if (executionType === 'open-action-window') {
+          this.sendNewActionMessage(newAction, 'updated')
+          currentAction = this.visibleActionsQueue.find((a) => a.id === newAction.id) || null
+        } else if (executionType === 'queue-but-open-action-window') {
+          this.sendNewActionMessage(newAction, 'queued')
+          currentAction = this.currentAction || this.visibleActionsQueue[0] || null
+        }
         this.#setCurrentAction(currentAction)
       } else {
         this.emitUpdate()
@@ -160,20 +165,20 @@ export class ActionsController extends EventEmitter {
       return
     }
 
-    if (withPriority) {
+    if (position === 'first') {
       this.actionsQueue.unshift(newAction)
     } else {
       this.actionsQueue.push(newAction)
     }
 
-    if (executionType === 'open') {
-      this.sendNewActionMessage(newAction, withPriority ? 'unshift' : 'push')
-      const currentAction = withPriority
-        ? this.visibleActionsQueue[0] || null
-        : this.currentAction ||
-          this.visibleActionsQueue.find((a) => a.id === newAction.id) ||
-          this.visibleActionsQueue[0] ||
-          null
+    if (executionType !== 'queue') {
+      let currentAction = null
+      if (executionType === 'open-action-window') {
+        currentAction = this.visibleActionsQueue.find((a) => a.id === newAction.id) || null
+      } else if (executionType === 'queue-but-open-action-window') {
+        this.sendNewActionMessage(newAction, 'queued')
+        currentAction = this.currentAction || this.visibleActionsQueue[0] || null
+      }
       this.#setCurrentAction(currentAction)
     } else {
       this.emitUpdate()
@@ -235,17 +240,14 @@ export class ActionsController extends EventEmitter {
     this.#setCurrentAction(action)
   }
 
-  sendNewActionMessage(newAction: Action, type: 'push' | 'unshift' | 'update') {
+  sendNewActionMessage(newAction: Action, type: 'queued' | 'updated') {
     if (this.visibleActionsQueue.length > 1 && newAction.type !== 'benzin') {
       if (this.actionWindow.loaded) {
-        this.#windowManager.sendWindowToastMessage(messageOnNewAction(newAction, type), {
-          type: 'success'
-        })
+        const message = messageOnNewAction(newAction, type)
+        if (message) this.#windowManager.sendWindowToastMessage(message, { type: 'success' })
       } else {
-        this.actionWindow.pendingMessage = {
-          message: messageOnNewAction(newAction, type),
-          options: { type: 'success' }
-        }
+        const message = messageOnNewAction(newAction, type)
+        if (message) this.actionWindow.pendingMessage = { message, options: { type: 'success' } }
       }
     }
   }

--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -149,7 +149,10 @@ export class ActionsController extends EventEmitter {
         this.sendNewActionMessage(newAction, 'update')
         const currentAction = withPriority
           ? this.visibleActionsQueue[0] || null
-          : this.currentAction || this.visibleActionsQueue[0] || null
+          : this.currentAction ||
+            this.visibleActionsQueue.find((a) => a.id === newAction.id) ||
+            this.visibleActionsQueue[0] ||
+            null
         this.#setCurrentAction(currentAction)
       } else {
         this.emitUpdate()
@@ -167,7 +170,10 @@ export class ActionsController extends EventEmitter {
       this.sendNewActionMessage(newAction, withPriority ? 'unshift' : 'push')
       const currentAction = withPriority
         ? this.visibleActionsQueue[0] || null
-        : this.currentAction || this.visibleActionsQueue[0] || null
+        : this.currentAction ||
+          this.visibleActionsQueue.find((a) => a.id === newAction.id) ||
+          this.visibleActionsQueue[0] ||
+          null
       this.#setCurrentAction(currentAction)
     } else {
       this.emitUpdate()

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1274,7 +1274,7 @@ export class MainController extends EventEmitter {
         networkId: network.id,
         selectedAccountAddr: userRequest.meta.accountAddr,
         session: dappPromise.session,
-        rejectUserRequest: this.rejectUserRequest.bind(this)
+        dappPromise
       }),
       'last',
       'open-action-window'

--- a/src/libs/actions/actions.ts
+++ b/src/libs/actions/actions.ts
@@ -64,7 +64,7 @@ export const getAccountOpFromAction = (
   return accountOpAction.accountOp
 }
 
-export const messageOnNewAction = (action: Action, addType: 'push' | 'unshift' | 'update') => {
+export const messageOnNewAction = (action: Action, addType: 'queued' | 'updated') => {
   let requestType = ''
   if (action.type === 'accountOp') requestType = 'Sign Transaction'
   if (action.type === 'signMessage') requestType = 'Sign Message'
@@ -76,12 +76,13 @@ export const messageOnNewAction = (action: Action, addType: 'push' | 'unshift' |
       requestType = 'Get Encryption Public Key'
   }
 
-  if (addType === 'push') {
+  if (addType === 'queued') {
     return `A new${requestType ? ` ${requestType} ` : ' '}request was queued.`
   }
-  if (addType === 'unshift') {
-    return `A new${requestType ? ` ${requestType} ` : ' '}request was added.`
+
+  if (addType === 'updated') {
+    return `${requestType ? ` ${requestType} ` : ' '}request was updated.`
   }
 
-  return `${requestType ? ` ${requestType} ` : ' '}request was updated.`
+  return null
 }

--- a/src/libs/main/main.ts
+++ b/src/libs/main/main.ts
@@ -2,7 +2,7 @@ import { AccountOpAction, Action } from '../../controllers/actions/actions'
 import { Account, AccountId } from '../../interfaces/account'
 import { DappProviderRequest } from '../../interfaces/dapp'
 import { Network, NetworkId } from '../../interfaces/network'
-import { Calls, SignUserRequest, UserRequest } from '../../interfaces/userRequest'
+import { Calls, DappUserRequest, SignUserRequest, UserRequest } from '../../interfaces/userRequest'
 import generateSpoofSig from '../../utils/generateSpoofSig'
 import { isSmartAccount } from '../account/account'
 import { AccountOp } from '../accountOp/accountOp'
@@ -38,16 +38,14 @@ export const buildSwitchAccountUserRequest = ({
   selectedAccountAddr,
   networkId,
   session,
-  rejectUserRequest
+  dappPromise
 }: {
   nextUserRequest: UserRequest
   selectedAccountAddr: string
   networkId: Network['id']
   session: DappProviderRequest['session']
-  rejectUserRequest: (reason: string, userRequestId: string | number) => void
+  dappPromise: DappUserRequest['dappPromise']
 }): UserRequest => {
-  const userRequestId = nextUserRequest.id
-
   return {
     id: ACCOUNT_SWITCH_USER_REQUEST,
     action: {
@@ -64,11 +62,8 @@ export const buildSwitchAccountUserRequest = ({
       isSignAction: false
     },
     dappPromise: {
-      session,
-      resolve: () => {},
-      reject: () => {
-        rejectUserRequest('Switch account request rejected', userRequestId)
-      }
+      ...dappPromise,
+      resolve: () => {}
     }
   }
 }

--- a/src/libs/main/main.ts
+++ b/src/libs/main/main.ts
@@ -31,6 +31,8 @@ export const batchCallsFromUserRequests = ({
   )
 }
 
+export const ACCOUNT_SWITCH_USER_REQUEST = 'ACCOUNT_SWITCH_USER_REQUEST'
+
 export const buildSwitchAccountUserRequest = ({
   nextUserRequest,
   selectedAccountAddr,
@@ -47,7 +49,7 @@ export const buildSwitchAccountUserRequest = ({
   const userRequestId = nextUserRequest.id
 
   return {
-    id: Number(nextUserRequest.id) + 222, // Otherwise the ids will be the same
+    id: ACCOUNT_SWITCH_USER_REQUEST,
     action: {
       kind: 'switchAccount',
       params: {


### PR DESCRIPTION
**Issues before the fixes:**
* When there are batched or pending actions while using the Beastwhisperer of Legends, the extension should switch accounts twice—once to sign a message and once for a transaction. However, after switching accounts, the extension opens the first or a random action instead of processing the next action added by Legends.
* The transfer form was adding actions with priority, reversing their order—meaning the first added action becomes the last in the list.
* When multiple swap and bridge routes are pending, creating a new route or opening an existing one incorrectly triggers the signAccountOp screen with a random accountOp instead of the selected one.
* An unnecessary toast notification appeared when the signAccountOp screen opened, stating that the displayed accountOp was added—this was redundant and provided no new information to the user.

**What's new:**
* withPriority changed to actionPriority: 'first' | 'last'
* executionType changed to actionExecutionType with 3 states instead of 2: 
    * 'open-action-window' prev 'open'
    * 'queue'
    * 'queue-but-open-action-window' this is the new type that will queue the action and open the action-window with the first action in the queue
    * if the upcoming request requires account change add it to the userRequests after the SwitchAccountAction is resolved to prevent opening a random pending action instead of the queued one