### PR TITLE
Bug/ Closing entry point authorization request window doesn't reject the queued transaction

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -335,9 +335,9 @@ export class MainController extends EventEmitter {
           (r) => r.action.kind !== 'calls'
         )
         userRequestsToRejectOnWindowClose.forEach((r) =>
-          r.dappPromise?.reject(ethErrors.provider.userRejectedRequest())
+          this.rejectUserRequest(ethErrors.provider.userRejectedRequest().message, r.id)
         )
-        this.userRequests = this.userRequests.filter((r) => r.action.kind === 'calls')
+
         this.userRequestWaitingAccountSwitch = []
         this.emitUpdate()
       }
@@ -772,6 +772,10 @@ export class MainController extends EventEmitter {
     if (!signedMessage) return
 
     if (signedMessage.fromActionId === ENTRY_POINT_AUTHORIZATION_REQUEST_ID) {
+      console.log({
+        userRequests: this.userRequests,
+        actionsQueue: this.actions.actionsQueue
+      })
       const accountOpAction = makeSmartAccountOpAction({
         account: this.accounts.accounts.filter((a) => a.addr === signedMessage.accountAddr)[0],
         networkId: signedMessage.networkId,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -772,10 +772,6 @@ export class MainController extends EventEmitter {
     if (!signedMessage) return
 
     if (signedMessage.fromActionId === ENTRY_POINT_AUTHORIZATION_REQUEST_ID) {
-      console.log({
-        userRequests: this.userRequests,
-        actionsQueue: this.actions.actionsQueue
-      })
       const accountOpAction = makeSmartAccountOpAction({
         account: this.accounts.accounts.filter((a) => a.addr === signedMessage.accountAddr)[0],
         networkId: signedMessage.networkId,


### PR DESCRIPTION
## How to reproduce:
1. Create a new SA
2. Open legends
3. Select a character
4. Click on the close button of the action window when you see the entry point auth request
5. Select the same character again
6. Sign the entry point auth request
7. Expect 1 mint transaction
Closes https://github.com/AmbireTech/ambire-app/issues/3188