### PR TITLE
Humanizer: humanizer ascii module incorrectly assumed plaintext in call.data

### DIFF
--- a/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
+++ b/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
@@ -19,6 +19,9 @@ export const asciiModule: HumanizerCallModule = (
   const newCalls = currentIrCalls.map((call) => {
     if (call.data === '0x') return call
     if (call.fullVisualization && !checkIfUnknownAction(call?.fullVisualization)) return call
+    // assuming that if there are only 4 bytes it is probably just contract method call
+    // and further logic is irrelevant
+    if (call.data.length === '0x12345678'.length) return call
     let messageAsText
     try {
       messageAsText = toUtf8String(call.data)


### PR DESCRIPTION
the ASCII module assumed the call.data was a valid ascii sctring, but it was just method invocation, for which we did not have humanizer

the function itself is `0x1249c58b`

bug:
![image](https://github.com/user-attachments/assets/1dcb47d3-5a81-447f-ad0c-4e1516b0c8b0)
should actually be (ignore the address):
![image](https://github.com/user-attachments/assets/83383cdc-006e-4166-b89a-322560dcc0eb)
