### PR TITLE
Fix/ Swap and bridge action-window session not cleared

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -2285,6 +2285,9 @@ export class MainController extends EventEmitter {
   onOneClickSwapClose() {
     const signAccountOp = this.swapAndBridge.signAccountOpController
 
+    // Always unload the screen when the action window is closed
+    this.swapAndBridge.unloadScreen('action-window', true)
+
     if (!signAccountOp) return
 
     // Remove the active route if it exists
@@ -2292,7 +2295,6 @@ export class MainController extends EventEmitter {
       this.swapAndBridge.removeActiveRoute(signAccountOp.accountOp.meta.swapTxn.activeRouteId)
     }
 
-    this.swapAndBridge.unloadScreen('action-window', true)
     this.#abortHWSign(signAccountOp)
 
     const network = this.networks.networks.find(

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -532,11 +532,7 @@ export class SwapAndBridgeController extends EventEmitter {
 
   unloadScreen(sessionId: string, forceUnload?: boolean) {
     const isFormDirty = !!this.fromAmount || !!this.toSelectedToken
-    const signAccountOpCtrlStatus = this.signAccountOpController?.status?.type
-    const isSigningOrBroadcasting =
-      signAccountOpCtrlStatus && noStateUpdateStatuses.includes(signAccountOpCtrlStatus)
-    const shouldPersistState =
-      ((isFormDirty && sessionId === 'popup') || isSigningOrBroadcasting) && !forceUnload
+    const shouldPersistState = isFormDirty && sessionId === 'popup' && !forceUnload
 
     if (shouldPersistState) return
 


### PR DESCRIPTION
## How to reproduce:
1. Select an account that has a trezor signer
2. Do a swap
3. Close the swap action window after the swap completes
4. Opening the extension popup shouldn't open swap and bridge

The swap and bridge `signAccountOp` is reset on broadcast. `onOneClickSwapClose` was being called but `if (!signAccountOp) return` was returning so the session wasn't being cleared.