### PR TITLE
Feature / Attempt to sort Swap & Bridge "Receive" tokens by market cap via cena.ambire.com

### DIFF
--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -1,4 +1,4 @@
-import { Contract, getAddress, Interface, MaxUint256 } from 'ethers'
+import { Contract, getAddress, Interface, MaxUint256, ZeroAddress } from 'ethers'
 
 import ERC20 from '../../../contracts/compiled/IERC20.json'
 import { Account, AccountOnchainState } from '../../interfaces/account'
@@ -77,6 +77,14 @@ export const attemptToSortTokensByMarketCap = async ({
     console.error('Sorting Swap & Bridge tokens by market failed', e)
     return tokens
   }
+}
+
+export const sortNativeTokenFirst = (tokens: SwapAndBridgeToToken[]) => {
+  return tokens.sort((a, b) => {
+    if (a.address === ZeroAddress) return -1
+    if (b.address === ZeroAddress) return 1
+    return 0
+  })
 }
 
 export const sortTokenListResponse = (

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -56,8 +56,8 @@ export const sortTokenListResponse = (
       if (comparisonResult !== 0) return comparisonResult
     }
 
-    // Otherwise, just alphabetical
-    return (a.name || '').localeCompare(b.name || '')
+    // Otherwise, don't change, persist the order from the service provider
+    return 0
   })
 }
 

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -78,7 +78,7 @@ export const attemptToSortTokensByMarketCap = async ({
     })
   } catch (e) {
     // Fail silently, no biggie
-    console.error('Sorting Swap & Bridge tokens by market failed', e)
+    console.error(`Sorting Swap & Bridge tokens by market for network with id ${chainId} failed`, e)
     return tokens
   }
 }

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -53,6 +53,10 @@ export const attemptToSortTokensByMarketCap = async ({
     const tokenAddressesByMarketCapRes = await fetch(
       `https://cena.ambire.com/api/v3/lists/byMarketCap/${chainId}`
     )
+
+    if (tokenAddressesByMarketCapRes.status !== 200)
+      throw new Error(`Got status ${tokenAddressesByMarketCapRes.status} from the API.`)
+
     const tokenAddressesByMarketCap = await tokenAddressesByMarketCapRes.json()
 
     // Highest market cap comes first from the response

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -57,7 +57,11 @@ export const attemptToSortTokensByMarketCap = async ({
 
     // Highest market cap comes first from the response
     const addressPriority = new Map(
-      tokenAddressesByMarketCap.data.map((addr: string, index: number) => [addr, index])
+      tokenAddressesByMarketCap.data.map((addr: string, index: number) => [
+        // FIXME: Incoming addresses are not check summed, temporarily use lowercase comparison
+        addr.toLowerCase(),
+        index
+      ])
     )
 
     // Sort the result by the market cap response order position (highest first)

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -28,7 +28,8 @@ import { TokenResult } from '../../libs/portfolio'
 import {
   addCustomTokensIfNeeded,
   attemptToSortTokensByMarketCap,
-  convertPortfolioTokenToSwapAndBridgeToToken
+  convertPortfolioTokenToSwapAndBridgeToToken,
+  sortNativeTokenFirst
 } from '../../libs/swapAndBridge/swapAndBridge'
 import { FEE_PERCENT, ZERO_ADDRESS } from '../socket/constants'
 import { disabledAssetSymbols, MAYAN_BRIDGE } from './consts'
@@ -322,17 +323,19 @@ export class LiFiAPI {
         'Unable to retrieve the list of supported receive tokens. Please reload to try again.'
     })
 
-    const result: SwapAndBridgeToToken[] = response.tokens[toChainId].map((t: LiFiToken) =>
+    const tokens: SwapAndBridgeToToken[] = response.tokens[toChainId].map((t: LiFiToken) =>
       normalizeLiFiTokenToSwapAndBridgeToToken(t, toChainId)
     )
 
-    const sortedResult = await attemptToSortTokensByMarketCap({
+    const sortedTokens = await attemptToSortTokensByMarketCap({
       fetch: this.#fetch,
       chainId: toChainId,
-      tokens: result
+      tokens
     })
 
-    return addCustomTokensIfNeeded({ chainId: toChainId, tokens: sortedResult })
+    const withCustomTokens = addCustomTokensIfNeeded({ chainId: toChainId, tokens: sortedTokens })
+
+    return sortNativeTokenFirst(withCustomTokens)
   }
 
   async getToken({

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -27,6 +27,7 @@ import {
 import { TokenResult } from '../../libs/portfolio'
 import {
   addCustomTokensIfNeeded,
+  attemptToSortTokensByMarketCap,
   convertPortfolioTokenToSwapAndBridgeToToken
 } from '../../libs/swapAndBridge/swapAndBridge'
 import { FEE_PERCENT, ZERO_ADDRESS } from '../socket/constants'
@@ -227,7 +228,7 @@ export class LiFiAPI {
 
   // eslint-disable-next-line class-methods-use-this
   async getHealth() {
-    // Li.Fi’s v1 API doesn't have a dedicated health endpoint
+    // Li.Fi's v1 API doesn't have a dedicated health endpoint
     return true
   }
 
@@ -325,7 +326,13 @@ export class LiFiAPI {
       normalizeLiFiTokenToSwapAndBridgeToToken(t, toChainId)
     )
 
-    return addCustomTokensIfNeeded({ chainId: toChainId, tokens: result })
+    const sortedResult = await attemptToSortTokensByMarketCap({
+      fetch: this.#fetch,
+      chainId: toChainId,
+      tokens: result
+    })
+
+    return addCustomTokensIfNeeded({ chainId: toChainId, tokens: sortedResult })
   }
 
   async getToken({


### PR DESCRIPTION
The default sorting by LiFi is random. Enhance it by:

- Added: Attempting to sort Swap & Bridge "Receive" tokens by market cap via cena.ambire.com and gracefully fallback to silently not sorting, if something goes wrong (note: currently, cena.ambire.com doesn't return results for custom networks)
- Changed: Sort native tokens always first, then custom tokens ($WALLET), then all the rest.

Resolves https://github.com/AmbireTech/ambire-app/issues/4635