### PR TITLE
Fix/ `toTokenList` doesn't match `toChainId` (race condition in swapAndBridge)

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -938,6 +938,9 @@ export class SwapAndBridgeController extends EventEmitter {
       }
       return
     }
+
+    const toTokenListKeyAtStart = this.#toTokenListKey
+
     this.updateToTokenListStatus = 'LOADING'
     this.#updateToTokenListThrottle.time = now
     this.removeError('to-token-list-fetch-failed', false)
@@ -989,6 +992,10 @@ export class SwapAndBridgeController extends EventEmitter {
       }
     }
 
+    // The key has changed, meaning the user has modified the form,
+    // so we should not update the to token list as another update is in progress
+    if (toTokenListKeyAtStart !== this.#toTokenListKey) return
+
     const toTokenNetwork = this.#networks.networks.find((n) => Number(n.chainId) === this.toChainId)
     // should never happen
     if (!toTokenNetwork) {
@@ -1001,6 +1008,10 @@ export class SwapAndBridgeController extends EventEmitter {
       .filter((t) => t.chainId === toTokenNetwork.chainId)
       .filter((token) => !toTokenList.some((t) => t.address === token.address))
       .map((t) => convertPortfolioTokenToSwapAndBridgeToToken(t, Number(toTokenNetwork.chainId)))
+
+    // The key has changed, meaning the user has modified the form,
+    // so we should not update the to token list as another update is in progress
+    if (toTokenListKeyAtStart !== this.#toTokenListKey) return
 
     this.#toTokenList = sortTokenListResponse(
       [...toTokenList, ...additionalTokensFromPortfolio],


### PR DESCRIPTION
## How to reproduce:
1. Throttle the background script to 3G/4G
2. Select an account that has assets on multiple networks (at least 2)
3. Open swap and bridge
Now you must do these quickly :arrow_down: 
4.  There will be a default fromToken. We will call its network 1
5. Change the toNetwork to network 2
6. Quickly change the fromToken to the default token (on network 1)

The network in the toNetwork dropdown will be 1, while the toTokenList will be with tokens from network 2

## Why?
The list of toTokens of network 1 is cached. When you change to network 2 and quickly change the toToken, this happens:
1. toChainId is 1
2. You trigger a network change. toChainId becomes 2, toTokenList will be updated in 1-2 seconds when the request resolves
3. You trigger a second network change back to network 1. toTokenList is updated immediately and toChainId becomes 1
4. The request with the toTokenList of network 2 resolves, toTokenList is updated
5. :boom: 

 
Closes https://github.com/AmbireTech/ambire-app/issues/5011