### PR TITLE
Fix / pass additional portfolio tokens to array in calculating account portfolio

### DIFF
--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -238,6 +238,11 @@ export function calculateSelectedAccountPortfolio(
       const networkTotal = Number(result?.total?.usd) || 0
       newTotalBalance += networkTotal
 
+      if (network === 'gasTank' || network === 'rewards') {
+        const networkTokens = result?.tokens || []
+        tokens.push(...networkTokens)
+      }
+
       const networkCollections = result?.collections || []
       collections.push(...networkCollections)
     }


### PR DESCRIPTION
Fixes an issue with gas tank tokens not visible on the Dashboard. Buf after refactoring from [this](https://github.com/AmbireTech/ambire-common/pull/1231) PR 