### PR TITLE
Bug/ Offline banner flashing and #getAdditionalPortfolio not awaited

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1082,14 +1082,20 @@ export class MainController extends EventEmitter {
     // come in the same tick. Otherwise the UI may flash the wrong error.
     const latestState = this.portfolio.getLatestPortfolioState(accountAddr)
     const latestStateKeys = Object.keys(latestState)
-
-    if (!latestStateKeys.length) return
-
     const isAllReady = latestStateKeys.every((networkId) => {
       return isNetworkReady(latestState[networkId])
     })
 
-    if (!isAllReady) return
+    // Set isOffline back to false if the portfolio is loading.
+    // This is done to prevent the UI from flashing the offline error
+    if (!latestStateKeys.length || !isAllReady) {
+      // Skip unnecessary updates
+      if (!this.isOffline) return
+
+      this.isOffline = false
+      this.emitUpdate()
+      return
+    }
 
     const allPortfolioNetworksHaveErrors = latestStateKeys.every((networkId) => {
       const state = latestState[networkId]


### PR DESCRIPTION
## How to reproduce:
1. Open the extension and wait for an account to load
2. Turn off your internet
3. Open the extension and force reload the account
4. Close the extension
5. Wait 15 seconds
6. Turn your internet on
7. Open the extension
8. Wait for the portfolio to load. The offline banner shouldn't flash
## The cause:
1. isOffline is not set to false while the portfolio is loading
2. `updateIsOffline` is called after `await this.portfolio.updateSelectedAccount` but await doesn't await the additional portfolio state. What can happen is- the portfolio loads but the additional portfolio doesn't. As a consequence `updateIsOffline` is called and `f (!isAllReady) return` prevents the flag from being set to false. You can exacerbate this problem by adding `await new Promise((resolve) => setTimeout(resolve, 4000))` in `portfolio:441`