### PR TITLE
Fix / Skip defi fetch until a new txn is made on accounts without defi positions

### DIFF
--- a/src/controllers/defiPositions/defiPositions.test.ts
+++ b/src/controllers/defiPositions/defiPositions.test.ts
@@ -88,7 +88,8 @@ const prepareTest = async () => {
     selectedAccount: selectedAccountCtrl,
     keystore: keystoreCtrl,
     providers: providersCtrl,
-    networks: networksCtrl
+    networks: networksCtrl,
+    accounts: accountsCtrl
   })
 
   return {

--- a/src/controllers/defiPositions/defiPositions.ts
+++ b/src/controllers/defiPositions/defiPositions.ts
@@ -11,6 +11,7 @@ import {
   PositionsByProvider,
   ProviderName
 } from '../../libs/defiPositions/types'
+import { AccountsController } from '../accounts/accounts'
 import EventEmitter from '../eventEmitter/eventEmitter'
 import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
@@ -25,9 +26,11 @@ export class DefiPositionsController extends EventEmitter {
 
   #keystore: KeystoreController
 
-  #providers: ProvidersController
+  #accounts: AccountsController
 
   #networks: NetworksController
+
+  #providers: ProvidersController
 
   #fetch: Fetch
 
@@ -44,15 +47,17 @@ export class DefiPositionsController extends EventEmitter {
     storage,
     selectedAccount,
     keystore,
-    providers,
-    networks
+    accounts,
+    networks,
+    providers
   }: {
     fetch: Fetch
     storage: StorageController
     selectedAccount: SelectedAccountController
     keystore: KeystoreController
-    providers: ProvidersController
+    accounts: AccountsController
     networks: NetworksController
+    providers: ProvidersController
   }) {
     super()
 
@@ -60,8 +65,9 @@ export class DefiPositionsController extends EventEmitter {
     this.#storage = storage
     this.#selectedAccount = selectedAccount
     this.#keystore = keystore
-    this.#providers = providers
+    this.#accounts = accounts
     this.#networks = networks
+    this.#providers = providers
   }
 
   #setProviderError(
@@ -90,9 +96,10 @@ export class DefiPositionsController extends EventEmitter {
     const shouldForceUpdatePositions = forceUpdate && this.sessionIds.length && hasKeys
     if (shouldForceUpdatePositions) maxDataAgeMs = 30000 // half a min
 
-    let latestUpdatedAt: number | undefined = undefined
+    let latestUpdatedAt: number | undefined
 
     const accountState = Object.values(this.#state[accountAddr])
+    // eslint-disable-next-line no-restricted-syntax
     for (const network of accountState) {
       if (typeof network.updatedAt === 'number') {
         if (latestUpdatedAt === undefined || network.updatedAt > latestUpdatedAt) {
@@ -227,7 +234,8 @@ export class DefiPositionsController extends EventEmitter {
             isLoading: false,
             positionsByProvider: [...filteredPrevious, ...customPositions],
             updatedAt: hasErrors ? state.updatedAt : Date.now(),
-            error
+            error,
+            lastFetchForNonce: this.#getNonce(selectedAccountAddr, chain)
           }
         }
       } catch (e) {
@@ -236,7 +244,8 @@ export class DefiPositionsController extends EventEmitter {
           providerErrors: this.#state[selectedAccountAddr][chain].providerErrors || [],
           isLoading: false,
           positionsByProvider: previousPositions || [],
-          error: DeFiPositionsError.CriticalError
+          error: DeFiPositionsError.CriticalError,
+          lastFetchForNonce: this.#getNonce(selectedAccountAddr, chain)
         }
       }
 
@@ -284,13 +293,16 @@ export class DefiPositionsController extends EventEmitter {
         providerErrors: this.#state[selectedAccountAddr][chain].providerErrors || [],
         isLoading: false,
         positionsByProvider: Array.from(positionMap.values()),
-        updatedAt: Date.now()
+        updatedAt: Date.now(),
+        lastFetchForNonce: this.#getNonce(selectedAccountAddr, chain)
       }
     }
 
     prepareNetworks()
 
     if (this.#getShouldSkipUpdate(selectedAccountAddr, maxDataAgeMs, forceUpdate)) return
+    if (this.#getShouldSkipUpdateOnAccountWithNoDefiPositions(selectedAccountAddr, forceUpdate))
+      return
 
     let debankPositions: PositionsByProvider[] = []
 
@@ -403,6 +415,36 @@ export class DefiPositionsController extends EventEmitter {
     })
 
     return positionsByProviderWithPrices
+  }
+
+  #getShouldSkipUpdateOnAccountWithNoDefiPositions(accountAddr: string, forceUpdate?: boolean) {
+    if (forceUpdate) return false
+    if (!this.#accounts.accountStates[accountAddr]) return false
+
+    if (!this.#state[accountAddr]) return false
+    if (Object.values(this.#state[accountAddr]).some((p) => p.positionsByProvider.length))
+      return false
+
+    const hasNewNonce = Object.entries(this.#accounts.accountStates[accountAddr]).some(
+      ([chainId, networkState]) => {
+        if (!this.#state[accountAddr][chainId].lastFetchForNonce) return false
+        return networkState.nonce > this.#state[accountAddr][chainId].lastFetchForNonce
+      }
+    )
+
+    return !hasNewNonce
+  }
+
+  #getNonce(accountAddr: string, chainId: bigint | string) {
+    if (!this.#accounts.accountStates) return undefined
+    if (!this.#accounts.accountStates[accountAddr]) return undefined
+
+    const networkState = this.#accounts.accountStates[accountAddr][chainId.toString()]
+    if (!networkState) return undefined
+
+    if (networkState.isErc4337Enabled) return networkState.erc4337Nonce
+
+    return networkState.nonce
   }
 
   removeNetworkData(chainId: bigint) {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -320,6 +320,7 @@ export class MainController extends EventEmitter {
       storage: this.storage,
       selectedAccount: this.selectedAccount,
       keystore: this.keystore,
+      accounts: this.accounts,
       networks: this.networks,
       providers: this.providers
     })

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -84,7 +84,8 @@ const defiPositionsCtrl = new DefiPositionsController({
   selectedAccount: selectedAccountCtrl,
   keystore,
   networks: networksCtrl,
-  providers: providersCtrl
+  providers: providersCtrl,
+  accounts: accountsCtrl
 })
 
 const notificationManager = {

--- a/src/libs/defiPositions/types.ts
+++ b/src/libs/defiPositions/types.ts
@@ -56,6 +56,7 @@ export interface NetworkState {
   updatedAt?: number
   error?: string | null
   providerErrors?: ProviderError[]
+  lastFetchForNonce?: bigint
 }
 
 export type NetworksWithPositions = {


### PR DESCRIPTION
* The DeFi positions request to Debank will be skipped for accounts without DeFi activity until a nonce increase is detected