### PR TITLE
stkWallet: add stakeAndWrap and innetMint methods 

### DIFF
--- a/contracts/stkWALLET.sol
+++ b/contracts/stkWALLET.sol
@@ -2,97 +2,100 @@
 pragma solidity ^0.8.19;
 
 interface IXWallet {
-	function balanceOf(address owner) external view returns (uint256);
-	function shareValue() external view returns (uint256);
-	function transfer(address to, uint256 amount) external returns (bool);
-	function transferFrom(address from, address to, uint256 amount) external returns (bool);
+  function balanceOf(address owner) external view returns (uint256);
+
+  function shareValue() external view returns (uint256);
+
+  function transfer(address to, uint256 amount) external returns (bool);
+
+  function transferFrom(address from, address to, uint256 amount) external returns (bool);
 }
 
 contract stkWALLET {
-	// ERC20 stuff
-	// Constants
-	string public constant name = "Staked $WALLET";
-	uint8 public constant decimals = 18;
-	string public constant symbol = "stkWALLET";
+  // ERC20 stuff
+  // Constants
+  string public constant name = 'Staked $WALLET';
+  uint8 public constant decimals = 18;
+  string public constant symbol = 'stkWALLET';
 
-	// Immutables
-	IXWallet xWallet;
+  // Immutables
+  IXWallet xWallet;
 
-	// Mutable variables
-	mapping(address => uint256) public shares;
-	mapping(address => mapping(address => uint256)) private allowed;
+  // Mutable variables
+  mapping(address => uint256) public shares;
+  mapping(address => mapping(address => uint256)) private allowed;
 
-	// ERC20 events
-	event Approval(address indexed owner, address indexed spender, uint256 amount);
-	event Transfer(address indexed from, address indexed to, uint256 amount);
-	// Custom events
-	event ShareValueUpdate(uint256 shareValue);
+  // ERC20 events
+  event Approval(address indexed owner, address indexed spender, uint256 amount);
+  event Transfer(address indexed from, address indexed to, uint256 amount);
+  // Custom events
+  event ShareValueUpdate(uint256 shareValue);
 
-	// ERC20 methods
-	// Note: any xWALLET sent to this contract will be burned as there's nothing that can be done with it. Expected behavior.
-	function totalSupply() external view returns (uint256) {
-		return (xWallet.balanceOf(address(this)) * xWallet.shareValue()) / 1e18;
-	}
+  // ERC20 methods
+  // Note: any xWALLET sent to this contract will be burned as there's nothing that can be done with it. Expected behavior.
+  function totalSupply() external view returns (uint256) {
+    return (xWallet.balanceOf(address(this)) * xWallet.shareValue()) / 1e18;
+  }
 
-	function balanceOf(address owner) external view returns (uint256 balance) {
-		return (shares[owner] * xWallet.shareValue()) / 1e18;
-	}
+  function balanceOf(address owner) external view returns (uint256 balance) {
+    return (shares[owner] * xWallet.shareValue()) / 1e18;
+  }
 
-	function transfer(address to, uint256 amount) external returns (bool success) {
-		require(to != address(this) && to != address(0), "BAD_ADDRESS");
-		uint256 shareValue = xWallet.shareValue();
-		uint256 sharesAmount = (amount * 1e18) / shareValue;
-		shares[msg.sender] = shares[msg.sender] - sharesAmount;
-		shares[to] = shares[to] + sharesAmount;
-		emit Transfer(msg.sender, to, amount);
-		emit ShareValueUpdate(shareValue);
-		return true;
-	}
+  function transfer(address to, uint256 amount) external returns (bool success) {
+    require(to != address(this) && to != address(0), 'BAD_ADDRESS');
+    uint256 shareValue = xWallet.shareValue();
+    uint256 sharesAmount = (amount * 1e18) / shareValue;
+    shares[msg.sender] = shares[msg.sender] - sharesAmount;
+    shares[to] = shares[to] + sharesAmount;
+    emit Transfer(msg.sender, to, amount);
+    emit ShareValueUpdate(shareValue);
+    return true;
+  }
 
-	function transferFrom(address from, address to, uint256 amount) external returns (bool success) {
-		require(to != address(this) && to != address(0), "BAD_ADDRESS");
-		uint256 shareValue = xWallet.shareValue();
-		uint256 sharesAmount = (amount * 1e18) / shareValue;
-		shares[from] = shares[from] - sharesAmount;
-		uint256 prevAllowance = allowed[from][msg.sender];
-		if (prevAllowance < type(uint256).max) allowed[from][msg.sender] = prevAllowance - amount;
-		shares[to] = shares[to] + sharesAmount;
-		emit Transfer(from, to, amount);
-		emit ShareValueUpdate(shareValue);
-		return true;
-	}
+  function transferFrom(address from, address to, uint256 amount) external returns (bool success) {
+    require(to != address(this) && to != address(0), 'BAD_ADDRESS');
+    uint256 shareValue = xWallet.shareValue();
+    uint256 sharesAmount = (amount * 1e18) / shareValue;
+    shares[from] = shares[from] - sharesAmount;
+    uint256 prevAllowance = allowed[from][msg.sender];
+    if (prevAllowance < type(uint256).max) allowed[from][msg.sender] = prevAllowance - amount;
+    shares[to] = shares[to] + sharesAmount;
+    emit Transfer(from, to, amount);
+    emit ShareValueUpdate(shareValue);
+    return true;
+  }
 
-	function approve(address spender, uint256 amount) external returns (bool success) {
-		allowed[msg.sender][spender] = amount;
-		emit Approval(msg.sender, spender, amount);
-		return true;
-	}
+  function approve(address spender, uint256 amount) external returns (bool success) {
+    allowed[msg.sender][spender] = amount;
+    emit Approval(msg.sender, spender, amount);
+    return true;
+  }
 
-	function allowance(address owner, address spender) external view returns (uint256 remaining) {
-		return allowed[owner][spender];
-	}
+  function allowance(address owner, address spender) external view returns (uint256 remaining) {
+    return allowed[owner][spender];
+  }
 
-	constructor(IXWallet token) {
-		xWallet = token;
-	}
+  constructor(IXWallet token) {
+    xWallet = token;
+  }
 
-	// NTE: no need to implement entering/exiting with $WALLET, we can just use wrap/unwrap
+  // NTE: no need to implement entering/exiting with $WALLET, we can just use wrap/unwrap
 
-	// convert xWALLET to stkWALLET
-	function wrapAll() external {
-		wrap(xWallet.balanceOf(msg.sender));
-	}
+  // convert xWALLET to stkWALLET
+  function wrapAll() external {
+    wrap(xWallet.balanceOf(msg.sender));
+  }
 
-	function wrap(uint256 shareAmount) public {
-		shares[msg.sender] += shareAmount;
-		require(xWallet.transferFrom(msg.sender, address(this), shareAmount));
-		emit Transfer(address(0), msg.sender, (shareAmount * xWallet.shareValue()) / 1e18);
-	}
+  function wrap(uint256 shareAmount) public {
+    shares[msg.sender] += shareAmount;
+    require(xWallet.transferFrom(msg.sender, address(this), shareAmount));
+    emit Transfer(address(0), msg.sender, (shareAmount * xWallet.shareValue()) / 1e18);
+  }
 
-	// this is used to trigger unstaking
-	function unwrap(uint256 shareAmount) external {
-		shares[msg.sender] -= shareAmount;
-		require(xWallet.transfer(msg.sender, shareAmount));
-		emit Transfer(msg.sender, address(0), (shareAmount * xWallet.shareValue()) / 1e18);
-	}
+  // this is used to trigger unstaking
+  function unwrap(uint256 shareAmount) external {
+    shares[msg.sender] -= shareAmount;
+    require(xWallet.transfer(msg.sender, shareAmount));
+    emit Transfer(msg.sender, address(0), (shareAmount * xWallet.shareValue()) / 1e18);
+  }
 }

--- a/contracts/stkWALLET.sol
+++ b/contracts/stkWALLET.sol
@@ -2,124 +2,119 @@
 pragma solidity ^0.8.19;
 
 interface IXWallet {
-  function balanceOf(address owner) external view returns (uint256);
-
-  function shareValue() external view returns (uint256);
-
-  function transfer(address to, uint256 amount) external returns (bool);
-
-  function transferFrom(address from, address to, uint256 amount) external returns (bool);
-
-  function enter(uint256 amount) external;
+	function balanceOf(address owner) external view returns (uint256);
+	function shareValue() external view returns (uint256);
+	function transfer(address to, uint256 amount) external returns (bool);
+	function transferFrom(address from, address to, uint256 amount) external returns (bool);
+	function enter(uint256 amount) external;
 }
 
 interface IWallet {
   function transferFrom(address from, address to, uint256 amount) external returns (bool);
-
   function approve(address, uint) external;
 }
 
 contract stkWALLET {
-  // ERC20 stuff
-  // Constants
-  string public constant name = 'Staked $WALLET';
-  uint8 public constant decimals = 18;
-  string public constant symbol = 'stkWALLET';
+	// ERC20 stuff
+	// Constants
+	string public constant name = "Staked $WALLET";
+	uint8 public constant decimals = 18;
+	string public constant symbol = "stkWALLET";
 
-  // Immutables
-  IXWallet xWallet;
-  IWallet wallet;
+	// Immutables
+	IXWallet xWallet;
+	IWallet wallet;
 
-  // Mutable variables
-  mapping(address => uint256) public shares;
-  mapping(address => mapping(address => uint256)) private allowed;
+	// Mutable variables
+	mapping(address => uint256) public shares;
+	mapping(address => mapping(address => uint256)) private allowed;
 
-  // ERC20 events
-  event Approval(address indexed owner, address indexed spender, uint256 amount);
-  event Transfer(address indexed from, address indexed to, uint256 amount);
-  // Custom events
-  event ShareValueUpdate(uint256 shareValue);
+	// ERC20 events
+	event Approval(address indexed owner, address indexed spender, uint256 amount);
+	event Transfer(address indexed from, address indexed to, uint256 amount);
+	// Custom events
+	event ShareValueUpdate(uint256 shareValue);
 
-  // ERC20 methods
-  // Note: any xWALLET sent to this contract will be burned as there's nothing that can be done with it. Expected behavior.
-  function totalSupply() external view returns (uint256) {
-    return (xWallet.balanceOf(address(this)) * xWallet.shareValue()) / 1e18;
-  }
+	// ERC20 methods
+	// Note: any xWALLET sent to this contract will be burned as there's nothing that can be done with it. Expected behavior.
+	function totalSupply() external view returns (uint256) {
+		return (xWallet.balanceOf(address(this)) * xWallet.shareValue()) / 1e18;
+	}
 
-  function balanceOf(address owner) external view returns (uint256 balance) {
-    return (shares[owner] * xWallet.shareValue()) / 1e18;
-  }
+	function balanceOf(address owner) external view returns (uint256 balance) {
+		return (shares[owner] * xWallet.shareValue()) / 1e18;
+	}
 
-  function transfer(address to, uint256 amount) external returns (bool success) {
-    require(to != address(this) && to != address(0), 'BAD_ADDRESS');
-    uint256 shareValue = xWallet.shareValue();
-    uint256 sharesAmount = (amount * 1e18) / shareValue;
-    shares[msg.sender] = shares[msg.sender] - sharesAmount;
-    shares[to] = shares[to] + sharesAmount;
-    emit Transfer(msg.sender, to, amount);
-    emit ShareValueUpdate(shareValue);
-    return true;
-  }
+	function transfer(address to, uint256 amount) external returns (bool success) {
+		require(to != address(this) && to != address(0), "BAD_ADDRESS");
+		uint256 shareValue = xWallet.shareValue();
+		uint256 sharesAmount = (amount * 1e18) / shareValue;
+		shares[msg.sender] = shares[msg.sender] - sharesAmount;
+		shares[to] = shares[to] + sharesAmount;
+		emit Transfer(msg.sender, to, amount);
+		emit ShareValueUpdate(shareValue);
+		return true;
+	}
 
-  function transferFrom(address from, address to, uint256 amount) external returns (bool success) {
-    require(to != address(this) && to != address(0), 'BAD_ADDRESS');
-    uint256 shareValue = xWallet.shareValue();
-    uint256 sharesAmount = (amount * 1e18) / shareValue;
-    shares[from] = shares[from] - sharesAmount;
-    uint256 prevAllowance = allowed[from][msg.sender];
-    if (prevAllowance < type(uint256).max) allowed[from][msg.sender] = prevAllowance - amount;
-    shares[to] = shares[to] + sharesAmount;
-    emit Transfer(from, to, amount);
-    emit ShareValueUpdate(shareValue);
-    return true;
-  }
+	function transferFrom(address from, address to, uint256 amount) external returns (bool success) {
+		require(to != address(this) && to != address(0), "BAD_ADDRESS");
+		uint256 shareValue = xWallet.shareValue();
+		uint256 sharesAmount = (amount * 1e18) / shareValue;
+		shares[from] = shares[from] - sharesAmount;
+		uint256 prevAllowance = allowed[from][msg.sender];
+		if (prevAllowance < type(uint256).max) allowed[from][msg.sender] = prevAllowance - amount;
+		shares[to] = shares[to] + sharesAmount;
+		emit Transfer(from, to, amount);
+		emit ShareValueUpdate(shareValue);
+		return true;
+	}
 
-  function approve(address spender, uint256 amount) external returns (bool success) {
-    allowed[msg.sender][spender] = amount;
-    emit Approval(msg.sender, spender, amount);
-    return true;
-  }
+	function approve(address spender, uint256 amount) external returns (bool success) {
+		allowed[msg.sender][spender] = amount;
+		emit Approval(msg.sender, spender, amount);
+		return true;
+	}
 
-  function allowance(address owner, address spender) external view returns (uint256 remaining) {
-    return allowed[owner][spender];
-  }
+	function allowance(address owner, address spender) external view returns (uint256 remaining) {
+		return allowed[owner][spender];
+	}
 
-  constructor(IWallet _wallet, IXWallet _xWallet) {
-    wallet = _wallet;
-    xWallet = _xWallet;
-  }
+	constructor(IWallet _wallet, IXWallet _xWallet) {
+		wallet = _wallet;
+		xWallet = _xWallet;
+	}
 
-  // convert xWALLET to stkWALLET
-  function wrapAll() external {
-    wrap(xWallet.balanceOf(msg.sender));
-  }
+	// convert xWALLET to stkWALLET
+	function wrapAll() external {
+		wrap(xWallet.balanceOf(msg.sender));
+	}
 
-  function innerMintTo(address to, uint shareAmount) internal {
-    shares[to] += shareAmount;
-    emit Transfer(address(0), to, (shareAmount * xWallet.shareValue()) / 1e18);
-  }
+	function innerMintTo(address to, uint shareAmount) internal {
+		shares[to] += shareAmount;
+		emit Transfer(address(0), to, (shareAmount * xWallet.shareValue()) / 1e18);
+	}
 
-  function wrap(uint256 shareAmount) public {
-    require(xWallet.transferFrom(msg.sender, address(this), shareAmount));
-    innerMintTo(msg.sender, shareAmount);
-  }
+	function wrap(uint256 shareAmount) public {
+		require(xWallet.transferFrom(msg.sender, address(this), shareAmount));
+		innerMintTo(msg.sender, shareAmount);
+	}
 
-  // this is used to trigger unstaking
-  function unwrap(uint256 shareAmount) external {
-    shares[msg.sender] -= shareAmount;
-    require(xWallet.transfer(msg.sender, shareAmount));
-    emit Transfer(msg.sender, address(0), (shareAmount * xWallet.shareValue()) / 1e18);
-  }
+	// this is used to trigger unstaking
+	function unwrap(uint256 shareAmount) external {
+		shares[msg.sender] -= shareAmount;
+		require(xWallet.transfer(msg.sender, shareAmount));
+		emit Transfer(msg.sender, address(0), (shareAmount * xWallet.shareValue()) / 1e18);
+	}
 
-  // convert WALLET to stkWALLET
-  function stakeAndWrap(uint256 amount) external {
-    require(wallet.transferFrom(msg.sender, address(this), amount));
-    uint256 balanceBefore = xWallet.balanceOf(address(this));
-    wallet.approve(address(xWallet), amount);
-    xWallet.enter(amount);
-    uint256 balanceAfter = xWallet.balanceOf(address(this));
+	// convert WALLET to stkWALLET
+	function stakeAndWrap(uint256 amount) external {
+		require(wallet.transferFrom(msg.sender, address(this), amount));
+		uint256 balanceBefore = xWallet.balanceOf(address(this));
+		wallet.approve(address(xWallet), amount);
+		xWallet.enter(amount);
+		uint256 balanceAfter = xWallet.balanceOf(address(this));
 
-    require(balanceAfter > balanceBefore);
-    innerMintTo(msg.sender, balanceAfter - balanceBefore);
-  }
+		require(balanceAfter > balanceBefore);
+		innerMintTo(msg.sender, balanceAfter - balanceBefore);
+	}
 }

--- a/scripts/deployStkWallet.ts
+++ b/scripts/deployStkWallet.ts
@@ -1,0 +1,16 @@
+require('dotenv').config()
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { ethers } = require('hardhat')
+
+async function main() {
+  const WALLET_ADDRESS = '0x88800092ff476844f74dc2fc427974bbee2794ae'
+  const XWALLET_ADDRESS = '0x47cd7e91c3cbaaf266369fe8518345fc4fc12935'
+
+  const stkWALLET = await ethers.deployContract('stkWALLET', [WALLET_ADDRESS, XWALLET_ADDRESS])
+  console.log(`stkWALLET deployed at ${stkWALLET.target}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/test/stkWallet/stkWallet.ts
+++ b/test/stkWallet/stkWallet.ts
@@ -24,7 +24,7 @@ describe('stkWallet', () => {
       params: [
         {
           forking: {
-            jsonRpcUrl: 'https://invictus.ambire.com/ethereum-2',
+            jsonRpcUrl: 'https://invictus.ambire.com/ethereum-5',
             blockNumber: 14390000
           }
         }

--- a/test/stkWallet/stkWallet.ts
+++ b/test/stkWallet/stkWallet.ts
@@ -23,24 +23,6 @@ describe('stkWallet', () => {
       method: 'hardhat_reset',
       params: [
         {
-          networks: {
-            hardhat: {
-              forking: {
-                url: 'https://invictus.ambire.com/ethereum'
-                // blockNumber: 12345678 // Optional
-              }
-            }
-          }
-        }
-      ]
-    })
-  })
-
-  beforeEach('successfully deploys the ambire account', async () => {
-    await network.provider.request({
-      method: 'hardhat_reset',
-      params: [
-        {
           forking: {
             jsonRpcUrl: 'https://invictus.ambire.com/ethereum',
             blockNumber: 14390000
@@ -48,6 +30,9 @@ describe('stkWallet', () => {
         }
       ]
     })
+  })
+
+  beforeEach('Use fork of mainnet', async () => {
     ;[signer] = await ethers.getSigners()
 
     const slot = solidityPackedKeccak256(['uint256', 'uint256'], [signer.address, 1])

--- a/test/stkWallet/stkWallet.ts
+++ b/test/stkWallet/stkWallet.ts
@@ -1,0 +1,90 @@
+import '@nomicfoundation/hardhat-chai-matchers'
+
+import { expect } from 'chai'
+import { Contract, MaxUint256, solidityPackedKeccak256 } from 'ethers'
+import { ethers, network } from 'hardhat'
+
+import { ERC20 } from '../../src/libs/humanizer/const/abis'
+
+describe('stkWallet', () => {
+  let signer: any
+  let stkWallet: any
+  const WALLET_ADDRESS = '0x88800092ff476844f74dc2fc427974bbee2794ae'
+  const XWALLET_ADDRESS = '0x47cd7e91c3cbaaf266369fe8518345fc4fc12935'
+  const walletContract = new Contract(WALLET_ADDRESS, ERC20, ethers)
+  const xWalletContract = new Contract(
+    XWALLET_ADDRESS,
+    [...ERC20, 'function enter(uint amount) external'],
+    ethers
+  )
+
+  before(async () => {
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          networks: {
+            hardhat: {
+              forking: {
+                url: 'https://invictus.ambire.com/ethereum'
+                // blockNumber: 12345678 // Optional
+              }
+            }
+          }
+        }
+      ]
+    })
+  })
+
+  beforeEach('successfully deploys the ambire account', async () => {
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: 'https://invictus.ambire.com/ethereum',
+            blockNumber: 14390000
+          }
+        }
+      ]
+    })
+    ;[signer] = await ethers.getSigners()
+
+    const slot = solidityPackedKeccak256(['uint256', 'uint256'], [signer.address, 1])
+
+    // Override storage slot
+    await ethers.provider.send('hardhat_setStorageAt', [
+      WALLET_ADDRESS,
+      slot,
+      `0x${MaxUint256.toString(16)}`
+    ])
+
+    const StkWallet = await ethers.getContractFactory('stkWALLET')
+    stkWallet = await StkWallet.deploy(WALLET_ADDRESS, XWALLET_ADDRESS)
+  })
+  it('Basic wrap with xWALLET ', async () => {
+    const amount = BigInt(10 * 1e18)
+    await (walletContract.connect(signer) as any).approve(XWALLET_ADDRESS, amount)
+    await (xWalletContract.connect(signer) as any).enter(amount)
+
+    const balanceInXWallet = await xWalletContract.balanceOf(signer.address)
+    await (xWalletContract.connect(signer) as any).approve(stkWallet.target, balanceInXWallet)
+    await (stkWallet.connect(signer) as any).wrap(balanceInXWallet)
+    expect(await xWalletContract.balanceOf(stkWallet.target)).eq(balanceInXWallet)
+    expect(await stkWallet.balanceOf(signer.address)).gt(amount)
+  })
+
+  it('Basic stake and wrap with WALLET ', async () => {
+    const amount = BigInt(10 * 1e18)
+    await (walletContract.connect(signer) as any).approve(stkWallet.target, amount)
+    // await (walletContract.connect(signer) as any).approve(XWALLET_ADDRESS, amount)
+
+    const xWalletBalanceOfStkWalletBefore = await xWalletContract.balanceOf(stkWallet.target)
+    await (stkWallet.connect(signer) as any).stakeAndWrap(amount)
+    const xWalletBalanceOfStkWalletAfter = await xWalletContract.balanceOf(stkWallet.target)
+    const newXWallets = xWalletBalanceOfStkWalletAfter - xWalletBalanceOfStkWalletBefore
+    const storedXWallets = await stkWallet.shares(signer.address)
+
+    expect(newXWallets).eq(storedXWallets)
+  })
+})

--- a/test/stkWallet/stkWallet.ts
+++ b/test/stkWallet/stkWallet.ts
@@ -24,7 +24,7 @@ describe('stkWallet', () => {
       params: [
         {
           forking: {
-            jsonRpcUrl: 'https://cloudflare-eth.com',
+            jsonRpcUrl: 'https://eth.llamarpc.com',
             blockNumber: 14390000
           }
         }

--- a/test/stkWallet/stkWallet.ts
+++ b/test/stkWallet/stkWallet.ts
@@ -24,7 +24,7 @@ describe('stkWallet', () => {
       params: [
         {
           forking: {
-            jsonRpcUrl: 'https://docs-demo.quiknode.pro/',
+            jsonRpcUrl: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
             blockNumber: 14390000
           }
         }

--- a/test/stkWallet/stkWallet.ts
+++ b/test/stkWallet/stkWallet.ts
@@ -24,7 +24,7 @@ describe('stkWallet', () => {
       params: [
         {
           forking: {
-            jsonRpcUrl: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
+            jsonRpcUrl: 'https://invictus.ambire.com/ethereum-2',
             blockNumber: 14390000
           }
         }

--- a/test/stkWallet/stkWallet.ts
+++ b/test/stkWallet/stkWallet.ts
@@ -24,7 +24,7 @@ describe('stkWallet', () => {
       params: [
         {
           forking: {
-            jsonRpcUrl: 'https://eth.llamarpc.com',
+            jsonRpcUrl: 'https://docs-demo.quiknode.pro/',
             blockNumber: 14390000
           }
         }

--- a/test/stkWallet/stkWallet.ts
+++ b/test/stkWallet/stkWallet.ts
@@ -24,7 +24,7 @@ describe('stkWallet', () => {
       params: [
         {
           forking: {
-            jsonRpcUrl: 'https://invictus.ambire.com/ethereum',
+            jsonRpcUrl: 'https://cloudflare-eth.com',
             blockNumber: 14390000
           }
         }


### PR DESCRIPTION
- add stakeAndWrap to reduce the number of calls for converting WALLET -> stkWALLET
- moves some minting logic from wrap to innerMint to be reused by stakeAndWrap
- basic test
- script for deploying stkWALLET