### PR TITLE
Add/ `removeNetworkData` method to activity

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -273,6 +273,21 @@ export class ActivityController extends EventEmitter {
     await Promise.all(promises)
   }
 
+  removeNetworkData(id: Network['id']) {
+    Object.keys(this.accountsOps).forEach(async (sessionId) => {
+      const state = this.accountsOps[sessionId]
+      const isFilteredByRemovedNetwork = state.filters.network === id
+
+      if (isFilteredByRemovedNetwork) {
+        await this.filterAccountsOps(
+          sessionId,
+          { account: state.filters.account },
+          state.pagination
+        )
+      }
+    })
+  }
+
   async addAccountOp(accountOp: SubmittedAccountOp) {
     await this.#initialLoadPromise
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1885,6 +1885,7 @@ export class MainController extends EventEmitter {
     this.portfolio.removeNetworkData(id)
     this.defiPositions.removeNetworkData(id)
     this.accountAdder.removeNetworkData(id)
+    this.activity.removeNetworkData(id)
   }
 
   async resolveAccountOpAction(data: any, actionId: AccountOpAction['id']) {


### PR DESCRIPTION
Remove network filters if account ops are filtered by networkId and that network is removed.