### PR TITLE
fix: chain id on paymaster service discrepancy

### DIFF
--- a/src/libs/erc7677/erc7677.ts
+++ b/src/libs/erc7677/erc7677.ts
@@ -19,14 +19,15 @@ export function getPaymasterService(
   if (!capabilities || !capabilities.paymasterService) return undefined
 
   // hex may come with a leading zero or not. Prepare for both
-  const chainIdHex = toBeHex(chainId) as `0x${string}`
-  const chainIdQuantity = toQuantity(chainId) as `0x${string}`
-  const paymasterService =
-    chainIdHex in capabilities.paymasterService
-      ? capabilities.paymasterService[chainIdHex]
-      : capabilities.paymasterService[chainIdQuantity]
-  if (!paymasterService) return undefined
+  const chainIds = Object.keys(capabilities.paymasterService)
+  const chainIdHex = toBeHex(chainId).toLowerCase() as `0x${string}`
+  const chainIdQuantity = toQuantity(chainId).toLowerCase() as `0x${string}`
+  const foundChainId: any = chainIds.find(
+    (id) => id.toLowerCase() === chainIdHex || id.toLowerCase() === chainIdQuantity
+  )
+  if (!foundChainId) return undefined
 
+  const paymasterService = capabilities.paymasterService[foundChainId]
   paymasterService.id = new Date().getTime()
   return paymasterService
 }


### PR DESCRIPTION
Eliminate as much as possible the chain id formatting issues on receiving a paymaster service object