### PR TITLE
Update/ Load portfolio tokens as early as possible (selectAccount)

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -260,13 +260,17 @@ export class SelectedAccountController extends EventEmitter {
       this.#isPortfolioLoadingFromScratch
     )
 
+    // Reset the loading timestamp if the portfolio is ready
     if (this.portfolioStartedLoadingAtTimestamp && newSelectedAccountPortfolio.isAllReady) {
       this.portfolioStartedLoadingAtTimestamp = null
     }
 
+    // Set the loading timestamp when the portfolio starts loading
     if (!this.portfolioStartedLoadingAtTimestamp && !newSelectedAccountPortfolio.isAllReady) {
       this.portfolioStartedLoadingAtTimestamp = Date.now()
     }
+
+    // Reset isPortfolioLoadingFromScratch flag when the portfolio has finished the initial load
     if (this.#isPortfolioLoadingFromScratch && newSelectedAccountPortfolio.isAllReady) {
       this.#isPortfolioLoadingFromScratch = false
     }

--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -200,7 +200,7 @@ export function calculateSelectedAccountPortfolio(
   portfolioStartedLoadingAtTimestamp: number | null,
   defiPositionsAccountState: DefiPositionsAccountState,
   hasSignAccountOp: boolean,
-  isPreviousStateSatisfactory: boolean
+  isLoadingFromScratch: boolean
 ): SelectedAccountPortfolio {
   const now = Date.now()
   const shouldShowPartialResult =
@@ -294,7 +294,7 @@ export function calculateSelectedAccountPortfolio(
       // The network is not ready
       !isNetworkReady(networkData) ||
       // The networks is ready but the previous state isn't satisfactory and the network is still loading
-      (!isPreviousStateSatisfactory && networkData?.isLoading) ||
+      (isLoadingFromScratch && networkData?.isLoading) ||
       // The total balance and token list are affected by the defi positions
       defiPositionsAccountState[network]?.isLoading
     ) {


### PR DESCRIPTION
## Changes:
- Streamline `const isLoadingFromScratch = this.portfolio === DEFAULT_SELECTED_ACCOUNT_PORTFOLIO` to `#isPortfolioLoadingFromScratch`
- Display tokens as early as possible. We used to do it before https://github.com/AmbireTech/ambire-common/pull/1378) but the current implementation is better. Before we were only displaying the tokens from the first network:
```
if (
      // Fully loaded
      newSelectedAccountPortfolio.isReadyToVisualize ||
      // Has tokens to show
      (!this.portfolio?.tokens?.length && newSelectedAccountPortfolio.tokens.length) || <--- This is true only once
      // There is a simulation
      !!newSelectedAccountPortfolio.networkSimulatedAccountOp
    ) {
      this.portfolio = newSelectedAccountPortfolio
      this.#updatePortfolioErrors(true)
    }
```