### PR TITLE
Bug / JS error toasts caused by missing `provider` dep for the Deployless class

### DIFF
--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -265,7 +265,8 @@ export class Paymaster extends AbstractPaymaster {
     op: AccountOp,
     userOp: UserOperation
   ): Promise<PaymasterSuccessReponse | PaymasterErrorReponse> {
-    if (!this.provider) throw new Error('provider not set, did you call init?')
+    const provider = this.provider
+    if (!provider) throw new Error('provider not set, did you call init?')
     if (!this.network) throw new Error('network not set, did you call init?')
 
     // request the paymaster with a timeout window
@@ -279,7 +280,7 @@ export class Paymaster extends AbstractPaymaster {
         salt: acc.creation?.salt,
         key: acc.associatedKeys[0],
         // eslint-disable-next-line no-underscore-dangle
-        rpcUrl: this.provider!._getConnection().url,
+        rpcUrl: provider._getConnection().url,
         bundler: userOp.bundler
       })
     })


### PR DESCRIPTION
When refreshing the balance, this happened:

<img width="722" height="113" alt="Screenshot 2025-07-23 at 12 21 23" src="https://github.com/user-attachments/assets/bd4180f4-74d5-4999-bd6b-46f39d3cd5f7" />

Full details: https://goodmorning-dev.slack.com/archives/C0644227TAP/p1753200412351269

So this PR tweaks:

- Fixed: Handle the case when the `provider` prop is a Provider instance, do not always assume it's JsonRpcProvider.
- Changed: Refactor to type narrowing vs non-null assertions (`!`)