### PR TITLE
Config / Migrate to single transaction bridging quotes ONLY for the build-in Swap & Bridge

### DIFF
--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -273,7 +273,7 @@ export class SocketAPI {
       userAddress,
       isContractCall: isSmartAccount.toString(), // only get quotes with that are compatible with contracts
       sort,
-      singleTxOnly: 'false',
+      singleTxOnly: 'true',
       defaultSwapSlippage: '1',
       uniqueRoutesPerBridge: 'true'
     })


### PR DESCRIPTION
Prev we've used Socket's "multi transaction" bridging, because it gave the most options across many pairs we've tried with. It involves 2 or more transactions for the user either on the source or destination chain. Ref: https://docs.bungee.exchange/bungee-manual/socket-api/guides/multi-tx-bridging

To simplify the build-in Swap & Bridge, as part of https://github.com/AmbireTech/ambire-app/issues/4151, we're migrating to the "single transaction" bridging now - a single transaction on the sending chain and **no transaction on the destination chain**. Ref: https://docs.bungee.exchange/bungee-manual/socket-api/guides/single-tx-bridging

TODO: Sync with the others and test different scenarios, to make sure the shortcoming of having no routes for most of the pairs (that we experienced before) is not a game changer.