### PR TITLE
Fix / amountPostSimulation NOT added to pendingToken amount on tokens calculation

### DIFF
--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -185,7 +185,7 @@ const calculateTokenArray = (
       return {
         ...pendingToken,
         latestAmount: latestToken?.amount,
-        pendingAmount: pendingToken.amount
+        pendingAmount: pendingToken.amountPostSimulation
       }
     })
   }


### PR DESCRIPTION
Fixes issue [3959](https://github.com/AmbireTech/ambire-app/issues/3959) 

Since deployless adds the simulation amount as amountPostSimulation, we incorrectly pass the 'latest' amount from the pending token in the calculation of tokens in calculateTokenArray.

<img width="798" alt="Screenshot 2025-02-05 at 18 47 10" src="https://github.com/user-attachments/assets/290dbf28-9c69-4663-bf8d-5b599b29b6ef" />
