### PR TITLE
Fix/ Rejecting an account op from a banner opens an action window

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -2328,7 +2328,9 @@ export class MainController extends EventEmitter {
       .filter((call) => !!call.fromUserRequestId)
       .map((call) => call.fromUserRequestId)
 
-    await this.rejectUserRequests(err, requestIdsToRemove as string[])
+    await this.rejectUserRequests(err, requestIdsToRemove as string[], {
+      shouldOpenNextRequest: shouldOpenNextAction
+    })
 
     this.emitUpdate()
   }

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -277,7 +277,8 @@ export const getAccountOpBanners = ({
                 actionName: 'reject-accountOp',
                 meta: {
                   err: 'User rejected the transaction request.',
-                  actionId: actions[0].id
+                  actionId: actions[0].id,
+                  shouldOpenNextAction: false
                 }
               }
             : undefined,


### PR DESCRIPTION
## How to reproduce:
1. Select a BA
2. Open send and batch a request on network A
3. Add one more request, but on a different network
4. Open the dashboard
5. Reject either request
6. An action window shouldn't open