### PR TITLE
Sign Message: allow v1 accs to sign anything if OG mode is activated

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -32,6 +32,7 @@ import {
 import { AddNetworkRequestParams, Network, NetworkId } from '../../interfaces/network'
 import { NotificationManager } from '../../interfaces/notification'
 import { RPCProvider } from '../../interfaces/provider'
+import { TraceCallDiscoveryStatus } from '../../interfaces/signAccountOp'
 import { Storage } from '../../interfaces/storage'
 import { SocketAPISendTransactionRequest } from '../../interfaces/swapAndBridge'
 import { Calls, DappUserRequest, SignUserRequest, UserRequest } from '../../interfaces/userRequest'
@@ -127,7 +128,6 @@ import { ProvidersController } from '../providers/providers'
 import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 /* eslint-disable no-underscore-dangle */
 import { SignAccountOpController, SigningStatus } from '../signAccountOp/signAccountOp'
-import { TraceCallDiscoveryStatus } from '../../interfaces/signAccountOp'
 import { SignMessageController } from '../signMessage/signMessage'
 import { SwapAndBridgeController, SwapAndBridgeFormStatus } from '../swapAndBridge/swapAndBridge'
 
@@ -794,7 +794,7 @@ export class MainController extends EventEmitter {
       return this.emitError({ level: 'major', message, error })
     }
 
-    await this.signMessage.sign()
+    await this.signMessage.sign(this.invite.isOG)
 
     const signedMessage = this.signMessage.signedMessage
     // Error handling on the prev step will notify the user, it's fine to return here

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -123,7 +123,7 @@ export class SignMessageController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async #sign() {
+  async #sign(isOG = false) {
     if (!this.isInitialized) {
       return SignMessageController.#throwNotInitialized()
     }
@@ -171,7 +171,8 @@ export class SignMessageController extends EventEmitter {
             network,
             account,
             accountState,
-            this.#signer
+            this.#signer,
+            isOG
           )
         }
 
@@ -187,7 +188,8 @@ export class SignMessageController extends EventEmitter {
             account,
             accountState,
             this.#signer,
-            network
+            network,
+            isOG
           )
         }
       } catch (error: any) {
@@ -261,8 +263,8 @@ export class SignMessageController extends EventEmitter {
     }
   }
 
-  async sign() {
-    await this.withStatus('sign', async () => this.#sign())
+  async sign(isOG = false) {
+    await this.withStatus('sign', async () => this.#sign(isOG))
   }
 
   removeAccountData(address: Account['addr']) {

--- a/src/libs/signMessage/signMessage.test.ts
+++ b/src/libs/signMessage/signMessage.test.ts
@@ -292,23 +292,6 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     }
   })
 
-  test('Signing [V1 SA]: plain text, should throw an error as it disallowed to sign message with contains address in it on unsupported chain', async () => {
-    const accountStates = await getAccountsInfo([v1Account])
-    const signer = await keystore.getSigner(v1siger.keyPublicAddress, 'internal')
-
-    await expect(
-      getPlainTextSignature(
-        `test with address in the message on unsupported chain: ${v1Account.addr}`,
-        unsupportedNetwork,
-        v1Account,
-        accountStates[v1Account.addr][ethereumNetwork.id],
-        signer
-      )
-    ).rejects.toThrow(
-      `Signing messages is disallowed for v1 accounts on ${unsupportedNetwork.name}`
-    )
-  })
-
   test('Signing [V1 SA]: disallowed plain text, but with OG mode', async () => {
     const signer = await keystore.getSigner(v1siger.keyPublicAddress, 'internal')
     const accountStates = await getAccountsInfo([v1Account])
@@ -318,14 +301,6 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     const plaintextSigNoAddrInMessage = await getPlainTextSignature(
       'test',
       ethereumNetwork,
-      v1Account,
-      accountState,
-      signer,
-      true
-    )
-    const plaintextSigUnsupportedChain = await getPlainTextSignature(
-      `test with address in the message on unsupported chain: ${v1Account.addr}`,
-      unsupportedNetwork,
       v1Account,
       accountState,
       signer,
@@ -347,7 +322,6 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     )
 
     expect(plaintextSigNoAddrInMessage).toBeTruthy()
-    expect(plaintextSigUnsupportedChain).toBeTruthy()
     expect(typedSigNoAddrInMessage).toBeTruthy()
   })
   test('Signing [EOA]: eip-712', async () => {

--- a/src/libs/signMessage/signMessage.test.ts
+++ b/src/libs/signMessage/signMessage.test.ts
@@ -309,6 +309,47 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     )
   })
 
+  test('Signing [V1 SA]: disallowed plain text, but with OG mode', async () => {
+    const signer = await keystore.getSigner(v1siger.keyPublicAddress, 'internal')
+    const accountStates = await getAccountsInfo([v1Account])
+
+    const accountState = accountStates[v1Account.addr][ethereumNetwork.id]
+
+    const plaintextSigNoAddrInMessage = await getPlainTextSignature(
+      'test',
+      ethereumNetwork,
+      v1Account,
+      accountState,
+      signer,
+      true
+    )
+    const plaintextSigUnsupportedChain = await getPlainTextSignature(
+      `test with address in the message on unsupported chain: ${v1Account.addr}`,
+      unsupportedNetwork,
+      v1Account,
+      accountState,
+      signer,
+      true
+    )
+
+    const typedData = getTypedData(
+      ethereumNetwork.chainId,
+      v1siger.keyPublicAddress, // this is the difference
+      hashMessage('test')
+    )
+    const typedSigNoAddrInMessage = await getEIP712Signature(
+      typedData,
+      v1Account,
+      accountState,
+      signer,
+      polygonNetwork,
+      true
+    )
+
+    expect(plaintextSigNoAddrInMessage).toBeTruthy()
+    expect(plaintextSigUnsupportedChain).toBeTruthy()
+    expect(typedSigNoAddrInMessage).toBeTruthy()
+  })
   test('Signing [EOA]: eip-712', async () => {
     const accountStates = await getAccountsInfo([eoaAccount])
     const accountState = accountStates[eoaAccount.addr][ethereumNetwork.id]

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -426,22 +426,15 @@ export async function getPlainTextSignature(
       checksummedHexAddrWithout0x.slice(2)
     )
 
-    if (!isOG) {
-      if (
-        !network.predefined &&
-        !relayerAdditionalNetworks.find((net) => net.chainId === network.chainId)
-      ) {
-        throw new Error(`Signing messages is disallowed for v1 accounts on ${network.name}`)
-      }
-
-      if (
-        !isAsciiAddressInMessage &&
-        !isLowercaseHexAddressInMessage &&
-        !isChecksummedHexAddressInMessage
+    if (
+      !isOG &&
+      !isAsciiAddressInMessage &&
+      !isLowercaseHexAddressInMessage &&
+      !isChecksummedHexAddressInMessage
+    ) {
+      throw new Error(
+        'Signing messages is disallowed for v1 accounts. Please contact support to proceed'
       )
-        throw new Error(
-          'Signing messages is disallowed for v1 accounts. Please contact support to proceed'
-        )
     }
 
     return wrapUnprotected(await signer.signMessage(messageHex))

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -394,7 +394,7 @@ export async function getPlainTextSignature(
   account: Account,
   accountState: AccountOnchainState,
   signer: KeystoreSigner,
-  isOG: boolean
+  isOG = false
 ): Promise<string> {
   const dedicatedToOneSA = signer.key.dedicatedToOneSA
 
@@ -468,7 +468,7 @@ export async function getEIP712Signature(
   accountState: AccountOnchainState,
   signer: KeystoreSigner,
   network: Network,
-  isOG: boolean
+  isOG = false
 ): Promise<string> {
   if (!message.types.EIP712Domain) {
     throw new Error(


### PR DESCRIPTION
## Self explanatory - if the user has OG mode activated, do not disallow message signatures for V1 accs
## To test
- attempt to sign a plaintext  or typed message, that does not include the address of the accounts (should not be allowed)
- activate OG mode
- attempt step 1 again, but now should be successful

Resolves: https://github.com/AmbireTech/ambire-app/issues/4034