### PR TITLE
UX/ Display an appropriate error if the user input is outside of a token's valid range

### DIFF
--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -135,6 +135,14 @@ const validateSendTransferAmount = (
   }
 
   if (!(sanitizedAmount && Number(sanitizedAmount) > 0)) {
+    // The user has entered an amount that is outside of the valid range.
+    if (Number(amount) > 0) {
+      return {
+        success: false,
+        message: `The amount must be greater than 0.${'0'.repeat(selectedAsset.decimals - 1)}1`
+      }
+    }
+
     return {
       success: false,
       message: 'The amount must be greater than 0.'

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -136,10 +136,10 @@ const validateSendTransferAmount = (
 
   if (!(sanitizedAmount && Number(sanitizedAmount) > 0)) {
     // The user has entered an amount that is outside of the valid range.
-    if (Number(amount) > 0) {
+    if (Number(amount) > 0 && selectedAsset.decimals && selectedAsset.decimals > 0) {
       return {
         success: false,
-        message: `The amount must be greater than 0.${'0'.repeat(selectedAsset.decimals - 1)}1`
+        message: `The amount must be greater than 0.${'0'.repeat(selectedAsset.decimals - 1)}1.`
       }
     }
 


### PR DESCRIPTION
If you input `0` or `0.000` the regular message is displayed. If you input `0.0000001` and the token is USDT the new message is displayed.

Closes https://github.com/AmbireTech/ambire-app/issues/4772