### PR TITLE
Fix/ Error decoder formats custom contract error to an invalid utf8 string and breaks humanization

### DIFF
--- a/src/libs/errorDecoder/errorDecoder.test.ts
+++ b/src/libs/errorDecoder/errorDecoder.test.ts
@@ -170,13 +170,21 @@ describe('Error decoders work', () => {
       expect(decodedError.reason).toBe('transfer amount exceeds balance')
       expect(decodedError.data).toBe('transfer amount exceeds balance')
     })
-    it("Error doesn't gets overwritten by Panic/Revert if it is panic or revert", async () => {
+    it("Error doesn't get overwritten by Panic/Revert if it is panic or revert", async () => {
       const error = new InnerCallFailureError(TEST_MESSAGE_REVERT_DATA, [], base)
       const decodedError = decodeError(error)
 
       expect(decodedError.type).toEqual(ErrorType.RevertError)
       expect(decodedError.reason).toBe('Test message')
       expect(decodedError.data).toBe(TEST_MESSAGE_REVERT_DATA)
+    })
+    it('Should preserve custom error data as reason when handling InnerCallFailureError containing a custom error', () => {
+      const customErrorData =
+        '0x275c273c00000000000000000000000000000000000000000000000000000000000000190000000000000000000000000000000000000000000000000000000000000018'
+      const error = new InnerCallFailureError(customErrorData, [], base)
+      const decodedError = decodeError(error)
+      expect(decodedError.type).toEqual(ErrorType.InnerCallFailureError)
+      expect(decodedError.reason).toBe(customErrorData)
     })
   })
   describe('CustomErrorHandler', () => {

--- a/src/libs/errorDecoder/helpers.test.ts
+++ b/src/libs/errorDecoder/helpers.test.ts
@@ -1,0 +1,22 @@
+import { countUnicodeLettersAndNumbers } from './helpers'
+
+describe('Error decoder helpers', () => {
+  it('countUnicodeLettersAndNumbers', () => {
+    const result = countUnicodeLettersAndNumbers('Hello, world!')
+    expect(result).toBe(10)
+
+    // Mix of valid and invalid characters
+    const result2 = countUnicodeLettersAndNumbers('Hello, world! \uD83D\uDE00')
+    expect(result2).toBe(10)
+
+    // All invalid characters
+    const result3 = countUnicodeLettersAndNumbers('\uD83D\uDE00\uD83D\uDE00')
+    expect(result3).toBe(0)
+
+    const result4 = countUnicodeLettersAndNumbers('1234567890')
+    expect(result4).toBe(10)
+
+    const result5 = countUnicodeLettersAndNumbers('!@#$%^&*()')
+    expect(result5).toBe(0)
+  })
+})

--- a/src/libs/errorDecoder/helpers.ts
+++ b/src/libs/errorDecoder/helpers.ts
@@ -43,6 +43,21 @@ const isReasonValid = (reason: string | null): boolean => {
 }
 
 /**
+ * Counts the number of valid Unicode numbers and letters in a string.
+ */
+const countValidUnicodeCharacters = (str: string): number => {
+  let validCount = 0
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charAt(i)
+    // Check if it's an alphabetic character (from any language) or a number
+    if (/[\p{L}\p{N}]/u.test(char)) {
+      validCount++
+    }
+  }
+  return validCount
+}
+
+/**
  * Some reasons are encoded in hex, this function will decode them to a human-readable string
  * which can then be matched to a specific error message.
  */
@@ -53,7 +68,10 @@ const formatReason = (reason: string): string => {
     return trimmedReason
 
   try {
-    return toUtf8String(trimmedReason)
+    const decodedString = toUtf8String(trimmedReason)
+
+    // Return the decoded string if it contains valid Unicode letters
+    return countValidUnicodeCharacters(decodedString) > 0 ? decodedString : trimmedReason
   } catch {
     return trimmedReason
   }

--- a/src/libs/errorDecoder/helpers.ts
+++ b/src/libs/errorDecoder/helpers.ts
@@ -45,7 +45,7 @@ const isReasonValid = (reason: string | null): boolean => {
 /**
  * Counts the number of valid Unicode numbers and letters in a string.
  */
-const countValidUnicodeCharacters = (str: string): number => {
+const countUnicodeLettersAndNumbers = (str: string): number => {
   let validCount = 0
   for (let i = 0; i < str.length; i++) {
     const char = str.charAt(i)
@@ -71,7 +71,7 @@ const formatReason = (reason: string): string => {
     const decodedString = toUtf8String(trimmedReason)
 
     // Return the decoded string if it contains valid Unicode letters
-    return countValidUnicodeCharacters(decodedString) > 0 ? decodedString : trimmedReason
+    return countUnicodeLettersAndNumbers(decodedString) > 0 ? decodedString : trimmedReason
   } catch {
     return trimmedReason
   }
@@ -111,5 +111,6 @@ export {
   getErrorCodeStringFromReason,
   isReasonValid,
   getDataFromError,
-  formatReason
+  formatReason,
+  countUnicodeLettersAndNumbers
 }


### PR DESCRIPTION
Extracted error reasons are formatted in `decodeError`. In certain conditions, we attempt to convert hex string errors to UTF-8 strings. The problem is that we weren't checking if the converted UTF-8 string is valid.
## Before:
![image](https://github.com/user-attachments/assets/934c8c80-c744-4fc7-981d-524fb76c0a75)
## After:
![image](https://github.com/user-attachments/assets/3d797899-7969-4e0c-923d-abe495332678)

Closes https://github.com/AmbireTech/ambire-app/issues/4356