### PR TITLE
Fix/ Portfolio and swap and bridge unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "humanizer:generate:combineHumanizerJsons": "node scripts/combineHumanizerJsons.js",
     "compile:contracts": "ts-node scripts/compileContracts.js",
     "hardhat": "npx hardhat compile; npx hardhat test",
-    "jest": "jest --forceExit",
+    "jest": "node runTests.js",
     "build": "tsc src/libs/deployless/deployless.ts -t es5",
     "prettier": "prettier --write 'contracts/**/*.sol'",
     "lint:fix": "eslint ./src/** --ext .js,.jsx,.ts,.tsx --fix"

--- a/runTests.js
+++ b/runTests.js
@@ -1,0 +1,19 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { run } = require('jest-cli')
+
+async function runTests() {
+  try {
+    // Run the portfolio test first in isolation. This is required
+    // to ensure that the 'batching works' test doesn't intercept requests
+    // from other tests.
+    await run(['src/libs/portfolio/portfolio.test.ts'])
+
+    // Run remaining tests in parallel
+    await run(['--forceExit=true', '--testPathIgnorePatterns=src/libs/portfolio/portfolio.test.ts'])
+  } catch (error) {
+    console.error('Test execution failed:', error)
+    process.exit(1)
+  }
+}
+
+runTests()

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -207,26 +207,17 @@ describe('SwapAndBridge Controller', () => {
     await swapAndBridgeController.initForm('1')
     expect(swapAndBridgeController.sessionIds).toContain('1')
   })
-  test('should update portfolio token list', (done) => {
-    let emitCounter = 0
-    const unsubscribe = swapAndBridgeController.onUpdate(async () => {
-      emitCounter++
-      if (emitCounter === 4) {
-        expect(swapAndBridgeController.toTokenList).toHaveLength(3)
-        expect(swapAndBridgeController.toTokenList).not.toContainEqual(
-          expect.objectContaining({
-            address: swapAndBridgeController.fromSelectedToken?.address
-          })
-        )
-        expect(swapAndBridgeController.toSelectedToken).toBeNull()
-        unsubscribe()
-        done()
-      }
-    })
-
+  test('should update portfolio token list', async () => {
     expect(swapAndBridgeController.fromChainId).toEqual(1)
     expect(swapAndBridgeController.fromSelectedToken).toEqual(null)
-    swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
+    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
+    expect(swapAndBridgeController.toTokenList).toHaveLength(3)
+    expect(swapAndBridgeController.toTokenList).not.toContainEqual(
+      expect.objectContaining({
+        address: swapAndBridgeController.fromSelectedToken?.address
+      })
+    )
+    expect(swapAndBridgeController.toSelectedToken).toBeNull()
     expect(swapAndBridgeController.fromSelectedToken).not.toBeNull()
     expect(swapAndBridgeController.fromSelectedToken?.address).toEqual(
       '0x0000000000000000000000000000000000000000' // the one with highest balance


### PR DESCRIPTION
The portfolio test was failing because the `monitor` method intercepted requests from other tests.
