### PR TITLE
Config / Temporarily exclude Mayan bridge for SAs (they do not support batching)

### DIFF
--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -223,6 +223,10 @@ export class SocketAPI {
       params.append('feeTakerAddress', feeTakerAddress)
       params.append('feePercent', FEE_PERCENT.toString())
     }
+    // TODO: Temporarily exclude Mayan bridge when fetching quotes for SA, as
+    // batching is currently not not supported by Mayan (and funds get lost).
+    if (isSmartAccount) params.append('excludeBridges', ['mayan'].join(','))
+
     const url = `${this.#baseUrl}/quote?${params.toString()}`
 
     let response = await this.#fetch(url, { headers: this.#headers })


### PR DESCRIPTION
I found this the hard way, it turned out Mayan bridge don't support batching (and if bridges get batched, funds get lost).

The good news is that Mayan said that's not a protocol limitation and that they expect to have it ready end of next week.