### PR TITLE
Fix/faster next broadcast

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -247,6 +247,11 @@ export class AccountsController extends EventEmitter {
     return this.accountStates[addr][chainId.toString()]
   }
 
+  async forceFetchPendingState(addr: string, chainId: bigint): Promise<AccountOnchainState> {
+    await this.updateAccountState(addr, 'pending', [chainId])
+    return this.accountStates[addr][chainId.toString()]
+  }
+
   toJSON() {
     return {
       ...this,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -217,8 +217,6 @@ export class MainController extends EventEmitter {
 
   #signAccountOpSigningPromise?: Promise<AccountOp | void | null>
 
-  #signAccountOpBroadcastPromise?: Promise<SubmittedAccountOp>
-
   #traceCallTimeoutId: ReturnType<typeof setTimeout> | null = null
 
   constructor({
@@ -686,17 +684,7 @@ export class MainController extends EventEmitter {
     // Error handling on the prev step will notify the user, it's fine to return here
     if (this.signAccountOp?.status?.type !== SigningStatus.Done) return
 
-    return this.withStatus(
-      'broadcastSignedAccountOp',
-      async () => {
-        // Reset the promise in the `finally` block to ensure it doesn't remain unresolved if an error is thrown
-        this.#signAccountOpBroadcastPromise = this.#broadcastSignedAccountOp().finally(() => {
-          this.#signAccountOpBroadcastPromise = undefined
-        })
-        return this.#signAccountOpBroadcastPromise
-      },
-      true
-    )
+    this.#broadcastSignedAccountOp()
   }
 
   destroySignAccOp() {
@@ -1747,7 +1735,6 @@ export class MainController extends EventEmitter {
       }
 
       if (this.#signAccountOpSigningPromise) await this.#signAccountOpSigningPromise
-      if (this.#signAccountOpBroadcastPromise) await this.#signAccountOpBroadcastPromise
 
       const account = this.accounts.accounts.find((x) => x.addr === meta.accountAddr)!
       const accountState = await this.accounts.getOrFetchAccountOnChainState(
@@ -1989,23 +1976,16 @@ export class MainController extends EventEmitter {
       }
     }
 
-    // Note: this may take a while!
-    const txnId = await this.activity.getConfirmedTxId(submittedAccountOp)
-
+    const dappHandlers = []
     // eslint-disable-next-line no-restricted-syntax
     for (const call of calls) {
       const uReq = this.userRequests.find((r) => r.id === call.fromUserRequestId)
       if (uReq) {
-        if (txnId) {
-          // If the call has a txnId, resolve the promise with it.
-          // This could happen when an EOA account is broadcasting multiple transactions.
-          uReq.dappPromise?.resolve({ hash: call.txnId || txnId })
-        } else {
-          uReq.dappPromise?.reject(
-            ethErrors.rpc.transactionRejected({
-              message: 'Transaction rejected by the bundler'
-            })
-          )
+        if (uReq.dappPromise) {
+          dappHandlers.push({
+            promise: uReq.dappPromise,
+            txnId: call.txnId
+          })
         }
 
         this.removeUserRequest(uReq.id, {
@@ -2019,6 +1999,27 @@ export class MainController extends EventEmitter {
         })
       }
     }
+
+    // emitting the removed user req
+    this.emitUpdate()
+
+    // this could take a while
+    // return the txnId to the dapp once it's confirmed as return a txId
+    // that could be front ran would cause bad UX on the dapp side
+    const txnId = await this.activity.getConfirmedTxId(submittedAccountOp)
+    dappHandlers.forEach((handler) => {
+      if (txnId) {
+        // If the call has a txnId, resolve the promise with it.
+        // This could happen when an EOA account is broadcasting multiple transactions.
+        handler.promise.resolve({ hash: handler.txnId || txnId })
+      } else {
+        handler.promise.reject(
+          ethErrors.rpc.transactionRejected({
+            message: 'Transaction rejected by the bundler'
+          })
+        )
+      }
+    })
 
     this.emitUpdate()
   }
@@ -2143,7 +2144,7 @@ export class MainController extends EventEmitter {
       try {
         const feePayerKey = this.keystore.getFeePayerKey(accountOp)
         if (feePayerKey instanceof Error) {
-          return await this.throwBroadcastAccountOp({
+          return this.throwBroadcastAccountOp({
             message: feePayerKey.message,
             accountState
           })
@@ -2198,7 +2199,7 @@ export class MainController extends EventEmitter {
             }
           }
         } else {
-          return await this.throwBroadcastAccountOp({ error, accountState })
+          return this.throwBroadcastAccountOp({ error, accountState })
         }
       } finally {
         this.signAccountOp?.update({ signedTransactionsCount: null })
@@ -2379,7 +2380,6 @@ export class MainController extends EventEmitter {
           : 'The transaction was'
       } successfully signed and broadcast to the network.`
     })
-    return Promise.resolve(submittedAccountOp)
   }
 
   // ! IMPORTANT !
@@ -2438,11 +2438,9 @@ export class MainController extends EventEmitter {
         isReplacementFeeLow = true
         if (this.signAccountOp) this.signAccountOp.simulate()
       } else if (originalMessage.includes('INSUFFICIENT_PRIVILEGE')) {
-        message = `Signer key not supported on this network.${
-          !accountState?.isV2
-            ? 'You can add/change signers from the web wallet or contact support.'
-            : 'Please contact support.'
-        }`
+        message = accountState?.isV2
+          ? 'Broadcast failed because of a pending transaction. Please try again'
+          : 'Signer key not supported on this network'
       } else if (originalMessage.includes('underpriced')) {
         message =
           'Transaction fee underpriced. Please select a higher transaction speed and try again'
@@ -2451,6 +2449,15 @@ export class MainController extends EventEmitter {
       } else if (originalMessage.includes('Failed to fetch') && isRelayer) {
         message =
           'Currently, the Ambire relayer seems to be down. Please try again a few moments later or broadcast with a Basic Account'
+      } else if (originalMessage.includes('user nonce') && isRelayer) {
+        if (this.signAccountOp) {
+          this.accounts
+            .updateAccountState(this.signAccountOp.accountOp.accountAddr, 'pending', [
+              this.signAccountOp.accountOp.chainId
+            ])
+            .then(() => this.signAccountOp?.simulate())
+            .catch((e) => e)
+        }
       }
     }
 
@@ -2474,9 +2481,11 @@ export class MainController extends EventEmitter {
     this.signAccountOp?.updateStatus(SigningStatus.ReadyToSign, isReplacementFeeLow)
     this.feePayerKey = null
 
-    return Promise.reject(
-      new EmittableError({ level: 'major', message, error: _err || new Error(message) })
-    )
+    this.emitError({
+      message,
+      level: 'major',
+      error: new Error('failed to retrieve saved seed phrase from keystore')
+    })
   }
 
   get isSignRequestStillActive(): boolean {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -144,6 +144,8 @@ export const noStateUpdateStatuses = [
 ]
 
 export class SignAccountOpController extends EventEmitter {
+  #accounts: AccountsController
+
   #keystore: KeystoreController
 
   #portfolio: PortfolioController
@@ -153,8 +155,6 @@ export class SignAccountOpController extends EventEmitter {
   account: Account
 
   baseAccount: BaseAccount
-
-  accountState: AccountOnchainState
 
   #network: Network
 
@@ -248,6 +248,7 @@ export class SignAccountOpController extends EventEmitter {
   ) {
     super()
 
+    this.#accounts = accounts
     this.#keystore = keystore
     this.#portfolio = portfolio
     this.#externalSignerControllers = externalSignerControllers
@@ -258,7 +259,6 @@ export class SignAccountOpController extends EventEmitter {
       keystore.keys.filter((key) => account.associatedKeys.includes(key.addr)),
       network
     )
-    this.accountState = accountState
     this.#network = network
     this.fromActionId = fromActionId
     this.accountOp = structuredClone(accountOp)
@@ -1355,11 +1355,15 @@ export class SignAccountOpController extends EventEmitter {
   ): Promise<UserOperation> {
     const gasFeePayment = this.accountOp.gasFeePayment!
     let erc4337Estimation = this.estimation.estimation!.bundlerEstimation as Erc4337GasLimits
+    const accountState = await this.#accounts.getOrFetchAccountOnChainState(
+      this.accountOp.accountAddr,
+      this.accountOp.chainId
+    )
 
     if (shouldReestimate) {
       const newEstimate = await bundlerEstimate(
         this.baseAccount,
-        this.accountState,
+        accountState,
         this.accountOp,
         this.#network,
         [this.selectedOption!.token],
@@ -1382,7 +1386,7 @@ export class SignAccountOpController extends EventEmitter {
 
     const userOperation = getUserOperation(
       this.account,
-      this.accountState,
+      accountState,
       this.accountOp,
       this.bundlerSwitcher.getBundler().getName(),
       this.accountOp.meta?.entryPointAuthorization,
@@ -1433,6 +1437,14 @@ export class SignAccountOpController extends EventEmitter {
       }
     }
 
+    const errorResponse = response as PaymasterErrorReponse
+    if (errorResponse.message.indexOf('invalid account nonce') !== -1) {
+      // silenly continuing on error as this is an attempt for an UX improvement
+      await this.#accounts
+        .updateAccountState(this.accountOp.accountAddr, 'pending', [this.accountOp.chainId])
+        .catch((e) => e)
+    }
+
     // auto-retry once if it was the ambire paymaster
     if (paymaster.canAutoRetryOnFailure() && counter === 0) {
       const reestimatedUserOp = await this.#getInitialUserOp(true, eip7702Auth)
@@ -1442,7 +1454,7 @@ export class SignAccountOpController extends EventEmitter {
     return {
       required: true,
       success: false,
-      errorResponse: response as PaymasterErrorReponse
+      errorResponse
     }
   }
 
@@ -1527,6 +1539,11 @@ export class SignAccountOpController extends EventEmitter {
       this.accountOp.activatorCall = getActivatorCall(this.accountOp.accountAddr)
     }
 
+    const accountState = await this.#accounts.getOrFetchAccountOnChainState(
+      this.accountOp.accountAddr,
+      this.accountOp.chainId
+    )
+
     try {
       // plain EOA
       if (
@@ -1541,7 +1558,7 @@ export class SignAccountOpController extends EventEmitter {
         this.accountOp.signature = await getExecuteSignature(
           this.#network,
           this.accountOp,
-          this.accountState,
+          accountState,
           signer
         )
       } else if (broadcastOption === BROADCAST_OPTIONS.byBundler) {
@@ -1565,10 +1582,10 @@ export class SignAccountOpController extends EventEmitter {
           const contract = getContractImplementation(this.#network.chainId)
           eip7702Auth = get7702Sig(
             this.#network.chainId,
-            this.accountState.nonce,
+            accountState.nonce,
             contract,
             signer.sign7702(
-              getAuthorizationHash(this.#network.chainId, contract, this.accountState.nonce)
+              getAuthorizationHash(this.#network.chainId, contract, accountState.nonce)
             )
           )
 
@@ -1579,12 +1596,12 @@ export class SignAccountOpController extends EventEmitter {
           const epActivatorTypedData = await getEntryPointAuthorization(
             this.account.addr,
             this.#network.chainId,
-            this.accountState.nonce
+            accountState.nonce
           )
           const epSignature = await getEIP712Signature(
             epActivatorTypedData,
             this.account,
-            this.accountState,
+            accountState,
             signer,
             this.#network
           )
@@ -1657,12 +1674,10 @@ export class SignAccountOpController extends EventEmitter {
         // Relayer
         this.#addFeePayment()
 
-        // TODO: THINK ABOUT FETCHING THE NONCE FROM THE PENDING STATE AT THIS POINT
-        // DO SMT LIKE: FETCH THE NONCE, IF HIGHER USE IT
         this.accountOp.signature = await getExecuteSignature(
           this.#network,
           this.accountOp,
-          this.accountState,
+          accountState,
           signer
         )
       }

--- a/src/libs/errorHumanizer/broadcastErrorhumanizer.test.ts
+++ b/src/libs/errorHumanizer/broadcastErrorhumanizer.test.ts
@@ -45,7 +45,7 @@ describe('Broadcast errors are humanized', () => {
     const humanizedError = getHumanReadableBroadcastError(error)
 
     expect(humanizedError.message).toBe(
-      `${PREFIX}the user nonce is too low. Is there a pending transaction? Please try broadcasting again.`
+      `${PREFIX}of a pending transaction. Please try broadcasting again.`
     )
   })
   it('Random relayer error is displayed to the user', () => {

--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -92,8 +92,7 @@ const BROADCAST_OR_ESTIMATION_ERRORS: ErrorHumanizerError[] = [
   },
   {
     reasons: ['user nonce too low'],
-    message:
-      'the user nonce is too low. Is there a pending transaction? Please try broadcasting again.'
+    message: 'of a pending transaction. Please try broadcasting again.'
   },
   // dApp interactions
   {


### PR DESCRIPTION
Goal:
* don't wait for broadcast to confirm in order to be able to broadcast again

How:
* we resolve the user request before the final txnId (confirmation) is found but we resolve the dapp requests after the final, confirmed txnId is found
* we scan for nonce discrepancy issues and try to counter them
* fetch the newest account nonce wherever possible