### PR TITLE
Fix/swap and bridge bugs and improvements

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -605,6 +605,10 @@ export class MainController extends EventEmitter {
       })
     }
 
+    if (type === SIGN_ACCOUNT_OP_SWAP) {
+      this.swapAndBridge.signAccountOpController?.simulateSwapOrBridge()
+    }
+
     await this.withStatus(
       'signAccountOp',
       async () => {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -23,6 +23,7 @@ import { ExternalSignerControllers, Key, KeystoreSignerType } from '../../interf
 import { AddNetworkRequestParams, Network } from '../../interfaces/network'
 import { NotificationManager } from '../../interfaces/notification'
 import { RPCProvider } from '../../interfaces/provider'
+import { EstimationStatus } from '../estimation/types'
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { TraceCallDiscoveryStatus } from '../../interfaces/signAccountOp'
 import { Storage } from '../../interfaces/storage'
@@ -388,7 +389,20 @@ export class MainController extends EventEmitter {
       portfolioUpdate: () => {
         this.updateSelectedAccountPortfolio(true)
       },
-      userRequests: this.userRequests
+      userRequests: this.userRequests,
+      isMainSignAccountOpThrowingAnEstimationError: (
+        fromChainId: number | null,
+        toChainId: number | null
+      ) => {
+        return (
+          this.signAccountOp &&
+          fromChainId &&
+          toChainId &&
+          this.signAccountOp.estimation.status === EstimationStatus.Error &&
+          this.signAccountOp.accountOp.chainId === BigInt(fromChainId) &&
+          fromChainId === toChainId
+        )
+      }
     })
     this.domains = new DomainsController(this.providers.providers)
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -606,7 +606,18 @@ export class MainController extends EventEmitter {
     }
 
     if (type === SIGN_ACCOUNT_OP_SWAP) {
-      this.swapAndBridge.signAccountOpController?.simulateSwapOrBridge()
+      this.swapAndBridge.signAccountOpController?.simulateSwapOrBridge().then(() => {
+        // if an error has ocurred while signing and we're back to SigningStatus.ReadyToSign,
+        // override the pending results as they will be incorrect
+        if (
+          this.swapAndBridge.signAccountOpController &&
+          this.swapAndBridge.signAccountOpController.status?.type === SigningStatus.ReadyToSign
+        ) {
+          this.portfolio.overridePendingResults(
+            this.swapAndBridge.signAccountOpController.accountOp
+          )
+        }
+      })
     }
 
     await this.withStatus(

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -687,6 +687,10 @@ export class SignAccountOpController extends EventEmitter {
     await this.estimation.estimate(this.accountOp)
   }
 
+  async simulateSwapOrBridge() {
+    await this.#portfolio.simulateAccountOp(this.accountOp)
+  }
+
   update({
     gasPrices,
     feeToken,

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1865,6 +1865,7 @@ export class SwapAndBridgeController extends EventEmitter {
       this.emitUpdate()
     })
     this.signAccountOpController.onError((error) => {
+      this.#portfolio.overridePendingResults(this.signAccountOpController!.accountOp)
       this.emitError(error)
     })
 


### PR DESCRIPTION
Changes:
1. Start the simulation the moment the user "signs" on swap & bridge controller, one click mode. If an error is encountered along the way, remove the simulation. Also, there's a race condition where if an error is encountered immediately, it will try to remove the pending simulation before the simulation has concluded, resulting in the simulation showing after a while. So we check if the sign account op status is ReadyToSign when the simulation concludes at that point and if it is, we remove it.
2. isMainSignAccountOpThrowingAnEstimationError - as the name suggests, we're showing an error msg to the user if there's an estimation error in the batch