### PR TITLE
Fix: prioritize gas tank for fee call

### DIFF
--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -133,7 +133,7 @@ export class Paymaster extends AbstractPaymaster {
     if (!this.network) throw new Error('network not set, did you call init?')
 
     if (this.type === 'Ambire') {
-      const feeToken = getFeeTokenForEstimate(feeTokens, this.network)
+      const feeToken = getFeeTokenForEstimate(feeTokens)
       if (!feeToken) return undefined
 
       return getFeeCall(feeToken)


### PR DESCRIPTION
Prioritize gas tank for fee call estimation as otherwise, if the native is chosen over it, it could lead to a transaction revert on estimation for a valid swap