### PR TITLE
Fix: deployless token mapping

### DIFF
--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -231,7 +231,7 @@ export async function getTokens(
       tokenName = token.name
     } catch (e: any) {
       console.log(
-        `no name was found for a token with a symbol of: ${token.symbol}, address: ${address} on ${network.name}`
+        `no name was found for a token with a symbol of: ${symbol}, address: ${address} on ${network.name}`
       )
     }
 

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -219,15 +219,20 @@ export async function getTokens(
   tokenAddrs: string[]
 ): Promise<[[TokenError, TokenResult][], MetaData][]> {
   const mapToken = (token: any, address: string) => {
-    const symbol = overrideSymbol(address, network.chainId, token.symbol)
+    let symbol = 'Unknown'
+    try {
+      symbol = overrideSymbol(address, network.chainId, token.symbol)
+    } catch (e: any) {
+      console.log(`no symbol was found for token with address ${address} on ${network.name}`)
+    }
+
     let tokenName = symbol
     try {
       tokenName = token.name
     } catch (e: any) {
-      // token.name should be a valid getter but if it's not because
-      // the implemented token is not following strictly erc-20 standards,
-      // we allow the execution to proceed
-      if (!e.message.includes('accessing property "name"')) throw e
+      console.log(
+        `no name was found for a token with a symbol of: ${token.symbol}, address: ${address} on ${network.name}`
+      )
     }
 
     return {

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -219,6 +219,20 @@ export async function getTokens(
   tokenAddrs: string[]
 ): Promise<[[TokenError, TokenResult][], MetaData][]> {
   const mapToken = (token: any, address: string) => {
+    let symbol = 'Unknown'
+    try {
+      symbol = overrideSymbol(address, network.chainId, token.symbol)
+    } catch (e: any) {
+      // this is just in case some token is returned with a symbol
+    }
+
+    let tokenName = symbol
+    try {
+      tokenName = token.name
+    } catch (e: any) {
+      // some tokens are returned without a name and this is how we catch them
+    }
+
     return {
       amount: token.amount,
       chainId: network.chainId,
@@ -226,11 +240,11 @@ export async function getTokens(
       name:
         address === '0x0000000000000000000000000000000000000000'
           ? network.nativeAssetName
-          : token.name,
+          : tokenName,
       symbol:
         address === '0x0000000000000000000000000000000000000000'
           ? network.nativeAssetSymbol
-          : overrideSymbol(address, network.chainId, token.symbol),
+          : symbol,
       address,
       flags: getFlags({}, network.chainId.toString(), network.chainId, address)
     } as TokenResult

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -219,18 +219,15 @@ export async function getTokens(
   tokenAddrs: string[]
 ): Promise<[[TokenError, TokenResult][], MetaData][]> {
   const mapToken = (token: any, address: string) => {
-    let symbol = 'Unknown'
-    try {
-      symbol = overrideSymbol(address, network.chainId, token.symbol)
-    } catch (e: any) {
-      // this is just in case some token is returned with a symbol
-    }
-
+    const symbol = overrideSymbol(address, network.chainId, token.symbol)
     let tokenName = symbol
     try {
       tokenName = token.name
     } catch (e: any) {
-      // some tokens are returned without a name and this is how we catch them
+      // token.name should be a valid getter but if it's not because
+      // the implemented token is not following strictly erc-20 standards,
+      // we allow the execution to proceed
+      if (!e.message.includes('accessing property "name"')) throw e
     }
 
     return {


### PR DESCRIPTION
A token without a name was returned from deployless and broke the network