### PR TITLE
Feature/user ops nonces

### DIFF
--- a/src/controllers/estimation/estimation.ts
+++ b/src/controllers/estimation/estimation.ts
@@ -52,6 +52,8 @@ export class EstimationController extends EventEmitter {
 
   #activity: ActivityController
 
+  #notFatalBundlerError?: Error
+
   constructor(
     keystore: KeystoreController,
     accounts: AccountsController,
@@ -197,6 +199,9 @@ export class EstimationController extends EventEmitter {
       this.status = EstimationStatus.Success
       this.estimationRetryError = null
       this.availableFeeOptions = this.#getAvailableFeeOptions(baseAcc, op)
+      if (estimation.bundler instanceof Error) {
+        this.#notFatalBundlerError = estimation.bundler
+      }
     } else {
       this.estimation = null
       this.error = estimation
@@ -251,6 +256,14 @@ export class EstimationController extends EventEmitter {
         id: 'bundler-failure',
         title:
           'Smart account fee options are temporarily unavailable. You can pay fee with an EOA account or try again later'
+      })
+    }
+
+    if (this.#notFatalBundlerError?.cause === '4337_INVALID_NONCE') {
+      warnings.push({
+        id: 'bundler-nonce-discrepancy',
+        title:
+          'Pending transaction detected! Please wait for its confirmation to have more payment options available'
       })
     }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -464,6 +464,7 @@ export class MainController extends EventEmitter {
       this.accounts,
       this.keystore,
       this.portfolio,
+      this.activity,
       this.#externalSignerControllers,
       this.providers,
       relayerUrl
@@ -671,6 +672,7 @@ export class MainController extends EventEmitter {
         this.networks,
         this.keystore,
         this.portfolio,
+        this.activity,
         this.#externalSignerControllers,
         this.selectedAccount.account,
         network,

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -21,10 +21,12 @@ import { FullEstimationSummary } from '../../libs/estimate/interfaces'
 import { GasRecommendation } from '../../libs/gasPrice/gasPrice'
 import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
 import { TokenResult } from '../../libs/portfolio'
+import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import { filterNotUsedEIP712Types, getTypedData } from '../../libs/signMessage/signMessage'
 import { BundlerSwitcher } from '../../services/bundlers/bundlerSwitcher'
 import { getRpcProvider } from '../../services/provider'
 import { AccountsController } from '../accounts/accounts'
+import { ActivityController } from '../activity/activity'
 import { EstimationController } from '../estimation/estimation'
 import { EstimationStatus } from '../estimation/types'
 import { GasPriceController } from '../gasPrice/gasPrice'
@@ -32,6 +34,7 @@ import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
 import { PortfolioController } from '../portfolio/portfolio'
 import { ProvidersController } from '../providers/providers'
+import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 import { StorageController } from '../storage/storage'
 import { getFeeSpeedIdentifier } from './helper'
 import { FeeSpeed, SigningStatus } from './signAccountOp'
@@ -440,12 +443,29 @@ const init = async (
   const bundlerSwitcher = new BundlerSwitcher(network, () => {
     return false
   })
+  const callRelayer = relayerCall.bind({ url: '', fetch })
+  const selectedAccountCtrl = new SelectedAccountController({
+    storage: storageCtrl,
+    accounts: accountsCtrl
+  })
+  const activity = new ActivityController(
+    storageCtrl,
+    fetch,
+    callRelayer,
+    accountsCtrl,
+    selectedAccountCtrl,
+    providersCtrl,
+    networksCtrl,
+    portfolio,
+    () => Promise.resolve()
+  )
   const estimationController = new EstimationController(
     keystore,
     accountsCtrl,
     networksCtrl,
     providers,
     portfolio,
+    activity,
     bundlerSwitcher
   )
   estimationController.estimation = estimationOrMock

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -485,6 +485,7 @@ const init = async (
     networksCtrl,
     keystore,
     portfolio,
+    activity,
     {},
     account,
     network,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -296,6 +296,7 @@ export class SignAccountOpController extends EventEmitter {
       networks,
       provider,
       portfolio,
+      activity,
       this.bundlerSwitcher
     )
     const emptyFunc = () => {}
@@ -1449,15 +1450,6 @@ export class SignAccountOpController extends EventEmitter {
       }
     }
 
-    const userOperation = getUserOperation(
-      this.account,
-      accountState,
-      this.accountOp,
-      this.bundlerSwitcher.getBundler().getName(),
-      this.accountOp.meta?.entryPointAuthorization,
-      eip7702Auth
-    )
-
     // if broadcast but not confirmed for this network and an userOp,
     // check if the nonces match. If they do, increment the current nonce
     const notConfirmedUserOp = this.#activity.broadcastedButNotConfirmed.find(
@@ -1466,13 +1458,15 @@ export class SignAccountOpController extends EventEmitter {
         accOp.gasFeePayment &&
         accOp.gasFeePayment.broadcastOption === BROADCAST_OPTIONS.byBundler
     )
-    if (
-      notConfirmedUserOp &&
-      notConfirmedUserOp.asUserOperation &&
-      notConfirmedUserOp.asUserOperation.nonce === userOperation.nonce
-    ) {
-      userOperation.nonce = toBeHex(BigInt(userOperation.nonce) + 1n)
-    }
+    const userOperation = getUserOperation(
+      this.account,
+      accountState,
+      this.accountOp,
+      this.bundlerSwitcher.getBundler().getName(),
+      this.accountOp.meta?.entryPointAuthorization,
+      eip7702Auth,
+      notConfirmedUserOp?.asUserOperation
+    )
 
     userOperation.preVerificationGas = erc4337Estimation.preVerificationGas
     userOperation.callGasLimit = toBeHex(

--- a/src/controllers/signAccountOp/signAccountOpTester.ts
+++ b/src/controllers/signAccountOp/signAccountOpTester.ts
@@ -5,6 +5,7 @@ import { Network } from '../../interfaces/network'
 import { RPCProvider } from '../../interfaces/provider'
 import { AccountOp } from '../../libs/accountOp/accountOp'
 import { AccountsController } from '../accounts/accounts'
+import { ActivityController } from '../activity/activity'
 import { EstimationController } from '../estimation/estimation'
 import { GasPriceController } from '../gasPrice/gasPrice'
 import { KeystoreController } from '../keystore/keystore'
@@ -18,6 +19,7 @@ export class SignAccountOpTesterController extends SignAccountOpController {
     networks: NetworksController,
     keystore: KeystoreController,
     portfolio: PortfolioController,
+    activity: ActivityController,
     externalSignerControllers: ExternalSignerControllers,
     account: Account,
     network: Network,
@@ -35,6 +37,7 @@ export class SignAccountOpTesterController extends SignAccountOpController {
       networks,
       keystore,
       portfolio,
+      activity,
       externalSignerControllers,
       account,
       network,

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2134,6 +2134,7 @@ export class SwapAndBridgeController extends EventEmitter {
       this.#networks,
       this.#keystore,
       this.#portfolio,
+      this.#activity,
       this.#externalSignerControllers,
       this.#selectedAccount.account,
       network,

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -1,5 +1,6 @@
 import { formatUnits, isAddress, parseUnits } from 'ethers'
 
+import { ActivityController } from 'controllers/activity/activity'
 import { FEE_COLLECTOR } from '../../consts/addresses'
 import { AddressState } from '../../interfaces/domains'
 import { ExternalSignerControllers } from '../../interfaces/keystore'
@@ -123,6 +124,8 @@ export class TransferController extends EventEmitter {
   // Holds the initial load promise, so that one can wait until it completes
   #initialLoadPromise: Promise<void>
 
+  #activity: ActivityController
+
   constructor(
     storage: StorageController,
     humanizerInfo: HumanizerMeta,
@@ -132,6 +135,7 @@ export class TransferController extends EventEmitter {
     accounts: AccountsController,
     keystore: KeystoreController,
     portfolio: PortfolioController,
+    activity: ActivityController,
     externalSignerControllers: ExternalSignerControllers,
     providers: ProvidersController,
     relayerUrl: string
@@ -147,6 +151,7 @@ export class TransferController extends EventEmitter {
     this.#accounts = accounts
     this.#keystore = keystore
     this.#portfolio = portfolio
+    this.#activity = activity
     this.#externalSignerControllers = externalSignerControllers
     this.#providers = providers
     this.#relayerUrl = relayerUrl
@@ -608,6 +613,7 @@ export class TransferController extends EventEmitter {
       this.#networks,
       this.#keystore,
       this.#portfolio,
+      this.#activity,
       this.#externalSignerControllers,
       this.#selectedAccountData.account,
       network,

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -89,9 +89,6 @@ export async function getEstimation(
   const criticalError = baseAcc.getEstimationCriticalError(fullEstimation, op)
   if (criticalError) return criticalError
 
-  // TODO: if the bundler is the preferred method of estimation, re-estimate
-  // we can switch it if there's no ambire gas error
-
   let flags = {}
   if (!(ambireGas instanceof Error) && ambireGas) flags = { ...ambireGas.flags }
   if (!(bundlerGas instanceof Error) && bundlerGas) flags = { ...bundlerGas.flags }

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -1,4 +1,4 @@
-import { BaseAccount } from 'libs/account/BaseAccount'
+import { BaseAccount } from '../account/BaseAccount'
 
 import { AccountOnchainState } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
@@ -6,6 +6,7 @@ import { RPCProvider } from '../../interfaces/provider'
 import { BundlerSwitcher } from '../../services/bundlers/bundlerSwitcher'
 import { AccountOp } from '../accountOp/accountOp'
 import { TokenResult } from '../portfolio'
+import { UserOperation } from '../userOperation/types'
 import { ambireEstimateGas } from './ambireEstimation'
 import { bundlerEstimate } from './estimateBundler'
 import { estimateWithRetries } from './estimateWithRetries'
@@ -30,7 +31,8 @@ export async function getEstimation(
   feeTokens: TokenResult[],
   nativeToCheck: string[],
   switcher: BundlerSwitcher,
-  errorCallback: Function
+  errorCallback: Function,
+  activityUserOp?: UserOperation
 ): Promise<FullEstimation | Error> {
   const ambireEstimation = ambireEstimateGas(
     baseAcc,
@@ -49,7 +51,9 @@ export async function getEstimation(
     feeTokens,
     provider,
     switcher,
-    errorCallback
+    errorCallback,
+    undefined,
+    activityUserOp
   )
   const providerEstimation = providerEstimateGas(
     baseAcc.getAccount(),

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -106,7 +106,8 @@ export async function bundlerEstimate(
   provider: RPCProvider,
   switcher: BundlerSwitcher,
   errorCallback: Function,
-  eip7702Auth?: EIP7702Auth
+  eip7702Auth?: EIP7702Auth,
+  activityUserOp?: UserOperation
 ): Promise<Erc4337GasLimits | Error | null> {
   if (!baseAcc.supportsBundlerEstimation()) return null
 
@@ -119,7 +120,8 @@ export async function bundlerEstimate(
     localOp,
     initialBundler.getName(),
     op.meta?.entryPointAuthorization,
-    eip7702Auth
+    eip7702Auth,
+    activityUserOp
   )
   // set the callData
   if (userOp.activatorCall) localOp.activatorCall = userOp.activatorCall

--- a/src/libs/relayerCall/relayerCall.test.ts
+++ b/src/libs/relayerCall/relayerCall.test.ts
@@ -40,9 +40,7 @@ describe('Relayer', () => {
       // it should never come here
       expect(true).toBe(false)
     } catch (e: any) {
-      expect(e.message).toBe(
-        'Fee payment is 0, perhaps an invalid fee option has been chosen. Please choose another fee option to try again or contact Ambire support'
-      )
+      expect(e.message).toBe('Invalid payment option. Please contact support')
     }
   })
   test('Test sending a relayer call with an invalid fee payment - it should say that the fee payment is 0', async () => {
@@ -77,9 +75,7 @@ describe('Relayer', () => {
       // it should never come here
       expect(true).toBe(false)
     } catch (e: any) {
-      expect(e.message).toBe(
-        'Fee payment is 0, perhaps an invalid fee option has been chosen. Please choose another fee option to try again or contact Ambire support'
-      )
+      expect(e.message).toBe('Invalid payment option. Please contact support')
     }
   })
 })

--- a/src/libs/userOperation/userOperation.ts
+++ b/src/libs/userOperation/userOperation.ts
@@ -276,3 +276,11 @@ export const parseLogs = (
     success: userOpLog[1]
   }
 }
+
+/**
+ * Get all the bundler statuses that indicate that an userOp
+ * is either pending to be mined or successfully included in the blockchain
+ */
+export function getUserOpPendingOrSuccessStatuses(): string[] {
+  return ['found', 'submitted', 'not_submitted', 'included', 'queued']
+}

--- a/src/libs/userOperation/userOperation.ts
+++ b/src/libs/userOperation/userOperation.ts
@@ -123,11 +123,16 @@ export function getUserOperation(
   accountOp: AccountOp,
   bundler: BUNDLER,
   entryPointSig?: string,
-  eip7702Auth?: EIP7702Auth
+  eip7702Auth?: EIP7702Auth,
+  activityUserOp?: UserOperation
 ): UserOperation {
+  const accountStateNonce = toBeHex(accountState.erc4337Nonce)
   const userOp: UserOperation = {
     sender: accountOp.accountAddr,
-    nonce: toBeHex(accountState.erc4337Nonce),
+    nonce:
+      activityUserOp && accountStateNonce === activityUserOp.nonce
+        ? toBeHex(accountState.erc4337Nonce + 1n)
+        : accountStateNonce,
     callData: '0x',
     callGasLimit: toBeHex(0),
     verificationGasLimit: toBeHex(0),

--- a/src/services/bundlers/types.ts
+++ b/src/services/bundlers/types.ts
@@ -13,6 +13,14 @@ export interface GasSpeeds {
 }
 
 export interface UserOpStatus {
-  status: 'rejected' | 'not_found' | 'found'
+  status:
+    | 'rejected'
+    | 'not_found'
+    | 'found'
+    | 'submitted'
+    | 'not_submitted'
+    | 'included'
+    | 'failed'
+    | 'queued'
   transactionHash?: Hex
 }


### PR DESCRIPTION
Fixes:
* update the calls in signAccountOp and do a re-estimate only if they are different
* if there's an userOp with an old nonce, try to find the newest one at estimation level and proceed. If the network is ethereum, display a temp error message instead (as the bundler is too slow to handle this)
* add an estimation warning when there is a bundler nonce discrepancy (as you can still broadcast with ETH)