### PR TITLE
Bug / Remove emitting Swap & Bridge updates optimization when there is no active session

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -201,13 +201,6 @@ export class SwapAndBridgeController extends EventEmitter {
     this.#initialLoadPromise = this.#load()
   }
 
-  emitUpdate() {
-    // Override emitUpdate to not emit updates if there are no active sessions
-    if (!this.sessionIds.length) return
-
-    super.emitUpdate()
-  }
-
   async #load() {
     await this.#networks.initialLoadPromise
     await this.#selectedAccount.initialLoadPromise


### PR DESCRIPTION
Emitting Swap & Bridge updates optimization when there is no active session causes glitches if one makes a bridge and closes the Swap & Bridge screen.

Banners on the Dashboard don't update accordingly, the success bridge "cancel" button does not dismiss the banner and other troubles.

Since we memoize the Swap & Bridge controller state in the React context, over-emitting updates when there is no active session is not so bad (especially compared to not emitting when needed). The other approach would be to use `forceUpdate` in the Swap & Bridge controller when needed, but we had a sync-up offline and concluded it would be an overkill.

Resolves https://github.com/AmbireTech/ambire-app/issues/3863 and https://github.com/AmbireTech/ambire-app/issues/3925