### PR TITLE
Fix: estimation nonce for estimateGas() was incorrect

### DIFF
--- a/src/interfaces/account.ts
+++ b/src/interfaces/account.ts
@@ -34,7 +34,7 @@ export interface AccountCreation {
 export interface AccountOnchainState {
   accountAddr: string
   isDeployed: boolean
-  // this is a number and not a bigint because of ethers (it uses number for nonces)
+  eoaNonce: bigint | null
   nonce: bigint
   erc4337Nonce: bigint
   associatedKeys: { [key: string]: string }

--- a/src/libs/accountState/accountState.ts
+++ b/src/libs/accountState/accountState.ts
@@ -85,6 +85,7 @@ export async function getAccountState(
 
     return {
       accountAddr: account.addr,
+      eoaNonce: accResult.isEOA ? eoaNonces[account.addr] : null,
       nonce: !isSmartAccount(account) && !isSmarterEoa ? eoaNonces[account.addr] : accResult.nonce,
       erc4337Nonce: accResult.erc4337Nonce,
       isDeployed: accResult.isDeployed,

--- a/src/libs/estimate/providerEstimateGas.ts
+++ b/src/libs/estimate/providerEstimateGas.ts
@@ -68,7 +68,7 @@ export async function providerEstimateGas(
           to: properties.to,
           value: properties.value,
           data: properties.data,
-          nonce: '0x0'
+          nonce: toBeHex(accountState.eoaNonce as bigint)
         },
         'pending',
         {
@@ -91,7 +91,7 @@ export async function providerEstimateGas(
       to: properties.to,
       value: properties.value,
       data: properties.data,
-      nonce: 0,
+      nonce: Number(accountState.eoaNonce),
       blockTag: 'pending'
     })
     .catch(getHumanReadableEstimationError)

--- a/src/libs/tracer/debugTraceCall.test.ts
+++ b/src/libs/tracer/debugTraceCall.test.ts
@@ -72,6 +72,7 @@ describe('Debug tracecall detection for transactions', () => {
     state = {
       accountAddr: ACCOUNT_ADDRESS,
       nonce: 1n,
+      eoaNonce: 1n,
       erc4337Nonce: 115792089237316195423570985008687907853269984665640564039457584007913129639935n,
       isDeployed: true,
       isV2: true,


### PR DESCRIPTION
Add the eoa nonce to the account state and use it in provder estimateGas().  
Future wise, we should separate the nonce in the account state into smartAccNonce & erc4337 nonce. Otherwise, it's too difficult to understand which is the correct nonce to use in different situations as our account types have become more complex