### PR TITLE
Bug/ Duplicate error if signAccountOp is not initialized

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -662,8 +662,8 @@ export class MainController extends EventEmitter {
         if (!this.signAccountOp) {
           const message =
             'The signing process was not initialized as expected. Please try again later or contact Ambire support if the issue persists.'
-          const error = new Error('SignAccountOp is not initialized')
-          this.emitError({ level: 'major', message, error })
+
+          const error = new EmittableError({ level: 'major', message })
           return Promise.reject(error)
         }
 


### PR DESCRIPTION
The error is emitted once using `emitError` and a second time because of `withStatus`