### PR TITLE
Bug/ Current action not reset on removeAction (actions ctrl)

### DIFF
--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -207,8 +207,11 @@ export class ActionsController extends EventEmitter {
 
   removeAction(actionId: Action['id'], shouldOpenNextAction: boolean = true) {
     this.actionsQueue = this.actionsQueue.filter((a) => a.id !== actionId)
-    if (shouldOpenNextAction) {
-      this.#setCurrentAction(this.visibleActionsQueue[0] || null)
+
+    if (!this.visibleActionsQueue.length) {
+      this.#setCurrentAction(null)
+    } else if (shouldOpenNextAction) {
+      this.#setCurrentAction(this.visibleActionsQueue[0])
     }
   }
 


### PR DESCRIPTION
## How to reproduce:
1. Open a sign account op and don't close it
2. Open the extension popup and reject the transaction from the banner

Closes https://github.com/AmbireTech/ambire-app/issues/4084
Closes https://github.com/AmbireTech/ambire-app/issues/3924