### PR TITLE
Swap&Bridge retry mechanism

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -40,6 +40,7 @@ import {
   getIsTokenEligibleForSwapAndBridge,
   getSwapAndBridgeCalls,
   lifiTokenListFilter,
+  mapNativeToAddr,
   sortPortfolioTokenList,
   sortTokenListResponse
 } from '../../libs/swapAndBridge/swapAndBridge'
@@ -611,9 +612,16 @@ export class SwapAndBridgeController extends EventEmitter {
       fromAmountFieldMode,
       fromSelectedToken,
       toChainId,
-      toSelectedTokenAddr,
       routePriority
     } = props
+
+    // map the token back
+    const chainId = toChainId ?? this.toChainId
+    const toSelectedTokenAddr =
+      chainId && props.toSelectedTokenAddr
+        ? mapNativeToAddr(this.#serviceProviderAPI.id, Number(chainId), props.toSelectedTokenAddr)
+        : undefined
+
     const { emitUpdate = true, updateQuote = true } = updateProps || {}
     let shouldUpdateToTokenList = false
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -483,9 +483,11 @@ export class SwapAndBridgeController extends EventEmitter {
     sessionId: string,
     params?: {
       preselectedFromToken?: Pick<TokenResult, 'address' | 'chainId'>
+      preselectedToToken?: Pick<TokenResult, 'address' | 'chainId'>
+      fromAmount?: string
     }
   ) {
-    const { preselectedFromToken } = params || {}
+    const { preselectedFromToken, preselectedToToken, fromAmount } = params || {}
     await this.#initialLoadPromise
 
     if (this.sessionIds.includes(sessionId)) return
@@ -519,7 +521,9 @@ export class SwapAndBridgeController extends EventEmitter {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.#serviceProviderAPI.updateHealth()
     await this.updatePortfolioTokenList(this.#selectedAccount.portfolio.tokens, {
-      preselectedToken: preselectedFromToken
+      preselectedToken: preselectedFromToken,
+      preselectedToToken,
+      fromAmount
     })
     this.isTokenListLoading = false
     // Do not await on purpose as it's not critical for the controller state to be ready
@@ -621,6 +625,9 @@ export class SwapAndBridgeController extends EventEmitter {
       chainId && props.toSelectedTokenAddr
         ? mapNativeToAddr(this.#serviceProviderAPI.id, Number(chainId), props.toSelectedTokenAddr)
         : undefined
+    // when we init the form by using the retry button
+    const shouldNotResetFromAmount =
+      fromAmount && props.toSelectedTokenAddr && fromSelectedToken && toChainId
 
     const { emitUpdate = true, updateQuote = true } = updateProps || {}
     let shouldUpdateToTokenList = false
@@ -722,7 +729,8 @@ export class SwapAndBridgeController extends EventEmitter {
       }
 
       const shouldResetFromTokenAmount =
-        isFromNetworkChanged || this.fromSelectedToken?.address !== fromSelectedToken.address
+        !shouldNotResetFromAmount &&
+        (isFromNetworkChanged || this.fromSelectedToken?.address !== fromSelectedToken.address)
       if (shouldResetFromTokenAmount) {
         this.fromAmount = ''
         this.fromAmountInFiat = ''
@@ -757,7 +765,10 @@ export class SwapAndBridgeController extends EventEmitter {
     if (emitUpdate) this.#emitUpdateIfNeeded()
 
     await Promise.all([
-      shouldUpdateToTokenList ? this.updateToTokenList(true, nextToToken?.address) : undefined,
+      shouldUpdateToTokenList
+        ? // we put toSelectedTokenAddr so that "retry" btn functionality works
+          this.updateToTokenList(true, nextToToken?.address || toSelectedTokenAddr)
+        : undefined,
       updateQuote ? this.updateQuote({ debounce: true }) : undefined
     ])
   }
@@ -797,9 +808,11 @@ export class SwapAndBridgeController extends EventEmitter {
     nextPortfolioTokenList: TokenResult[],
     params?: {
       preselectedToken?: Pick<TokenResult, 'address' | 'chainId'>
+      preselectedToToken?: Pick<TokenResult, 'address' | 'chainId'>
+      fromAmount?: string
     }
   ) {
-    const { preselectedToken } = params || {}
+    const { preselectedToken, preselectedToToken, fromAmount } = params || {}
     const tokens = nextPortfolioTokenList.filter(getIsTokenEligibleForSwapAndBridge)
     this.portfolioTokenList = sortPortfolioTokenList(
       // Filtering out hidden tokens here means: 1) They won't be displayed in
@@ -835,7 +848,10 @@ export class SwapAndBridgeController extends EventEmitter {
     if (!this.fromSelectedToken?.isSwitchedToToken && shouldUpdateFromSelectedToken) {
       await this.updateForm(
         {
-          fromSelectedToken: fromSelectedTokenInNextPortfolio || this.portfolioTokenList[0] || null
+          fromSelectedToken: fromSelectedTokenInNextPortfolio || this.portfolioTokenList[0] || null,
+          toSelectedTokenAddr: preselectedToToken?.address,
+          toChainId: preselectedToToken?.chainId,
+          fromAmount
         },
         {
           emitUpdate: false

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -349,7 +349,7 @@ const addCustomTokensIfNeeded = ({
 // the celo native token is at an address 0x471EcE3750Da237f93B8E339c536989b8978a438
 // and LiFi doesn't work if we pass address 0 for this. We map it only for
 // lifi to make the swap work in this case
-const lifiMapTokenAddr = (chainId: number, tokenAddr: string) => {
+const lifiMapNativeToAddr = (chainId: number, tokenAddr: string) => {
   if (tokenAddr !== ZeroAddress) return tokenAddr
   // celo chain
   if (chainId !== 42220) return tokenAddr
@@ -362,6 +362,23 @@ const lifiTokenListFilter = (t: SwapAndBridgeToToken) => {
   return !(t.chainId === 42220 && t.address === '0x471EcE3750Da237f93B8E339c536989b8978a438')
 }
 
+/**
+ * Map the token address back to native when needed
+ */
+const mapNativeToAddr = (
+  serviceProviderId: 'lifi' | 'socket',
+  chainId: number,
+  tokenAddr: string
+) => {
+  if (serviceProviderId === 'socket') return tokenAddr
+
+  if (chainId !== 42220) return tokenAddr
+
+  if (tokenAddr !== '0x471EcE3750Da237f93B8E339c536989b8978a438') return tokenAddr
+
+  return ZeroAddress
+}
+
 export {
   addCustomTokensIfNeeded,
   buildSwapAndBridgeUserRequests,
@@ -369,6 +386,7 @@ export {
   getActiveRoutesLowestServiceTime,
   getActiveRoutesUpdateInterval,
   getSwapAndBridgeCalls,
-  lifiMapTokenAddr,
-  lifiTokenListFilter
+  lifiMapNativeToAddr,
+  lifiTokenListFilter,
+  mapNativeToAddr
 }

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -29,7 +29,7 @@ import {
   addCustomTokensIfNeeded,
   attemptToSortTokensByMarketCap,
   convertPortfolioTokenToSwapAndBridgeToToken,
-  lifiMapTokenAddr,
+  lifiMapNativeToAddr,
   sortNativeTokenFirst
 } from '../../libs/swapAndBridge/swapAndBridge'
 import { FEE_PERCENT, ZERO_ADDRESS } from '../socket/constants'
@@ -44,7 +44,7 @@ const normalizeLiFiTokenToSwapAndBridgeToToken = (
 
   return {
     name,
-    address: lifiMapTokenAddr(toChainId, address),
+    address: lifiMapNativeToAddr(toChainId, address),
     decimals,
     symbol,
     icon,
@@ -418,9 +418,9 @@ export class LiFiAPI {
     const body = {
       fromChainId: fromChainId.toString(),
       fromAmount: fromAmount.toString(),
-      fromTokenAddress: lifiMapTokenAddr(fromChainId, fromTokenAddress),
+      fromTokenAddress: lifiMapNativeToAddr(fromChainId, fromTokenAddress),
       toChainId: toChainId.toString(),
-      toTokenAddress: lifiMapTokenAddr(toChainId, toTokenAddress),
+      toTokenAddress: lifiMapNativeToAddr(toChainId, toTokenAddress),
       fromAddress: userAddress,
       toAddress: userAddress,
       options: {


### PR DESCRIPTION
When updating the "to token" in the form update, we need to make sure to map it back from the provider to our internal codebase (CELO token on Celo comes as an address from lifi which we've banned, it should be addr 0). The only change needed for the retry mechanism to work on the common side