### PR TITLE
Update/ Don't update the account state of view-only accounts in the background

### DIFF
--- a/src/controllers/accountPicker/accountPicker.test.ts
+++ b/src/controllers/accountPicker/accountPicker.test.ts
@@ -87,11 +87,13 @@ describe('AccountPicker', () => {
   )
   providersCtrl = new ProvidersController(networksCtrl)
   providersCtrl.providers = providers
+  const keystoreController = new KeystoreController('default', storageCtrl, {}, windowManager)
 
   const accountsCtrl = new AccountsController(
     storageCtrl,
     providersCtrl,
     networksCtrl,
+    keystoreController,
     () => {},
     () => {},
     () => {}

--- a/src/controllers/accounts/accounts.test.ts
+++ b/src/controllers/accounts/accounts.test.ts
@@ -3,7 +3,11 @@ import fetch from 'node-fetch'
 import { describe, expect, test } from '@jest/globals'
 
 import { relayerUrl } from '../../../test/config'
-import { produceMemoryStore, waitForAccountsCtrlFirstLoad } from '../../../test/helpers'
+import {
+  mockInternalKeys,
+  produceMemoryStore,
+  waitForAccountsCtrlFirstLoad
+} from '../../../test/helpers'
 import { mockWindowManager } from '../../../test/helpers/window'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { networks } from '../../consts/networks'
@@ -42,6 +46,10 @@ describe('AccountsController', () => {
   const providers = Object.fromEntries(
     networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
   )
+
+  const mockKeys = mockInternalKeys(accounts)
+
+  storage.set('keystoreKeys', mockKeys)
 
   let providersCtrl: ProvidersController
   const storageCtrl = new StorageController(storage)

--- a/src/controllers/accounts/accounts.test.ts
+++ b/src/controllers/accounts/accounts.test.ts
@@ -4,10 +4,12 @@ import { describe, expect, test } from '@jest/globals'
 
 import { relayerUrl } from '../../../test/config'
 import { produceMemoryStore, waitForAccountsCtrlFirstLoad } from '../../../test/helpers'
+import { mockWindowManager } from '../../../test/helpers/window'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { networks } from '../../consts/networks'
 import { Storage } from '../../interfaces/storage'
 import { getRpcProvider } from '../../services/provider'
+import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
 import { ProvidersController } from '../providers/providers'
 import { StorageController } from '../storage/storage'
@@ -54,6 +56,7 @@ describe('AccountsController', () => {
       providersCtrl.removeProvider(id)
     }
   )
+  const windowManager = mockWindowManager().windowManager
   providersCtrl = new ProvidersController(networksCtrl)
   providersCtrl.providers = providers
 
@@ -64,6 +67,7 @@ describe('AccountsController', () => {
       storageCtrl,
       providersCtrl,
       networksCtrl,
+      new KeystoreController('default', storageCtrl, {}, windowManager),
       () => {},
       () => {},
       () => {}
@@ -91,7 +95,7 @@ describe('AccountsController', () => {
     expect(acc?.preferences.pfp).toEqual('predefined-image')
   })
   test('removeAccountData', async () => {
-    await accountsCtrl.updateAccountStates()
+    await accountsCtrl.updateAccountStates(accounts[0].addr)
     expect(accountsCtrl.accounts.length).toBeGreaterThan(0)
     expect(Object.keys(accountsCtrl.accountStates).length).toBeGreaterThan(0)
     expect(accountsCtrl.areAccountStatesLoading).toBe(false)

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -76,7 +76,6 @@ export class AccountsController extends EventEmitter {
       if (account.addr === selectedAccountAddr) return true
 
       const accountKeys = this.#keystore.getAccountKeys(account)
-      console.log(`Account ${account.addr} keys: `, accountKeys)
       const isViewOnly = accountKeys.length === 0
 
       // If the account is not selected, update the account state in the background

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -76,6 +76,7 @@ export class AccountsController extends EventEmitter {
       if (account.addr === selectedAccountAddr) return true
 
       const accountKeys = this.#keystore.getAccountKeys(account)
+      console.log(`Account ${account.addr} keys: `, accountKeys)
       const isViewOnly = accountKeys.length === 0
 
       // If the account is not selected, update the account state in the background

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -10,6 +10,7 @@ import {
 import { getUniqueAccountsArray } from '../../libs/account/account'
 import { getAccountState } from '../../libs/accountState/accountState'
 import EventEmitter, { Statuses } from '../eventEmitter/eventEmitter'
+import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
 import { ProvidersController } from '../providers/providers'
 import { StorageController } from '../storage/storage'
@@ -25,6 +26,8 @@ export class AccountsController extends EventEmitter {
   #networks: NetworksController
 
   #providers: ProvidersController
+
+  #keystore: KeystoreController
 
   accounts: Account[] = []
 
@@ -49,6 +52,7 @@ export class AccountsController extends EventEmitter {
     storage: StorageController,
     providers: ProvidersController,
     networks: NetworksController,
+    keystore: KeystoreController,
     onAddAccounts: (accounts: Account[]) => void,
     updateProviderIsWorking: (chainId: bigint, isWorking: boolean) => void,
     onAccountStateUpdate: () => void
@@ -57,6 +61,7 @@ export class AccountsController extends EventEmitter {
     this.#storage = storage
     this.#providers = providers
     this.#networks = networks
+    this.#keystore = keystore
     this.#onAddAccounts = onAddAccounts
     this.#updateProviderIsWorking = updateProviderIsWorking
     this.#onAccountStateUpdate = onAccountStateUpdate
@@ -65,10 +70,26 @@ export class AccountsController extends EventEmitter {
     this.initialLoadPromise = this.#load()
   }
 
+  #getAccountsToUpdateAccountStatesInBackground(selectedAccountAddr?: string | null): Account[] {
+    return this.accounts.filter((account) => {
+      // Always update the selected account state in the background
+      if (account.addr === selectedAccountAddr) return true
+
+      const accountKeys = this.#keystore.getAccountKeys(account)
+      const isViewOnly = accountKeys.length === 0
+
+      // If the account is not selected, update the account state in the background
+      // only if it's not view-only. We update the account state
+      // in the background so EOAs can be used as a broadcast option.
+      return !isViewOnly
+    })
+  }
+
   async #load() {
     await this.#networks.initialLoadPromise
     await this.#providers.initialLoadPromise
     const accounts = await this.#storage.get('accounts', [])
+    const initialSelectedAccountAddr = await this.#storage.get('selectedAccount', null)
     this.accounts = getUniqueAccountsArray(accounts)
 
     // Emit an update before updating account states as the first state update may take some time
@@ -76,11 +97,22 @@ export class AccountsController extends EventEmitter {
     // Don't await this. Networks should update one by one
     // NOTE: YOU MUST USE waitForAccountsCtrlFirstLoad IN TESTS
     // TO ENSURE ACCOUNT STATE IS LOADED
-    this.#updateAccountStates(this.accounts)
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.#updateAccountStates(
+      this.#getAccountsToUpdateAccountStatesInBackground(initialSelectedAccountAddr)
+    )
   }
 
-  async updateAccountStates(blockTag: string | number = 'latest', networks: bigint[] = []) {
-    await this.#updateAccountStates(this.accounts, blockTag, networks)
+  async updateAccountStates(
+    selectedAccountAddr: string | undefined,
+    blockTag: string | number = 'latest',
+    networks: bigint[] = []
+  ) {
+    await this.#updateAccountStates(
+      this.#getAccountsToUpdateAccountStatesInBackground(selectedAccountAddr),
+      blockTag,
+      networks
+    )
   }
 
   async updateAccountState(

--- a/src/controllers/actions/actions.test.ts
+++ b/src/controllers/actions/actions.test.ts
@@ -13,6 +13,7 @@ import { Calls, DappUserRequest, SignUserRequest } from '../../interfaces/userRe
 import { BROADCAST_OPTIONS } from '../../libs/broadcast/broadcast'
 import { getRpcProvider } from '../../services/provider'
 import { AccountsController } from '../accounts/accounts'
+import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
 import { ProvidersController } from '../providers/providers'
 import { SelectedAccountController } from '../selectedAccount/selectedAccount'
@@ -167,6 +168,7 @@ describe('Actions Controller', () => {
       storageCtrl,
       providersCtrl,
       networksCtrl,
+      new KeystoreController('default', storageCtrl, {}, windowManager),
       () => {},
       () => {},
       () => {}

--- a/src/controllers/activity/activity.test.ts
+++ b/src/controllers/activity/activity.test.ts
@@ -203,6 +203,7 @@ describe('Activity Controller ', () => {
       storageCtrl,
       providersCtrl,
       networksCtrl,
+      keystore,
       () => {},
       () => {},
       () => {}

--- a/src/controllers/addressBook/addressBook.test.ts
+++ b/src/controllers/addressBook/addressBook.test.ts
@@ -4,12 +4,14 @@ import { expect, jest } from '@jest/globals'
 
 import { relayerUrl } from '../../../test/config'
 import { produceMemoryStore } from '../../../test/helpers'
+import { mockWindowManager } from '../../../test/helpers/window'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { networks } from '../../consts/networks'
 import { Account } from '../../interfaces/account'
 import { Storage } from '../../interfaces/storage'
 import { getRpcProvider } from '../../services/provider'
 import { AccountsController } from '../accounts/accounts'
+import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
 import { ProvidersController } from '../providers/providers'
 import { SelectedAccountController } from '../selectedAccount/selectedAccount'
@@ -82,6 +84,7 @@ describe('AddressBookController', () => {
     storageCtrl,
     providersCtrl,
     networksCtrl,
+    new KeystoreController('default', storageCtrl, {}, mockWindowManager().windowManager),
     () => {},
     () => {},
     () => {}

--- a/src/controllers/defiPositions/defiPositions.test.ts
+++ b/src/controllers/defiPositions/defiPositions.test.ts
@@ -68,6 +68,7 @@ const prepareTest = async () => {
     storageCtrl,
     providersCtrl,
     networksCtrl,
+    keystoreCtrl,
     () => {},
     () => {},
     () => {}

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -156,6 +156,7 @@ export class KeystoreController extends EventEmitter {
         return { ...s, id: 'legacy-saved-seed', label: 'Recovery Phrase 1' }
       })
       this.#keystoreKeys = keystoreKeys
+      console.log('Debug: Keystore keys loaded', this.#keystoreKeys)
     } catch (e) {
       this.emitError({
         message:
@@ -988,6 +989,7 @@ export class KeystoreController extends EventEmitter {
   }
 
   getAccountKeys(acc: Account): Key[] {
+    console.log('Debug: Keystore getAccountKeys', this.keys, acc)
     return this.keys.filter((key) => acc.associatedKeys.includes(key.addr))
   }
 

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -156,7 +156,6 @@ export class KeystoreController extends EventEmitter {
         return { ...s, id: 'legacy-saved-seed', label: 'Recovery Phrase 1' }
       })
       this.#keystoreKeys = keystoreKeys
-      console.log('Debug: Keystore keys loaded', this.#keystoreKeys)
     } catch (e) {
       this.emitError({
         message:
@@ -989,7 +988,6 @@ export class KeystoreController extends EventEmitter {
   }
 
   getAccountKeys(acc: Account): Key[] {
-    console.log('Debug: Keystore getAccountKeys', this.keys, acc)
     return this.keys.filter((key) => acc.associatedKeys.includes(key.addr))
   }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -292,6 +292,7 @@ export class MainController extends EventEmitter {
       this.storage,
       this.providers,
       this.networks,
+      this.keystore,
       async (accounts) => {
         const defaultSelectedAccount = getDefaultSelectedAccount(accounts)
         if (defaultSelectedAccount) {

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -189,6 +189,7 @@ const prepareTest = () => {
     storageCtrl,
     providersCtrl,
     networksCtrl,
+    keystore,
     () => {},
     () => {},
     () => {}

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -44,10 +44,20 @@ const networksCtrl = new NetworksController(
 providersCtrl = new ProvidersController(networksCtrl)
 providersCtrl.providers = providers
 
+const windowManager = mockWindowManager().windowManager
+
+const keystore = new KeystoreController(
+  'default',
+  storageCtrl,
+  { internal: KeystoreSigner },
+  windowManager
+)
+
 const accountsCtrl = new AccountsController(
   storageCtrl,
   providersCtrl,
   networksCtrl,
+  keystore,
   () => {},
   () => {},
   () => {}
@@ -57,15 +67,6 @@ const selectedAccountCtrl = new SelectedAccountController({
   storage: storageCtrl,
   accounts: accountsCtrl
 })
-
-const windowManager = mockWindowManager().windowManager
-
-const keystore = new KeystoreController(
-  'default',
-  storageCtrl,
-  { internal: KeystoreSigner },
-  windowManager
-)
 
 const portfolioCtrl = new PortfolioController(
   storageCtrl,

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -381,6 +381,7 @@ const init = async (
     storageCtrl,
     providersCtrl,
     networksCtrl,
+    keystore,
     () => {},
     () => {},
     () => {}

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -341,6 +341,7 @@ const init = async (
   const storage: Storage = produceMemoryStore()
   const storageCtrl = new StorageController(storage)
   await storageCtrl.set('accounts', [account])
+  await storageCtrl.set('selectedAccount', account.addr)
   const keystore = new KeystoreController(
     'default',
     storageCtrl,
@@ -1172,7 +1173,6 @@ describe('Negative cases', () => {
       },
       true
     )
-
     // @ts-ignore
     controller.update({
       hasNewEstimation: true,
@@ -1181,7 +1181,6 @@ describe('Negative cases', () => {
       signingKeyAddr: eoaSigner.keyPublicAddress,
       signingKeyType: 'internal'
     })
-
     await controller.sign()
 
     if (!controller.accountOp?.signature) {

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -128,6 +128,7 @@ describe('SignMessageController', () => {
       storageCtrl,
       providersCtrl,
       networksCtrl,
+      keystoreCtrl,
       () => {},
       () => {},
       () => {}

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -72,10 +72,14 @@ const networksCtrl = new NetworksController(
 
 providersCtrl = new ProvidersController(networksCtrl)
 providersCtrl.providers = providers
+
+const keystore = new KeystoreController('default', storageCtrl, {}, windowManager)
+
 const accountsCtrl = new AccountsController(
   storageCtrl,
   providersCtrl,
   networksCtrl,
+  keystore,
   () => {},
   () => {},
   () => {}
@@ -99,8 +103,6 @@ const inviteCtrl = new InviteController({
 })
 
 const callRelayer = relayerCall.bind({ url: '', fetch })
-
-const keystore = new KeystoreController('default', storageCtrl, {}, windowManager)
 
 const portfolioCtrl = new PortfolioController(
   storageCtrl,

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -24,6 +24,24 @@ import { StorageController } from '../storage/storage'
 import { SocketAPIMock } from './socketApiMock'
 import { SwapAndBridgeController } from './swapAndBridge'
 
+const accounts = [
+  {
+    addr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
+    associatedKeys: [],
+    initialPrivileges: [],
+    creation: {
+      factoryAddr: '0xBf07a0Df119Ca234634588fbDb5625594E2a5BCA',
+      bytecode:
+        '0x7f00000000000000000000000000000000000000000000000000000000000000017f02c94ba85f2ea274a3869293a0a9bf447d073c83c617963b0be7c862ec2ee44e553d602d80604d3d3981f3363d3d373d3d3d363d732a2b85eb1054d6f0c6c2e37da05ed3e5fea684ef5af43d82803e903d91602b57fd5bf3',
+      salt: '0x2ee01d932ede47b0b2fb1b6af48868de9f86bfc9a5be2f0b42c0111cf261d04c'
+    },
+    preferences: {
+      label: DEFAULT_ACCOUNT_LABEL,
+      pfp: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+    }
+  }
+]
+
 // Notice
 // The status of swapAndBridge.ts is a bit more difficult to test
 // as we now have this code:
@@ -74,6 +92,8 @@ providersCtrl = new ProvidersController(networksCtrl)
 providersCtrl.providers = providers
 
 const keystore = new KeystoreController('default', storageCtrl, {}, windowManager)
+
+storage.set('selectedAccount', accounts[0].addr)
 
 const accountsCtrl = new AccountsController(
   storageCtrl,
@@ -128,24 +148,6 @@ const activityCtrl = new ActivityController(
 )
 
 const socketAPIMock = new SocketAPIMock({ fetch, apiKey: '' })
-
-const accounts = [
-  {
-    addr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
-    associatedKeys: [],
-    initialPrivileges: [],
-    creation: {
-      factoryAddr: '0xBf07a0Df119Ca234634588fbDb5625594E2a5BCA',
-      bytecode:
-        '0x7f00000000000000000000000000000000000000000000000000000000000000017f02c94ba85f2ea274a3869293a0a9bf447d073c83c617963b0be7c862ec2ee44e553d602d80604d3d3981f3363d3d373d3d3d363d732a2b85eb1054d6f0c6c2e37da05ed3e5fea684ef5af43d82803e903d91602b57fd5bf3',
-      salt: '0x2ee01d932ede47b0b2fb1b6af48868de9f86bfc9a5be2f0b42c0111cf261d04c'
-    },
-    preferences: {
-      label: DEFAULT_ACCOUNT_LABEL,
-      pfp: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
-    }
-  }
-]
 
 const PORTFOLIO_TOKENS = [
   {

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -10,7 +10,7 @@ import fetch from 'node-fetch'
 import { expect } from '@jest/globals'
 
 import { relayerUrl, velcroUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
+import { mockInternalKeys, produceMemoryStore } from '../../../test/helpers'
 import { mockWindowManager } from '../../../test/helpers/window'
 import { EIP7702Auth } from '../../consts/7702'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
@@ -27,7 +27,7 @@ import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import { getRpcProvider } from '../../services/provider'
 import { AccountsController } from '../accounts/accounts'
 import { ActivityController } from '../activity/activity'
-import { AddressBookController, Contacts } from '../addressBook/addressBook'
+import { AddressBookController } from '../addressBook/addressBook'
 import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
 import { PortfolioController } from '../portfolio/portfolio'
@@ -61,7 +61,6 @@ const PLACEHOLDER_SELECTED_ACCOUNT: Account = {
 const XWALLET_ADDRESS = '0x47Cd7E91C3CBaAF266369fe8518345fc4FC12935'
 const STK_WALLET_ADDRESS = '0xE575cC6EC0B5d176127ac61aD2D3d9d19d1aa4a0'
 
-const CONTACTS: Contacts = []
 const ethPortfolio = new Portfolio(fetch, provider, ethereum, velcroUrl)
 const polygonPortfolio = new Portfolio(fetch, polygonProvider, polygon, velcroUrl)
 
@@ -72,8 +71,6 @@ const providers = Object.fromEntries(
 )
 
 let providersCtrl: ProvidersController
-
-const EMPTY_ACCOUNT_ADDR = '0xA098B9BccaDd9BAEc311c07433e94C9d260CbC07'
 
 const account = {
   addr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
@@ -91,79 +88,16 @@ const account = {
   }
 }
 
-const account2 = {
-  addr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
-  associatedKeys: [],
-  initialPrivileges: [],
-  creation: {
-    factoryAddr: '0xBf07a0Df119Ca234634588fbDb5625594E2a5BCA',
-    bytecode:
-      '0x7f00000000000000000000000000000000000000000000000000000000000000017f02c94ba85f2ea274a3869293a0a9bf447d073c83c617963b0be7c862ec2ee44e553d602d80604d3d3981f3363d3d373d3d3d363d732a2b85eb1054d6f0c6c2e37da05ed3e5fea684ef5af43d82803e903d91602b57fd5bf3',
-    salt: '0x2ee01d932ede47b0b2fb1b6af48868de9f86bfc9a5be2f0b42c0111cf261d04c'
-  },
-  preferences: {
-    label: DEFAULT_ACCOUNT_LABEL,
-    pfp: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
-  }
-}
-
-const account3 = {
-  addr: '0x018D034c782db8462d864996dE3c297bcf66f86A',
-  initialPrivileges: [
-    [
-      '0xdD6487aa74f0158733e8a36E466A98f4aEE9c179',
-      '0x0000000000000000000000000000000000000000000000000000000000000002'
-    ]
-  ],
-  associatedKeys: ['0xdD6487aa74f0158733e8a36E466A98f4aEE9c179'],
-  creation: {
-    factoryAddr: '0xa8202f888b9b2dfa5ceb2204865018133f6f179a',
-    bytecode:
-      '0x7f00000000000000000000000000000000000000000000000000000000000000027f9405c22160986551985df269a2a18b4e60aa0a1347bd75cbcea777ea18692b1c553d602d80604d3d3981f3363d3d373d3d3d363d730e370942ebe4d026d05d2cf477ff386338fc415a5af43d82803e903d91602b57fd5bf3',
-    salt: '0x0000000000000000000000000000000000000000000000000000000000000000'
-  },
-  preferences: {
-    label: DEFAULT_ACCOUNT_LABEL,
-    pfp: '0x018D034c782db8462d864996dE3c297bcf66f86A'
-  }
-}
-
-const account4 = {
-  addr: '0x3e2D734349654166a2Ad92CaB2437A76a70B650a',
-  initialPrivileges: [
-    [
-      '0xBd84Cc40a5b5197B5B61919c22A55e1c46d2A3bb',
-      '0x0000000000000000000000000000000000000000000000000000000000000002'
-    ]
-  ],
-  associatedKeys: ['0xBd84Cc40a5b5197B5B61919c22A55e1c46d2A3bb'],
-  creation: {
-    factoryAddr: '0x26cE6745A633030A6faC5e64e41D21fb6246dc2d',
-    bytecode:
-      '0x7f00000000000000000000000000000000000000000000000000000000000000027ff33cc417366b7e38d2706a67ab46f85465661c28b864b521441180d15df82251553d602d80604d3d3981f3363d3d373d3d3d363d730f2aa7bcda3d9d210df69a394b6965cb2566c8285af43d82803e903d91602b57fd5bf3',
-    salt: '0x0000000000000000000000000000000000000000000000000000000000000000'
-  },
-  preferences: {
-    label: DEFAULT_ACCOUNT_LABEL,
-    pfp: '0x3e2D734349654166a2Ad92CaB2437A76a70B650a'
-  }
-}
-
-const emptyAccount = {
-  addr: EMPTY_ACCOUNT_ADDR,
-  initialPrivileges: [],
-  associatedKeys: [],
-  creation: null,
-  preferences: {
-    label: DEFAULT_ACCOUNT_LABEL,
-    pfp: EMPTY_ACCOUNT_ADDR
-  }
-}
-
 const storage = produceMemoryStore()
 const storageCtrl = new StorageController(storage)
 
-storageCtrl.set('accounts', [account, account2, account3, account4, emptyAccount])
+const accounts = [account]
+
+const mockKeys = mockInternalKeys(accounts as Account[])
+
+storage.set('keystoreKeys', mockKeys)
+
+storageCtrl.set('accounts', accounts)
 
 const networksCtrl = new NetworksController(
   storageCtrl,

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -4,9 +4,11 @@
 /* eslint-disable @typescript-eslint/no-useless-constructor */
 /* eslint-disable max-classes-per-file */
 
-import { expect } from '@jest/globals'
 import { hexlify, randomBytes } from 'ethers'
 import fetch from 'node-fetch'
+
+import { expect } from '@jest/globals'
+
 import { relayerUrl, velcroUrl } from '../../../test/config'
 import { produceMemoryStore } from '../../../test/helpers'
 import { mockWindowManager } from '../../../test/helpers/window'
@@ -177,15 +179,6 @@ const networksCtrl = new NetworksController(
 providersCtrl = new ProvidersController(networksCtrl)
 providersCtrl.providers = providers
 
-const accountsCtrl = new AccountsController(
-  storageCtrl,
-  providersCtrl,
-  networksCtrl,
-  () => {},
-  () => {},
-  () => {}
-)
-
 // TODO - this mocks are being duplicated across the tests. Should reuse it.
 class InternalSigner {
   key
@@ -257,11 +250,6 @@ class LedgerSigner {
   }
 }
 
-const selectedAccountCtrl = new SelectedAccountController({
-  storage: storageCtrl,
-  accounts: accountsCtrl
-})
-
 const windowManager = mockWindowManager().windowManager
 const keystoreSigners = { internal: InternalSigner, ledger: LedgerSigner }
 const keystoreController = new KeystoreController(
@@ -270,6 +258,21 @@ const keystoreController = new KeystoreController(
   keystoreSigners,
   windowManager
 )
+
+const accountsCtrl = new AccountsController(
+  storageCtrl,
+  providersCtrl,
+  networksCtrl,
+  keystoreController,
+  () => {},
+  () => {},
+  () => {}
+)
+
+const selectedAccountCtrl = new SelectedAccountController({
+  storage: storageCtrl,
+  accounts: accountsCtrl
+})
 
 const addressBookController = new AddressBookController(
   storageCtrl,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -382,6 +382,22 @@ const waitForAccountsCtrlFirstLoad = async (accountsCtrl: AccountsController) =>
   })
 }
 
+/**
+ * Creates internal keys for the given accounts.
+ * Most often used to force the accounts controller to fetch
+ * the account states for the given accounts.
+ */
+const mockInternalKeys = (accounts: Account[]) =>
+  accounts.map((acc) => ({
+    addr: acc.associatedKeys[0],
+    label: 'test key',
+    type: 'internal',
+    dedicatedToOneSA: false,
+    meta: {
+      createdAt: new Date().getTime()
+    }
+  }))
+
 export {
   buildUserOp,
   getAccountGasLimits,
@@ -395,6 +411,7 @@ export {
   getSignerKey,
   getTargetNonce,
   getTimelockData,
+  mockInternalKeys,
   produceMemoryStore,
   sendFunds,
   waitForAccountsCtrlFirstLoad


### PR DESCRIPTION
We don't need the account state of view-only accounts, as they cannot be used as a broadcasting option. The account state of view-only accounts is only fetched if the account is selected.

## App PR:
https://github.com/AmbireTech/ambire-app/pull/5049

## To be done:
- [x] Fix unit tests

Closes https://github.com/AmbireTech/ambire-app/issues/4862