### PR TITLE
Config / Resolve TypeScript compiler errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ambire-common",
-  "version": "2.47.1",
+  "version": "2.51.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ambire-common",
-      "version": "2.47.1",
+      "version": "2.51.1",
       "dependencies": {
         "@lifi/types": "^17.7.1",
         "aes-js": "^3.1.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,5 +35,5 @@
     "strictPropertyInitialization": true,
     "resolveJsonModule": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "lib": ["ESNext", "DOM"],
     "types": ["node", "jest", "mocha"],
     "target": "ESNext",
-    "module": "ES2020",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "baseUrl": "src/",
+    "outDir": "./dist",
     "noEmit": false,
     "noEmitOnError": true,
     "noEmitHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": ["ESNext", "DOM"],
     "types": ["node", "jest", "mocha"],
     "target": "ESNext",
+    "module": "ES2020",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Missing `outDir` was causing errors on my Mac (VS Code) for some reason (although I read that this should fallback gracefully https://www.typescriptlang.org/tsconfig/#outDir)

<img width="1167" alt="Screenshot 2025-05-05 at 18 36 40" src="https://github.com/user-attachments/assets/bf6ad02f-aa24-430a-b92a-948c987a88f8" />

Also fixes a minor inconsistency in package-lock v.