### PR TITLE
Fix / Sign Message - Overwrite bug 

### DIFF
--- a/src/interfaces/userRequest.ts
+++ b/src/interfaces/userRequest.ts
@@ -17,7 +17,7 @@ export interface Calls {
 }
 export interface PlainTextMessage {
   kind: 'message'
-  message: string | Uint8Array
+  message: string
 }
 
 export interface TypedMessage {

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -231,19 +231,23 @@ export function mapSignatureV(sigRaw: string) {
   return hexlify(sig)
 }
 
+// Either `message` or `typedData` must be provided - never both.
 type Props = {
-  network?: Network
-  provider?: JsonRpcProvider
-  signer?: string
+  network: Network
+  provider: JsonRpcProvider
+  signer: string
   signature: string | Uint8Array
-  message?: string | Uint8Array
-  typedData?: {
-    domain: TypedDataDomain
-    types: Record<string, Array<TypedDataField>>
-    message: Record<string, any>
-  }
-  finalDigest?: string
-}
+} & (
+  | { message: string | Uint8Array; typedData?: never }
+  | {
+      typedData: {
+        domain: TypedDataDomain
+        types: Record<string, Array<TypedDataField>>
+        message: Record<string, any>
+      }
+      message?: never
+    }
+)
 
 /**
  * Verifies the signature of a message using the provided signer and signature
@@ -252,7 +256,7 @@ type Props = {
  * `eth_call`, tries to verify the signature using ERC-6492, ERC-1271, and
  * `ecrecover`, and returns the value to the function.
  *
- * Note: you only need to pass one of: typedData, finalDigest, message
+ * Note: you only need to pass one of: `message` or `typedData`
  */
 export async function verifyMessage({
   network,
@@ -260,14 +264,10 @@ export async function verifyMessage({
   signer,
   signature,
   message,
-  typedData,
-  finalDigest
-}: (
-  | Required<Pick<Props, 'message'>>
-  | Required<Pick<Props, 'typedData'>>
-  | Required<Pick<Props, 'finalDigest'>>
-) &
-  Props): Promise<boolean> {
+  typedData
+}: Props): Promise<boolean> {
+  let finalDigest: string
+
   if (message) {
     try {
       finalDigest = hashMessage(message)
@@ -279,7 +279,14 @@ export async function verifyMessage({
         }`
       )
     }
-  } else if (typedData) {
+  } else {
+    // According to the Props definition, either `message` or `typedData` must be provided.
+    // However, TypeScript struggles with this `else` condition, incorrectly treating `typedData` as undefined.
+    // To prevent TypeScript from complaining, we've added this runtime validation.
+    if (!typedData) {
+      throw new Error("Either 'message' or 'typedData' must be provided.")
+    }
+
     // To resolve the "ambiguous primary types or unused types" error, remove
     // the `EIP712Domain` from `types` object. The domain type is inbuilt in
     // the EIP712 standard and hence TypedDataEncoder so you do not need to
@@ -329,9 +336,9 @@ export async function verifyMessage({
   let callResult
   try {
     const deploylessVerify = fromDescriptor(
-      provider!,
+      provider,
       UniversalSigValidator,
-      !network!.rpcNoStateOverride
+      !network.rpcNoStateOverride
     )
     const deploylessRes = await deploylessVerify.call('isValidSigWithSideEffects', [
       signer,


### PR DESCRIPTION
Closes https://github.com/AmbireTech/ambire-app/issues/3263.

- Fix: The SignMessage controller was incorrectly overriding the original message string with a hex value, resulting in a non-human-readable message when signing fails.
- Change: Simplified `PlainTextMessage.message` to accept only `string` values.
- Change: Improved TypeScript parameter definitions for `verifyMessage` by making the main properties required. Enforced a strict requirement that either `message` or `typedData` must be provided, but not both.
- Remove: Removed `finalDigest` parameter as it was never passed to `verifyMessage`. Refactored `verifyMessage` to ensure it only accepts either `message` or `typedData`, never both.