### PR TITLE
Enable 7702 for Gnosis

### DIFF
--- a/src/consts/7702.ts
+++ b/src/consts/7702.ts
@@ -15,6 +15,10 @@ export const networks7702: Custom7702Settings = {
   // sepolia
   '11155111': {
     implementation: EIP_7702_AMBIRE_ACCOUNT
+  },
+  // gnosis
+  '100': {
+    implementation: EIP_7702_AMBIRE_ACCOUNT
   }
 }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -2294,7 +2294,7 @@ export class MainController extends EventEmitter {
 
       // broadcast through bundler's service
       let userOperationHash
-      const bundler = bundlerSwitcher.getBundler(userOperation.eip7702Auth)
+      const bundler = bundlerSwitcher.getBundler()
       try {
         userOperationHash = await bundler.broadcast(userOperation, network)
       } catch (e: any) {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1425,7 +1425,7 @@ export class SignAccountOpController extends EventEmitter {
       this.account,
       accountState,
       this.accountOp,
-      this.bundlerSwitcher.getBundler(eip7702Auth).getName(),
+      this.bundlerSwitcher.getBundler().getName(),
       this.accountOp.meta?.entryPointAuthorization,
       eip7702Auth
     )

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -112,7 +112,7 @@ export async function bundlerEstimate(
 
   const account = baseAcc.getAccount()
   const localOp = { ...op }
-  const initialBundler = switcher.getBundler(eip7702Auth)
+  const initialBundler = switcher.getBundler()
   const userOp = getUserOperation(
     account,
     accountState,

--- a/src/services/bundlers/bundlerSwitcher.ts
+++ b/src/services/bundlers/bundlerSwitcher.ts
@@ -1,7 +1,6 @@
 /* eslint-disable class-methods-use-this */
 
-import { EIP7702Auth } from '../../consts/7702'
-import { BUNDLER, PIMLICO } from '../../consts/bundlers'
+import { BUNDLER } from '../../consts/bundlers'
 import { Account } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
 import { Bundler } from './bundler'
@@ -32,11 +31,7 @@ export class BundlerSwitcher {
     return bundlers && bundlers.length > 1
   }
 
-  getBundler(eip7702Auth?: EIP7702Auth): Bundler {
-    // force get a bundler under given circumstances:
-    // if eip7702Auth is provided, only PIMLICO can broadcast it
-    if (eip7702Auth) return getBundlerByName(PIMLICO)
-
+  getBundler(): Bundler {
     return this.bundler
   }
 

--- a/src/services/bundlers/getBundler.ts
+++ b/src/services/bundlers/getBundler.ts
@@ -22,8 +22,8 @@ export function getBundlerByName(bundlerName: BUNDLER): Bundler {
  * If it's set, get it. If not, use pimlico
  */
 export function getDefaultBundler(network: Network): Bundler {
-  // hardcode biconomy for Gnosis and Sonic as they support state override
-  if (network.chainId === 100n || network.chainId === 146n) return getBundlerByName(BICONOMY)
+  // hardcode biconomy for Sonic as it's not supported by pimlico
+  if (network.chainId === 146n) return getBundlerByName(BICONOMY)
 
   const bundlerName = network.erc4337.defaultBundler ? network.erc4337.defaultBundler : PIMLICO
   return getBundlerByName(bundlerName)


### PR DESCRIPTION
Make pimlico the default bundler for gnosis - they resolved their state override issues