### PR TITLE
Update/ Better UX when the portfolio is slow

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1001,16 +1001,8 @@ export class MainController extends EventEmitter {
     )
   }
 
-  async reloadSelectedAccount(
-    options: {
-      forceUpdate?: boolean
-      networkId?: NetworkId
-    } = {
-      forceUpdate: true,
-      networkId: undefined
-    }
-  ) {
-    const { forceUpdate, networkId } = options
+  async reloadSelectedAccount(options?: { forceUpdate?: boolean; networkId?: NetworkId }) {
+    const { forceUpdate = true, networkId } = options || {}
     const networkToUpdate = networkId
       ? this.networks.networks.find((n) => n.id === networkId)
       : undefined

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -382,14 +382,17 @@ export class PortfolioController extends EventEmitter {
     this.emitUpdate()
   }
 
-  #getCanSkipUpdate(networkState?: NetworkState, forceUpdate?: boolean) {
+  #getCanSkipUpdate(
+    networkState?: NetworkState,
+    forceUpdate?: boolean,
+    maxDataAgeMs: number = this.#minUpdateInterval
+  ) {
     const hasImportantErrors = networkState?.errors.some((e) => e.level === 'critical')
 
     if (forceUpdate || !networkState || networkState.criticalError || hasImportantErrors)
       return false
     const updateStarted = networkState.result?.updateStarted || 0
-    const isWithinMinUpdateInterval =
-      !!updateStarted && Date.now() - updateStarted < this.#minUpdateInterval
+    const isWithinMinUpdateInterval = !!updateStarted && Date.now() - updateStarted < maxDataAgeMs
 
     return isWithinMinUpdateInterval || networkState.isLoading
   }
@@ -401,7 +404,8 @@ export class PortfolioController extends EventEmitter {
     network: Network,
     portfolioLib: Portfolio,
     portfolioProps: Partial<GetOptions> & { blockTag: 'latest' | 'pending' },
-    forceUpdate: boolean
+    forceUpdate: boolean,
+    maxDataAgeMs?: number
   ): Promise<boolean> {
     const blockTag = portfolioProps.blockTag
     const stateKeys = {
@@ -414,7 +418,11 @@ export class PortfolioController extends EventEmitter {
       // and portfolio will not be updated
       accountState[network.id] = { isLoading: false, isReady: false, errors: [] }
     }
-    const canSkipUpdate = this.#getCanSkipUpdate(accountState[network.id], forceUpdate)
+    const canSkipUpdate = this.#getCanSkipUpdate(
+      accountState[network.id],
+      forceUpdate,
+      maxDataAgeMs
+    )
 
     if (canSkipUpdate) return false
 
@@ -502,7 +510,7 @@ export class PortfolioController extends EventEmitter {
     accountId: AccountId,
     network?: Network,
     accountOps?: { [key: string]: AccountOp[] },
-    opts?: { forceUpdate: boolean }
+    opts?: { forceUpdate?: boolean; maxDataAgeMs?: number }
   ) {
     await this.#initialLoadPromise
     const selectedAccount = this.#accounts.accounts.find((x) => x.addr === accountId)
@@ -579,7 +587,8 @@ export class PortfolioController extends EventEmitter {
                 blockTag: 'latest',
                 ...allHints
               },
-              forceUpdate
+              forceUpdate,
+              opts?.maxDataAgeMs
             ),
             this.updatePortfolioState(
               accountId,
@@ -596,7 +605,8 @@ export class PortfolioController extends EventEmitter {
                 isEOA: !isSmartAccount(selectedAccount),
                 ...allHints
               },
-              forceUpdate
+              forceUpdate,
+              opts?.maxDataAgeMs
             )
           ])
 

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -124,7 +124,7 @@ const accounts = [
 const waitSelectedAccCtrlPortfolioAllReady = () => {
   return new Promise((resolve) => {
     const unsubscribe = selectedAccountCtrl.onUpdate(() => {
-      if (selectedAccountCtrl.portfolio.isAllReady) {
+      if (selectedAccountCtrl.portfolio.isReadyToVisualize) {
         unsubscribe()
         resolve(true)
       }

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -124,7 +124,7 @@ const accounts = [
 const waitSelectedAccCtrlPortfolioAllReady = () => {
   return new Promise((resolve) => {
     const unsubscribe = selectedAccountCtrl.onUpdate(() => {
-      if (selectedAccountCtrl.portfolio.isReadyToVisualize) {
+      if (selectedAccountCtrl.portfolio.isAllReady) {
         unsubscribe()
         resolve(true)
       }

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -38,7 +38,7 @@ export const DEFAULT_SELECTED_ACCOUNT_PORTFOLIO = {
   tokenAmounts: [],
   totalBalance: 0,
   isReadyToVisualize: false,
-  isAllReady: true,
+  isAllReady: false,
   networkSimulatedAccountOp: {},
   latest: {},
   pending: {}
@@ -248,14 +248,11 @@ export class SelectedAccountController extends EventEmitter {
       hasSignAccountOp
     )
 
-    if (this.portfolioStartedLoadingAtTimestamp && newSelectedAccountPortfolio.isReadyToVisualize) {
+    if (this.portfolioStartedLoadingAtTimestamp && newSelectedAccountPortfolio.isAllReady) {
       this.portfolioStartedLoadingAtTimestamp = null
     }
 
-    if (
-      !this.portfolioStartedLoadingAtTimestamp &&
-      !newSelectedAccountPortfolio.isReadyToVisualize
-    ) {
+    if (!this.portfolioStartedLoadingAtTimestamp && !newSelectedAccountPortfolio.isAllReady) {
       this.portfolioStartedLoadingAtTimestamp = Date.now()
     }
 

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -38,6 +38,7 @@ export const DEFAULT_SELECTED_ACCOUNT_PORTFOLIO = {
   tokenAmounts: [],
   totalBalance: 0,
   isAllReady: false,
+  isLoading: true,
   networkSimulatedAccountOp: {},
   latest: {},
   pending: {}
@@ -243,6 +244,7 @@ export class SelectedAccountController extends EventEmitter {
       latestStateSelectedAccountWithDefiPositions,
       pendingStateSelectedAccountWithDefiPositions,
       this.portfolio,
+      this.portfolioStartedLoadingAtTimestamp,
       hasSignAccountOp
     )
 

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -37,8 +37,8 @@ export const DEFAULT_SELECTED_ACCOUNT_PORTFOLIO = {
   collections: [],
   tokenAmounts: [],
   totalBalance: 0,
-  isAllReady: false,
-  isLoading: true,
+  isReadyToVisualize: false,
+  isAllReady: true,
   networkSimulatedAccountOp: {},
   latest: {},
   pending: {}
@@ -138,7 +138,7 @@ export class SelectedAccountController extends EventEmitter {
       this.#debounceFunctionCallsOnSameTick('updateSelectedAccountDefiPositions', () => {
         this.#updateSelectedAccountDefiPositions()
 
-        if (!this.areDefiPositionsLoading && this.portfolio.isAllReady) {
+        if (!this.areDefiPositionsLoading && this.portfolio.isReadyToVisualize) {
           this.#updateSelectedAccountPortfolio(true)
           this.#updateDefiPositionsErrors()
         }
@@ -248,16 +248,19 @@ export class SelectedAccountController extends EventEmitter {
       hasSignAccountOp
     )
 
-    if (this.portfolioStartedLoadingAtTimestamp && newSelectedAccountPortfolio.isAllReady) {
+    if (this.portfolioStartedLoadingAtTimestamp && newSelectedAccountPortfolio.isReadyToVisualize) {
       this.portfolioStartedLoadingAtTimestamp = null
     }
 
-    if (!this.portfolioStartedLoadingAtTimestamp && !newSelectedAccountPortfolio.isAllReady) {
+    if (
+      !this.portfolioStartedLoadingAtTimestamp &&
+      !newSelectedAccountPortfolio.isReadyToVisualize
+    ) {
       this.portfolioStartedLoadingAtTimestamp = Date.now()
     }
 
     if (
-      newSelectedAccountPortfolio.isAllReady ||
+      newSelectedAccountPortfolio.isReadyToVisualize ||
       (!this.portfolio?.tokens?.length && newSelectedAccountPortfolio.tokens.length)
     ) {
       this.portfolio = newSelectedAccountPortfolio
@@ -364,7 +367,7 @@ export class SelectedAccountController extends EventEmitter {
       !this.#networks ||
       !this.#providers ||
       !this.#portfolio ||
-      !this.portfolio.isAllReady
+      !this.portfolio.isReadyToVisualize
     ) {
       this.#portfolioErrors = []
       if (!skipUpdate) {

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -183,6 +183,7 @@ export class SelectedAccountController extends EventEmitter {
     this.#defiPositionsErrors = []
     this.resetSelectedAccountPortfolio(true)
     this.dashboardNetworkFilter = null
+    this.portfolioStartedLoadingAtTimestamp = null
 
     if (!account) {
       await this.#storage.remove('selectedAccount')

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -216,7 +216,7 @@ export class SwapAndBridgeController extends EventEmitter {
 
     this.#selectedAccount.onUpdate(() => {
       this.#debounceFunctionCallsOnSameTick('updateFormOnSelectedAccountUpdate', () => {
-        if (this.#selectedAccount.portfolio.isAllReady) {
+        if (this.#selectedAccount.portfolio.isReadyToVisualize) {
           this.isTokenListLoading = false
           this.updatePortfolioTokenList(this.#selectedAccount.portfolio.tokens)
           // To token list includes selected account portfolio tokens, it should get an update too

--- a/src/interfaces/selectedAccount.ts
+++ b/src/interfaces/selectedAccount.ts
@@ -27,6 +27,7 @@ export interface SelectedAccountPortfolio {
   collections: CollectionResultInterface[]
   totalBalance: number
   isAllReady: boolean
+  isLoading: boolean
   networkSimulatedAccountOp: NetworkSimulatedAccountOp
   latest: SelectedAccountPortfolioState
   pending: SelectedAccountPortfolioState

--- a/src/interfaces/selectedAccount.ts
+++ b/src/interfaces/selectedAccount.ts
@@ -26,8 +26,8 @@ export interface SelectedAccountPortfolio {
   tokens: SelectedAccountPortfolioTokenResult[]
   collections: CollectionResultInterface[]
   totalBalance: number
+  isReadyToVisualize: boolean
   isAllReady: boolean
-  isLoading: boolean
   networkSimulatedAccountOp: NetworkSimulatedAccountOp
   latest: SelectedAccountPortfolioState
   pending: SelectedAccountPortfolioState

--- a/src/interfaces/selectedAccount.ts
+++ b/src/interfaces/selectedAccount.ts
@@ -26,7 +26,12 @@ export interface SelectedAccountPortfolio {
   tokens: SelectedAccountPortfolioTokenResult[]
   collections: CollectionResultInterface[]
   totalBalance: number
+  /** Either all portfolio networks have loaded or a timeout has been reached and there are tokens.
+   * @example - If the user has 3 networks and 2 of them have loaded, but the third has not and a timeout has been reached
+   * the value of isReadyToVisualize will be true.
+   */
   isReadyToVisualize: boolean
+  /** True after all networks have loaded */
   isAllReady: boolean
   networkSimulatedAccountOp: NetworkSimulatedAccountOp
   latest: SelectedAccountPortfolioState

--- a/src/libs/deployless/deployless.ts
+++ b/src/libs/deployless/deployless.ts
@@ -190,7 +190,7 @@ export class Deployless {
       callPromise,
       new Promise((_resolve, reject) => {
         // Custom providers may take longer to respond, so we set a longer timeout for them.
-        setTimeout(() => reject(new Error('rpc-timeout')), this.isProviderInvictus ? 5000 : 15000)
+        setTimeout(() => reject(new Error('rpc-timeout')), this.isProviderInvictus ? 15000 : 20000)
       })
     ])
 

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -18,7 +18,15 @@ export type Action = {
 }
 
 export type SelectedAccountBalanceError = {
-  id: string
+  id:
+    | `custom-rpcs-down-${NetworkId}`
+    | 'rpcs-down'
+    | 'portfolio-critical'
+    | 'loading-too-long'
+    | 'defi-critical'
+    | 'defi-prices'
+    | `${string}-defi-positions-error`
+    | keyof typeof PORTFOLIO_LIB_ERROR_NAMES
   networkIds: NetworkId[]
   type: 'error' | 'warning'
   title: string

--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -201,7 +201,7 @@ export function calculateSelectedAccountPortfolio(
 
   const hasLatest = latestStateSelectedAccount && Object.keys(latestStateSelectedAccount).length
   let allReady = !!hasLatest
-  let isLoading = !allReady
+  let isAllReady = !allReady
 
   const hasPending = pendingStateSelectedAccount && Object.keys(pendingStateSelectedAccount).length
   if (!hasLatest && !hasPending) {
@@ -209,8 +209,8 @@ export function calculateSelectedAccountPortfolio(
       tokens: accountPortfolio?.tokens || [],
       collections: accountPortfolio?.collections || [],
       totalBalance: accountPortfolio?.totalBalance || 0,
+      isReadyToVisualize: false,
       isAllReady: false,
-      isLoading: true,
       networkSimulatedAccountOp: accountPortfolio?.networkSimulatedAccountOp || {},
       latest: latestStateSelectedAccount,
       pending: pendingStateSelectedAccount
@@ -286,17 +286,17 @@ export function calculateSelectedAccountPortfolio(
   if (shouldShowPartialResult && !allReady) {
     // Allow the user to operate with the tokens that have loaded
     allReady = true
-    isLoading = true
+    isAllReady = false
   } else {
-    isLoading = !allReady
+    isAllReady = allReady
   }
 
   return {
     totalBalance: newTotalBalance,
     tokens,
     collections,
-    isAllReady: allReady,
-    isLoading,
+    isReadyToVisualize: allReady,
+    isAllReady,
     networkSimulatedAccountOp: simulatedAccountOps,
     latest: stripPortfolioState(latestStateSelectedAccount),
     pending: stripPortfolioState(pendingStateSelectedAccount)

--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -200,8 +200,8 @@ export function calculateSelectedAccountPortfolio(
   let newTotalBalance: number = 0
 
   const hasLatest = latestStateSelectedAccount && Object.keys(latestStateSelectedAccount).length
-  let allReady = !!hasLatest
-  let isAllReady = !allReady
+  let isAllReady = !!hasLatest
+  let isReadyToVisualize = false
 
   const hasPending = pendingStateSelectedAccount && Object.keys(pendingStateSelectedAccount).length
   if (!hasLatest && !hasPending) {
@@ -279,23 +279,22 @@ export function calculateSelectedAccountPortfolio(
     }
 
     if (!isNetworkReady(networkData)) {
-      allReady = false
+      isAllReady = false
     }
   })
 
-  if (shouldShowPartialResult && !allReady) {
+  const tokensWithAmount = tokens.filter((token) => token.amount)
+
+  if ((shouldShowPartialResult && tokensWithAmount.length && !isAllReady) || isAllReady) {
     // Allow the user to operate with the tokens that have loaded
-    allReady = true
-    isAllReady = false
-  } else {
-    isAllReady = allReady
+    isReadyToVisualize = true
   }
 
   return {
     totalBalance: newTotalBalance,
     tokens,
     collections,
-    isReadyToVisualize: allReady,
+    isReadyToVisualize,
     isAllReady,
     networkSimulatedAccountOp: simulatedAccountOps,
     latest: stripPortfolioState(latestStateSelectedAccount),


### PR DESCRIPTION
## Changes:
- Add: `isReadyToVisualize` flag to the portfolio in `selectedAccount`. It's true when all networks have loaded or when a timeout has passed. This allows the UI to display tokens when some networks are taking too long (As opposed to the previous logic which required all networks to have loaded)
- Change: Selected account portfolio error to return `networkNames` instead of `networkIds`
- Change: Deployless timeouts to 15000/20000 from 5000/15000
- Change: Update the portfolio on popup open only if 5 minutes have passed since the last update (Imo we should implement similar logic for `defiPositions` and `accountState` as we are updating them every time a popup is opened)
- Fix: `portfolioStartedLoadingAtTimestamp` not reset after changing the selected account

Closes https://github.com/AmbireTech/ambire-app/issues/3853