### PR TITLE
Bug / Handle tokens with `0` decimals in the Swap & Bridge and Transfer controllers max calculations

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -234,7 +234,8 @@ export class SwapAndBridgeController extends EventEmitter {
 
   get maxFromAmount(): string {
     const tokenRef = this.#getFromSelectedTokenInPortfolio() || this.fromSelectedToken
-    if (!tokenRef || getTokenAmount(tokenRef) === 0n || !tokenRef.decimals) return '0'
+    if (!tokenRef || getTokenAmount(tokenRef) === 0n || typeof tokenRef.decimals !== 'number')
+      return '0'
 
     return formatUnits(getTokenAmount(tokenRef), tokenRef.decimals)
   }
@@ -460,7 +461,10 @@ export class SwapAndBridgeController extends EventEmitter {
           return
         }
 
-        if (this.fromAmountFieldMode === 'fiat' && this.fromSelectedToken?.decimals) {
+        if (
+          this.fromAmountFieldMode === 'fiat' &&
+          typeof this.fromSelectedToken?.decimals === 'number'
+        ) {
           this.fromAmountInFiat = fromAmount
 
           // Get the number of decimals

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -149,7 +149,7 @@ export class TransferController extends EventEmitter {
     if (
       !this.selectedToken ||
       getTokenAmount(this.selectedToken) === 0n ||
-      !this.selectedToken.decimals
+      typeof this.selectedToken.decimals !== 'number'
     )
       return '0'
 
@@ -395,7 +395,7 @@ export class TransferController extends EventEmitter {
       return
     }
 
-    if (this.amountFieldMode === 'fiat' && this.selectedToken?.decimals) {
+    if (this.amountFieldMode === 'fiat' && typeof this.selectedToken?.decimals === 'number') {
       this.amountInFiat = fieldValue
 
       // Get the number of decimals


### PR DESCRIPTION
For the Swap & Bridge max calculations, the check(s) if a token has decimals was written is a way that `0` (that may be a valid value) turns out to be falsy. Tweak by checking if decimals is a number instead (and fallback only if not).

Example with SEND on Base, now having correct balance:

<img width="669" alt="Screenshot 2025-01-22 at 11 27 03" src="https://github.com/user-attachments/assets/c8a1d7cc-43a4-4fc8-aa03-03d49810998b" />

Same problem solved for the Transfer controller, now having correct balance:

<img width="674" alt="Screenshot 2025-01-22 at 15 02 23" src="https://github.com/user-attachments/assets/80213c74-a5b6-47b8-afa2-82688e81a158" />
