### PR TITLE
Bug / Sign Account Op subscriptions management in the Transfer and Swap & Bridge controllers to prevent memory leaks and incorrect state handling

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -243,6 +243,8 @@ export class SwapAndBridgeController extends EventEmitter {
    */
   #signAccountOpController: SignAccountOpController | null = null
 
+  #signAccountOpSubscriptions: Function[] = []
+
   #portfolioUpdate: Function
 
   #isMainSignAccountOpThrowingAnEstimationError: Function | undefined
@@ -2044,6 +2046,10 @@ export class SwapAndBridgeController extends EventEmitter {
   }
 
   destroySignAccountOp() {
+    // Unsubscribe from all previous subscriptions
+    this.#signAccountOpSubscriptions.forEach((unsubscribe) => unsubscribe())
+    this.#signAccountOpSubscriptions = []
+
     if (!this.signAccountOpController) return
     this.signAccountOpController.reset()
     this.#signAccountOpController = null
@@ -2184,26 +2190,34 @@ export class SwapAndBridgeController extends EventEmitter {
     this.emitUpdate()
 
     // propagate updates from signAccountOp here
-    this.#signAccountOpController.onUpdate(() => {
-      this.emitUpdate()
-    })
-    this.#signAccountOpController.onError((error) => {
-      // TODO: Might be obsolete, because the simulation for the one click swap starts when broadcast succeeds
-      if (this.signAccountOpController)
-        this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
+    this.#signAccountOpSubscriptions.push(
+      this.#signAccountOpController.onUpdate(() => {
+        this.emitUpdate()
+      })
+    )
+    this.#signAccountOpSubscriptions.push(
+      this.#signAccountOpController.onError((error) => {
+        // TODO: Might be obsolete, because the simulation for the one click swap starts when broadcast succeeds
+        if (this.signAccountOpController)
+          this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
 
-      this.emitError(error)
-    })
+        this.emitError(error)
+      })
+    )
     // if the estimation emits an error, handle it
-    this.#signAccountOpController.estimation.onUpdate(() => {
-      if (
-        this.signAccountOpController?.accountOp.meta?.swapTxn?.activeRouteId &&
-        this.signAccountOpController.estimation.status === EstimationStatus.Error
-      ) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.onEstimationFailure(this.signAccountOpController.accountOp.meta.swapTxn.activeRouteId)
-      }
-    })
+    this.#signAccountOpSubscriptions.push(
+      this.#signAccountOpController.estimation.onUpdate(() => {
+        if (
+          this.signAccountOpController?.accountOp.meta?.swapTxn?.activeRouteId &&
+          this.signAccountOpController.estimation.status === EstimationStatus.Error
+        ) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          this.onEstimationFailure(
+            this.signAccountOpController.accountOp.meta.swapTxn.activeRouteId
+          )
+        }
+      })
+    )
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.reestimate(userTxn)

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -243,6 +243,10 @@ export class SwapAndBridgeController extends EventEmitter {
    */
   #signAccountOpController: SignAccountOpController | null = null
 
+  /**
+   * Holds all subscriptions (on update and on error) to the signAccountOpController.
+   * This is needed to unsubscribe from the subscriptions when the controller is destroyed.
+   */
   #signAccountOpSubscriptions: Function[] = []
 
   #portfolioUpdate: Function

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2197,9 +2197,11 @@ export class SwapAndBridgeController extends EventEmitter {
     )
     this.#signAccountOpSubscriptions.push(
       this.#signAccountOpController.onError((error) => {
-        // TODO: Might be obsolete, because the simulation for the one click swap starts when broadcast succeeds
-        if (this.signAccountOpController)
-          this.#portfolio.overridePendingResults(this.signAccountOpController.accountOp)
+        // Need to clean the pending results for THIS signAccountOpController
+        // specifically. NOT the one from the getter (this.signAccountOpController)
+        // that is ALWAYS up-to-date with the current quote and the current form state.
+        if (this.#signAccountOpController)
+          this.#portfolio.overridePendingResults(this.#signAccountOpController.accountOp)
 
         this.emitError(error)
       })

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2050,7 +2050,9 @@ export class SwapAndBridgeController extends EventEmitter {
   }
 
   destroySignAccountOp() {
-    // Unsubscribe from all previous subscriptions
+    // Always attempt to unsubscribe from all previous subscriptions,
+    // because the signAccountOpController getter might return null,
+    // but prev references to the signAccountOpController might still exist.
     this.#signAccountOpSubscriptions.forEach((unsubscribe) => unsubscribe())
     this.#signAccountOpSubscriptions = []
 
@@ -2192,6 +2194,11 @@ export class SwapAndBridgeController extends EventEmitter {
     )
 
     this.emitUpdate()
+
+    // Unsubscribe from all previous subscriptions, if any exist, because the
+    // sign account op does NOT destroys before every initSignAccountOpIfNeeded() call
+    this.#signAccountOpSubscriptions.forEach((unsubscribe) => unsubscribe())
+    this.#signAccountOpSubscriptions = []
 
     // propagate updates from signAccountOp here
     this.#signAccountOpSubscriptions.push(

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2211,6 +2211,7 @@ export class SwapAndBridgeController extends EventEmitter {
         // Need to clean the pending results for THIS signAccountOpController
         // specifically. NOT the one from the getter (this.signAccountOpController)
         // that is ALWAYS up-to-date with the current quote and the current form state.
+        // Due to the async nature, it might not exist - an issue caught by our crash reporting.
         if (this.#signAccountOpController)
           this.#portfolio.overridePendingResults(this.#signAccountOpController.accountOp)
 


### PR DESCRIPTION
Solves a couple of problems found recently, namely:

- Fixed: Unsubscribe (clean up) sign account op subscriptions (on update and error) when instance gets destroyed for the Transfer and Swap & Bridge controllers
- Fixed: Swap & Bridge controller on sign account op controller error should clean the pending balances for the correct sign account op ref.