### PR TITLE
Bug/: EOA simulation not working when `signAccountOp` ctrl isn't initialized

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -28,7 +28,6 @@ import { ExternalSignerControllers, Key, KeystoreSignerType } from '../../interf
 import { AddNetworkRequestParams, Network } from '../../interfaces/network'
 import { NotificationManager } from '../../interfaces/notification'
 import { RPCProvider } from '../../interfaces/provider'
-import { EstimationStatus } from '../estimation/types'
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { TraceCallDiscoveryStatus } from '../../interfaces/signAccountOp'
 import { Storage } from '../../interfaces/storage'
@@ -83,6 +82,8 @@ import {
   buildMintVestingRequest,
   buildTransferUserRequest
 } from '../../libs/transfer/userRequest'
+/* eslint-disable no-underscore-dangle */
+import { LiFiAPI } from '../../services/lifi/api'
 import { paymasterFactory } from '../../services/paymaster'
 import { failedPaymasters } from '../../services/paymaster/FailedPaymasters'
 import shortenAddress from '../../utils/shortenAddress'
@@ -101,6 +102,7 @@ import { DappsController } from '../dapps/dapps'
 import { DefiPositionsController } from '../defiPositions/defiPositions'
 import { DomainsController } from '../domains/domains'
 import { EmailVaultController } from '../emailVault/emailVault'
+import { EstimationStatus } from '../estimation/types'
 import EventEmitter, { ErrorRef, Statuses } from '../eventEmitter/eventEmitter'
 import { FeatureFlagsController } from '../featureFlags/featureFlags'
 import { InviteController } from '../invite/invite'
@@ -110,8 +112,6 @@ import { PhishingController } from '../phishing/phishing'
 import { PortfolioController } from '../portfolio/portfolio'
 import { ProvidersController } from '../providers/providers'
 import { SelectedAccountController } from '../selectedAccount/selectedAccount'
-/* eslint-disable no-underscore-dangle */
-import { LiFiAPI } from '../../services/lifi/api'
 import { SignAccountOpController, SigningStatus } from '../signAccountOp/signAccountOp'
 import { SignMessageController } from '../signMessage/signMessage'
 import { StorageController } from '../storage/storage'
@@ -773,7 +773,7 @@ export class MainController extends EventEmitter {
       const accountOpsForSimulation = getAccountOpsForSimulation(
         account,
         this.actions.visibleActionsQueue,
-        network
+        this.networks.networks
       )
       // update the portfolio only if new tokens were found through tracing
       if (learnedNewTokens || learnedNewNfts) {
@@ -1157,14 +1157,10 @@ export class MainController extends EventEmitter {
     await this.#initialLoadPromise
     if (!this.selectedAccount.account) return
 
-    const signAccountOpChainId = this.signAccountOp?.accountOp.chainId
-    const networkData =
-      network || this.networks.networks.find((n) => n.chainId === signAccountOpChainId)
-
     const accountOpsToBeSimulatedByNetwork = getAccountOpsForSimulation(
       this.selectedAccount.account,
       this.actions.visibleActionsQueue,
-      networkData
+      this.networks.networks
     )
 
     await this.portfolio.updateSelectedAccount(

--- a/src/libs/actions/actions.ts
+++ b/src/libs/actions/actions.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-cycle
 import { AccountOpAction, Action } from '../../controllers/actions/actions'
 import { DappProviderRequest } from '../../interfaces/dapp'
-import { AccountOp } from '../accountOp/accountOp'
 
 export const dappRequestMethodToActionKind = (method: DappProviderRequest['method']) => {
   if (['call', 'calls', 'eth_sendTransaction', 'wallet_sendCalls'].includes(method)) return 'calls'
@@ -17,25 +16,6 @@ export const dappRequestMethodToActionKind = (method: DappProviderRequest['metho
   if (['personal_sign'].includes(method)) return 'message'
   // method to camelCase
   return method.replace(/_(.)/g, (m, p1) => p1.toUpperCase())
-}
-
-export const getAccountOpsByNetwork = (
-  accountAddr: string,
-  actions: Action[]
-): { [key: string]: AccountOp[] } | undefined => {
-  const accountOps = (actions.filter((a) => a.type === 'accountOp') as AccountOpAction[])
-    .map((a) => a.accountOp)
-    .filter((op) => op.accountAddr === accountAddr)
-
-  if (!accountOps.length) return undefined
-
-  return accountOps.reduce((acc: any, accountOp) => {
-    const { chainId } = accountOp
-    if (!acc[chainId.toString()]) acc[chainId.toString()] = []
-
-    acc[chainId.toString()].push(accountOp)
-    return acc
-  }, {})
 }
 
 export const getAccountOpActionsByNetwork = (

--- a/src/libs/main/main.ts
+++ b/src/libs/main/main.ts
@@ -7,7 +7,6 @@ import generateSpoofSig from '../../utils/generateSpoofSig'
 import { isSmartAccount } from '../account/account'
 import { AccountOp } from '../accountOp/accountOp'
 import { Call } from '../accountOp/types'
-import { getAccountOpsByNetwork } from '../actions/actions'
 
 export const batchCallsFromUserRequests = ({
   accountAddr,
@@ -142,17 +141,28 @@ export const makeAccountOpAction = ({
 export const getAccountOpsForSimulation = (
   account: Account,
   visibleActionsQueue: Action[],
-  network?: Network
-):
-  | {
-      [key: string]: AccountOp[]
-    }
-  | undefined => {
+  networks: Network[]
+): { [key: string]: AccountOp[] } | undefined => {
   const isSmart = isSmartAccount(account)
+  const accountOps = (
+    visibleActionsQueue.filter((a) => a.type === 'accountOp') as AccountOpAction[]
+  )
+    .map((a) => a.accountOp)
+    .filter((op) => op.accountAddr === account.addr)
 
-  // Simulation isn't supported by EOAs if the network doesn't support state override
-  if (!isSmart && (!network || network.rpcNoStateOverride)) return undefined
+  if (!accountOps.length) return undefined
 
-  // Simulate all account ops for the account
-  return getAccountOpsByNetwork(account.addr, visibleActionsQueue) || undefined
+  return accountOps.reduce((acc: any, accountOp) => {
+    const { chainId } = accountOp
+    const networkData = networks.find((n) => n.chainId === chainId)
+
+    // We cannot simulate if the account isn't smart and the network's RPC doesn't support
+    // state override
+    if (!isSmart && (!networkData || networkData.rpcNoStateOverride)) return acc
+
+    if (!acc[chainId.toString()]) acc[chainId.toString()] = []
+
+    acc[chainId.toString()].push(accountOp)
+    return acc
+  }, {})
 }


### PR DESCRIPTION
The simulation of account operations fails for EOAs when the signAccountOp controller isn't initialized due to a condition in our code:
```
// Simulation isn't supported by EOAs if the network doesn't support state override
if (!isSmart && (!network || network.rpcNoStateOverride)) return undefined
```
That is because `network` is undefined, as shown in the following code block:
```
const signAccountOpChainId = this.signAccountOp?.accountOp.chainId
const networkData = network || this.networks.networks.find((n) => n.chainId === signAccountOpChainId)
```
