### PR TITLE
Fix Typos in Comments and Variable Names in signMessage.ts

### DIFF
--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -589,7 +589,7 @@ export async function getEIP712Signature(
   }
 
   // we do not allow signers who are not dedicated to one account to sign eip-712
-  // messsages in v2 as it could lead to reusing that key from
+  // messages in v2 as it could lead to reusing that key from
   const dedicatedToOneSA = signer.key.dedicatedToOneSA
   if (!dedicatedToOneSA) {
     throw new Error(
@@ -641,7 +641,7 @@ export function adjustEntryPointAuthorization(entryPointSig: string): string {
 export function getAuthorizationHash(chainId: bigint, contractAddr: Hex, nonce: bigint): Hex {
   return keccak256(
     concat([
-      '0x05', // magic authrorization string
+      '0x05', // magic authorization string
       encodeRlp([
         // zeros are empty bytes in rlp encoding
         chainId !== 0n ? toBeHex(chainId) : '0x',


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the `src/libs/signMessage/signMessage.ts` file. Specifically, it fixes the spelling of "messages" in a comment and "authorization" in a magic string comment. These changes improve code readability and maintain consistency in naming conventions. No functional changes have been made to the code.
