### PR TITLE
Fix / loss of keys after execution of the legacy saved seed migration

### DIFF
--- a/src/controllers/storage/storage.ts
+++ b/src/controllers/storage/storage.ts
@@ -526,7 +526,9 @@ export class StorageController extends EventEmitter {
       // eslint-disable-next-line no-await-in-loop
       await accountPicker.findAndSetLinkedAccountsPromise
 
-      const matchingAddresses = accountPicker.allKeysOnPage
+      const matchingAddresses = accountPicker.allKeysOnPage.filter((k) =>
+        updatedKeyMap.has(`${k}:internal`)
+      )
 
       if (matchingAddresses.length === 0) break
 


### PR DESCRIPTION
There is a bug introduced with the migration that associates keys to the legacy saved seed. After running the migration for each account only a single key will remain due to a problem in the mapping where the keys are mapped by addr only and not by addr and type resulting to an array with unique keys by addr at the end.

Affected users are those that had a legacy saved seed and at the same time account/s with multiple signers

**This PR fixes that so all future execution of the migration will keep the same number of keys in the storage**