### PR TITLE
UX/ Lifi api minor improvements

### DIFF
--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -281,7 +281,7 @@ export class LiFiAPI {
           setTimeout(() => {
             reject(
               new SwapAndBridgeProviderApiError(
-                'Our service provider is temporarily unavailable. Error details: Request timeout out'
+                'Our service provider is temporarily unavailable or your internet connection is too slow. Error details: Request timeout out'
               )
             )
           }, this.#requestTimeoutMs)

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -281,7 +281,7 @@ export class LiFiAPI {
           setTimeout(() => {
             reject(
               new SwapAndBridgeProviderApiError(
-                'Our service provider is temporarily unavailable or your internet connection is too slow. Error details: Request timeout out'
+                'Our service provider is temporarily unavailable or your internet connection is too slow. Error details: Request timeout'
               )
             )
           }, this.#requestTimeoutMs)
@@ -304,8 +304,7 @@ export class LiFiAPI {
     try {
       responseBody = await response.json()
     } catch (e: any) {
-      const error =
-        'Our service provider is temporarily unavailable. Error details: Non-JSON response received.'
+      const error = 'Our service provider is temporarily unavailable.'
       throw new SwapAndBridgeProviderApiError(error)
     }
 

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -1,10 +1,10 @@
 import {
   ExtendedChain as LiFiExtendedChain,
-  Step as LiFiIncludedStep,
+  LiFiStep,
   Route as LiFiRoute,
   RoutesResponse as LiFiRoutesResponse,
   StatusResponse as LiFiRouteStatusResponse,
-  LiFiStep,
+  Step as LiFiIncludedStep,
   Token as LiFiToken,
   TokensResponse as LiFiTokensResponse
 } from '@lifi/types'
@@ -221,6 +221,8 @@ export class LiFiAPI {
 
   #headers: RequestInitWithCustomHeaders['headers']
 
+  #requestTimeoutMs = 5000
+
   isHealthy: boolean | null = null
 
   constructor({ apiKey, fetch }: { apiKey?: string; fetch: Fetch }) {
@@ -273,7 +275,18 @@ export class LiFiAPI {
     let response: CustomResponse
 
     try {
-      response = await fetchPromise
+      response = await Promise.race([
+        fetchPromise,
+        new Promise<CustomResponse>((_, reject) => {
+          setTimeout(() => {
+            reject(
+              new SwapAndBridgeProviderApiError(
+                'Our service provider is temporarily unavailable. Error details: Request timeout out'
+              )
+            )
+          }, this.#requestTimeoutMs)
+        })
+      ])
     } catch (e: any) {
       const message = e?.message || 'no message'
       const status = e?.status ? `, status: <${e.status}>` : ''
@@ -291,8 +304,8 @@ export class LiFiAPI {
     try {
       responseBody = await response.json()
     } catch (e: any) {
-      const message = e?.message || 'no message'
-      const error = `${errorPrefix} Error details: <Unexpected non-JSON response from our service provider>, message: <${message}>`
+      const error =
+        'Our service provider is temporarily unavailable. Error details: Non-JSON response received.'
       throw new SwapAndBridgeProviderApiError(error)
     }
 


### PR DESCRIPTION
## Changes:
- Timeout API requests after 5 seconds. I tested swap and bridge with network throttling set to Regular 3G, and 5 seconds were enough even then
- Updates the non-JSON response error message. The previous message was way too long and confusing for non-devs

The old message:
![image](https://github.com/user-attachments/assets/77101b22-d0df-4813-9910-0a90db6207f6)

Potentially fixes https://github.com/AmbireTech/ambire-app/issues/4964, tho I'm not sure so let's not close it for now
