### PR TITLE
Update/ Portfolio price caching

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -422,7 +422,7 @@ export class PortfolioController extends EventEmitter {
 
     try {
       const result = await portfolioLib.get(accountId, {
-        priceRecency: 60000,
+        priceRecency: 60000 * 5,
         additionalErc20Hints: [additionalHint, ...temporaryTokensToFetch.map((x) => x.address)],
         disableAutoDiscovery: true
       })
@@ -582,7 +582,7 @@ export class PortfolioController extends EventEmitter {
 
     try {
       const result = await portfolioLib.get(accountId, {
-        priceRecency: 60000,
+        priceRecency: 60000 * 5,
         priceCache: state.result?.priceCache,
         fetchPinned: !hasNonZeroTokens,
         ...portfolioProps

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -354,13 +354,15 @@ export class Portfolio {
 
           priceIn = getPriceFromCache(token.address, localOpts.priceRecencyOnFailure) || []
 
-          // Avoid duplicate errors, because this.bachedGecko is called for each token and if
-          // there is an error it will most likely be the same for all tokens
           if (
+            // Avoid duplicate errors, because this.bachedGecko is called for each token and if
+            // there is an error it will most likely be the same for all tokens
             !errors.find(
               (x) =>
                 x.name === PORTFOLIO_LIB_ERROR_NAMES.PriceFetchError && x.message === errorMessage
-            )
+            ) &&
+            // Don't display an error if there is a cached price
+            !priceIn.length
           ) {
             errors.push({
               name: PORTFOLIO_LIB_ERROR_NAMES.PriceFetchError,


### PR DESCRIPTION
## Changes:
- Changes price recency from 1 min to 5 min
- Change: Don't display an error banner on price fetch if there is a cached price 

The aim is to reduce the number of calls to cena and display error banners less frequently.