### PR TITLE
Bug/ Relayer error handler swallows error reasons

### DIFF
--- a/src/libs/errorDecoder/errorDecoder.test.ts
+++ b/src/libs/errorDecoder/errorDecoder.test.ts
@@ -299,7 +299,9 @@ describe('Error decoders work', () => {
 
       expect(decodedError.type).toEqual(ErrorType.RelayerError)
       expect(decodedError.reason).toBe('Transaction too old')
-      expect(decodedError.data).toBe('')
+      expect(decodedError.data).toBe(
+        '0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000135472616e73616374696f6e20746f6f206f6c6400000000000000000000000000'
+      )
     })
     it('Relayer returns a HEX RPC error as message which is then handled by RevertErrorHandler', async () => {
       const error = new RelayerError(

--- a/src/libs/errorDecoder/handlers/relayer.ts
+++ b/src/libs/errorDecoder/handlers/relayer.ts
@@ -22,10 +22,12 @@ class RelayerErrorHandler implements ErrorHandler {
     } else {
       // RPC error returned as string
       reason = error.message.match(/reason="([^"]*)"/)?.[1] || ''
+      finalData = error.message.match(/data="([^"]*)"/)?.[1] || ''
 
-      if (!isReasonValid(reason)) {
-        finalData = error.message.match(/data="([^"]*)"/)?.[1] || ''
-        reason = ''
+      // The response isn't a stringified RPC error so the
+      // reason is likely the error message
+      if (!isReasonValid(reason) && !finalData) {
+        reason = error.message
       }
     }
 

--- a/src/libs/errorHumanizer/broadcastErrorhumanizer.test.ts
+++ b/src/libs/errorHumanizer/broadcastErrorhumanizer.test.ts
@@ -2,8 +2,10 @@ import { describe, expect } from '@jest/globals'
 
 import { RelayerPaymasterError } from '../errorDecoder/customErrors'
 import { MockRpcError } from '../errorDecoder/errorDecoder.test'
+import { RelayerError } from '../relayerCall/relayerCall'
 import { getHumanReadableBroadcastError } from './index'
 
+const PREFIX = 'The transaction cannot be broadcast because '
 describe('Broadcast errors are humanized', () => {
   it('Paymaster: selected fee too low', async () => {
     // @TODO: Mock the error properly or adjust the condition in getHumanReadableBroadcastError
@@ -20,7 +22,7 @@ describe('Broadcast errors are humanized', () => {
     const humanizedError = getHumanReadableBroadcastError(error)
 
     expect(humanizedError.message).toBe(
-      'The transaction cannot be broadcast because the selected fee is too low. Please select a higher transaction speed and try again.'
+      `${PREFIX}the selected fee is too low. Please select a higher transaction speed and try again.`
     )
   })
   it('Transaction underpriced', () => {
@@ -34,7 +36,25 @@ describe('Broadcast errors are humanized', () => {
     const humanizedError = getHumanReadableBroadcastError(error)
 
     expect(humanizedError.message).toBe(
-      'The transaction cannot be broadcast because it is underpriced. Please select a higher transaction speed and try again.'
+      `${PREFIX}it is underpriced. Please select a higher transaction speed and try again.`
+    )
+  })
+  it('Relayer user nonce too low', () => {
+    const error = new RelayerError('user nonce too low', {}, {})
+
+    const humanizedError = getHumanReadableBroadcastError(error)
+
+    expect(humanizedError.message).toBe(
+      `${PREFIX}the user nonce is too low. Is there a pending transaction? Please try broadcasting again.`
+    )
+  })
+  it('Random relayer error is displayed to the user', () => {
+    const error = new RelayerError('the hamsters have stopped running', {}, {})
+
+    const humanizedError = getHumanReadableBroadcastError(error)
+
+    expect(humanizedError.message).toBe(
+      `${PREFIX}of an unknown error (Origin: Relayer call). Error code: the hamsters have stopped running\nPlease try again or contact Ambire support for assistance.`
     )
   })
 })

--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -72,6 +72,11 @@ const BROADCAST_OR_ESTIMATION_ERRORS: ErrorHumanizerError[] = [
     message:
       'the Ambire relayer is temporarily down.\nPlease try again or contact Ambire support for assistance.'
   },
+  {
+    reasons: ['user nonce too low'],
+    message:
+      'the user nonce is too low. Is there a pending transaction? Please try broadcasting again.'
+  },
   // dApp interactions
   {
     reasons: ['INSUFFICIENT_INPUT_AMOUNT'],


### PR DESCRIPTION
The handler wasn't falling back to `error.message` if the response wasn't a stringified RPC error.

Please pay special attention to the new error message.

Closes https://github.com/AmbireTech/ambire-app/issues/3843