### PR TITLE
Filter disabledByDefault relayer networks

### DIFF
--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -192,11 +192,12 @@ export class NetworksController extends EventEmitter {
     const updatedNetworks = { ...finalNetworks }
     try {
       const res = await this.#callRelayer('/v2/config/networks')
-      relayerNetworks = res.data.extensionConfigNetworks.filter(
-        (network: RelayerNetworkConfigResponse) => !network.disabledByDefault
-      )
+      relayerNetworks = res.data.extensionConfigNetworks
 
       Object.entries(relayerNetworks).forEach(([_chainId, network]) => {
+        // for the time being, we don't want to show disabledByDefault networks
+        if (network.disabledByDefault) return
+
         const chainId = BigInt(_chainId)
         const relayerNetwork = mapRelayerNetworkConfigToAmbireNetwork(chainId, network)
         const storedNetwork = Object.values(networksInStorage).find((n) => n.chainId === chainId)

--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -192,7 +192,9 @@ export class NetworksController extends EventEmitter {
     const updatedNetworks = { ...finalNetworks }
     try {
       const res = await this.#callRelayer('/v2/config/networks')
-      relayerNetworks = res.data.extensionConfigNetworks
+      relayerNetworks = res.data.extensionConfigNetworks.filter(
+        (network: RelayerNetworkConfigResponse) => !network.disabledByDefault
+      )
 
       Object.entries(relayerNetworks).forEach(([_chainId, network]) => {
         const chainId = BigInt(_chainId)

--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -175,6 +175,7 @@ export type RelayerNetwork = {
       increasePreVerGas?: number
     }
   }
+  disabledByDefault?: boolean
 }
 
 export type RelayerNetworkConfigResponse = { [chainId: string]: RelayerNetwork }


### PR DESCRIPTION
We're going to be adding a lot of "disabledByDefault" networks to the relayer. We will probably deploy a live relayer with these networks before the extension version with disabled by default networks is live. So we filter out initially these networks initially and we will remove this filter once the feature is out