### PR TITLE
Bug/ Portfolio loading states not updated during simulation (selectedAccount)

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -278,8 +278,12 @@ export class SelectedAccountController extends EventEmitter {
     }
 
     if (
+      // Fully loaded
       newSelectedAccountPortfolio.isReadyToVisualize ||
-      (!this.portfolio?.tokens?.length && newSelectedAccountPortfolio.tokens.length)
+      // Has tokens to show
+      (!this.portfolio?.tokens?.length && newSelectedAccountPortfolio.tokens.length) ||
+      // There is a simulation
+      !!newSelectedAccountPortfolio.networkSimulatedAccountOp
     ) {
       this.portfolio = newSelectedAccountPortfolio
       this.#updatePortfolioErrors(true)


### PR DESCRIPTION
## The problem:
In `Simulation.tsx` we rely on the `isLoading` flag of the current network. It wasn't being updated to true so the `Simulation` was flashing with the "no-changes" view.
## About the fix:
This is the easy fix. A better fix would be to always update the "raw" portfolio state and have a condition only for tokens/balance/collections etc.
### Example:
- Update `latest.ethereum.isLoading` immediately
- Update `tokens` if `(newSelectedAccountPortfolio.isReadyToVisualize || (!this.portfolio?.tokens?.length && newSelectedAccountPortfolio.tokens.length))`