### PR TITLE
Fix / Extension Crashing Upon Network Removal

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -151,6 +151,18 @@ export class SelectedAccountController extends EventEmitter {
       })
     })
 
+    this.#networks.onUpdate(() => {
+      this.#debounceFunctionCallsOnSameTick('resetDashboardNetworkFilterIfNeeded', () => {
+        if (!this.dashboardNetworkFilter) return
+        const dashboardFilteredNetwork = this.#networks!.networks.find(
+          (n) => n.id === this.dashboardNetworkFilter
+        )
+
+        // reset the dashboardNetworkFilter if the network is removed
+        if (!dashboardFilteredNetwork) this.setDashboardNetworkFilter(null)
+      })
+    })
+
     this.#accounts.onUpdate(() => {
       this.#debounceFunctionCallsOnSameTick('updateSelectedAccount', () => {
         this.#updateSelectedAccount()
@@ -294,14 +306,22 @@ export class SelectedAccountController extends EventEmitter {
     }
   }
 
-  #debounceFunctionCallsOnSameTick(funcName: string, func: Function) {
+  #debounceFunctionCallsOnSameTick(funcName: string, func: () => void) {
     if (this.#shouldDebounceFlags[funcName]) return
     this.#shouldDebounceFlags[funcName] = true
 
     // Debounce multiple calls in the same tick and only execute one of them
     setTimeout(() => {
       this.#shouldDebounceFlags[funcName] = false
-      func()
+      try {
+        func()
+      } catch (error: any) {
+        this.emitError({
+          level: 'minor',
+          message: `The execution of ${funcName} in SelectedAccountController failed`,
+          error: new Error(error)
+        })
+      }
     }, 0)
   }
 

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -319,7 +319,7 @@ export class SelectedAccountController extends EventEmitter {
         this.emitError({
           level: 'minor',
           message: `The execution of ${funcName} in SelectedAccountController failed`,
-          error: new Error(error)
+          error
         })
       }
     }, 0)

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -176,7 +176,7 @@ export const getNetworksWithPortfolioErrorErrors = ({
     // In case of additional networks don't check the RPC as there isn't one
     if (
       criticalError &&
-      (['gasTank', 'rewards'].includes(network) || providers[network].isWorking)
+      (['gasTank', 'rewards'].includes(network) || providers[network]?.isWorking)
     ) {
       errors = addPortfolioError(errors, network, 'portfolio-critical')
       return


### PR DESCRIPTION
* Fixed: Service worker crashes upon network removal due to missing error handling in the selectedAccountCtrl
* Fixed: Resolved FE crashes and display of unknown or undefined texts on the Dashboard by resetting the state of dashboardNetworkFilter after the filtered network is removed