### PR TITLE
Add/ `isExactMatch` check to error humanizer

### DIFF
--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -112,12 +112,14 @@ const BROADCAST_OR_ESTIMATION_ERRORS: ErrorHumanizerError[] = [
   {
     reasons: ['80'],
     message:
-      "the smart contract you're interacting with doesn't support this operation. This could be due to contract restrictions, insufficient permissions, or specific conditions that haven't been met. Please review the requirements of this operation or consult the contract documentation."
+      "the smart contract you're interacting with doesn't support this operation. This could be due to contract restrictions, insufficient permissions, or specific conditions that haven't been met. Please review the requirements of this operation or consult the contract documentation.",
+    isExactMatch: true
   },
   {
     reasons: ['STF'],
     message:
-      'of one of the following reasons: missing approval, insufficient approved amount, the amount exceeds the account balance.'
+      'of one of the following reasons: missing approval, insufficient approved amount, the amount exceeds the account balance.',
+    isExactMatch: true
   },
   {
     reasons: [EXPIRED_PREFIX, 'Router: EXPIRED', 'Transaction too old', 'BAL#508', 'SWAP_DEADLINE'],

--- a/src/libs/errorHumanizer/helpers.ts
+++ b/src/libs/errorHumanizer/helpers.ts
@@ -59,10 +59,11 @@ const getHumanReadableErrorMessage = (
 
       const isMatching = error.reasons.some((errorReason) => {
         const lowerCaseReason = errorReason.toLowerCase()
+        const lowerCaseCheckAgainst = checkAgainst.toLowerCase()
 
         if (isExactMatch) {
           // Try a simple equality check first
-          if (errorReason === checkAgainst) return true
+          if (lowerCaseCheckAgainst === lowerCaseReason) return true
 
           // Split checkAgainst by spaces and check if any of the parts
           // match the lowerCaseReason
@@ -71,7 +72,7 @@ const getHumanReadableErrorMessage = (
           return splitCheckAgainst.some((part) => part.toLowerCase() === lowerCaseReason)
         }
 
-        return checkAgainst.toLowerCase().includes(lowerCaseReason)
+        return lowerCaseCheckAgainst.includes(lowerCaseReason)
       })
       if (!isMatching) return
 

--- a/src/libs/errorHumanizer/helpers.ts
+++ b/src/libs/errorHumanizer/helpers.ts
@@ -55,9 +55,15 @@ const getHumanReadableErrorMessage = (
 
   if (checkAgainst) {
     errors.forEach((error) => {
-      const isMatching = error.reasons.some((errorReason) =>
-        checkAgainst.toLowerCase().includes(errorReason.toLowerCase())
-      )
+      const { isExactMatch } = error
+
+      const isMatching = error.reasons.some((errorReason) => {
+        if (isExactMatch) {
+          return errorReason === checkAgainst
+        }
+
+        return checkAgainst.toLowerCase().includes(errorReason.toLowerCase())
+      })
       if (!isMatching) return
 
       message = `${messagePrefix ? `${messagePrefix} ` : ''}${error.message}`

--- a/src/libs/errorHumanizer/helpers.ts
+++ b/src/libs/errorHumanizer/helpers.ts
@@ -65,6 +65,7 @@ const getHumanReadableErrorMessage = (
           if (errorReason === checkAgainst) return true
 
           // Split checkAgainst by spaces and check if any of the parts
+          // match the lowerCaseReason
           const splitCheckAgainst = checkAgainst.split(' ')
 
           return splitCheckAgainst.some((part) => part.toLowerCase() === lowerCaseReason)

--- a/src/libs/errorHumanizer/helpers.ts
+++ b/src/libs/errorHumanizer/helpers.ts
@@ -53,16 +53,24 @@ const getHumanReadableErrorMessage = (
   const checkAgainst = reason || e?.error?.message || e?.message
   let message = null
 
-  if (checkAgainst) {
+  if (checkAgainst && typeof checkAgainst === 'string') {
     errors.forEach((error) => {
       const { isExactMatch } = error
 
       const isMatching = error.reasons.some((errorReason) => {
+        const lowerCaseReason = errorReason.toLowerCase()
+
         if (isExactMatch) {
-          return errorReason === checkAgainst
+          // Try a simple equality check first
+          if (errorReason === checkAgainst) return true
+
+          // Split checkAgainst by spaces and check if any of the parts
+          const splitCheckAgainst = checkAgainst.split(' ')
+
+          return splitCheckAgainst.some((part) => part.toLowerCase() === lowerCaseReason)
         }
 
-        return checkAgainst.toLowerCase().includes(errorReason.toLowerCase())
+        return checkAgainst.toLowerCase().includes(lowerCaseReason)
       })
       if (!isMatching) return
 

--- a/src/libs/errorHumanizer/types.ts
+++ b/src/libs/errorHumanizer/types.ts
@@ -1,6 +1,7 @@
 type ErrorHumanizerError = {
   reasons: string[]
   message: string
+  isExactMatch?: boolean
 }
 
 export type { ErrorHumanizerError }


### PR DESCRIPTION
Error reasons like '80' can be included in a lot of hex reasons. This PR adds the flag `isExactMatch` to reasons and extends the logic in `getHumanReadableErrorMessage`
![image](https://github.com/user-attachments/assets/c5760c5c-aa15-4898-be43-c6d1f0f18aff)
