### PR TITLE
Fix: swap&bridge on from token chain change

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1848,13 +1848,22 @@ export class SwapAndBridgeController extends EventEmitter {
     const calls = !isBridge ? [...userRequestCalls, ...swapOrBridgeCalls] : [...swapOrBridgeCalls]
 
     if (this.signAccountOpController) {
-      this.signAccountOpController.update({ calls })
+      // if the chain id has changed, we need to destroy the sign account op
+      if (
+        this.signAccountOpController.accountOp.meta &&
+        this.signAccountOpController.accountOp.meta.swapTxn &&
+        this.signAccountOpController.accountOp.meta.swapTxn.chainId !== userTxn.chainId
+      ) {
+        this.destroySignAccountOp()
+      } else {
+        this.signAccountOpController.update({ calls })
 
-      // add the real swapTxn
-      if (!this.signAccountOpController.accountOp.meta)
-        this.signAccountOpController.accountOp.meta = {}
-      this.signAccountOpController.accountOp.meta.swapTxn = userTxn
-      return
+        // add the real swapTxn
+        if (!this.signAccountOpController.accountOp.meta)
+          this.signAccountOpController.accountOp.meta = {}
+        this.signAccountOpController.accountOp.meta.swapTxn = userTxn
+        return
+      }
     }
 
     const baseAcc = getBaseAccount(


### PR DESCRIPTION
If you get provided a valid quote and later decide to change the from token to a token from another chain, you get infinite quote failure as we updated the sign account op (which is for a different chain) instead of destroying it and initializing a new one.

This fixes that