### PR TITLE
Defi positions: hardcode addresses for some custom chains for defi positions

### DIFF
--- a/src/libs/defiPositions/defiAddresses.ts
+++ b/src/libs/defiPositions/defiAddresses.ts
@@ -20,7 +20,51 @@ export const AAVE_V3 = {
   },
   '56': {
     poolAddr: '0x6807dc923806fE8Fd134338EABCA509979a7e0cB'
+  },
+  '43114': {
+    poolAddr: '0x794a61358D6845594F94dc1DB02A252b5b4814aD'
+  },
+  // custom chains
+  // harmony
+  // unreliable
+  // '1666600000': {
+  // poolAddr: '0x794a61358D6845594F94dc1DB02A252b5b4814aD'
+  // },
+  // fantom
+  // not listed int he dapp
+  // '250': {
+  // poolAddr: '0x794a61358D6845594F94dc1DB02A252b5b4814aD'
+  // },
+  // metis
+  // unreliable
+  // '1088': {
+  // poolAddr: '0x90df02551bB792286e8D4f13E0e357b4Bf1D6a57'
+  // },
+  // gnosis
+  '100': {
+    poolAddr: '0xb50201558B00496A145fE76f7424749556E326D8'
   }
+  // zkSync
+  // we have not deployless here
+  // unreliable
+  // '324': {
+  //   poolAddr: '0x78e30497a3c7527d953c6B1E3541b021A98Ac43c'
+  // }
+  // linea
+  // unreliable
+  // '59144': {
+  //   poolAddr: '0xc47b8C00b0f69a36fa203Ffeac0334874574a8Ac'
+  // }
+  // sonic
+  // unreliable
+  // '146': {
+  //   poolAddr: '0x5362dBb1e601abF3a4c14c22ffEdA64042E5eAA3'
+  // }
+  // celo
+  // unreliable
+  // '42220': {
+  // poolAddr: '0x3E59A31363E2ad014dcbc521c4a0d5757d9f3402'
+  // }
 }
 
 export const UNISWAP_V3 = {
@@ -47,5 +91,34 @@ export const UNISWAP_V3 = {
   '56': {
     nonfungiblePositionManagerAddr: '0x7b8a01b39d58278b5de7e48c8449c9f4f5170613',
     factoryAddr: '0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7'
+  },
+  // not deployed on scroll
+  // '534352': {},
+  // custom chains
+  // zkSync
+  // unreliable
+  // '324': {
+  //   nonfungiblePositionManagerAddr: '0x0616e5762c1E7Dc3723c50663dF10a162D690a86',
+  //   factoryAddr: '0x8FdA5a7a8dCA67BBcDd10F02Fa0649A937215422'
+  // },
+  // celo
+  '42220': {
+    nonfungiblePositionManagerAddr: '0x3d79EdAaBC0EaB6F08ED885C05Fc0B014290D95A',
+    factoryAddr: '0xAfE208a311B21f13EF87E33A90049fC17A7acDEc'
+  },
+  // blast
+  '81457': {
+    nonfungiblePositionManagerAddr: '0xB218e4f7cF0533d4696fDfC419A0023D33345F28',
+    factoryAddr: '0x792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd'
+  },
+  // zora
+  '7777777': {
+    nonfungiblePositionManagerAddr: '0xbC91e8DfA3fF18De43853372A3d7dfe585137D78',
+    factoryAddr: '0x7145F8aeef1f6510E92164038E1B6F8cB2c42Cbb'
+  },
+  // world chain
+  '480': {
+    nonfungiblePositionManagerAddr: '0xec12a9F9a09f50550686363766Cc153D03c27b5e',
+    factoryAddr: '0x7a5028BDa40e7B173C278C5342087826455ea25a'
   }
 }


### PR DESCRIPTION
## add aave for:
- avalanche
- gnosis

## add uni v3 for:
- celo
- blast
- zora
- world chain

## To test add the the following addresses as view only:
- aave avalanche 0xc6fE438c3d3e9b9E18e6fa47921B04ECa19dCC57
- aave gnosis 0x6f7C6691f9387C4e7e05291945ab352CED0Dbdd2
- uni celo 0x4645375145aEbE85f6058f2DD81462162b068084
- uni blast 0x5501872a79D4B56631D9eB9432b1A2c948896C20
- uni zora 0x6f7C6691f9387C4e7e05291945ab352CED0Dbdd2
- uni wrld chain 0xEdc00A53B17E633c486207CF06f3c7bB6066A319

### note:
some known addresses are not hardcoded because our existing code fails with them and this is not a priority. The issue might be with rpc's but, again, debugging such issues with custom chains is not a prioriry