### PR TITLE
UX/ Swap state consistency, UI responsiveness and error handling

### DIFF
--- a/src/classes/SwapAndBridgeProviderApiError.ts
+++ b/src/classes/SwapAndBridgeProviderApiError.ts
@@ -1,7 +1,10 @@
 export default class SwapAndBridgeProviderApiError extends Error {
-  constructor(message: string) {
+  shortMessage?: string
+
+  constructor(message: string, shortMessage?: string) {
     super()
     this.name = 'SwapAndBridgeProviderApiError'
     this.message = message
+    this.shortMessage = shortMessage
   }
 }

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -220,6 +220,16 @@ export class SwapAndBridgeController extends EventEmitter {
 
   #providers: ProvidersController
 
+  /**
+   * A possibly outdated instance of the SignAccountOpController. Please always
+   * read the public getter `signAccountOpController` to get the up-to-date
+   * instance. If updating a route consists of:
+   * QUOTE FETCH -> ROUTE START -> ROUTE ESTIMATION
+   *
+   * This instance may be outdated during QUOTE FETCH -> ROUTE START
+   * The reason is that the controller is not immediately destroyed after the
+   * form changes, but instead is being updated after the route is started.
+   */
   #signAccountOpController: SignAccountOpController | null = null
 
   #portfolioUpdate: Function
@@ -389,6 +399,10 @@ export class SwapAndBridgeController extends EventEmitter {
     )
   }
 
+  /**
+   * Returns an instance of the SignAccountOpController that is ALWAYS up-to-date with the current
+   * quote and the current form state.
+   */
   get signAccountOpController() {
     const controllerFromQuoteId = this.#signAccountOpController?.accountOp.meta?.fromQuoteId
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1395,6 +1395,7 @@ export class SwapAndBridgeController extends EventEmitter {
       if (this.quote || this.quoteRoutesStatuses) {
         this.quote = null
         this.quoteRoutesStatuses = {}
+        this.updateQuoteStatus = 'INITIAL'
         this.#emitUpdateIfNeeded()
       }
       return

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1477,7 +1477,11 @@ export class SwapAndBridgeController extends EventEmitter {
 
       // Display the error in the UI only if it has a shortMessage
       // as we don't have much space and there is a default error message
-      if ('shortMessage' in humanizedError && humanizedError.shortMessage) {
+      if (
+        'shortMessage' in humanizedError &&
+        humanizedError.shortMessage &&
+        typeof humanizedError.shortMessage === 'string'
+      ) {
         return {
           success: false,
           id: 'no-routes',

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1477,6 +1477,8 @@ export class SwapAndBridgeController extends EventEmitter {
     } catch (error: any) {
       const humanizedError = getHumanReadableSwapAndBridgeError(error)
 
+      // Display the error in the UI only if it has a shortMessage
+      // as we don't have much space and there is a default error message
       if ('shortMessage' in humanizedError && humanizedError.shortMessage) {
         return {
           success: false,

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1420,8 +1420,6 @@ export class SwapAndBridgeController extends EventEmitter {
       return
     }
 
-    // @TODO: Consider if we want to display a skeleton loader if updateQuote is called
-    // by the interval
     if (!skipStatusUpdate) {
       this.updateQuoteStatus = 'LOADING'
       this.removeError('no-routes')

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -1,9 +1,9 @@
 import { AbiCoder, getBytes, Interface, keccak256, toBeHex } from 'ethers'
 
-import { SINGLETON } from '../../consts/deploy'
-import { AccountId } from '../../interfaces/account'
 // eslint-disable-next-line import/no-cycle
 import { EIP7702Auth } from '../../consts/7702'
+import { SINGLETON } from '../../consts/deploy'
+import { AccountId } from '../../interfaces/account'
 import { Key } from '../../interfaces/keystore'
 import { SwapAndBridgeSendTxRequest } from '../../interfaces/swapAndBridge'
 import { PaymasterService } from '../erc7677/types'
@@ -76,6 +76,8 @@ export interface AccountOp {
     walletSendCallsVersion?: string
     delegation?: EIP7702Auth
     setDelegation?: boolean
+    /** Used to determine if the account op is up-to-date with the latest quote */
+    fromQuoteId?: string
   }
   flags?: {
     hideActivityBanner?: boolean

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -1,10 +1,10 @@
 import {
   ExtendedChain as LiFiExtendedChain,
-  Step as LiFiIncludedStep,
+  LiFiStep,
   Route as LiFiRoute,
   RoutesResponse as LiFiRoutesResponse,
   StatusResponse as LiFiRouteStatusResponse,
-  LiFiStep,
+  Step as LiFiIncludedStep,
   Token as LiFiToken,
   TokensResponse as LiFiTokensResponse
 } from '@lifi/types'
@@ -33,6 +33,7 @@ import {
 } from '../../libs/swapAndBridge/swapAndBridge'
 import { FEE_PERCENT, ZERO_ADDRESS } from '../socket/constants'
 import { MAYAN_BRIDGE } from './consts'
+import { getHumanReadableErrorMessage } from './helpers'
 
 const normalizeLiFiTokenToSwapAndBridgeToToken = (
   token: LiFiToken,
@@ -285,8 +286,14 @@ export class LiFiAPI {
     }
 
     if (!response.ok) {
-      const message = JSON.stringify(responseBody)
-      const error = `${errorPrefix} Our service provider upstream error: <${message}>`
+      const humanizedMessage = getHumanReadableErrorMessage(errorPrefix, responseBody)
+
+      if (humanizedMessage) {
+        throw new SwapAndBridgeProviderApiError(humanizedMessage)
+      }
+
+      const fallbackMessage = JSON.stringify(responseBody)
+      const error = `${errorPrefix} Our service provider upstream error: <${fallbackMessage}>`
       throw new SwapAndBridgeProviderApiError(error)
     }
 

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -272,8 +272,9 @@ export class LiFiAPI {
     }
 
     if (response.status === 429) {
-      const error = `Our service provider received too many requests, temporarily preventing your request from being processed. ${errorPrefix}`
-      throw new SwapAndBridgeProviderApiError(error)
+      const error =
+        'Our service provider received too many requests, temporarily preventing your request from being processed.'
+      throw new SwapAndBridgeProviderApiError(error, 'Too many requests')
     }
 
     let responseBody: T

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -274,7 +274,7 @@ export class LiFiAPI {
     if (response.status === 429) {
       const error =
         'Our service provider received too many requests, temporarily preventing your request from being processed.'
-      throw new SwapAndBridgeProviderApiError(error, 'Too many requests')
+      throw new SwapAndBridgeProviderApiError(error, 'Rate limit reached, try again later.')
     }
 
     let responseBody: T

--- a/src/services/lifi/consts.ts
+++ b/src/services/lifi/consts.ts
@@ -1,1 +1,11 @@
+import { ErrorHumanizerError } from '../../libs/errorHumanizer/types'
+
 export const MAYAN_BRIDGE = 'mayan'
+
+export const HUMANIZED_ERRORS: ErrorHumanizerError[] = [
+  {
+    reasons: ['could not find token'],
+    message:
+      'The token you are trying to swap is not supported by our service provider. Please select another token.'
+  }
+]

--- a/src/services/lifi/helpers.ts
+++ b/src/services/lifi/helpers.ts
@@ -1,0 +1,51 @@
+import { HUMANIZED_ERRORS } from './consts'
+
+export const getHumanReadableErrorMessage = (
+  errorPrefix: string,
+  error?: unknown
+): string | null => {
+  // The code should be safe but we must ensure that humanizing errors
+  // does not throw an error itself
+  try {
+    if (!error || typeof error !== 'object' || !('message' in error)) {
+      return null
+    }
+
+    const checkAgainst = error?.message
+
+    let message = null
+
+    if (checkAgainst && typeof checkAgainst === 'string') {
+      HUMANIZED_ERRORS.forEach((humanizedError) => {
+        const { isExactMatch } = humanizedError
+
+        const isMatching = humanizedError.reasons.some((errorReason) => {
+          const lowerCaseReason = errorReason.toLowerCase()
+          const lowerCaseCheckAgainst = checkAgainst.toLowerCase()
+
+          if (isExactMatch) {
+            // Try a simple equality check first
+            if (lowerCaseCheckAgainst === lowerCaseReason) return true
+
+            // Split checkAgainst by spaces and check if any of the parts
+            // match the lowerCaseReason
+            const splitCheckAgainst = checkAgainst.split(' ')
+
+            return splitCheckAgainst.some((part) => part.toLowerCase() === lowerCaseReason)
+          }
+
+          return lowerCaseCheckAgainst.includes(lowerCaseReason)
+        })
+        if (!isMatching) return
+
+        message = humanizedError.message
+      })
+    }
+
+    return message
+  } catch (e) {
+    console.error('Error while getting human readable error message in lifi.ts:', e)
+
+    return null
+  }
+}


### PR DESCRIPTION
## Fixes:
### Old promises affect the new state:
We run a bunch of promises when fetching the quote/estimating the route. If the changes the properties of a swap while it's being fetched/estimated, the new swap SHOULD NOT be affected by the old promises. This is done using multiple techniques:
1. There are two `signAccountOpController` variables - a private one that may be outdated and a public one that is always up to date. This is done to prevent the split second in which there is a quote and the old `signAccountOp` estimation's status is `success` - during this split-second, the status of the swap and bridge controller is `ReadyToSubmit`, while it should be `ReadyToEstimate`
2. `updateQuoteId` is checked during estimation, too - this fixes another split-second window caused by the quote fetch debounce
3. Other minor changes you can see in the diff
Before:
![image](https://github.com/user-attachments/assets/7be67c7b-b21e-4635-b10a-2c6b7f9e4f57)
### No error when the user hits rate limits
After:
![image](https://github.com/user-attachments/assets/9a020fcb-8d0d-431c-9123-07adb53009ba)
### Unsupported token error not humanised

Before:
![image](https://github.com/user-attachments/assets/34f4f3da-438b-4273-b495-f85642492f85)
After:
![image](https://github.com/user-attachments/assets/0bff9960-bb20-4b62-a3a9-da019e0391cd)
