### PR TITLE
Fix: bundler estimation bug + 7702 receiving native as fee

### DIFF
--- a/src/libs/account/EOA7702.ts
+++ b/src/libs/account/EOA7702.ts
@@ -145,7 +145,7 @@ export class EOA7702 extends BaseAccount {
   }
 
   canUseReceivingNativeForFee(): boolean {
-    return false
+    return !this.accountState.isSmarterEoa
   }
 
   getBroadcastCalldata(accountOp: AccountOp): Hex {

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -164,16 +164,6 @@ export function getSignableCalls(op: AccountOp): [string, string, string][] {
   return callsToSign
 }
 
-export function getSignableCallsForBundlerEstimate(op: AccountOp): [string, string, string][] {
-  const callsToSign = getSignableCalls(op)
-  // add the fee call one more time when doing a bundler estimate
-  // this is because the feeCall during estimation is fake (approve instead
-  // of transfer, incorrect amount) and more ofteh than not, this causes
-  // a lower estimation than the real one, causing bad UX in the process
-  if (op.feeCall) callsToSign.push(callToTuple(op.feeCall))
-  return callsToSign
-}
-
 export function getSignableHash(
   addr: AccountId,
   chainId: bigint,

--- a/src/libs/calls/calls.ts
+++ b/src/libs/calls/calls.ts
@@ -14,7 +14,7 @@ const ERC20Interface = new Interface(ERC20.abi)
 export function getFeeCall(feeToken: TokenResult): Call {
   // set a bigger number for gas tank / approvals so on
   // L2s it could calculate the preVerificationGas better
-  const gasTankOrApproveAmount = 500000000n * BigInt(feeToken.decimals)
+  const gasTankOrApproveAmount = 500n * BigInt(feeToken.decimals)
 
   if (feeToken.flags.onGasTank) {
     return {

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -16,7 +16,7 @@ import { BundlerSwitcher } from '../../services/bundlers/bundlerSwitcher'
 import { GasSpeeds } from '../../services/bundlers/types'
 import { paymasterFactory } from '../../services/paymaster'
 import { BaseAccount } from '../account/BaseAccount'
-import { AccountOp, getSignableCallsForBundlerEstimate } from '../accountOp/accountOp'
+import { AccountOp, getSignableCalls } from '../accountOp/accountOp'
 import { PaymasterEstimationData } from '../erc7677/types'
 import { getHumanReadableEstimationError } from '../errorHumanizer'
 import { TokenResult } from '../portfolio'
@@ -127,14 +127,10 @@ export async function bundlerEstimate(
   const ambireAccount = new Interface(AmbireAccount.abi)
   userOp.signature = getSigForCalculations()
 
-  userOp.callData = ambireAccount.encodeFunctionData('executeBySender', [
-    getSignableCallsForBundlerEstimate(localOp)
-  ])
+  userOp.callData = ambireAccount.encodeFunctionData('executeBySender', [getSignableCalls(localOp)])
   const paymaster = await paymasterFactory.create(op, userOp, account, network, provider)
   localOp.feeCall = paymaster.getFeeCallForEstimation(feeTokens)
-  userOp.callData = ambireAccount.encodeFunctionData('executeBySender', [
-    getSignableCallsForBundlerEstimate(localOp)
-  ])
+  userOp.callData = ambireAccount.encodeFunctionData('executeBySender', [getSignableCalls(localOp)])
   const feeCallType = paymaster.getFeeCallType(feeTokens)
 
   if (paymaster.isUsable()) {


### PR DESCRIPTION
Fix: do not use two approvals for estimation, use only one; enable receiving ETH to be used as payment if the account is 7702 but has not transitioned to 7702, yet