### PR TITLE
Fix / AccountPicker AddAccounts Bug

### DIFF
--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -143,6 +143,8 @@ export class AccountPickerController extends EventEmitter {
 
   #alreadyImportedAccounts: Account[] = []
 
+  addAccountsPromise?: Promise<void>
+
   #onAddAccountsSuccessCallback: () => Promise<void>
 
   #onAddAccountsSuccessCallbackPromise?: Promise<void>
@@ -445,6 +447,7 @@ export class AccountPickerController extends EventEmitter {
   }
 
   async reset(resetInitParams: boolean = true) {
+    await this.addAccountsPromise
     if (resetInitParams) this.initParams = null
     this.keyIterator = null
     this.selectedAccountsFromCurrentSession = []
@@ -769,6 +772,13 @@ export class AccountPickerController extends EventEmitter {
    * the newly added accounts data (like preferences, keys and others)
    */
   async addAccounts(accounts?: SelectedAccountForImport[]) {
+    this.addAccountsPromise = this.#addAccounts(accounts).finally(() => {
+      this.addAccountsPromise = undefined
+    })
+    await this.addAccountsPromise
+  }
+
+  async #addAccounts(accounts?: SelectedAccountForImport[]) {
     if (!this.isInitialized) return this.#throwNotInitialized()
     if (!this.keyIterator) return this.#throwMissingKeyIterator()
 


### PR DESCRIPTION
**Added logic to prevent the accountPicker from resetting while addAccounts is in progress.**
---
Тhis fixes an issue where accounts added from a seed, pk or HW could end up in a view-only state. This is possible because we reset the accountPicker if the current screen is not one of: account-personalize or account-picker. Doing this during the accounts and keys import process, leads to a state where the accounts are added first but their corresponding keys are not because the accountPicker state is empty due to the reset.