### PR TITLE
fix(humanzier): ascii call.data module to have treshold for valid bytes

### DIFF
--- a/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
+++ b/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import { toUtf8String, ZeroAddress } from 'ethers'
+import { getBytes, toUtf8String, ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerCallModule, IrCall } from '../../interfaces'
@@ -12,22 +12,34 @@ import {
   getToken
 } from '../../utils'
 
+function tryGetMEssageAsText(msg: string) {
+  const bytes = getBytes(msg)
+  const expectedPortionOfValidChars = 0.9
+  const numberOfValidCharacters = bytes.filter((x) => x >= 0x20 && x <= 0x7e).length
+
+  if (bytes.length * expectedPortionOfValidChars < numberOfValidCharacters) {
+    try {
+      return toUtf8String(msg)
+    } catch (_) {
+      return null
+    }
+  }
+  return null
+}
 export const asciiModule: HumanizerCallModule = (
   accountOp: AccountOp,
   currentIrCalls: IrCall[]
 ) => {
   const newCalls = currentIrCalls.map((call) => {
-    if (call.data === '0x') return call
+    if (!call.data || call.data === '0x') return call
     if (call.fullVisualization && !checkIfUnknownAction(call?.fullVisualization)) return call
     // assuming that if there are only 4 bytes it is probably just contract method call
     // and further logic is irrelevant
     if (call.data.length === '0x12345678'.length) return call
-    let messageAsText
-    try {
-      messageAsText = toUtf8String(call.data)
-    } catch {
-      return call
-    }
+
+    let messageAsText = tryGetMEssageAsText(call.data)
+    if (!messageAsText) return call
+
     const sendNativeHumanization = call.value
       ? [getLabel('and'), getAction('Send'), getToken(ZeroAddress, call.value)]
       : []


### PR DESCRIPTION
If at least 10% of the bytes in the call.data are not valid ascii (characters not between ' ' and '~')

resolves: https://github.com/AmbireTech/ambire-app/issues/4632
with data: `0x2e1a7d4d0000000000000000000000000000000000000000000000000000000000001d5a`

before,  this data resulted in :
![image](https://github.com/user-attachments/assets/ccad1b21-1935-4c9a-b5a4-fcaa7c561954)

after this pr (withdraw is the actual contract call, it has nothing to do with  this module):
![image](https://github.com/user-attachments/assets/2608ed0a-be2b-4a0d-b782-cb9ed377a386)
