### PR TITLE
Add: 7702 activator gas

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -901,7 +901,7 @@ export class SignAccountOpController extends EventEmitter {
 
         for (const [speed, speedValue] of Object.entries(this.bundlerGasPrices as GasSpeeds)) {
           const simulatedGasLimit =
-            BigInt(estimation.bundlerEstimation.callGasLimit) +
+            BigInt(this.gasUsed) +
             BigInt(estimation.bundlerEstimation.preVerificationGas) +
             BigInt(option.gasUsed)
           const gasPrice = BigInt(speedValue.maxFeePerGas)


### PR DESCRIPTION
Add the 7702 activator gas to the initial estimation to make sure the paymaster doesn't complain for low payment IF the account has not become a 7702 account, yet