### PR TITLE
Fix/ Self closing action window on firefox

### DIFF
--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -320,7 +320,7 @@ export class ActionsController extends EventEmitter {
       }
 
       try {
-        this.#windowManager.remove('popup') // no need to await this to speed up the action-window opening
+        await this.#windowManager.remove('popup')
         this.actionWindow.openWindowPromise = this.#windowManager
           .open({ customSize, baseWindowId })
           .finally(() => {
@@ -347,7 +347,7 @@ export class ActionsController extends EventEmitter {
       return
 
     try {
-      this.#windowManager.remove('popup') // no need to await this to speed up the action-window opening
+      await this.#windowManager.remove('popup')
       this.actionWindow.focusWindowPromise = this.#windowManager
         .focus(this.actionWindow.windowProps)
         .finally(() => {


### PR DESCRIPTION
## How to reproduce:
1. Use a dev gecko build
2. Open Firefox
3. Open an action window
4. Batch/close it
5. Open the extension popup
6. Open the pending action from the banner
7. Do it until the action window closes by itself