### PR TITLE
Expose the error message to the user if encountered instead of hiding it

### DIFF
--- a/src/libs/broadcast/broadcast.ts
+++ b/src/libs/broadcast/broadcast.ts
@@ -55,10 +55,13 @@ async function estimateGas(
   from: string,
   call: Call,
   nonce: number,
+  error?: Error,
   counter: number = 0
 ): Promise<bigint> {
   // this should happen only in the case of internet issues
-  if (counter > 10) throw new Error('Failed estimating gas from broadcast')
+  if (counter > 10) {
+    throw new Error(`Failed estimating gas for broadcast${error ? `: ${error.message}` : ''}`)
+  }
 
   const callEstimateGas = provider
     .send('eth_estimateGas', [
@@ -97,7 +100,7 @@ async function estimateGas(
   // the error is most likely because of an incorrect RPC pending state
   if (gasLimit instanceof Error || hasNonceDiscrepancyOnApproval) {
     await wait(1500)
-    return estimateGas(provider, from, call, nonce, counter + 1)
+    return estimateGas(provider, from, call, nonce, gasLimit, counter + 1)
   }
 
   return gasLimit

--- a/src/libs/errorDecoder/errorDecoder.ts
+++ b/src/libs/errorDecoder/errorDecoder.ts
@@ -13,6 +13,7 @@ import BiconomyEstimationErrorHandler from './handlers/biconomy'
 import InternalHandler from './handlers/internal'
 import PimlicoEstimationErrorHandler from './handlers/pimlico'
 import RelayerErrorHandler from './handlers/relayer'
+import UnknownWithMessageHandler from './handlers/unknownWithMessage'
 import { formatReason, getDataFromError, isReasonValid } from './helpers'
 import { DecodedError, ErrorType } from './types'
 
@@ -27,6 +28,7 @@ const PREPROCESSOR_BUNDLER_HANDLERS = [
 ]
 const PREPROCESSOR_HANDLERS = [BundlerErrorHandler, RelayerErrorHandler, InnerCallFailureHandler]
 const ERROR_HANDLERS = [
+  UnknownWithMessageHandler,
   InternalHandler,
   RpcErrorHandler,
   CustomErrorHandler,

--- a/src/libs/errorDecoder/handlers/unknownWithMessage.ts
+++ b/src/libs/errorDecoder/handlers/unknownWithMessage.ts
@@ -1,0 +1,22 @@
+/* eslint-disable class-methods-use-this */
+import { DecodedError, ErrorHandler, ErrorType } from '../types'
+
+class UnknownWithMessageHandler implements ErrorHandler {
+  message: string = ''
+
+  public matches(data: string, error: any) {
+    const itMatches = error instanceof Error && !!error.message
+    if (itMatches) this.message = error.message
+    return itMatches
+  }
+
+  public handle(data: string): DecodedError {
+    return {
+      type: ErrorType.UnknownWithMessage,
+      reason: this.message,
+      data
+    }
+  }
+}
+
+export default UnknownWithMessageHandler

--- a/src/libs/errorDecoder/types.ts
+++ b/src/libs/errorDecoder/types.ts
@@ -22,7 +22,9 @@ export enum ErrorType {
   /** Error due to the user rejecting a transaction */
   UserRejectionError = 'UserRejectionError',
   /** Error due to an inner call failure during estimation */
-  InnerCallFailureError = 'InnerCallFailureError'
+  InnerCallFailureError = 'InnerCallFailureError',
+  /** Unknown error but a message for what is the cause is passed in the Error object */
+  UnknownWithMessage = 'UnknownWithMessage'
 }
 
 export type DecodedError = {

--- a/src/libs/errorHumanizer/helpers.ts
+++ b/src/libs/errorHumanizer/helpers.ts
@@ -36,6 +36,8 @@ function getGenericMessageFromType(
     case ErrorType.PanicError:
     case ErrorType.RevertError:
       return `${messagePrefix} of a contract error.${messageSuffixNoSupport}`
+    case ErrorType.UnknownWithMessage:
+      return `Unexpected error:${messageSuffixNoSupport.replace('Error code:', '')}`
     default:
       return lastResortMessage
   }


### PR DESCRIPTION
This is the result. Before, it was "unexpected error"

<img width="602" alt="Screenshot 2025-06-04 at 11 00 52" src="https://github.com/user-attachments/assets/81348866-f784-4cb8-b2c2-48135001bab6" />
