### PR TITLE
Fix/ Incorrect usd -> amount conversion in swap and transfer

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -655,7 +655,7 @@ export class SwapAndBridgeController extends EventEmitter {
           this.fromAmountInFiat = fromAmount
 
           // Get the number of decimals
-          const amountInFiatDecimals = fromAmount.split('.')[1]?.length || 0
+          const amountInFiatDecimals = 10
           const { tokenPriceBigInt, tokenPriceDecimals } = convertTokenPriceToBigInt(tokenPrice)
 
           // Convert the numbers to big int

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -2,33 +2,33 @@ import { formatUnits, isAddress, parseUnits } from 'ethers'
 
 import { FEE_COLLECTOR } from '../../consts/addresses'
 import { AddressState } from '../../interfaces/domains'
+import { ExternalSignerControllers } from '../../interfaces/keystore'
 import { TransferUpdate } from '../../interfaces/transfer'
 import { isSmartAccount } from '../../libs/account/account'
+import { getBaseAccount } from '../../libs/account/getBaseAccount'
+import { AccountOp } from '../../libs/accountOp/accountOp'
+import { Call } from '../../libs/accountOp/types'
+import { getAmbirePaymasterService } from '../../libs/erc7677/erc7677'
 import { HumanizerMeta } from '../../libs/humanizer/interfaces'
+import { randomId } from '../../libs/humanizer/utils'
 import { TokenResult } from '../../libs/portfolio'
 import { getTokenAmount } from '../../libs/portfolio/helpers'
 import { getSanitizedAmount } from '../../libs/transfer/amount'
+import { buildTransferUserRequest } from '../../libs/transfer/userRequest'
 import { validateSendTransferAddress, validateSendTransferAmount } from '../../services/validations'
+import { getAddressFromAddressState } from '../../utils/domains'
 import { convertTokenPriceToBigInt } from '../../utils/numbers/formatters'
+import wait from '../../utils/wait'
+import { AccountsController } from '../accounts/accounts'
 import { AddressBookController } from '../addressBook/addressBook'
+import { EstimationStatus } from '../estimation/types'
 import EventEmitter from '../eventEmitter/eventEmitter'
+import { KeystoreController } from '../keystore/keystore'
+import { NetworksController } from '../networks/networks'
+import { PortfolioController } from '../portfolio/portfolio'
+import { ProvidersController } from '../providers/providers'
 import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 import { SignAccountOpController } from '../signAccountOp/signAccountOp'
-import { randomId } from '../../libs/humanizer/utils'
-import { AccountsController } from '../accounts/accounts'
-import { KeystoreController } from '../keystore/keystore'
-import { PortfolioController } from '../portfolio/portfolio'
-import { ExternalSignerControllers } from '../../interfaces/keystore'
-import { ProvidersController } from '../providers/providers'
-import { NetworksController } from '../networks/networks'
-import { buildTransferUserRequest } from '../../libs/transfer/userRequest'
-import { Call } from '../../libs/accountOp/types'
-import { getAddressFromAddressState } from '../../utils/domains'
-import { getBaseAccount } from '../../libs/account/getBaseAccount'
-import { getAmbirePaymasterService } from '../../libs/erc7677/erc7677'
-import { EstimationStatus } from '../estimation/types'
-import wait from '../../utils/wait'
-import { AccountOp } from '../../libs/accountOp/accountOp'
 import { StorageController } from '../storage/storage'
 
 const CONVERSION_PRECISION = 16
@@ -446,7 +446,7 @@ export class TransferController extends EventEmitter {
       this.amountInFiat = fieldValue
 
       // Get the number of decimals
-      const amountInFiatDecimals = fieldValue.split('.')[1]?.length || 0
+      const amountInFiatDecimals = 10
       const { tokenPriceBigInt, tokenPriceDecimals } = convertTokenPriceToBigInt(tokenPrice)
 
       // Convert the numbers to big int


### PR DESCRIPTION
## How to reproduce:
1. Import 0xf443Bb657f9BE2A22BFa6522C4406700c23A97b4
2. Select 0xf443Bb657f9BE2A22BFa6522C4406700c23A97b4
3. Open the dashboard, click on ADX-Staking, and then click on Send
4. Switch to USD mode
5. Input 1 USD
6. Add an arbitrary number of decimals, e.g. `1.000`
7. The converted token amount shouldn't change (test in v2, it does)

Closes https://github.com/AmbireTech/ambire-app/issues/4880