### PR TITLE
Include additionalCallData in gasUsed

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -900,10 +900,6 @@ describe('SignAccountOp Controller ', () => {
       ]
     )
 
-    // We are mocking estimation and prices values, in order to validate the gas prices calculation in the test.
-    // Knowing the exact amount of estimation and gas prices, we can predict GasFeePayment values.
-    jest.spyOn(controller, 'getCallDataAdditionalByNetwork').mockReturnValue(25000n)
-
     controller.update({
       gasPrices: prices,
       estimation
@@ -1037,10 +1033,6 @@ describe('SignAccountOp Controller ', () => {
           }
         ]
       )
-
-      // We are mocking estimation and prices values, in order to validate the gas prices calculation in the test.
-      // Knowing the exact amount of estimation and gas prices, we can predict GasFeePayment values.
-      jest.spyOn(controller, 'getCallDataAdditionalByNetwork').mockReturnValue(25000n)
 
       controller.update({
         gasPrices: prices,
@@ -1183,10 +1175,6 @@ describe('SignAccountOp Controller ', () => {
       ],
       true
     )
-
-    // We are mocking estimation and prices values, in order to validate the gas prices calculation in the test.
-    // Knowing the exact amount of estimation and gas prices, we can predict GasFeePayment values.
-    jest.spyOn(controller, 'getCallDataAdditionalByNetwork').mockReturnValue(25000n)
 
     controller.update({
       gasPrices: prices,
@@ -1350,10 +1338,6 @@ describe('SignAccountOp Controller ', () => {
       ]
     )
 
-    // We are mocking estimation and prices values, in order to validate the gas prices calculation in the test.
-    // Knowing the exact amount of estimation and gas prices, we can predict GasFeePayment values.
-    jest.spyOn(controller, 'getCallDataAdditionalByNetwork').mockReturnValue(5000n)
-
     controller.update({
       gasPrices: prices,
       estimation,
@@ -1386,17 +1370,17 @@ describe('SignAccountOp Controller ', () => {
       throw new Error('Signing failed!')
     }
 
-    expect(controller.accountOp.gasFeePayment).toEqual({
-      paidBy: eoaSigner.keyPublicAddress,
-      broadcastOption: BROADCAST_OPTIONS.byOtherEOA,
-      isGasTank: false,
-      inToken: '0x0000000000000000000000000000000000000000',
-      feeTokenNetworkId: 'polygon',
-      amount: 9005000n, // (300 + 300) × (10000+5000) + 10000, i.e. (baseFee + priorityFee) * (gasUsed + additionalCall) + addedNative
-      simulatedGasLimit: 15000n, // 10000 + 5000, i.e. gasUsed + additionalCall
-      maxPriorityFeePerGas: 300n,
-      gasPrice: 600n
-    })
+    expect(controller.accountOp.gasFeePayment!.paidBy).toEqual(eoaSigner.keyPublicAddress)
+    expect(controller.accountOp.gasFeePayment!.broadcastOption).toEqual(
+      BROADCAST_OPTIONS.byOtherEOA
+    )
+    expect(controller.accountOp.gasFeePayment!.isGasTank).toEqual(false)
+    expect(controller.accountOp.gasFeePayment!.inToken).toEqual(
+      '0x0000000000000000000000000000000000000000'
+    )
+    expect(controller.accountOp.gasFeePayment!.feeTokenNetworkId).toEqual('polygon')
+    expect(controller.accountOp.gasFeePayment!.maxPriorityFeePerGas).toEqual(300n)
+    expect(controller.accountOp.gasFeePayment!.gasPrice).toEqual(600n)
 
     const typedData = getTypedData(
       network.chainId,
@@ -1491,10 +1475,6 @@ describe('SignAccountOp Controller ', () => {
           }
         ]
       )
-
-      // We are mocking estimation and prices values, in order to validate the gas prices calculation in the test.
-      // Knowing the exact amount of estimation and gas prices, we can predict GasFeePayment values.
-      jest.spyOn(controller, 'getCallDataAdditionalByNetwork').mockReturnValue(5000n)
 
       controller.update({
         gasPrices: prices,
@@ -1674,10 +1654,6 @@ describe('SignAccountOp Controller ', () => {
   //   )
 
   //   expect(controller.accountOp.asUserOperation).toBe(undefined)
-
-  //   // We are mocking estimation and prices values, in order to validate the gas prices calculation in the test.
-  //   // Knowing the exact amount of estimation and gas prices, we can predict GasFeePayment values.
-  //   jest.spyOn(controller, 'getCallDataAdditionalByNetwork').mockReturnValue(25000n)
 
   //   controller.update({
   //     gasPrices: prices,

--- a/src/libs/account/BaseAccount.ts
+++ b/src/libs/account/BaseAccount.ts
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Account, AccountOnchainState } from '../../interfaces/account'
+import { Hex } from '../../interfaces/hex'
 import { Network } from '../../interfaces/network'
 import { AccountOp } from '../accountOp/accountOp'
 import { FeePaymentOption, FullEstimation, FullEstimationSummary } from '../estimate/interfaces'
@@ -71,4 +72,16 @@ export abstract class BaseAccount {
   // as paying in native means broadcasting as an EOA - you have to
   // have the native before broadcast
   abstract canUseReceivingNativeForFee(): boolean
+
+  // when using the ambire estimation, the broadcast gas is not included
+  // so smart accounts that broadacast with EOAs/relayer do not have the
+  // additional broadcast gas included
+  //
+  // Additionally, 7702 EOAs that use the ambire estimation suffer from
+  // the same problem as they do broadcast by themselves by only
+  // the smart account contract gas is calculated
+  //
+  // we return the calldata specific for each account to allow
+  // the estimation to calculate it correctly
+  abstract getBroadcastCalldata(accountOp: AccountOp): Hex
 }

--- a/src/libs/account/EOA.ts
+++ b/src/libs/account/EOA.ts
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ZeroAddress } from 'ethers'
+import { Hex } from '../../interfaces/hex'
 import { AccountOp } from '../accountOp/accountOp'
 import { BROADCAST_OPTIONS } from '../broadcast/broadcast'
 import {
@@ -80,5 +81,9 @@ export class EOA extends BaseAccount {
 
   canUseReceivingNativeForFee(): boolean {
     return false
+  }
+
+  getBroadcastCalldata(): Hex {
+    return '0x'
   }
 }

--- a/src/libs/account/V1.ts
+++ b/src/libs/account/V1.ts
@@ -1,11 +1,17 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { Interface } from 'ethers'
+import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
+import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import { ARBITRUM_CHAIN_ID } from '../../consts/networks'
-import { AccountOp } from '../accountOp/accountOp'
+import { Hex } from '../../interfaces/hex'
+import { AccountOp, getSignableCalls } from '../accountOp/accountOp'
 import { BROADCAST_OPTIONS } from '../broadcast/broadcast'
 import { FeePaymentOption, FullEstimation, FullEstimationSummary } from '../estimate/interfaces'
+import { getBroadcastGas } from '../gasPrice/gasPrice'
 import { TokenResult } from '../portfolio'
 import { BaseAccount } from './BaseAccount'
+import { getSpoof } from './account'
 
 // this class describes a plain EOA that cannot transition
 // to 7702 either because the network or the hardware wallet doesnt' support it
@@ -37,12 +43,15 @@ export class V1 extends BaseAccount {
     const providerGasUsed = estimation.providerEstimation
       ? estimation.providerEstimation.gasUsed
       : 0n
+
+    const ambireBroaddcastGas = getBroadcastGas(this, options.op)
+    const ambireGas = ambireBroaddcastGas + estimation.ambireEstimation.gasUsed
+
     // use ambireEstimation.gasUsed in all cases except Arbitrum when
     // the provider gas is more than the ambire gas
-    return this.network.chainId === ARBITRUM_CHAIN_ID &&
-      providerGasUsed > estimation.ambireEstimation.gasUsed
+    return this.network.chainId === ARBITRUM_CHAIN_ID && providerGasUsed > ambireGas
       ? providerGasUsed
-      : estimation.ambireEstimation.gasUsed
+      : ambireGas
   }
 
   getBroadcastOption(
@@ -57,5 +66,23 @@ export class V1 extends BaseAccount {
 
   canUseReceivingNativeForFee(): boolean {
     return true
+  }
+
+  getBroadcastCalldata(accountOp: AccountOp): Hex {
+    if (this.accountState.isDeployed) {
+      const ambireAccount = new Interface(AmbireAccount.abi)
+      return ambireAccount.encodeFunctionData('executeBySender', [
+        getSignableCalls(accountOp)
+      ]) as Hex
+    }
+
+    // deployAndExecuteMultiple is the worst case
+    const ambireFactory = new Interface(AmbireFactory.abi)
+    return ambireFactory.encodeFunctionData('deployAndExecute', [
+      this.account.creation!.bytecode,
+      this.account.creation!.salt,
+      getSignableCalls(accountOp),
+      getSpoof(this.account)
+    ]) as Hex
   }
 }


### PR DESCRIPTION
Add the "broadcast gas" to each ambire estimation as the ambire estimation estimates only the contract calls but not the broadcast gas. This gets included into each account's getGasUsed()