### PR TITLE
Config / Human-friendly message when Swap & Bridge service provider temporarily bans user requests

### DIFF
--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -118,12 +118,17 @@ export class SocketAPI {
       throw new SwapAndBridgeProviderApiError(error)
     }
 
+    if (response.status === 429) {
+      const error = `Our service provider received too many requests, temporarily preventing your request from being processed. ${errorPrefix}`
+      throw new SwapAndBridgeProviderApiError(error)
+    }
+
     let responseBody: SocketAPIResponse<T>
     try {
       responseBody = await response.json()
     } catch (e: any) {
       const message = e?.message || 'no message'
-      const error = `${errorPrefix} Error details: Unexpected non-JSON response from our service provider, message: <${message}>`
+      const error = `${errorPrefix} Error details: <Unexpected non-JSON response from our service provider>, message: <${message}>`
       throw new SwapAndBridgeProviderApiError(error)
     }
 


### PR DESCRIPTION
Improves a bit the error messaging when https://github.com/AmbireTech/ambire-app/issues/4000 happens.

<img width="1394" alt="Screenshot 2025-02-10 at 18 26 07" src="https://github.com/user-attachments/assets/e7f9c702-5197-4059-b313-ffd90d6f3090" />
