### PR TITLE
Fix / Always Pending Active Route due to a Failed Transaction

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1363,6 +1363,9 @@ export class SwapAndBridgeController extends EventEmitter {
       if (tx.userTxType === 'dex-swap') shouldUpdateActiveRouteStatus = true
     }
 
+    if (opStatus === AccountOpStatus.Failure || opStatus === AccountOpStatus.Rejected)
+      shouldUpdateActiveRouteStatus = true
+
     if (!shouldUpdateActiveRouteStatus) return
 
     if (opStatus === AccountOpStatus.Success) {

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1358,7 +1358,7 @@ export class SwapAndBridgeController extends EventEmitter {
 
     if (isSwap) shouldUpdateActiveRouteStatus = true
 
-    // check if it is the last tx of a 'bridge' is of type 'swap'
+    // force update active route if the last tx of a 'bridge' is of type 'swap'
     if (activeRoute.route.currentUserTxIndex + 1 === activeRoute.route.totalUserTx) {
       const tx = activeRoute.route.userTxs[activeRoute.route.currentUserTxIndex]
       if (!tx) return

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1356,9 +1356,10 @@ export class SwapAndBridgeController extends EventEmitter {
 
     const isSwap = activeRoute.route.fromChainId === activeRoute.route.toChainId
 
+    // force update the active route status if the route is of type 'swap'
     if (isSwap) shouldUpdateActiveRouteStatus = true
 
-    // force update active route if the last tx of a 'bridge' is of type 'swap'
+    // force update the active route status if the last tx of a 'bridge' is of type 'swap'
     if (activeRoute.route.currentUserTxIndex + 1 === activeRoute.route.totalUserTx) {
       const tx = activeRoute.route.userTxs[activeRoute.route.currentUserTxIndex]
       if (!tx) return
@@ -1366,7 +1367,7 @@ export class SwapAndBridgeController extends EventEmitter {
       if (tx.userTxType === 'dex-swap') shouldUpdateActiveRouteStatus = true
     }
 
-    // force update the active route status with an error message if the tx fails (for both swap and bridge)
+    // force update the active route with an error message if the tx fails (for both swap and bridge)
     if (opStatus === AccountOpStatus.Failure || opStatus === AccountOpStatus.Rejected)
       shouldUpdateActiveRouteStatus = true
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1353,9 +1353,12 @@ export class SwapAndBridgeController extends EventEmitter {
     if (!activeRoute) return
 
     let shouldUpdateActiveRouteStatus = false
-    if (activeRoute.route.fromChainId === activeRoute.route.toChainId)
-      shouldUpdateActiveRouteStatus = true
 
+    const isSwap = activeRoute.route.fromChainId === activeRoute.route.toChainId
+
+    if (isSwap) shouldUpdateActiveRouteStatus = true
+
+    // check if it is the last tx of a 'bridge' is of type 'swap'
     if (activeRoute.route.currentUserTxIndex + 1 === activeRoute.route.totalUserTx) {
       const tx = activeRoute.route.userTxs[activeRoute.route.currentUserTxIndex]
       if (!tx) return
@@ -1363,6 +1366,7 @@ export class SwapAndBridgeController extends EventEmitter {
       if (tx.userTxType === 'dex-swap') shouldUpdateActiveRouteStatus = true
     }
 
+    // force update the active route status with an error message if the tx fails (for both swap and bridge)
     if (opStatus === AccountOpStatus.Failure || opStatus === AccountOpStatus.Rejected)
       shouldUpdateActiveRouteStatus = true
 


### PR DESCRIPTION
* Fixed: active route status remains pending forever due to a failed transaction because Socket does not update the route status to Failed in that case