### PR TITLE
Fix/ use `getRpcProvider` everywhere to get rid of redundant eth_chainId calls

### DIFF
--- a/src/libs/defiPositions/defiPositions.test.ts
+++ b/src/libs/defiPositions/defiPositions.test.ts
@@ -1,8 +1,7 @@
-import { JsonRpcProvider } from 'ethers'
-
 import { describe, expect, test } from '@jest/globals'
 
 import { networks } from '../../consts/networks'
+import { getRpcProvider } from '../../services/provider'
 import { getAAVEPositions, getUniV3Positions } from './providers'
 
 describe('DeFi positions', () => {
@@ -18,8 +17,8 @@ describe('DeFi positions', () => {
   const polygon = networks.find((n) => n.chainId === 137n)
   if (!polygon) throw new Error('unable to find polygon network in consts')
 
-  const providerEthereum = new JsonRpcProvider('https://invictus.ambire.com/ethereum')
-  const providerPolygon = new JsonRpcProvider('https://invictus.ambire.com/polygon')
+  const providerEthereum = getRpcProvider(['https://invictus.ambire.com/ethereum'], 1n)
+  const providerPolygon = getRpcProvider(['https://invictus.ambire.com/polygon'], 137n)
 
   describe('Uni V3', () => {
     test('Get uni v3 positions on Polygon', async () => {

--- a/src/libs/deployless/deployless.test.ts
+++ b/src/libs/deployless/deployless.test.ts
@@ -1,8 +1,9 @@
-import { AbiCoder, concat, JsonRpcProvider, toBeHex } from 'ethers'
+import { AbiCoder, concat, toBeHex } from 'ethers'
 
 import { describe, expect, test } from '@jest/globals'
 
 import { addressOne } from '../../../test/config'
+import { getRpcProvider } from '../../services/provider'
 import { compile } from './compile'
 import { Deployless, DeploylessMode } from './deployless'
 
@@ -10,7 +11,7 @@ const helloWorld = compile('HelloWorld', {
   contractsFolder: 'test/contracts'
 })
 const deployErrBin = '0x6080604052348015600f57600080fd5b600080fdfe'
-const mainnetProvider = new JsonRpcProvider('https://invictus.ambire.com/ethereum')
+const mainnetProvider = getRpcProvider(['https://invictus.ambire.com/ethereum'], 1n)
 let deployless: Deployless
 
 describe('Deployless', () => {

--- a/src/libs/portfolio/portfolio.test.ts
+++ b/src/libs/portfolio/portfolio.test.ts
@@ -46,7 +46,7 @@ describe('Portfolio', () => {
   const USDT_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   const ethereum = networks.find((n) => n.chainId === 1n)
   if (!ethereum) throw new Error('unable to find ethereum network in consts')
-  const provider = new JsonRpcProvider('https://invictus.ambire.com/ethereum')
+  const provider = getRpcProvider(['https://invictus.ambire.com/ethereum'], 1n)
   const portfolio = new Portfolio(fetch, provider, ethereum, velcroUrl)
 
   async function getNonce(address: string) {

--- a/src/libs/tracer/debugTraceCall.test.ts
+++ b/src/libs/tracer/debugTraceCall.test.ts
@@ -1,8 +1,9 @@
-import { Interface, JsonRpcProvider, MaxUint256, solidityPackedKeccak256, toBeHex } from 'ethers'
+import { Interface, MaxUint256, solidityPackedKeccak256, toBeHex } from 'ethers'
 
 import { beforeAll, expect } from '@jest/globals'
 
 import { Account, AccountOnchainState } from '../../interfaces/account'
+import { getRpcProvider } from '../../services/provider'
 import { AccountOp } from '../accountOp/accountOp'
 import { BROADCAST_OPTIONS } from '../broadcast/broadcast'
 import { ERC20, ERC721 } from '../humanizer/const/abis'
@@ -15,7 +16,7 @@ const ACCOUNT_ADDRESS = '0x46C0C59591EbbD9b7994d10efF172bFB9325E240'
 
 // @TODO add minting and burning test
 describe('Debug tracecall detection for transactions', () => {
-  const provider = new JsonRpcProvider('https://invictus.ambire.com/optimism')
+  const provider = getRpcProvider(['https://invictus.ambire.com/optimism'], 10n)
   let account: Account
   let accountOp: AccountOp
   const nftIface: Interface = new Interface(ERC721)

--- a/src/services/assetInfo/assetInfo.ts
+++ b/src/services/assetInfo/assetInfo.ts
@@ -1,7 +1,6 @@
-import { JsonRpcProvider } from 'ethers'
-
 import { Network } from '../../interfaces/network'
 import { GetOptions, Portfolio, TokenResult } from '../../libs/portfolio'
+import { getRpcProvider } from '../provider'
 
 const RANDOM_ADDRESS = '0x0000000000000000000000000000000000000001'
 const scheduledActions: {
@@ -14,7 +13,8 @@ const scheduledActions: {
 } = {}
 
 export async function executeBatchedFetch(network: Network): Promise<void> {
-  const provider = new JsonRpcProvider(network.selectedRpcUrl || network.rpcUrls[0])
+  const rpcUrl = network.selectedRpcUrl || network.rpcUrls[0]
+  const provider = getRpcProvider([rpcUrl], network.chainId)
   const allAddresses =
     Array.from(new Set(scheduledActions[network.chainId.toString()]?.data.map((i) => i.address))) ||
     []


### PR DESCRIPTION
Closes https://github.com/AmbireTech/ambire-app/issues/4348