### PR TITLE
Bug/ portfolio `PriceFetchError` is never displayed

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -561,15 +561,15 @@ export class PortfolioController extends EventEmitter {
         ...portfolioProps
       })
 
-      const hasCriticalError = result.errors.some((e) => e.level === 'critical')
+      const hasError = result.errors.some((e) => e.level !== 'silent')
       const additionalHintsErc20Hints = portfolioProps.additionalErc20Hints || []
       let lastSuccessfulUpdate = accountState[network.id]?.result?.lastSuccessfulUpdate || 0
 
       // Reset lastSuccessfulUpdate on forceUpdate in case of critical errors as the user
       // is likely expecting a change in the portfolio.
-      if (forceUpdate && hasCriticalError) {
+      if (forceUpdate && hasError) {
         lastSuccessfulUpdate = 0
-      } else if (!hasCriticalError) {
+      } else if (!hasError) {
         // Update the last successful update only if there are no critical errors.
         lastSuccessfulUpdate = Date.now()
       }

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -338,7 +338,7 @@ export class Portfolio {
             errors.push({
               name: PORTFOLIO_LIB_ERROR_NAMES.PriceFetchError,
               message: errorMessage,
-              level: 'warning'
+              level: 'critical'
             })
           }
         }

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -338,7 +338,7 @@ export class Portfolio {
             errors.push({
               name: PORTFOLIO_LIB_ERROR_NAMES.PriceFetchError,
               message: errorMessage,
-              level: 'critical'
+              level: 'warning'
             })
           }
         }


### PR DESCRIPTION
The error is not displayed because `lastSuccessfulUpdate` is updated even when there are portfolio errors with the level `warning`. That is because we are checking if there has been a successful update in the last 10 minutes, and because `lastSuccessfulUpdate` is being updated, the error is not displayed unless there is another critical error.