### PR TITLE
Fix: Celo chain LiFi

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -38,6 +38,7 @@ import {
   getActiveRoutesForAccount,
   getIsBridgeTxn,
   getIsTokenEligibleForSwapAndBridge,
+  getLiFiTokenAddress,
   getSwapAndBridgeCalls,
   sortPortfolioTokenList,
   sortTokenListResponse
@@ -1212,10 +1213,10 @@ export class SwapAndBridgeController extends EventEmitter {
         const quoteResult = await this.#serviceProviderAPI.quote({
           fromAsset: this.fromSelectedToken,
           fromChainId: this.fromChainId!,
-          fromTokenAddress: this.fromSelectedToken.address,
+          fromTokenAddress: getLiFiTokenAddress(this.fromChainId!, this.fromSelectedToken.address),
           toAsset: this.toSelectedToken,
           toChainId: this.toChainId!,
-          toTokenAddress: this.toSelectedToken.address,
+          toTokenAddress: getLiFiTokenAddress(this.toChainId!, this.toSelectedToken.address),
           fromAmount: bigintFromAmount,
           userAddress: this.#selectedAccount.account.addr,
           isSmartAccount: !isBasicAccount(
@@ -1462,9 +1463,12 @@ export class SwapAndBridgeController extends EventEmitter {
     try {
       const routeResult = await this.#serviceProviderAPI.startRoute({
         fromChainId: this.quote!.fromChainId,
-        fromAssetAddress: this.quote!.fromAsset.address,
+        fromAssetAddress: getLiFiTokenAddress(
+          this.quote!.fromChainId,
+          this.quote!.fromAsset.address
+        ),
         toChainId: this.quote!.toChainId,
-        toAssetAddress: this.quote!.toAsset.address,
+        toAssetAddress: getLiFiTokenAddress(this.quote!.toChainId, this.quote!.toAsset.address),
         route: this.quote!.selectedRoute
       })
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -38,7 +38,6 @@ import {
   getActiveRoutesForAccount,
   getIsBridgeTxn,
   getIsTokenEligibleForSwapAndBridge,
-  getLiFiTokenAddress,
   getSwapAndBridgeCalls,
   sortPortfolioTokenList,
   sortTokenListResponse
@@ -1213,10 +1212,10 @@ export class SwapAndBridgeController extends EventEmitter {
         const quoteResult = await this.#serviceProviderAPI.quote({
           fromAsset: this.fromSelectedToken,
           fromChainId: this.fromChainId!,
-          fromTokenAddress: getLiFiTokenAddress(this.fromChainId!, this.fromSelectedToken.address),
+          fromTokenAddress: this.fromSelectedToken.address,
           toAsset: this.toSelectedToken,
           toChainId: this.toChainId!,
-          toTokenAddress: getLiFiTokenAddress(this.toChainId!, this.toSelectedToken.address),
+          toTokenAddress: this.toSelectedToken.address,
           fromAmount: bigintFromAmount,
           userAddress: this.#selectedAccount.account.addr,
           isSmartAccount: !isBasicAccount(
@@ -1463,12 +1462,9 @@ export class SwapAndBridgeController extends EventEmitter {
     try {
       const routeResult = await this.#serviceProviderAPI.startRoute({
         fromChainId: this.quote!.fromChainId,
-        fromAssetAddress: getLiFiTokenAddress(
-          this.quote!.fromChainId,
-          this.quote!.fromAsset.address
-        ),
+        fromAssetAddress: this.quote!.fromAsset.address,
         toChainId: this.quote!.toChainId,
-        toAssetAddress: getLiFiTokenAddress(this.quote!.toChainId, this.quote!.toAsset.address),
+        toAssetAddress: this.quote!.toAsset.address,
         route: this.quote!.selectedRoute
       })
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -39,6 +39,7 @@ import {
   getIsBridgeTxn,
   getIsTokenEligibleForSwapAndBridge,
   getSwapAndBridgeCalls,
+  lifiTokenListFilter,
   sortPortfolioTokenList,
   sortTokenListResponse
 } from '../../libs/swapAndBridge/swapAndBridge'
@@ -926,6 +927,11 @@ export class SwapAndBridgeController extends EventEmitter {
       [...toTokenList, ...additionalTokensFromPortfolio],
       this.portfolioTokenList.filter((t) => t.chainId === toTokenNetwork.chainId)
     )
+
+    // if the provider is lifi, filter out tokens that are not supported by it
+    if (this.#serviceProviderAPI.id === 'lifi') {
+      this.#toTokenList = this.#toTokenList.filter(lifiTokenListFilter)
+    }
 
     if (!this.toSelectedToken) {
       if (addressToSelect) {

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -357,6 +357,11 @@ const lifiMapTokenAddr = (chainId: number, tokenAddr: string) => {
   return '0x471EcE3750Da237f93B8E339c536989b8978a438'
 }
 
+const lifiTokenListFilter = (t: SwapAndBridgeToToken) => {
+  // disabled tokens, this one is CELO as an addr on CELO chain (exists as native)
+  return !(t.chainId === 42220 && t.address === '0x471EcE3750Da237f93B8E339c536989b8978a438')
+}
+
 export {
   addCustomTokensIfNeeded,
   buildSwapAndBridgeUserRequests,
@@ -364,5 +369,6 @@ export {
   getActiveRoutesLowestServiceTime,
   getActiveRoutesUpdateInterval,
   getSwapAndBridgeCalls,
-  lifiMapTokenAddr
+  lifiMapTokenAddr,
+  lifiTokenListFilter
 }

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -349,7 +349,7 @@ const addCustomTokensIfNeeded = ({
 // the celo native token is at an address 0x471EcE3750Da237f93B8E339c536989b8978a438
 // and LiFi doesn't work if we pass address 0 for this. We map it only for
 // lifi to make the swap work in this case
-const getLiFiTokenAddress = (chainId: number, tokenAddr: string) => {
+const lifiMapTokenAddr = (chainId: number, tokenAddr: string) => {
   if (tokenAddr !== ZeroAddress) return tokenAddr
   // celo chain
   if (chainId !== 42220) return tokenAddr
@@ -363,6 +363,6 @@ export {
   getActiveRoutesForAccount,
   getActiveRoutesLowestServiceTime,
   getActiveRoutesUpdateInterval,
-  getLiFiTokenAddress,
-  getSwapAndBridgeCalls
+  getSwapAndBridgeCalls,
+  lifiMapTokenAddr
 }

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -346,11 +346,23 @@ const addCustomTokensIfNeeded = ({
   return newTokens
 }
 
+// the celo native token is at an address 0x471EcE3750Da237f93B8E339c536989b8978a438
+// and LiFi doesn't work if we pass address 0 for this. We map it only for
+// lifi to make the swap work in this case
+const getLiFiTokenAddress = (chainId: number, tokenAddr: string) => {
+  if (tokenAddr !== ZeroAddress) return tokenAddr
+  // celo chain
+  if (chainId !== 42220) return tokenAddr
+
+  return '0x471EcE3750Da237f93B8E339c536989b8978a438'
+}
+
 export {
   addCustomTokensIfNeeded,
   buildSwapAndBridgeUserRequests,
   getActiveRoutesForAccount,
   getActiveRoutesLowestServiceTime,
   getActiveRoutesUpdateInterval,
+  getLiFiTokenAddress,
   getSwapAndBridgeCalls
 }

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -1,10 +1,10 @@
 import {
   ExtendedChain as LiFiExtendedChain,
-  LiFiStep,
+  Step as LiFiIncludedStep,
   Route as LiFiRoute,
   RoutesResponse as LiFiRoutesResponse,
   StatusResponse as LiFiRouteStatusResponse,
-  Step as LiFiIncludedStep,
+  LiFiStep,
   Token as LiFiToken,
   TokensResponse as LiFiTokensResponse
 } from '@lifi/types'
@@ -29,6 +29,7 @@ import {
   addCustomTokensIfNeeded,
   attemptToSortTokensByMarketCap,
   convertPortfolioTokenToSwapAndBridgeToToken,
+  lifiMapTokenAddr,
   sortNativeTokenFirst
 } from '../../libs/swapAndBridge/swapAndBridge'
 import { FEE_PERCENT, ZERO_ADDRESS } from '../socket/constants'
@@ -41,7 +42,14 @@ const normalizeLiFiTokenToSwapAndBridgeToToken = (
 ): SwapAndBridgeToToken => {
   const { name, address, decimals, symbol, logoURI: icon } = token
 
-  return { name, address, decimals, symbol, icon, chainId: toChainId }
+  return {
+    name,
+    address: lifiMapTokenAddr(toChainId, address),
+    decimals,
+    symbol,
+    icon,
+    chainId: toChainId
+  }
 }
 
 const normalizeLiFiStepToSwapAndBridgeStep = (parentStep: LiFiStep): SwapAndBridgeStep[] => {
@@ -408,9 +416,9 @@ export class LiFiAPI {
     const body = {
       fromChainId: fromChainId.toString(),
       fromAmount: fromAmount.toString(),
-      fromTokenAddress,
+      fromTokenAddress: lifiMapTokenAddr(fromChainId, fromTokenAddress),
       toChainId: toChainId.toString(),
-      toTokenAddress,
+      toTokenAddress: lifiMapTokenAddr(toChainId, toTokenAddress),
       fromAddress: userAddress,
       toAddress: userAddress,
       options: {


### PR DESCRIPTION
Fix: LiFi doesn't work on Celo with the chain's native token as it expects another address than addr 0. So we map it