### PR TITLE
Feature / Handle all possible validation message failures and display better human readable and programmer debuggable errors

### DIFF
--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -22,7 +22,6 @@ import { Hex } from '../../interfaces/hex'
 import { KeystoreSigner } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
 import { TypedMessage } from '../../interfaces/userRequest'
-import { decodeError } from '../errorDecoder'
 import hexStringToUint8Array from '../../utils/hexStringToUint8Array'
 import isSameAddr from '../../utils/isSameAddr'
 import { stripHexPrefix } from '../../utils/stripHexPrefix'
@@ -266,6 +265,7 @@ export async function verifyMessage({
     } catch (e: any) {
       throw Error(
         `Preparing the just signed (standard) message for validation failed. Please try again or contact Ambire support if the issue persists. Error details: ${
+          // TODO: Use the `reason` from the decodeError(e) instead, when this case is better handled in there
           e?.message || 'missing'
         }`
       )
@@ -333,9 +333,10 @@ export async function verifyMessage({
     else if (deploylessRes[0] === false) callResult = '0x00'
     else callResult = deploylessRes[0]
   } catch (e: any) {
-    const decodedError = decodeError(e)
     throw new Error(
-      `Validating the just signed message failed. Please try again or contact Ambire support if the issue persists. Error details: UniversalValidator call failed. ${decodedError.reason}`
+      `Validating the just signed message failed. Please try again or contact Ambire support if the issue persists. Error details: UniversalValidator call failed, more details: ${
+        e?.message || 'missing'
+      }`
     )
   }
 

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -265,7 +265,6 @@ export async function verifyMessage({
     } catch (e: any) {
       throw Error(
         `Preparing the just signed (standard) message for validation failed. Please try again or contact Ambire support if the issue persists. Error details: ${
-          // TODO: Use the `reason` from the decodeError(e) instead, when this case is better handled in there
           e?.message || 'missing'
         }`
       )
@@ -335,6 +334,7 @@ export async function verifyMessage({
   } catch (e: any) {
     throw new Error(
       `Validating the just signed message failed. Please try again or contact Ambire support if the issue persists. Error details: UniversalValidator call failed, more details: ${
+        // TODO: Use the `reason` from the decodeError(e) instead, when this case is better handled in there
         e?.message || 'missing'
       }`
     )

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -22,6 +22,7 @@ import { Hex } from '../../interfaces/hex'
 import { KeystoreSigner } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
 import { TypedMessage } from '../../interfaces/userRequest'
+import { decodeError } from '../errorDecoder'
 import hexStringToUint8Array from '../../utils/hexStringToUint8Array'
 import isSameAddr from '../../utils/isSameAddr'
 import { stripHexPrefix } from '../../utils/stripHexPrefix'
@@ -259,7 +260,16 @@ export async function verifyMessage({
 ) &
   Props): Promise<boolean> {
   if (message) {
-    finalDigest = hashMessage(message)
+    try {
+      finalDigest = hashMessage(message)
+      if (!finalDigest) throw Error('Hashing the message returned no (falsy) result.')
+    } catch (e: any) {
+      throw Error(
+        `Preparing the just signed (standard) message for validation failed. Please try again or contact Ambire support if the issue persists. Error details: ${
+          e?.message || 'missing'
+        }`
+      )
+    }
   } else if (typedData) {
     // To resolve the "ambiguous primary types or unused types" error, remove
     // the `EIP712Domain` from `types` object. The domain type is inbuilt in
@@ -272,32 +282,37 @@ export async function verifyMessage({
       delete typesWithoutEIP712Domain.EIP712Domain
     }
 
-    // the final digest for AmbireReadableOperation is the execute hash
-    // as it's wrapped in mode.standard and onchain gets transformed to
-    // an AmbireOperation
-    if ('AmbireReadableOperation' in typedData.types) {
-      const ambireReadableOperation = typedData.message as AmbireReadableOperation
-      finalDigest = hexlify(
-        getSignableHash(
-          ambireReadableOperation.addr,
-          ambireReadableOperation.chainId,
-          ambireReadableOperation.nonce,
-          ambireReadableOperation.calls.map(callToTuple)
+    try {
+      // the final digest for AmbireReadableOperation is the execute hash
+      // as it's wrapped in mode.standard and onchain gets transformed to
+      // an AmbireOperation
+      if ('AmbireReadableOperation' in typedData.types) {
+        const ambireReadableOperation = typedData.message as AmbireReadableOperation
+        finalDigest = hexlify(
+          getSignableHash(
+            ambireReadableOperation.addr,
+            ambireReadableOperation.chainId,
+            ambireReadableOperation.nonce,
+            ambireReadableOperation.calls.map(callToTuple)
+          )
         )
-      )
-    } else {
-      finalDigest = TypedDataEncoder.hash(
-        typedData.domain,
-        typesWithoutEIP712Domain,
-        typedData.message
+      } else {
+        finalDigest = TypedDataEncoder.hash(
+          typedData.domain,
+          typesWithoutEIP712Domain,
+          typedData.message
+        )
+      }
+
+      if (!finalDigest) throw Error('Hashing the typedData returned no (falsy) result.')
+    } catch (e: any) {
+      throw Error(
+        `Preparing the just signed (typed data) message for validation failed. Please try again or contact Ambire support if the issue persists. Error details: ${
+          e?.message || 'missing'
+        }`
       )
     }
   }
-
-  if (!finalDigest)
-    throw Error(
-      'Something went wrong while validating the message you signed. Please try again or contact Ambire support if the issue persists. Error details: missing one of the required props: message, unPrefixedMessage, typedData or finalDigest'
-    )
 
   // this 'magic' universal validator contract will deploy itself within the eth_call, try to verify the signature using
   // ERC-6492, ERC-1271 and ecrecover, and return the value to us
@@ -317,9 +332,10 @@ export async function verifyMessage({
     if (deploylessRes[0] === true) callResult = '0x01'
     else if (deploylessRes[0] === false) callResult = '0x00'
     else callResult = deploylessRes[0]
-  } catch {
+  } catch (e: any) {
+    const decodedError = decodeError(e)
     throw new Error(
-      'Something went wrong while validating the message you signed. If the problem persists, please contact Ambire support. Error details: call to UniversalValidator failed.'
+      `Validating the just signed message failed. Please try again or contact Ambire support if the issue persists. Error details: UniversalValidator call failed. ${decodedError.reason}`
     )
   }
 


### PR DESCRIPTION
Tweaks a bit the validation message possible failures:

- Fixed: In case the Ambire UniversalValidator (deployless) fails, include the actual error in the message so that its easier to reason about wtf happened - a temporary RPC or network issue or something else. Prev the error was swallowed.
  <img width="1309" alt="Screenshot 2025-01-22 at 17 35 28" src="https://github.com/user-attachments/assets/09e4612a-f4b0-4734-ad3f-55dd83998aff" />
- Changed: Handle all possible throws while preparing the message for validation and include them in the error message. Needed because all the EthersJS methods used in there (`hashMessage`, `getBytes`, `hexlify`, `TypedDataEncoder.hash`) can potentially throw. Prev these errors were swallowed.
  <img width="1316" alt="Screenshot 2025-01-22 at 17 22 41" src="https://github.com/user-attachments/assets/5ac01001-f8b7-4cea-a5e5-e92802adb78e" />