### PR TITLE
Bug/ Swap failure not humanized during broadcast

### DIFF
--- a/src/libs/errorDecoder/errorDecoder.test.ts
+++ b/src/libs/errorDecoder/errorDecoder.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../errorHumanizer/estimationErrorHumanizer'
 import { RELAYER_DOWN_MESSAGE, RelayerError } from '../relayerCall/relayerCall'
 import { PANIC_ERROR_PREFIX } from './constants'
-import { InnerCallFailureError, RelayerPaymasterError } from './customErrors'
+import { BundlerError, InnerCallFailureError, RelayerPaymasterError } from './customErrors'
 import { decodeError } from './errorDecoder'
 import { TRANSACTION_REJECTED_REASON } from './handlers/userRejection'
 import { DecodedError, ErrorType } from './types'
@@ -401,5 +401,37 @@ describe('Error decoders work', () => {
     expect(decodedError.reason).toBe('Inner call: 0x')
     const humanizedAvax = getHumanReadableEstimationError(decodedError)
     expect(humanizedAvax.message).toBe(`${MESSAGE_PREFIX} it reverted onchain with reason unknown.`)
+  })
+  describe('Handler interference', () => {
+    it('BundlerError should not be overwritten by Pimlico and Biconomy error handlers', async () => {
+      const bundlerError = new BundlerError(
+        'UserOperation reverted during simulation with reason: 0x7b36c479',
+        'pimlico'
+      )
+
+      const decodedError = decodeError(bundlerError)
+
+      expect(decodedError.type).toEqual(ErrorType.BundlerError)
+      expect(decodedError.reason).toBe('0x7b36c479')
+
+      const pimlicoSpecificError = new BundlerError('internal error', 'pimlico')
+
+      const decodedPimlicoError = decodeError(pimlicoSpecificError)
+
+      expect(decodedPimlicoError.type).toEqual(ErrorType.BundlerError)
+      expect(decodedPimlicoError.reason).toBe('pimlico: 500')
+    })
+    it('Panic error in InnerCallFailureError should be decoded as PanicError', async () => {
+      try {
+        await contract.panicUnderflow()
+      } catch (e: any) {
+        const decodedError = decodeError(e)
+
+        expect(decodedError.type).toEqual(ErrorType.PanicError)
+        expect(decodedError.reason).toBe(
+          'Arithmetic operation underflowed or overflowed outside of an unchecked block'
+        )
+      }
+    })
   })
 })

--- a/src/libs/errorDecoder/errorDecoder.ts
+++ b/src/libs/errorDecoder/errorDecoder.ts
@@ -15,11 +15,15 @@ import RelayerErrorHandler from './handlers/relayer'
 import { formatReason, getDataFromError, isReasonValid } from './helpers'
 import { DecodedError, ErrorType } from './types'
 
+// The order of these handlers is important!
+// Preprocessor handlers must be ordered by least specific to most specific
+// Why- because error reasons are overwritten by subsequent matching handlers
+// Error handlers must be ordered by most specific to least specific
+// Why- because the first valid reason cannot be overwritten by subsequent handlers
 const PREPROCESSOR_BUNDLER_HANDLERS = [
   BiconomyEstimationErrorHandler,
   PimlicoEstimationErrorHandler
 ]
-
 const PREPROCESSOR_HANDLERS = [BundlerErrorHandler, RelayerErrorHandler, InnerCallFailureHandler]
 const ERROR_HANDLERS = [
   RpcErrorHandler,

--- a/src/libs/errorDecoder/errorDecoder.ts
+++ b/src/libs/errorDecoder/errorDecoder.ts
@@ -64,7 +64,7 @@ export function decodeError(e: Error): DecodedError {
   // a third. So we will add additional handlers optionally
   const preprocessorHandlers = PREPROCESSOR_HANDLERS
   if (e instanceof BundlerError) {
-    preprocessorHandlers.push(...PREPROCESSOR_BUNDLER_HANDLERS)
+    preprocessorHandlers.unshift(...PREPROCESSOR_BUNDLER_HANDLERS)
   }
 
   // Run preprocessor handlers first

--- a/src/libs/errorHumanizer/broadcastErrorHumanizer.ts
+++ b/src/libs/errorHumanizer/broadcastErrorHumanizer.ts
@@ -25,7 +25,8 @@ export function getHumanReadableBroadcastError(e: Error | DecodedError) {
   const decodedError = e instanceof Error ? decodeError(e as Error) : (e as DecodedError)
   const commonError = humanizeEstimationOrBroadcastError(
     decodedError.reason,
-    getPrefix(decodedError.reason)
+    getPrefix(decodedError.reason),
+    e
   )
   let errorMessage = getHumanReadableErrorMessage(
     commonError,

--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -102,6 +102,10 @@ const BROADCAST_OR_ESTIMATION_ERRORS: ErrorHumanizerError[] = [
     message:
       'the swap has expired. Return to the app and reinitiate the swap if you wish to proceed.'
   },
+  {
+    reasons: ['0x7b36c479', '0x81ceff30'],
+    message: 'of a Swap failure. Please try performing the same swap again.'
+  },
   // bundler
   {
     reasons: ['biconomy: 400'],
@@ -145,11 +149,6 @@ const ESTIMATION_ERRORS: ErrorHumanizerError[] = [
       'ontract is not allowed'
     ],
     message: 'this app does not support Smart Account wallets. Use a Basic Account (EOA) instead.'
-  },
-  // Contract errors
-  {
-    reasons: ['0x7b36c479', '0x81ceff30'],
-    message: 'of a Swap failure. Please try performing the same swap again.'
   },
   {
     reasons: ['ERC721: token already minted'],

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
@@ -4,6 +4,7 @@ import { ethers } from 'hardhat'
 import { describe, expect } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
+import { BundlerError } from '../errorDecoder/customErrors'
 import { MockCustomError } from '../errorDecoder/errorDecoder.test'
 import { MESSAGE_PREFIX } from './estimationErrorHumanizer'
 import { getHumanReadableEstimationError } from './index'
@@ -37,7 +38,10 @@ describe('Estimation errors are humanized', () => {
   it('0x7b36c479 (PartialSwapsNotAllowed)', () => {
     const { restore } = suppressConsole()
     const EXPECTED_MESSAGE = `${MESSAGE_PREFIX} of a Swap failure. Please try performing the same swap again.`
-    const error = new Error('0x7b36c479')
+    const error = new BundlerError(
+      'UserOperation reverted during simulation with reason: 0x7b36c479',
+      'pimlico'
+    )
 
     const humanizedError = getHumanReadableEstimationError(error)
 

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
@@ -37,7 +37,6 @@ describe('Estimation errors are humanized', () => {
   it('0x7b36c479 (PartialSwapsNotAllowed)', () => {
     const { restore } = suppressConsole()
     const EXPECTED_MESSAGE = `${MESSAGE_PREFIX} of a Swap failure. Please try performing the same swap again.`
-
     const error = new Error('0x7b36c479')
 
     const humanizedError = getHumanReadableEstimationError(error)

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
@@ -4,7 +4,6 @@ import { ethers } from 'hardhat'
 import { describe, expect } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
-import { BundlerError } from '../errorDecoder/customErrors'
 import { MockCustomError } from '../errorDecoder/errorDecoder.test'
 import { MESSAGE_PREFIX } from './estimationErrorHumanizer'
 import { getHumanReadableEstimationError } from './index'
@@ -38,10 +37,7 @@ describe('Estimation errors are humanized', () => {
   it('0x7b36c479 (PartialSwapsNotAllowed)', () => {
     const { restore } = suppressConsole()
     const EXPECTED_MESSAGE = `${MESSAGE_PREFIX} of a Swap failure. Please try performing the same swap again.`
-    const error = new BundlerError(
-      'UserOperation reverted during simulation with reason: 0x7b36c479',
-      'pimlico'
-    )
+    const error = new Error('0x7b36c479')
 
     const humanizedError = getHumanReadableEstimationError(error)
 

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.ts
@@ -26,7 +26,8 @@ export function getHumanReadableEstimationError(e: Error | DecodedError) {
   const decodedError = e instanceof Error ? decodeError(e as Error) : (e as DecodedError)
   const commonError = humanizeEstimationOrBroadcastError(
     decodedError.reason,
-    getPrefix(decodedError.reason)
+    getPrefix(decodedError.reason),
+    e
   )
   let errorMessage = getHumanReadableErrorMessage(
     commonError,

--- a/src/libs/errorHumanizer/humanizeCommonCases.test.ts
+++ b/src/libs/errorHumanizer/humanizeCommonCases.test.ts
@@ -28,7 +28,7 @@ describe('Estimation/Broadcast common errors are humanized', () => {
       await contract.revertWithReason('Transaction too old')
     } catch (error: any) {
       const { reason } = decodeError(error)
-      const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX)
+      const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX, error)
 
       expect(message).toBe(
         `${MESSAGE_PREFIX} the swap has expired. Return to the app and reinitiate the swap if you wish to proceed.`
@@ -38,7 +38,7 @@ describe('Estimation/Broadcast common errors are humanized', () => {
   it('Rpc timeout', () => {
     const error = new Error('rpc-timeout')
     const { reason } = decodeError(error)
-    const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX)
+    const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX, error)
 
     expect(message).toBe(
       `${MESSAGE_PREFIX} of a problem with the RPC on this network. Please try again later, change the RPC or contact support for assistance.`
@@ -48,7 +48,7 @@ describe('Estimation/Broadcast common errors are humanized', () => {
     const error = new MockBundlerError('paymaster deposit too low')
 
     const { reason } = decodeError(error)
-    const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX)
+    const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX, error)
 
     expect(message).toBe(`${MESSAGE_PREFIX} ${insufficientPaymasterFunds}`)
   })
@@ -57,7 +57,7 @@ describe('Estimation/Broadcast common errors are humanized', () => {
       await contract.revertWithReason('insufficient funds')
     } catch (error: any) {
       const { reason } = decodeError(error)
-      const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX)
+      const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX, error)
 
       expect(message).toBe(
         `${MESSAGE_PREFIX} of insufficient funds for the transaction fee. Please add more fee tokens to your account and try again.`
@@ -69,7 +69,7 @@ describe('Estimation/Broadcast common errors are humanized', () => {
       await contract.revertWithReason('transfer amount exceeds balance')
     } catch (error: any) {
       const { reason } = decodeError(error)
-      const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX)
+      const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX, error)
 
       expect(message).toBe(
         `${MESSAGE_PREFIX} the transfer amount exceeds your account balance. Please check your balance or adjust the transfer amount.`
@@ -79,12 +79,16 @@ describe('Estimation/Broadcast common errors are humanized', () => {
   it('Returns null for unhandled error', () => {
     const reason = 'nema pari'
 
-    const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX)
+    const message = humanizeEstimationOrBroadcastError(reason, MESSAGE_PREFIX, new Error(reason))
 
     expect(message).toBe(null)
   })
   it('Relayer is down', () => {
-    const message = humanizeEstimationOrBroadcastError(RELAYER_DOWN_MESSAGE, MESSAGE_PREFIX)
+    const message = humanizeEstimationOrBroadcastError(
+      RELAYER_DOWN_MESSAGE,
+      MESSAGE_PREFIX,
+      new Error(RELAYER_DOWN_MESSAGE)
+    )
 
     expect(message).toBe(
       `${MESSAGE_PREFIX} the Ambire relayer is temporarily down.\nPlease try again or contact Ambire support for assistance.`

--- a/src/libs/errorHumanizer/humanizeCommonCases.ts
+++ b/src/libs/errorHumanizer/humanizeCommonCases.ts
@@ -2,15 +2,18 @@ import { BROADCAST_OR_ESTIMATION_ERRORS } from './errors'
 
 const humanizeEstimationOrBroadcastError = (
   reason: string | null,
-  prefix: string
+  prefix: string,
+  originalError: any
 ): string | null => {
   let message = null
 
   if (!reason) return message
 
+  const checkAgainst = reason || originalError?.error?.message || originalError?.message
+
   BROADCAST_OR_ESTIMATION_ERRORS.forEach((error) => {
     const isMatching = error.reasons.some((errorReason) =>
-      reason.toLowerCase().includes(errorReason.toLowerCase())
+      checkAgainst.toLowerCase().includes(errorReason.toLowerCase())
     )
     if (!isMatching) return
 

--- a/src/libs/errorHumanizer/humanizeCommonCases.ts
+++ b/src/libs/errorHumanizer/humanizeCommonCases.ts
@@ -7,8 +7,6 @@ const humanizeEstimationOrBroadcastError = (
 ): string | null => {
   let message = null
 
-  if (!reason) return message
-
   const checkAgainst = reason || originalError?.error?.message || originalError?.message
 
   BROADCAST_OR_ESTIMATION_ERRORS.forEach((error) => {


### PR DESCRIPTION
## Fixes:
- Fix: SwapFailed not humanized on broadcast- The swap could fail between reestimations, leading to a broadcast error that wasn’t properly humanized.
- Fix: PREPROCESSOR_BUNDLER_HANDLERS were interfering with PREPROCESSOR_HANDLERS (resetting the reason to '')
- Fix: `humanizeEstimationOrBroadcastError` doesn't fallback to error message if reason is falsy