### PR TITLE
increasePreVerGas prop for less "txn underpriced" errors

### DIFF
--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -69,7 +69,8 @@ const networks: Network[] = [
       hasPaymaster: true,
       hasBundlerSupport: true,
       bundlers: [PIMLICO, BICONOMY],
-      defaultBundler: BICONOMY
+      defaultBundler: BICONOMY,
+      increasePreVerGas: 5
     },
     isSAEnabled: true,
     areContractsDeployed: true,
@@ -161,7 +162,8 @@ const networks: Network[] = [
       hasPaymaster: true,
       hasBundlerSupport: true,
       bundlers: [PIMLICO, BICONOMY],
-      defaultBundler: PIMLICO
+      defaultBundler: PIMLICO,
+      increasePreVerGas: 5
     },
     isSAEnabled: true,
     areContractsDeployed: true,

--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -117,7 +117,8 @@ export class NetworksController extends EventEmitter {
           enabled: is4337Enabled(!!n.erc4337.hasBundlerSupport, n, this.#networks[n.id]?.force4337),
           hasPaymaster: n.erc4337.hasPaymaster,
           defaultBundler: n.erc4337.defaultBundler,
-          bundlers: n.erc4337.bundlers
+          bundlers: n.erc4337.bundlers,
+          increasePreVerGas: n.erc4337.increasePreVerGas ?? 0
         },
         nativeAssetId: n.nativeAssetId,
         nativeAssetSymbol: n.nativeAssetSymbol

--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -8,6 +8,9 @@ export interface Erc4337settings {
   hasBundlerSupport?: boolean
   bundlers?: BUNDLER[]
   defaultBundler?: BUNDLER
+  // increase the bundler estimation & gas price by a percent so we get
+  // "txn underpriced" errors less often
+  increasePreVerGas?: number
 }
 
 interface FeeOptions {

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -97,8 +97,26 @@ export abstract class Bundler {
     shouldStateOverride = false
   ): Promise<BundlerEstimateResult> {
     const estimatiton = await this.sendEstimateReq(userOperation, network, shouldStateOverride)
+
+    // Whole formula:
+    // final = estimation + estimation * percentage
+    // if percentage = 5% then percentage = 5/100 => 1/20
+    // final = estimation + estimation / 20
+    // here, we calculate the division (20 above)
+    const division = network.erc4337.increasePreVerGas
+      ? BigInt(100 / network.erc4337.increasePreVerGas)
+      : undefined
+
+    console.log('the division')
+    console.log(division)
+
+    // transform
+    const preVerificationGas = division
+      ? BigInt(estimatiton.preVerificationGas) + BigInt(estimatiton.preVerificationGas) / division
+      : BigInt(estimatiton.preVerificationGas)
+
     return {
-      preVerificationGas: toBeHex(estimatiton.preVerificationGas) as Hex,
+      preVerificationGas: toBeHex(preVerificationGas) as Hex,
       verificationGasLimit: toBeHex(estimatiton.verificationGasLimit) as Hex,
       callGasLimit: toBeHex(estimatiton.callGasLimit) as Hex,
       paymasterVerificationGasLimit: toBeHex(estimatiton.paymasterVerificationGasLimit) as Hex,

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -107,9 +107,6 @@ export abstract class Bundler {
       ? BigInt(100 / network.erc4337.increasePreVerGas)
       : undefined
 
-    console.log('the division')
-    console.log(division)
-
     // transform
     const preVerificationGas = division
       ? BigInt(estimatiton.preVerificationGas) + BigInt(estimatiton.preVerificationGas) / division


### PR DESCRIPTION
Add a prop `increasePreVerGas` to increase the preVerGas provided by the bundler on base/opt to make the UX better (less fee underpriced errors).

We already increase the max fee per gas and max priority fee per gas by 5/7/10/20 percent for slow/medium/fast/ape so I'd assume the problem is elsewhere. Trying out with `preVerGas` as it has been a reason for txn underpriced in the past and it was not increase until now