### PR TITLE
Rewards NFT: allow unminted tokens to have URI

### DIFF
--- a/contracts/rewardsNftImplementation.sol
+++ b/contracts/rewardsNftImplementation.sol
@@ -91,7 +91,6 @@ contract AmbireRewardsNFTImplementation is Ownable, IERC721Metadata, ERC721Enume
     uint tokenId
   ) public view override(ERC721, IERC721Metadata) returns (string memory) {
     address nftOwner = _ownerOf(tokenId);
-    require(nftOwner != address(0), 'tokenURI: token not minted');
 
     // not gas efficient but that is ok since this is a view function
     // used i <= currentSeason + 1, because we want to return URIs for the next season as well
@@ -99,7 +98,8 @@ contract AmbireRewardsNFTImplementation is Ownable, IERC721Metadata, ERC721Enume
       if (nftIds[nftOwner][i] > 0)
         return string(abi.encodePacked(baseURI, nftOwner.toHexString(), '/', i.toString()));
     }
-    revert('tokenURI: no such NFT found');
+    return
+      string(abi.encodePacked(baseURI, address(0).toHexString(), '/', currentSeason.toString()));
   }
 
   function setBaseUri(string calldata _baseURI) public onlyOwner {

--- a/test/RewardsNft/rewardsNft.ts
+++ b/test/RewardsNft/rewardsNft.ts
@@ -47,7 +47,9 @@ describe('Rewards nft', () => {
   })
 
   it('tokenURI', async () => {
-    await expect(rewardsNftContract.tokenURI(1)).to.be.revertedWith('tokenURI: token not minted')
+    expect(await rewardsNftContract.tokenURI(1)).eq(
+      'https://staging-relayer.ambire.com/legends/nft-meta/0x0000000000000000000000000000000000000000/0'
+    )
     await rewardsNftContract.mint(1, 1)
     expect(await rewardsNftContract.tokenURI(1)).eq(
       `https://staging-relayer.ambire.com/legends/nft-meta/${signer.address.toLowerCase()}/1`


### PR DESCRIPTION
Since we do not take the token URI from the simulation, if an NFT contract does not allow you to get the URI when the NFT has not owner, we cannot display the image in the simulation. 

This was a choice we made to simplify our stack and to solve other problems and reduce network requests.

This PR changes the Rewards NFT to allow unminted NFT's to have tokenURI so we can display some default token image