### PR TITLE
Fix/ Account label flickering between states on rename

### DIFF
--- a/src/controllers/accounts/accounts.test.ts
+++ b/src/controllers/accounts/accounts.test.ts
@@ -73,19 +73,8 @@ describe('AccountsController', () => {
     await waitForAccountsCtrlFirstLoad(accountsCtrl)
     expect(accountsCtrl.areAccountStatesLoading).toBe(false)
   })
-  test('update account preferences', (done) => {
-    const unsubscribe = accountsCtrl.onUpdate(() => {
-      if (accountsCtrl.statuses.updateAccountPreferences === 'SUCCESS') {
-        const acc = accountsCtrl.accounts.find(
-          (a) => a.addr === '0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0'
-        )
-        expect(acc?.preferences.label).toEqual('new-label')
-        expect(acc?.preferences.pfp).toEqual('predefined-image')
-        unsubscribe()
-        done()
-      }
-    })
-    accountsCtrl.updateAccountPreferences([
+  test('update account preferences', async () => {
+    await accountsCtrl.updateAccountPreferences([
       {
         addr: '0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0',
         preferences: {
@@ -94,6 +83,12 @@ describe('AccountsController', () => {
         }
       }
     ])
+
+    const acc = accountsCtrl.accounts.find(
+      (a) => a.addr === '0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0'
+    )
+    expect(acc?.preferences.label).toEqual('new-label')
+    expect(acc?.preferences.pfp).toEqual('predefined-image')
   })
   test('removeAccountData', async () => {
     await accountsCtrl.updateAccountStates()

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -16,7 +16,6 @@ import { StorageController } from '../storage/storage'
 
 const STATUS_WRAPPED_METHODS = {
   selectAccount: 'INITIAL',
-  updateAccountPreferences: 'INITIAL',
   addAccounts: 'INITIAL'
 } as const
 

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { getAddress, isAddress } from 'ethers'
 
 import {
@@ -203,14 +204,6 @@ export class AccountsController extends EventEmitter {
   }
 
   async updateAccountPreferences(accounts: { addr: string; preferences: AccountPreferences }[]) {
-    await this.withStatus(
-      'updateAccountPreferences',
-      async () => this.#updateAccountPreferences(accounts),
-      true
-    )
-  }
-
-  async #updateAccountPreferences(accounts: { addr: string; preferences: AccountPreferences }[]) {
     this.accounts = this.accounts.map((acc) => {
       const account = accounts.find((a) => a.addr === acc.addr)
       if (!account) return acc
@@ -220,8 +213,8 @@ export class AccountsController extends EventEmitter {
       return { ...acc, preferences: account.preferences }
     })
 
-    await this.#storage.set('accounts', this.accounts)
     this.emitUpdate()
+    await this.#storage.set('accounts', this.accounts)
   }
 
   get areAccountStatesLoading() {


### PR DESCRIPTION
## How to reproduce:
1. Open account settings
2. Rename an account
3. The label will change as follows: OLD -> NEW -> OLD -> NEW

## Why?
Because `withStatus` emits an update when the status changes to `LOADING`. We could fix this in the UI, but this status is not used anyway so I decided to fix it here.