### PR TITLE
Fix/ Portfolio one tick (update) without accountOps

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -568,6 +568,10 @@ export class PortfolioController extends EventEmitter {
       )
 
       accountState[network.id] = {
+        // We cache the previously simulated AccountOps
+        // in order to compare them with the newly passed AccountOps before executing a new updatePortfolioState.
+        // This allows us to identify any differences between the two.
+        accountOps: portfolioProps?.simulation?.accountOps,
         isReady: true,
         isLoading: false,
         errors: result.errors,
@@ -578,6 +582,7 @@ export class PortfolioController extends EventEmitter {
           total: getTotal(processedTokens)
         }
       }
+
       this.emitUpdate()
       return true
     } catch (e: any) {
@@ -767,13 +772,6 @@ export class PortfolioController extends EventEmitter {
               this.#previousHints = updatedStoragePreviousHints
               await this.#storage.set('previousHints', updatedStoragePreviousHints)
             }
-          }
-
-          // We cache the previously simulated AccountOps
-          // in order to compare them with the newly passed AccountOps before executing a new updatePortfolioState.
-          // This allows us to identify any differences between the two.
-          if (currentAccountOps) {
-            pendingState[network.id]!.accountOps = currentAccountOps
           }
         }
 


### PR DESCRIPTION
A bug has surfaced due to a recently added mechanism in `Simulation` that determines if the simulation is still loading:  

```
const isReloading = useMemo(() => {
  if (!network?.id || !initialSimulationLoaded) return false

  if (!isEstimationComplete) return true

  const portfolioAccountOpCalls = networkSimulatedAccountOp[network.id]?.calls
  const signAccountOpCalls = signAccountOpState?.accountOp.calls

  return portfolioAccountOpCalls?.length !== signAccountOpCalls?.length
}, [
  initialSimulationLoaded,
  isEstimationComplete,
  network?.id,
  networkSimulatedAccountOp,
  signAccountOpState?.accountOp.calls
])
```

As shown above, the logic compares `accountOps` from the **portfolio** with those from `signAccountOp`. The problem arises because we **cannot** rely on `network.isLoading` from the portfolio—it triggers too many reloads. Instead, we introduced this mechanism to mark the simulation as **loading** when the calls change.  

#### **Root Cause**  
After tracing the issue to the **portfolio controller**, I discovered that at a certain tick, `[network].accountOps` is **missing**, which leads to the mismatch and incorrect loading behavior.  