### PR TITLE
Refactor/ Move velcro call to the controller

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -784,7 +784,6 @@ export class PortfolioController extends EventEmitter {
               networkResult!.tokens
             )
 
-            console.log('readyToLearnTokens', readyToLearnTokens)
             if (readyToLearnTokens.length) {
               await this.learnTokens(readyToLearnTokens, network.id)
             }

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -147,17 +147,24 @@ export class PortfolioController extends EventEmitter {
         const baseCurrencies = [...new Set(queue.map((x) => x.data.baseCurrency))]
         return baseCurrencies.map((baseCurrency) => {
           const queueSegment = queue.filter((x) => x.data.baseCurrency === baseCurrency)
+          console.log(queueSegment)
+          // Create unique sets of network IDs and account addresses
+
           const url = `${velcroUrl}/multi-hints?networks=${queueSegment
             .map((x) => x.data.networkId)
             .join(',')}&accounts=${queueSegment
             .map((x) => x.data.accountAddr)
             .join(',')}&baseCurrency=${baseCurrency}`
-          return { queueSegment, url }
+
+          return { url, queueSegment }
         })
       },
       {
-        timeoutAfter: 3000,
-        timeoutErrorMessage: 'Velcro discovery timed out'
+        timeoutSettings: {
+          timeoutAfter: 3000,
+          timeoutErrorMessage: 'Velcro discovery timed out'
+        },
+        dedupeByKeys: ['networkId', 'accountAddr']
       }
     )
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -798,8 +798,6 @@ export class PortfolioController extends EventEmitter {
             // Either a valid response or there is no external API to fetch hints from
             const isExternalHintsApiResponseValid = !!externalApiNetworkHints || !network.hasRelayer
 
-            console.log('isExternalHintsApiResponseValid', isExternalHintsApiResponseValid)
-
             if (isExternalHintsApiResponseValid) {
               const updatedStoragePreviousHints = getUpdatedHints(
                 externalApiNetworkHints || null,

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -614,8 +614,8 @@ export class PortfolioController extends EventEmitter {
       const { erc20s: additionalErc20Hints, erc721s: additionalErc721Hints } = getNetworkHints(
         network.id,
         hintsFromExternalAPI,
-        this.#previousHints.learnedTokens,
-        this.#previousHints.learnedNfts,
+        this.#previousHints.learnedTokens ?? {},
+        this.#previousHints.learnedNfts ?? {},
         this.tokenPreferences,
         this.customTokens,
         this.#toBeLearnedTokens

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -670,11 +670,9 @@ export class PortfolioController extends EventEmitter {
     let hintsFromExternalAPIError: null | ExtendedErrorWithLevel = null
 
     try {
+      const networkIds = networks.filter(({ hasRelayer }) => hasRelayer).map((x) => x.id)
       const hintsFromExternalAPIByNetworksData = await this.#fetch(
-        `${this.#velcroUrl}/multi-hints?networks=${networks
-          .filter(({ hasRelayer }) => hasRelayer)
-          .map((x) => x.id)
-          .join(',')}&accounts=${this.#networks.networks
+        `${this.#velcroUrl}/multi-hints?networks=${networkIds.join(',')}&accounts=${networkIds
           .map(() => accountId)
           .join(',')}&baseCurrency=usd`
       )

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -679,12 +679,10 @@ export class PortfolioController extends EventEmitter {
 
       const result = await hintsFromExternalAPIByNetworksData.json()
 
+      if (!Array.isArray(result)) throw new Error('Invalid response from external API')
+
       // If the request is for one network the response is an object, otherwise it's an array of objects
-      if (Array.isArray(result)) {
-        hintsFromExternalAPIByNetworks = result
-      } else {
-        hintsFromExternalAPIByNetworks = [result]
-      }
+      hintsFromExternalAPIByNetworks = result
     } catch (e: any) {
       console.error('Error while fetching hints from external API', e)
       hintsFromExternalAPIError = e

--- a/src/libs/portfolio/constants.ts
+++ b/src/libs/portfolio/constants.ts
@@ -1,0 +1,10 @@
+const PORTFOLIO_HINT_ERRORS = {
+  /** External hints API (Velcro) request failed but fallback is sufficient */
+  NonCriticalApiHintsError: 'NonCriticalApiHintsError',
+  /** External API (Velcro) hints are older than X minutes */
+  StaleApiHintsError: 'StaleApiHintsError',
+  /** No external API (Velcro) hints are available- the request failed without fallback */
+  NoApiHintsError: 'NoApiHintsError'
+}
+
+export { PORTFOLIO_HINT_ERRORS }

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -560,13 +560,13 @@ export const getFormattedHintsError = (
         ? PORTFOLIO_HINT_ERRORS.StaleApiHintsError
         : PORTFOLIO_HINT_ERRORS.NonCriticalApiHintsError,
       message: errorMesssage,
-      level: 'critical'
+      level: isLastUpdateTooOld ? 'critical' : 'silent'
     }
   }
 
   return {
     name: PORTFOLIO_HINT_ERRORS.NoApiHintsError,
     message: errorMesssage,
-    level: 'silent'
+    level: 'critical'
   }
 }

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -96,7 +96,7 @@ export interface ExtendedError extends Error {
   simulationErrorMsg?: string
 }
 
-type ExtendedErrorWithLevel = ExtendedError & {
+export type ExtendedErrorWithLevel = ExtendedError & {
   level: 'critical' | 'warning' | 'silent'
 }
 
@@ -210,7 +210,6 @@ export interface GetOptions {
   simulation?: GetOptionsSimulation
   priceCache?: PriceCache
   priceRecency: number
-  previousHintsFromExternalAPI?: StrippedExternalHintsAPIResponse | null
   fetchPinned: boolean
   additionalErc20Hints?: Hints['erc20s']
   additionalErc721Hints?: Hints['erc721s']
@@ -221,7 +220,7 @@ export interface PreviousHintsStorage {
   learnedTokens: { [network in NetworkId]: { [tokenAddress: string]: string | null } }
   learnedNfts: { [network in NetworkId]: { [nftAddress: string]: bigint[] } }
   fromExternalAPI: {
-    [networkAndAccountKey: string]: GetOptions['previousHintsFromExternalAPI']
+    [networkAndAccountKey: string]: StrippedExternalHintsAPIResponse | null
   }
 }
 

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -105,13 +105,18 @@ export class Portfolio {
         })
       },
       {
-        timeoutAfter: 3000,
-        timeoutErrorMessage: `Velcro discovery timed out on ${network.id}`
+        timeoutSettings: {
+          timeoutAfter: 3000,
+          timeoutErrorMessage: `Velcro discovery timed out on ${network.id}`
+        },
+        dedupeByKeys: ['networkId', 'accountAddr']
       }
     )
     this.batchedGecko = batcher(fetch, geckoRequestBatcher, {
-      timeoutAfter: 3000,
-      timeoutErrorMessage: `Cena request timed out on ${network.id}`
+      timeoutSettings: {
+        timeoutAfter: 3000,
+        timeoutErrorMessage: `Cena request timed out on ${network.id}`
+      }
     })
     this.network = network
     this.deploylessTokens = fromDescriptor(provider, BalanceGetter, !network.rpcNoStateOverride)

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -154,7 +154,7 @@ export class Portfolio {
       errors.push({
         name: PORTFOLIO_LIB_ERROR_NAMES.ApiHintsError,
         message: errorMesssage,
-        level: 'silent'
+        level: 'critical'
       })
       // It's important for DX to see this error
       // eslint-disable-next-line no-console

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -7,6 +7,7 @@ import {
   NetworksWithPositions
 } from '../defiPositions/types'
 import { getNetworksWithFailedRPC } from '../networks/networks'
+import { PORTFOLIO_HINT_ERRORS } from '../portfolio/constants'
 import { AccountAssetsState } from '../portfolio/interfaces'
 import { PORTFOLIO_LIB_ERROR_NAMES } from '../portfolio/portfolio'
 
@@ -28,6 +29,7 @@ export type SelectedAccountBalanceError = {
     | 'defi-prices'
     | `${string}-defi-positions-error`
     | keyof typeof PORTFOLIO_LIB_ERROR_NAMES
+    | keyof typeof PORTFOLIO_HINT_ERRORS
   networkNames: string[]
   type: 'error' | 'warning'
   title: string
@@ -128,12 +130,12 @@ const addPortfolioError = (
         text = 'Account balance and asset prices may be inaccurate.'
         type = 'warning'
         break
-      case PORTFOLIO_LIB_ERROR_NAMES.NoApiHintsError:
+      case PORTFOLIO_HINT_ERRORS.NoApiHintsError:
         title = 'Automatic asset discovery is temporarily unavailable'
         text =
           'Your funds are safe, but your portfolio will be inaccurate. You can add assets manually or wait for the issue to be resolved.'
         break
-      case PORTFOLIO_LIB_ERROR_NAMES.StaleApiHintsError:
+      case PORTFOLIO_HINT_ERRORS.StaleApiHintsError:
         title = 'Automatic asset discovery is temporarily unavailable'
         text =
           'New assets may not be visible in your portfolio. You can add assets manually or wait for the issue to be resolved.'


### PR DESCRIPTION
Reduces the calls to velcro from `relayer networks * 2 (14)` to `1` for every portfolio update

Also fixes the error levels of hint related errors. For some reason `NoApiHintsError` was silent, while `NonCriticalApiHintsError` was critical...
```
      if (localOpts.previousHintsFromExternalAPI) {
        hints = { ...localOpts.previousHintsFromExternalAPI }
        const TEN_MINUTES = 10 * 60 * 1000
        const lastUpdate = localOpts.previousHintsFromExternalAPI.lastUpdate
        const isLastUpdateTooOld = Date.now() - lastUpdate > TEN_MINUTES

        errors.push({
          name: isLastUpdateTooOld
            ? PORTFOLIO_LIB_ERROR_NAMES.StaleApiHintsError
            : PORTFOLIO_LIB_ERROR_NAMES.NonCriticalApiHintsError,
          message: errorMesssage,
          level: 'critical'
        })
      } else {
        errors.push({
          name: PORTFOLIO_LIB_ERROR_NAMES.NoApiHintsError,
          message: errorMesssage,
          level: 'silent'
        })
      }
```