### PR TITLE
Feature/retry on underpriced

### DIFF
--- a/src/libs/paymaster/abstractPaymaster.ts
+++ b/src/libs/paymaster/abstractPaymaster.ts
@@ -29,6 +29,8 @@ export abstract class AbstractPaymaster {
 
   abstract isUsable(): boolean
 
+  abstract canAutoRetryOnFailure(): boolean
+
   abstract call(
     acc: Account,
     op: AccountOp,

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -305,4 +305,8 @@ export class Paymaster extends AbstractPaymaster {
 
     throw new Error('Paymaster not configured. Please contact support')
   }
+
+  canAutoRetryOnFailure(): boolean {
+    return this.type === 'Ambire'
+  }
 }


### PR DESCRIPTION
Retry the paymaster request on a relayer paymaster error, automatically, with a re-estimation. If it fails again, we show the error to the user