### PR TITLE
Feature / Optimize Swap & Bridge controller "To" token list

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -916,9 +916,9 @@ export class SwapAndBridgeController extends EventEmitter {
   get toTokenList(): SwapAndBridgeToToken[] {
     const isSwapping = this.fromChainId === this.toChainId
     if (isSwapping) {
-      // Swaps between same "from" and "to" tokens are not feasible, filter them out
       return (
         this.#toTokenList
+          // Swaps between same "from" and "to" tokens are not feasible, filter them out
           .filter((t) => t.address !== this.fromSelectedToken?.address)
           // For performance reasons, limit the number of tokens to max 50
           .slice(0, 50)

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -917,7 +917,12 @@ export class SwapAndBridgeController extends EventEmitter {
     const isSwapping = this.fromChainId === this.toChainId
     if (isSwapping) {
       // Swaps between same "from" and "to" tokens are not feasible, filter them out
-      return this.#toTokenList.filter((t) => t.address !== this.fromSelectedToken?.address)
+      return (
+        this.#toTokenList
+          .filter((t) => t.address !== this.fromSelectedToken?.address)
+          // For performance reasons, limit the number of tokens to max 50
+          .slice(0, 50)
+      )
     }
 
     return this.#toTokenList


### PR DESCRIPTION
Aims to improve the performance problems caused by big Swap & Bridge controller to token lists (example: on Ethereum) by:

- Changed: Limit the max number of tokens in the to token list to 50.
- Added: Search "To" token in the full (private) token list.