### PR TITLE
Fix: sponsorship on bundler lottery

### DIFF
--- a/src/libs/erc7677/erc7677.ts
+++ b/src/libs/erc7677/erc7677.ts
@@ -72,8 +72,15 @@ export async function getPaymasterData(
   network: Network
 ): Promise<PaymasterData> {
   const provider = getRpcProvider([service.url], network.chainId)
+  // TODO<Bobby>: better way to send the bundler
+  // send the whole userOp if the sponsorship is from ambire.com
+  // so we could fetch the bundler used
+  const reqUserOp: any = getCleanUserOp(userOp)[0]
+  if (service.url.indexOf('ambire.com') !== -1) {
+    reqUserOp.bundler = userOp.bundler
+  }
   return provider.send('pm_getPaymasterData', [
-    getCleanUserOp(userOp)[0],
+    reqUserOp,
     ERC_4337_ENTRYPOINT,
     toBeHex(network.chainId.toString()),
     service.context


### PR DESCRIPTION
Add: send the bundler along when using the sponsorship so it doesn't fail in case of biconomy