### PR TITLE
Fix / DeFi tokens - simulation and pending amounts

### DIFF
--- a/src/libs/defiPositions/types.ts
+++ b/src/libs/defiPositions/types.ts
@@ -19,6 +19,8 @@ export interface PositionAsset {
   symbol: string
   decimals: number
   amount: bigint
+  simulationAmount?: bigint
+  amountPostSimulation?: bigint
   priceIn: Price[]
   value?: number
   type: AssetType


### PR DESCRIPTION
The `amountPostSimulation` and `simulationAmount` properties were not set for the DeFi position assets.
Because of this, when attempting to withdraw a lending token, its simulation was not displayed or considered, and the balance of the collateral token was doubled (you got richer).

The PR addresses the following bug, which is demonstrated in the video below (withdrawing a lending token):
https://github.com/user-attachments/assets/3ff4250f-02da-4003-bee9-36b7ce35ff6c

The fix could also address https://github.com/AmbireTech/ambire-app/issues/3849.

💬  **TBD**: We are going to have a discussion on how to better handle DeFi tokens. The current approach, where we manually push created DeFi tokens to the Portfolio tokens, is error-prone, and we can easily miss adding a new property when the Portfolio token interface changes. Additionally, mutating the Portfolio balances based on DeFi tokens is not the best approach. At first glance, we could consider handling DeFi tokens as part of the Portfolio (amount + price + simulation) while ensuring that everything related to data normalization, health rate calculations, and other aspects is managed by the DeFi controller.