### PR TITLE
Config / Tweak the note for account must having a min of $10 to use the Gas Tank

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -407,7 +407,7 @@ export class SignAccountOpController extends EventEmitter {
     })
     if (balance < 10 && this.accountOp.gasFeePayment && this.accountOp.gasFeePayment.isGasTank) {
       errors.push(
-        "Gas tank isn't allowed on accounts with < $10 balance. Please add funds to your account"
+        'Your account must have a minimum overall balance of $10 to pay for gas via the Gas Tank. Please add funds to your account or choose another fee payment option.'
       )
     }
 


### PR DESCRIPTION
It got me confused that I need $10 in the Gas Tank (balance) too, so IMO this could benefit being more explicit + mentioning the alternative (choose another fee payment option).

<img width="499" alt="Screenshot 2025-02-06 at 17 26 54" src="https://github.com/user-attachments/assets/db673462-2b13-4d4b-abf0-4145f7d53242" />
