### PR TITLE
Fix/ Error reason is displayed twice for estimation errors

### DIFF
--- a/src/libs/errorDecoder/helpers.ts
+++ b/src/libs/errorDecoder/helpers.ts
@@ -77,10 +77,14 @@ const formatReason = (reason: string): string => {
   }
 }
 
-const getErrorCodeStringFromReason = (reason?: string, withSpace = true): string => {
+const truncateReason = (reason?: string): string => {
   if (!reason || !isReasonValid(reason)) return ''
 
-  const truncatedReason = reason.length > 100 ? `${reason.slice(0, 100)}...` : reason
+  return reason.length > 100 ? `${reason.slice(0, 100)}...` : reason
+}
+
+const getErrorCodeStringFromReason = (reason?: string, withSpace = true): string => {
+  const truncatedReason = truncateReason(reason)
 
   return `${withSpace ? ' ' : ''}Error code: ${truncatedReason}`
 }
@@ -112,5 +116,6 @@ export {
   isReasonValid,
   getDataFromError,
   formatReason,
-  countUnicodeLettersAndNumbers
+  countUnicodeLettersAndNumbers,
+  truncateReason
 }

--- a/src/libs/errorDecoder/helpers.ts
+++ b/src/libs/errorDecoder/helpers.ts
@@ -86,6 +86,8 @@ const truncateReason = (reason?: string): string => {
 const getErrorCodeStringFromReason = (reason?: string, withSpace = true): string => {
   const truncatedReason = truncateReason(reason)
 
+  if (!truncatedReason) return ''
+
   return `${withSpace ? ' ' : ''}Error code: ${truncatedReason}`
 }
 

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
@@ -71,9 +71,9 @@ describe('Estimation errors are humanized', () => {
 
     const humanizedError = getHumanReadableEstimationError(error)
 
-    expect(humanizedError.message).toBe(
-      `${MESSAGE_PREFIX} it will revert onchain. Error code: 0x12345678`
-    )
+    // NOTE: The error reason MUST NOT be included in the message.
+    // This is estimation specific - the reason is displayed separately
+    expect(humanizedError.message).toBe(`${MESSAGE_PREFIX} it will revert onchain.`)
     expect(humanizedError.isFallbackMessage).toBe(true)
     expect(humanizedError.cause).toBe('0x12345678')
   })

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.ts
@@ -50,7 +50,8 @@ export function getHumanReadableEstimationError(e: Error | DecodedError) {
       decodedError.reason,
       MESSAGE_PREFIX,
       LAST_RESORT_ERROR_MESSAGE,
-      e
+      e,
+      false
     )
   }
 

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.ts
@@ -1,3 +1,5 @@
+import { truncateReason } from 'libs/errorDecoder/helpers'
+
 import EmittableError from '../../classes/EmittableError'
 import ErrorHumanizerError from '../../classes/ErrorHumanizerError'
 import ExternalSignerError from '../../classes/ExternalSignerError'
@@ -56,7 +58,7 @@ export function getHumanReadableEstimationError(e: Error | DecodedError) {
   }
 
   return new ErrorHumanizerError(errorMessage, {
-    cause: decodedError.reason,
+    cause: decodedError.reason || (e instanceof Error ? truncateReason(e?.message) : ''),
     isFallbackMessage
   })
 }

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.ts
@@ -1,9 +1,8 @@
-import { truncateReason } from 'libs/errorDecoder/helpers'
-
 import EmittableError from '../../classes/EmittableError'
 import ErrorHumanizerError from '../../classes/ErrorHumanizerError'
 import ExternalSignerError from '../../classes/ExternalSignerError'
 import { decodeError } from '../errorDecoder'
+import { truncateReason } from '../errorDecoder/helpers'
 import { DecodedError } from '../errorDecoder/types'
 import { ESTIMATION_ERRORS, noPrefixReasons } from './errors'
 import { getGenericMessageFromType, getHumanReadableErrorMessage } from './helpers'

--- a/src/libs/errorHumanizer/helpers.test.ts
+++ b/src/libs/errorHumanizer/helpers.test.ts
@@ -105,6 +105,7 @@ describe('Generic error fallbacks work', () => {
       'The contract reverted',
       MESSAGE_PREFIX,
       '',
+      new Error('The contract reverted'),
       false
     )
 

--- a/src/libs/errorHumanizer/helpers.test.ts
+++ b/src/libs/errorHumanizer/helpers.test.ts
@@ -99,4 +99,15 @@ describe('Generic error fallbacks work', () => {
       'We encountered an unexpected issue: Servers stop working between 2AM and 8AM\nPlease try again or contact Ambire support for assistance.'
     )
   })
+  it('Error reason is not included in the message if withReason is false', () => {
+    const message = getGenericMessageFromType(
+      ErrorType.InnerCallFailureError,
+      'The contract reverted',
+      MESSAGE_PREFIX,
+      '',
+      false
+    )
+
+    expect(message).toBe(`${MESSAGE_PREFIX} it will revert onchain.`)
+  })
 })

--- a/src/libs/errorHumanizer/helpers.ts
+++ b/src/libs/errorHumanizer/helpers.ts
@@ -13,11 +13,17 @@ function getGenericMessageFromType(
   reason: DecodedError['reason'],
   messagePrefix: string,
   lastResortMessage: string,
-  originalError?: any
+  originalError?: any,
+  // Whether to include the reason in the message. This is needed
+  // for estimation errors where the reason is displayed separately
+  // and we don't want to repeat it in the message.
+  withReason = true
 ): string {
-  const messageSuffixNoSupport = getErrorCodeStringFromReason(
-    reason || originalError?.message || originalError?.error?.message || ''
-  )
+  const messageSuffixNoSupport = withReason
+    ? getErrorCodeStringFromReason(
+        reason || originalError?.message || originalError?.error?.message || ''
+      )
+    : ''
   const messageSuffix = `${messageSuffixNoSupport}\nPlease try again or contact Ambire support for assistance.`
   const origin = errorType?.split('Error')?.[0] || ''
 

--- a/src/libs/errorHumanizer/humanizeCommonCases.test.ts
+++ b/src/libs/errorHumanizer/humanizeCommonCases.test.ts
@@ -3,6 +3,7 @@ import { ethers } from 'hardhat'
 
 import { describe, expect } from '@jest/globals'
 
+import { suppressConsole } from '../../../test/helpers/console'
 import { decodeError } from '../errorDecoder'
 import { DecodedError, ErrorType } from '../errorDecoder/types'
 import { RELAYER_DOWN_MESSAGE, RelayerError } from '../relayerCall/relayerCall'
@@ -46,12 +47,14 @@ describe('Estimation/Broadcast common errors are humanized', () => {
     )
   })
   it('Paymaster deposit too low', async () => {
+    const consoleSuppressor = suppressConsole()
     const error = new MockBundlerError('paymaster deposit too low')
 
     const decodedError = decodeError(error)
     const message = humanizeEstimationOrBroadcastError(decodedError, MESSAGE_PREFIX, error)
 
     expect(message).toBe(`${MESSAGE_PREFIX} ${insufficientPaymasterFunds}`)
+    consoleSuppressor.restore()
   })
   it('Insufficient funds for gas', async () => {
     try {


### PR DESCRIPTION
The degradation comes from https://github.com/AmbireTech/ambire-common/pull/1520/files. I don't know what I was thinking when making some of the edits. I added comments that should remind us of the reasons behind our current approach.