### PR TITLE
Add: fetch an unique nonce id from the base account

### DIFF
--- a/src/controllers/defiPositions/defiPositions.ts
+++ b/src/controllers/defiPositions/defiPositions.ts
@@ -1,5 +1,6 @@
-import { AccountId } from '../../interfaces/account'
+import { Account, AccountId } from '../../interfaces/account'
 import { Fetch } from '../../interfaces/fetch'
+import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { getAssetValue } from '../../libs/defiPositions/helpers'
 import { getAAVEPositions, getUniV3Positions } from '../../libs/defiPositions/providers'
 import getAccountNetworksWithPositions from '../../libs/defiPositions/providers/helpers/networksWithPositions'
@@ -235,7 +236,7 @@ export class DefiPositionsController extends EventEmitter {
             positionsByProvider: [...filteredPrevious, ...customPositions],
             updatedAt: hasErrors ? state.updatedAt : Date.now(),
             error,
-            nonceId: this.#getNonceId(selectedAccountAddr, chain)
+            nonceId: this.#getNonceId(selectedAccount, chain)
           }
         }
       } catch (e) {
@@ -245,7 +246,7 @@ export class DefiPositionsController extends EventEmitter {
           isLoading: false,
           positionsByProvider: previousPositions || [],
           error: DeFiPositionsError.CriticalError,
-          nonceId: this.#getNonceId(selectedAccountAddr, chain)
+          nonceId: this.#getNonceId(selectedAccount, chain)
         }
       }
 
@@ -294,15 +295,14 @@ export class DefiPositionsController extends EventEmitter {
         isLoading: false,
         positionsByProvider: Array.from(positionMap.values()),
         updatedAt: Date.now(),
-        nonceId: this.#getNonceId(selectedAccountAddr, chain)
+        nonceId: this.#getNonceId(selectedAccount, chain)
       }
     }
 
     prepareNetworks()
 
     if (this.#getShouldSkipUpdate(selectedAccountAddr, maxDataAgeMs, forceUpdate)) return
-    if (this.#getShouldSkipUpdateOnAccountWithNoDefiPositions(selectedAccountAddr, forceUpdate))
-      return
+    if (this.#getShouldSkipUpdateOnAccountWithNoDefiPositions(selectedAccount, forceUpdate)) return
 
     let debankPositions: PositionsByProvider[] = []
 
@@ -417,20 +417,19 @@ export class DefiPositionsController extends EventEmitter {
     return positionsByProviderWithPrices
   }
 
-  #getShouldSkipUpdateOnAccountWithNoDefiPositions(accountAddr: string, forceUpdate?: boolean) {
+  #getShouldSkipUpdateOnAccountWithNoDefiPositions(acc: Account, forceUpdate?: boolean) {
     if (forceUpdate) return false
-    if (!this.#accounts.accountStates[accountAddr]) return false
+    if (!this.#accounts.accountStates[acc.addr]) return false
 
-    if (!this.#state[accountAddr]) return false
+    if (!this.#state[acc.addr]) return false
 
     // Don't skip if the account has any DeFi positions
-    if (Object.values(this.#state[accountAddr]).some((p) => p.positionsByProvider.length))
-      return false
+    if (Object.values(this.#state[acc.addr]).some((p) => p.positionsByProvider.length)) return false
 
-    const someNonceIdChanged = Object.keys(this.#accounts.accountStates[accountAddr]).some(
+    const someNonceIdChanged = Object.keys(this.#accounts.accountStates[acc.addr]).some(
       (chainId: string) => {
-        const posNonceId = this.#state[accountAddr][chainId].nonceId
-        const nonceId = this.#getNonceId(accountAddr, chainId)
+        const posNonceId = this.#state[acc.addr][chainId].nonceId
+        const nonceId = this.#getNonceId(acc, chainId)
 
         if (!nonceId || !posNonceId) return false
 
@@ -442,16 +441,18 @@ export class DefiPositionsController extends EventEmitter {
     return !someNonceIdChanged
   }
 
-  #getNonceId(accountAddr: string, chainId: bigint | string) {
+  #getNonceId(acc: Account, chainId: bigint | string) {
     if (!this.#accounts.accountStates) return undefined
-    if (!this.#accounts.accountStates[accountAddr]) return undefined
+    if (!this.#accounts.accountStates[acc.addr]) return undefined
 
-    const networkState = this.#accounts.accountStates[accountAddr][chainId.toString()]
+    const networkState = this.#accounts.accountStates[acc.addr][chainId.toString()]
     if (!networkState) return undefined
 
-    if (networkState.isEOA) return `${networkState.eoaNonce}-${networkState.erc4337Nonce}`
+    const network = this.#networks.networks.find((net) => net.chainId === chainId)
+    if (!network) return undefined
 
-    return `${networkState.nonce}-${networkState.erc4337Nonce}`
+    const baseAcc = getBaseAccount(acc, networkState, this.#keystore.getAccountKeys(acc), network)
+    return baseAcc.getNonceId()
   }
 
   removeNetworkData(chainId: bigint) {

--- a/src/libs/account/BaseAccount.ts
+++ b/src/libs/account/BaseAccount.ts
@@ -81,6 +81,11 @@ export abstract class BaseAccount {
   // each account should declare if it supports atomicity
   abstract getAtomicStatus(): 'unsupported' | 'supported' | 'ready'
 
+  /**
+   * Get a unique identifier of the current account nonce
+   */
+  abstract getNonceId(): string
+
   // this is specific for v2 accounts, hardcoding a false for all else
   shouldIncludeActivatorCall(broadcastOption: string) {
     return false

--- a/src/libs/account/EOA.ts
+++ b/src/libs/account/EOA.ts
@@ -97,4 +97,9 @@ export class EOA extends BaseAccount {
   getAtomicStatus(): 'unsupported' | 'supported' | 'ready' {
     return 'unsupported'
   }
+
+  getNonceId(): string {
+    // EOAs have only an execution layer nonce
+    return this.accountState.eoaNonce!.toString()
+  }
 }

--- a/src/libs/account/EOA7702.ts
+++ b/src/libs/account/EOA7702.ts
@@ -181,4 +181,9 @@ export class EOA7702 extends BaseAccount {
   getAtomicStatus(): 'unsupported' | 'supported' | 'ready' {
     return this.accountState.isSmarterEoa ? 'supported' : 'ready'
   }
+
+  getNonceId(): string {
+    // 7702 accounts have an execution layer nonce and an entry point nonce
+    return `${this.accountState.eoaNonce!.toString()}-${this.accountState.erc4337Nonce.toString()}`
+  }
 }

--- a/src/libs/account/V1.ts
+++ b/src/libs/account/V1.ts
@@ -93,4 +93,9 @@ export class V1 extends BaseAccount {
   getAtomicStatus(): 'unsupported' | 'supported' | 'ready' {
     return 'supported'
   }
+
+  getNonceId(): string {
+    // v1 accounts can only have an ambire smart contract nonce
+    return this.accountState.nonce.toString()
+  }
 }

--- a/src/libs/account/V2.ts
+++ b/src/libs/account/V2.ts
@@ -168,4 +168,9 @@ export class V2 extends BaseAccount {
   getAtomicStatus(): 'unsupported' | 'supported' | 'ready' {
     return 'supported'
   }
+
+  getNonceId(): string {
+    // v2 accounts have two nonces: ambire smart account & entry point nonce
+    return `${this.accountState.nonce.toString()}-${this.accountState.erc4337Nonce.toString()}`
+  }
 }


### PR DESCRIPTION
This PR just shows an example of how we leverage the `BaseAccount` class to separate the logic and get a better picture of what makes a unique nonce for each account implementation.  

