### PR TITLE
Bug / Extension crash caused by missing `accountOp` in case of Sign Account Op controller error

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2183,6 +2183,7 @@ export class SwapAndBridgeController extends EventEmitter {
       this.emitUpdate()
     })
     this.#signAccountOpController.onError((error) => {
+      // TODO: Might be obsolete, because the simulation for the one click swap starts when broadcast succeeds
       if (this.signAccountOpController)
         this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2183,7 +2183,7 @@ export class SwapAndBridgeController extends EventEmitter {
       this.emitUpdate()
     })
     this.#signAccountOpController.onError((error) => {
-      if (this.signAccountOpController?.accountOp)
+      if (this.signAccountOpController)
         this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
 
       this.emitError(error)

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2183,7 +2183,9 @@ export class SwapAndBridgeController extends EventEmitter {
       this.emitUpdate()
     })
     this.#signAccountOpController.onError((error) => {
-      this.#portfolio.overridePendingResults(this.signAccountOpController!.accountOp)
+      if (this.signAccountOpController?.accountOp)
+        this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
+
       this.emitError(error)
     })
     // if the estimation emits an error, handle it

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -635,7 +635,9 @@ export class TransferController extends EventEmitter {
       this.emitUpdate()
     })
     this.signAccountOpController.onError((error) => {
-      this.#portfolio.overridePendingResults(this.signAccountOpController!.accountOp)
+      if (this.signAccountOpController?.accountOp)
+        this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
+
       this.emitError(error)
     })
 

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -635,6 +635,7 @@ export class TransferController extends EventEmitter {
       this.emitUpdate()
     })
     this.signAccountOpController.onError((error) => {
+      // TODO: Might be obsolete, because the simulation for the one click transfer starts when broadcast succeeds
       if (this.signAccountOpController)
         this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
 

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -635,7 +635,7 @@ export class TransferController extends EventEmitter {
       this.emitUpdate()
     })
     this.signAccountOpController.onError((error) => {
-      if (this.signAccountOpController?.accountOp)
+      if (this.signAccountOpController)
         this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
 
       this.emitError(error)


### PR DESCRIPTION
Ref: https://monitor.ambire.com/organizations/ambire/issues/78