### PR TITLE
Fix: debug_traceCall fails on every first call on each network

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -753,14 +753,12 @@ export class MainController extends EventEmitter {
       const account = this.accounts.accounts.find((acc) => acc.addr === accountOp.accountAddr)!
       const state = this.accounts.accountStates[accountOp.accountAddr][accountOp.networkId]
       const provider = this.providers.providers[network.id]
-      const gasPrice = this.gasPrices[network.id]
       const { tokens, nfts } = await debugTraceCall(
         account,
         accountOp,
         provider,
         state,
         gasUsed,
-        gasPrice,
         !network.rpcNoStateOverride
       )
       const learnedNewTokens = this.portfolio.addTokensToBeLearned(tokens, network.id)

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-await-in-loop */
 
 import { ethErrors } from 'eth-rpc-errors'
-import { getAddress, getBigInt, isAddress, ZeroAddress } from 'ethers'
+import { getAddress, getBigInt, isAddress } from 'ethers'
 
 import EmittableError from '../../classes/EmittableError'
 import SwapAndBridgeError from '../../classes/SwapAndBridgeError'
@@ -718,7 +718,7 @@ export class MainController extends EventEmitter {
     this.emitUpdate()
   }
 
-  async traceCall(gasUsed: bigint) {
+  async traceCall() {
     const accountOp = this.signAccountOp?.accountOp
     if (!accountOp) return
 
@@ -758,7 +758,6 @@ export class MainController extends EventEmitter {
         accountOp,
         provider,
         state,
-        gasUsed,
         !network.rpcNoStateOverride
       )
       const learnedNewTokens = this.portfolio.addTokensToBeLearned(tokens, network.id)
@@ -2493,16 +2492,7 @@ export class MainController extends EventEmitter {
       // this eliminates the infinite loading bug if the estimation comes slower
       if (this.signAccountOp && estimation) {
         this.signAccountOp.update({ estimation })
-        if (shouldTraceCall)
-          this.traceCall(
-            baseAcc.getGasUsed(getEstimationSummary(estimation), {
-              // the fee token is always native for the trace call
-              feeToken: feeTokens.find(
-                (tok) => tok.address === ZeroAddress && !tok.flags.onGasTank
-              ) as TokenResult,
-              op: localAccountOp
-            })
-          )
+        if (shouldTraceCall) this.traceCall()
       }
     } catch (error: any) {
       this.signAccountOp?.calculateWarnings()

--- a/src/libs/tracer/debugTraceCall.test.ts
+++ b/src/libs/tracer/debugTraceCall.test.ts
@@ -145,16 +145,7 @@ describe('Debug tracecall detection for transactions', () => {
       }
     }
 
-    const res = await debugTraceCall(
-      account,
-      accountOp,
-      provider,
-      state,
-      // a lot of gas
-      100000000000000n,
-      true,
-      overrideData
-    )
+    const res = await debugTraceCall(account, accountOp, provider, state, true, overrideData)
 
     expect(res.nfts.length).toBe(1)
     expect(res.nfts[0][0]).toBe(NFT_ADDRESS)

--- a/src/libs/tracer/debugTraceCall.test.ts
+++ b/src/libs/tracer/debugTraceCall.test.ts
@@ -152,7 +152,6 @@ describe('Debug tracecall detection for transactions', () => {
       state,
       // a lot of gas
       100000000000000n,
-      [{ name: 'fast', gasPrice: 338318181550000000n }],
       true,
       overrideData
     )

--- a/src/libs/tracer/debugTraceCall.ts
+++ b/src/libs/tracer/debugTraceCall.ts
@@ -51,7 +51,6 @@ export async function debugTraceCall(
   op: AccountOp,
   provider: JsonRpcProvider,
   accountState: AccountOnchainState,
-  gasUsed: bigint,
   supportsStateOverride: boolean,
   overrideData?: any
 ): Promise<{ tokens: string[]; nfts: [string, bigint[]][] }> {
@@ -82,10 +81,7 @@ export async function debugTraceCall(
         to: params.to,
         value: toQuantity(params.value.toString()),
         data: params.data,
-        from: params.from,
-        // irrelevant
-        gasPrice: '0x1',
-        gas: toQuantity(gasUsed.toString())
+        from: params.from
       },
       'latest',
       {

--- a/src/libs/tracer/debugTraceCall.ts
+++ b/src/libs/tracer/debugTraceCall.ts
@@ -10,7 +10,6 @@ import { Account, AccountOnchainState } from '../../interfaces/account'
 import { getAccountDeployParams, getSpoof, isBasicAccount } from '../account/account'
 import { AccountOp, callToTuple, getSignableCalls } from '../accountOp/accountOp'
 import { DeploylessMode, fromDescriptor } from '../deployless/deployless'
-import { GasRecommendation } from '../gasPrice/gasPrice'
 import { getDeploylessOpts } from '../portfolio/getOnchainBalances'
 
 const NFT_COLLECTION_LIMIT = 100
@@ -53,7 +52,6 @@ export async function debugTraceCall(
   provider: JsonRpcProvider,
   accountState: AccountOnchainState,
   gasUsed: bigint,
-  gasPrices: GasRecommendation[],
   supportsStateOverride: boolean,
   overrideData?: any
 ): Promise<{ tokens: string[]; nfts: [string, bigint[]][] }> {
@@ -76,11 +74,6 @@ export async function debugTraceCall(
       op.calls.map(callToTuple)
     ]
   ]
-  const fast = gasPrices.find((gas: any) => gas.name === 'fast')
-  if (!fast) return { tokens: [], nfts: [] }
-
-  const gasPrice =
-    'gasPrice' in fast ? fast.gasPrice : fast.baseFeePerGas + fast.maxPriorityFeePerGas
 
   const params = getFunctionParams(account, op, accountState)
   const results: ({ erc: 20; address: string } | { erc: 721; address: string; tokenId: string })[] =
@@ -90,7 +83,8 @@ export async function debugTraceCall(
         value: toQuantity(params.value.toString()),
         data: params.data,
         from: params.from,
-        gasPrice: toQuantity(gasPrice.toString()),
+        // irrelevant
+        gasPrice: '0x1',
         gas: toQuantity(gasUsed.toString())
       },
       'latest',


### PR DESCRIPTION
When i open the wallet and try to do a swap on base, on my first attempt debug trace call will not work, then on second, third... it works, When switching to optimism, for example, the same happens, the first attempt fails, then succeeds. 

On first attempts we still do not have gasPrice data and we pass undefined instead of array, later resulting in attempting to access `.find` of undefined.

- setting the gasPrice to 1 fails on some chains
- awaiting gasPrices before starting simulation will be slow

instead we simply do not pass gas data to debug_traceCall and leave the rpc t o figure it out