### PR TITLE
Fix: select the next route on step txn failure

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1441,7 +1441,7 @@ export class SwapAndBridgeController extends EventEmitter {
   }
 
   async selectRoute(route: SwapAndBridgeRoute, isAutoSelectDisabled?: boolean) {
-    if (!this.quote || !this.quote.routes.length || !this.shouldEnableRoutesSelection) return
+    if (!this.quote || !this.quote.routes.length) return
     if (
       ![
         SwapAndBridgeFormStatus.ReadyToSubmit,
@@ -1795,10 +1795,6 @@ export class SwapAndBridgeController extends EventEmitter {
 
     const userTxn = await this.getRouteStartUserTx(false)
 
-    // TODO<swap&bridge>: if auto select route is disabled,
-    // return the error instead
-    // Also, the below code is not working well and needs changes
-    //
     // if no txn is provided because of a route failure (large slippage),
     // auto select the next route and continue on
     if (!userTxn) {

--- a/src/libs/tracer/debugTraceCall.test.ts
+++ b/src/libs/tracer/debugTraceCall.test.ts
@@ -16,7 +16,7 @@ const ACCOUNT_ADDRESS = '0x46C0C59591EbbD9b7994d10efF172bFB9325E240'
 
 // @TODO add minting and burning test
 describe('Debug tracecall detection for transactions', () => {
-  const provider = getRpcProvider(['https://mainnet.optimism.io'], 10n)
+  const provider = getRpcProvider(['https://optimism.api.onfinality.io/public'], 10n)
   let account: Account
   let accountOp: AccountOp
   const nftIface: Interface = new Interface(ERC721)

--- a/src/libs/tracer/debugTraceCall.test.ts
+++ b/src/libs/tracer/debugTraceCall.test.ts
@@ -16,7 +16,7 @@ const ACCOUNT_ADDRESS = '0x46C0C59591EbbD9b7994d10efF172bFB9325E240'
 
 // @TODO add minting and burning test
 describe('Debug tracecall detection for transactions', () => {
-  const provider = getRpcProvider(['https://invictus.ambire.com/optimism'], 10n)
+  const provider = getRpcProvider(['https://mainnet.optimism.io'], 10n)
   let account: Account
   let accountOp: AccountOp
   const nftIface: Interface = new Interface(ERC721)


### PR DESCRIPTION
when li.fi's stepTxn() failed, we didn't auto select the next route