### PR TITLE
Enable 7702 on BNB

### DIFF
--- a/src/consts/gasTankFeeTokens.ts
+++ b/src/consts/gasTankFeeTokens.ts
@@ -377,6 +377,13 @@ export default [
     icon: 'https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png'
   },
   {
+    address: '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82',
+    symbol: 'cake',
+    networkId: 'binance-smart-chain',
+    decimals: 18,
+    icon: 'https://assets.coingecko.com/coins/images/12632/standard/pancakeswap-cake-logo_%281%29.png?1696512440'
+  },
+  {
     address: '0x049d68029688eAbF473097a2fC38ef61633A3C7A',
     symbol: 'usdt',
     networkId: 'fantom',

--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -223,7 +223,7 @@ const networks: Network[] = [
     id: 'binance-smart-chain',
     name: 'Binance Smart Chain',
     nativeAssetSymbol: 'BNB',
-    has7702: false,
+    has7702: true,
     nativeAssetName: 'Binance Coin',
     rpcUrls: ['https://invictus.ambire.com/binance-smart-chain'],
     selectedRpcUrl: 'https://invictus.ambire.com/binance-smart-chain',

--- a/src/libs/account/BaseAccount.ts
+++ b/src/libs/account/BaseAccount.ts
@@ -65,4 +65,10 @@ export abstract class BaseAccount {
   shouldBroadcastCallsSeparately(op: AccountOp): boolean {
     return false
   }
+
+  // can the account type use the receiving amount after the estimation
+  // to pay the fee. Smart accounts can but EOA / 7702 EOAs cannot
+  // as paying in native means broadcasting as an EOA - you have to
+  // have the native before broadcast
+  abstract canUseReceivingNativeForFee(): boolean
 }

--- a/src/libs/account/EOA.ts
+++ b/src/libs/account/EOA.ts
@@ -77,4 +77,8 @@ export class EOA extends BaseAccount {
   shouldBroadcastCallsSeparately(op: AccountOp): boolean {
     return op.calls.length > 1
   }
+
+  canUseReceivingNativeForFee(): boolean {
+    return false
+  }
 }

--- a/src/libs/account/EOA7702.ts
+++ b/src/libs/account/EOA7702.ts
@@ -102,4 +102,8 @@ export class EOA7702 extends BaseAccount {
   shouldSignAuthorization(broadcastOption: string): boolean {
     return !this.accountState.isSmarterEoa && broadcastOption === BROADCAST_OPTIONS.byBundler
   }
+
+  canUseReceivingNativeForFee(): boolean {
+    return false
+  }
 }

--- a/src/libs/account/V1.ts
+++ b/src/libs/account/V1.ts
@@ -54,4 +54,8 @@ export class V1 extends BaseAccount {
     if (feeOption.paidBy !== this.getAccount().addr) return BROADCAST_OPTIONS.byOtherEOA
     return BROADCAST_OPTIONS.byRelayer
   }
+
+  canUseReceivingNativeForFee(): boolean {
+    return true
+  }
 }

--- a/src/libs/account/V2.ts
+++ b/src/libs/account/V2.ts
@@ -84,4 +84,8 @@ export class V2 extends BaseAccount {
       broadcastOption === BROADCAST_OPTIONS.byOtherEOA
     )
   }
+
+  canUseReceivingNativeForFee(): boolean {
+    return true
+  }
 }

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -34,7 +34,7 @@ export async function getEstimation(
   errorCallback: Function
 ): Promise<FullEstimation | Error> {
   const ambireEstimation = ambireEstimateGas(
-    baseAcc.getAccount(),
+    baseAcc,
     accountState,
     op,
     network,


### PR DESCRIPTION
Enable 7702 on BNB and fix a bug where an EOA7702 account with only USDT doing a swap to BNB had BNB appearing as a payment option while that is impossible as paying in native in EOA7702 can only happen if you already have native in your account before signing