### PR TITLE
signMessage: fix encoding of dynamic arrays in EIP-712

### DIFF
--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -93,14 +93,6 @@ interface AmbireReadableOperation {
   calls: { to: Hex; value: bigint; data: Hex }[]
 }
 
-// this is for cases where the type is an array
-function getBaseType(type: string): string {
-  if (type.endsWith('[]')) {
-    return type.slice(0, -2)
-  }
-  return type
-}
-
 // remove all types found in types that don't exist in types[primaryType]
 // as otherwise, ethers6 throws an error
 //
@@ -119,7 +111,9 @@ export function filterNotUsedEIP712Types(types: EIP712Types, primaryType: string
     const fields = types[current] || []
     // eslint-disable-next-line no-restricted-syntax
     for (const field of fields) {
-      const baseType = getBaseType(field.type)
+      // since the type might be an array of something,
+      // we parse it as we are interested in the base type only
+      const baseType = field.type.split('[')[0]
       if (types[baseType] && !visited.has(baseType)) {
         toVisit.push(baseType)
       }


### PR DESCRIPTION
The issue was that we removed unused types in the EIP-712 message `types` fields, but we used to incorrectly remove arrays of dynamic size. 

Example in [this tweet](https://x.com/khudatzada/status/1939688654625988727)
User attempts to list two NFTS for sale.

Testable with the Typed message in question:
```
{
    "kind": "typedMessage",
    "types": {
        "BulkOrder": [
            {
                "name": "tree",
                "type": "OrderComponents[2]"
            }
        ],
        "OrderComponents": [
            {
                "name": "offerer",
                "type": "address"
            },
            {
                "name": "zone",
                "type": "address"
            },
            {
                "name": "offer",
                "type": "OfferItem[]"
            },
            {
                "name": "consideration",
                "type": "ConsiderationItem[]"
            },
            {
                "name": "orderType",
                "type": "uint8"
            },
            {
                "name": "startTime",
                "type": "uint256"
            },
            {
                "name": "endTime",
                "type": "uint256"
            },
            {
                "name": "zoneHash",
                "type": "bytes32"
            },
            {
                "name": "salt",
                "type": "uint256"
            },
            {
                "name": "conduitKey",
                "type": "bytes32"
            },
            {
                "name": "counter",
                "type": "uint256"
            }
        ],
        "OfferItem": [
            {
                "name": "itemType",
                "type": "uint8"
            },
            {
                "name": "token",
                "type": "address"
            },
            {
                "name": "identifierOrCriteria",
                "type": "uint256"
            },
            {
                "name": "startAmount",
                "type": "uint256"
            },
            {
                "name": "endAmount",
                "type": "uint256"
            }
        ],
        "ConsiderationItem": [
            {
                "name": "itemType",
                "type": "uint8"
            },
            {
                "name": "token",
                "type": "address"
            },
            {
                "name": "identifierOrCriteria",
                "type": "uint256"
            },
            {
                "name": "startAmount",
                "type": "uint256"
            },
            {
                "name": "endAmount",
                "type": "uint256"
            },
            {
                "name": "recipient",
                "type": "address"
            }
        ]
    },
    "domain": {
        "name": "Seaport",
        "version": "1.6",
        "chainId": 8453,
        "verifyingContract": "0x0000000000000068f116a894984e2db1123eb395"
    },
    "message": {
        "tree": [
            {
                "offerer": "0x090102422f003438ee2e2709acebf9f060702306",
                "zone": "0x0000000000000000000000000000000000000000",
                "offer": [
                    {
                        "itemType": 2,
                        "token": "0x62e094f8b4ab1291dd2d8821ad3cba64b8b8c7a6",
                        "identifierOrCriteria": "790",
                        "startAmount": "1",
                        "endAmount": "1"
                    }
                ],
                "consideration": [
                    {
                        "itemType": 0,
                        "token": "0x0000000000000000000000000000000000000000",
                        "identifierOrCriteria": "0",
                        "startAmount": "970000000000000000",
                        "endAmount": "970000000000000000",
                        "recipient": "0x090102422f003438ee2e2709acebf9f060702306"
                    },
                    {
                        "itemType": 0,
                        "token": "0x0000000000000000000000000000000000000000",
                        "identifierOrCriteria": "0",
                        "startAmount": "5000000000000000",
                        "endAmount": "5000000000000000",
                        "recipient": "0x0000a26b00c1f0df003000390027140000faa719"
                    },
                    {
                        "itemType": 0,
                        "token": "0x0000000000000000000000000000000000000000",
                        "identifierOrCriteria": "0",
                        "startAmount": "25000000000000000",
                        "endAmount": "25000000000000000",
                        "recipient": "0x61de28c8bef7ad4786fb732a05fd59317eca2bfb"
                    }
                ],
                "orderType": 0,
                "startTime": "1751376310",
                "endTime": "1753968310",
                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                "salt": "27855337018906766782546881864045825683096516384821792734234219145737770391551",
                "conduitKey": "0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000",
                "counter": "0",
                "totalOriginalConsiderationItems": 3
            },
            {
                "offerer": "0x090102422f003438ee2e2709acebf9f060702306",
                "zone": "0x0000000000000000000000000000000000000000",
                "offer": [
                    {
                        "itemType": 2,
                        "token": "0x62e094f8b4ab1291dd2d8821ad3cba64b8b8c7a6",
                        "identifierOrCriteria": "1013",
                        "startAmount": "1",
                        "endAmount": "1"
                    }
                ],
                "consideration": [
                    {
                        "itemType": 0,
                        "token": "0x0000000000000000000000000000000000000000",
                        "identifierOrCriteria": "0",
                        "startAmount": "18333000000000000",
                        "endAmount": "18333000000000000",
                        "recipient": "0x090102422f003438ee2e2709acebf9f060702306"
                    },
                    {
                        "itemType": 0,
                        "token": "0x0000000000000000000000000000000000000000",
                        "identifierOrCriteria": "0",
                        "startAmount": "94500000000000",
                        "endAmount": "94500000000000",
                        "recipient": "0x0000a26b00c1f0df003000390027140000faa719"
                    },
                    {
                        "itemType": 0,
                        "token": "0x0000000000000000000000000000000000000000",
                        "identifierOrCriteria": "0",
                        "startAmount": "472500000000000",
                        "endAmount": "472500000000000",
                        "recipient": "0x61de28c8bef7ad4786fb732a05fd59317eca2bfb"
                    }
                ],
                "orderType": 0,
                "startTime": "1751376310",
                "endTime": "1753968310",
                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                "salt": "27855337018906766782546881864045825683096516384821792734247284322247575321829",
                "conduitKey": "0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000",
                "counter": "0",
                "totalOriginalConsiderationItems": 3
            }
        ]
    },
    "primaryType": "BulkOrder"
}
```

this part broke our logic `OrderComponents[2]`