### PR TITLE
Fix / Resolve AddChain dapp request on window close

### DIFF
--- a/src/controllers/actions/actions.test.ts
+++ b/src/controllers/actions/actions.test.ts
@@ -185,7 +185,7 @@ describe('Actions Controller', () => {
       selectedAccount: selectedAccountCtrl,
       windowManager,
       notificationManager,
-      onActionWindowClose: () => {}
+      onActionWindowClose: () => Promise.resolve()
     })
     expect(actionsCtrl).toBeDefined()
   })

--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -85,7 +85,7 @@ export class ActionsController extends EventEmitter {
 
   currentAction: Action | null = null
 
-  #onActionWindowClose: () => void
+  #onActionWindowClose: () => Promise<void>
 
   get visibleActionsQueue(): Action[] {
     return this.actionsQueue.filter((a) => {
@@ -129,7 +129,7 @@ export class ActionsController extends EventEmitter {
           message: 'Queued pending transactions are available on your Dashboard.'
         })
       }
-      this.#onActionWindowClose()
+      await this.#onActionWindowClose()
       this.emitUpdate()
     }
   }
@@ -143,7 +143,7 @@ export class ActionsController extends EventEmitter {
     selectedAccount: SelectedAccountController
     windowManager: WindowManager
     notificationManager: NotificationManager
-    onActionWindowClose: () => void
+    onActionWindowClose: () => Promise<void>
   }) {
     super()
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -366,11 +366,27 @@ export class MainController extends EventEmitter {
       selectedAccount: this.selectedAccount,
       windowManager,
       notificationManager,
-      onActionWindowClose: () => {
+      onActionWindowClose: async () => {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const r of this.userRequests) {
+          if (r.action.kind === 'walletAddEthereumChain') {
+            const chainId = r.action.params?.[0]?.chainId
+            console.log('onActionWindowClose', chainId)
+            // eslint-disable-next-line no-continue
+            if (!chainId) continue
+
+            const network = this.networks.networks.find((n) => n.chainId === BigInt(chainId))
+            console.log('onActionWindowClose', network)
+            if (network && !network.disabled) {
+              await this.resolveUserRequest(null, r.id)
+            }
+          }
+        }
+
         const userRequestsToRejectOnWindowClose = this.userRequests.filter(
           (r) => r.action.kind !== 'calls'
         )
-        this.rejectUserRequests(
+        await this.rejectUserRequests(
           ethErrors.provider.userRejectedRequest().message,
           userRequestsToRejectOnWindowClose.map((r) => r.id),
           // If the user closes a window and non-calls user requests exist,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -371,12 +371,10 @@ export class MainController extends EventEmitter {
         for (const r of this.userRequests) {
           if (r.action.kind === 'walletAddEthereumChain') {
             const chainId = r.action.params?.[0]?.chainId
-            console.log('onActionWindowClose', chainId)
             // eslint-disable-next-line no-continue
             if (!chainId) continue
 
             const network = this.networks.networks.find((n) => n.chainId === BigInt(chainId))
-            console.log('onActionWindowClose', network)
             if (network && !network.disabled) {
               await this.resolveUserRequest(null, r.id)
             }

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -95,7 +95,7 @@ const actionsCtrl = new ActionsController({
   selectedAccount: selectedAccountCtrl,
   windowManager,
   notificationManager,
-  onActionWindowClose: () => {}
+  onActionWindowClose: () => Promise.resolve()
 })
 
 const accounts = [

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -89,7 +89,7 @@ const actionsCtrl = new ActionsController({
   selectedAccount: selectedAccountCtrl,
   windowManager,
   notificationManager,
-  onActionWindowClose: () => {}
+  onActionWindowClose: () => Promise.resolve()
 })
 
 const inviteCtrl = new InviteController({


### PR DESCRIPTION
* If the AddChain action window is closed via the (X) icon, but the network was successfully added and is enabled, resolve the request to the dApp instead of rejecting it, which would otherwise be the default behavior.