### PR TITLE
Bug/ `identifiedBy` is missing in really old account ops

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -5,6 +5,7 @@ import { Network } from '../../interfaces/network'
 import { isSmartAccount } from '../../libs/account/account'
 import {
   fetchTxnId,
+  isIdentifiedByUserOpHash,
   SubmittedAccountOp,
   updateOpStatus
 } from '../../libs/accountOp/submittedAccountOp'
@@ -399,7 +400,7 @@ export class ActivityController extends EventEmitter {
               if (receipt) {
                 // if this is an user op, we have to check the logs
                 let isSuccess: boolean | undefined
-                if (accountOp.identifiedBy.type === 'UserOperation') {
+                if (isIdentifiedByUserOpHash(accountOp.identifiedBy)) {
                   const userOpEventLog = parseLogs(receipt.logs, accountOp.identifiedBy.identifier)
                   if (userOpEventLog) isSuccess = userOpEventLog.success
                 }

--- a/src/libs/accountOp/submittedAccountOp.ts
+++ b/src/libs/accountOp/submittedAccountOp.ts
@@ -1,4 +1,5 @@
 import { TransactionReceipt, ZeroAddress } from 'ethers'
+
 import { BUNDLER } from '../../consts/bundlers'
 import { Fetch } from '../../interfaces/fetch'
 import { Network } from '../../interfaces/network'
@@ -50,19 +51,19 @@ export interface SubmittedAccountOp extends AccountOp {
 }
 
 export function isIdentifiedByTxn(identifiedBy: AccountOpIdentifiedBy): boolean {
-  return identifiedBy.type === 'Transaction'
+  return identifiedBy && identifiedBy.type === 'Transaction'
 }
 
 export function isIdentifiedByUserOpHash(identifiedBy: AccountOpIdentifiedBy): boolean {
-  return identifiedBy.type === 'UserOperation'
+  return identifiedBy && identifiedBy.type === 'UserOperation'
 }
 
 export function isIdentifiedByRelayer(identifiedBy: AccountOpIdentifiedBy): boolean {
-  return identifiedBy.type === 'Relayer'
+  return identifiedBy && identifiedBy.type === 'Relayer'
 }
 
 export function isIdentifiedByMultipleTxn(identifiedBy: AccountOpIdentifiedBy): boolean {
-  return identifiedBy.type === 'MultipleTxns'
+  return identifiedBy && identifiedBy.type === 'MultipleTxns'
 }
 
 export function getDappIdentifier(op: SubmittedAccountOp) {


### PR DESCRIPTION
Old accountOps may not have `identifiedBy` which causes the error 

Closes https://github.com/AmbireTech/ambire-app/issues/4270