### PR TITLE
Performance: sooner debug trace call

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -640,6 +640,8 @@ export class SignAccountOpController extends EventEmitter {
     // no simulation / estimation if we're in a signing state
     if (!this.canUpdate()) return
 
+    if (shouldTraceCall) this.#traceCall(this)
+
     await Promise.all([
       this.#portfolio.simulateAccountOp(this.accountOp),
       this.estimation.estimate(this.accountOp).catch((e) => e)
@@ -679,8 +681,6 @@ export class SignAccountOpController extends EventEmitter {
     if (this.estimation.status === EstimationStatus.Error) {
       this.#portfolio.overridePendingResults(this.accountOp)
     }
-
-    if (shouldTraceCall) this.#traceCall()
   }
 
   async estimate() {
@@ -1738,6 +1738,10 @@ export class SignAccountOpController extends EventEmitter {
 
   canUpdate(): boolean {
     return !this.status || noStateUpdateStatuses.indexOf(this.status.type) === -1
+  }
+
+  setDiscoveryStatus(status: TraceCallDiscoveryStatus) {
+    this.traceCallDiscoveryStatus = status
   }
 
   toJSON() {


### PR DESCRIPTION
Put debug trace call before simulation/estimation for better performance: it gets batched along with the simulation/estimation rpc calls.  
We didn't do this before because we were working at the assumption that gasPrice / gasLimit was needed for debug trace call to work which is not true.  
A little bit more testing is needed before merging this as it actually might be a problem with some RPCs if they don't support batching of debug_traceCall along other requests