### PR TITLE
Fix / Arc Browser Action Window Focus

### DIFF
--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -124,6 +124,9 @@ export class ActionsController extends EventEmitter {
     this.#onActionWindowClose = onActionWindowClose
 
     this.#windowManager.event.on('windowRemoved', async (winId: number) => {
+      // When windowManager.focus is called, it may close and reopen the action window as part of its fallback logic.
+      // To avoid prematurely running the cleanup logic during that transition, we wait for focusWindowPromise to resolve.
+      await this.actionWindow.focusWindowPromise
       if (
         winId === this.actionWindow.windowProps?.id ||
         (!this.visibleActionsQueue.length && this.currentAction && this.actionWindow.windowProps)

--- a/src/controllers/defiPositions/defiPositions.ts
+++ b/src/controllers/defiPositions/defiPositions.ts
@@ -281,7 +281,8 @@ export class DefiPositionsController extends EventEmitter {
     let debankPositions: PositionsByProvider[] = []
 
     try {
-      const resp = await this.#fetch(`https://cena.ambire.com/api/v3/defi/${selectedAccountAddr}`)
+      const defiUrl = `https://cena.ambire.com/api/v3/defi/${selectedAccountAddr}`
+      const resp = await this.#fetch(defiUrl)
       const body = await resp.json()
       if (resp.status !== 200 || body?.message || body?.error) throw body
 


### PR DESCRIPTION
* On the Arc browser, it seems like there’s either a bug or an intentional restriction that prevents extensions from programmatically focusing existing windows. So if an action window is minimized or out of focus, we can’t bring it back to the front. As a workaround, we’ll need to implement fallback logic for Arc that closes the current action window and reopens it instead.