### PR TITLE
Fix / Transfer - Skip tracking on close

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -2422,7 +2422,6 @@ export class MainController extends EventEmitter {
   }
 
   onOneClickTransferClose() {
-    console.log('Transfer -> onOneClickTransferClose')
     const signAccountOp = this.transfer.signAccountOpController
 
     // Always unload the screen when the action window is closed

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -2420,6 +2420,7 @@ export class MainController extends EventEmitter {
   }
 
   onOneClickTransferClose() {
+    console.log('Transfer -> onOneClickTransferClose')
     const signAccountOp = this.transfer.signAccountOpController
 
     // Always unload the screen when the action window is closed
@@ -2827,8 +2828,11 @@ export class MainController extends EventEmitter {
     }
 
     if (type === SIGN_ACCOUNT_OP_TRANSFER) {
-      this.transfer.latestBroadcastedToken = this.transfer.selectedToken
-      this.transfer.latestBroadcastedAccountOp = submittedAccountOp
+      if (this.transfer.shouldTrackLatestBroadcastedAccountOp) {
+        this.transfer.latestBroadcastedToken = this.transfer.selectedToken
+        this.transfer.latestBroadcastedAccountOp = submittedAccountOp
+      }
+
       this.transfer.resetForm()
     }
 

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -201,7 +201,6 @@ export class TransferController extends EventEmitter {
 
   set shouldTrackLatestBroadcastedAccountOp(value: boolean) {
     this.#shouldTrackLatestBroadcastedAccountOp = value
-    this.emitUpdate()
   }
 
   // every time when updating selectedToken update the amount and maxAmount of the form
@@ -266,7 +265,6 @@ export class TransferController extends EventEmitter {
   }
 
   resetForm(shouldDestroyAccountOp = true) {
-    console.log('Transfer -> resetForm() called')
     this.selectedToken = null
     this.amount = ''
     this.amountInFiat = ''

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -126,6 +126,8 @@ export class TransferController extends EventEmitter {
 
   latestBroadcastedToken: TokenResult | null = null
 
+  #shouldTrackLatestBroadcastedAccountOp: boolean = true
+
   hasProceeded: boolean = false
 
   // Used to safely manage and cancel the periodic estimation loop.
@@ -193,6 +195,15 @@ export class TransferController extends EventEmitter {
     this.emitUpdate()
   }
 
+  get shouldTrackLatestBroadcastedAccountOp() {
+    return this.#shouldTrackLatestBroadcastedAccountOp
+  }
+
+  set shouldTrackLatestBroadcastedAccountOp(value: boolean) {
+    this.#shouldTrackLatestBroadcastedAccountOp = value
+    this.emitUpdate()
+  }
+
   // every time when updating selectedToken update the amount and maxAmount of the form
   set selectedToken(token: TokenResult | null) {
     if (!token || Number(getTokenAmount(token)) === 0) {
@@ -254,7 +265,8 @@ export class TransferController extends EventEmitter {
     )
   }
 
-  resetForm() {
+  resetForm(shouldDestroyAccountOp = true) {
+    console.log('Transfer -> resetForm() called')
     this.selectedToken = null
     this.amount = ''
     this.amountInFiat = ''
@@ -263,7 +275,10 @@ export class TransferController extends EventEmitter {
     this.#onRecipientAddressChange()
     this.programmaticUpdateCounter = 0
 
-    this.destroySignAccountOp()
+    if (shouldDestroyAccountOp) {
+      this.destroySignAccountOp()
+    }
+
     this.emitUpdate()
   }
 
@@ -345,6 +360,8 @@ export class TransferController extends EventEmitter {
     isTopUp,
     amountFieldMode
   }: TransferUpdate) {
+    this.shouldTrackLatestBroadcastedAccountOp = true
+
     if (humanizerInfo) {
       this.#humanizerInfo = humanizerInfo
     }
@@ -717,7 +734,7 @@ export class TransferController extends EventEmitter {
     this.emitUpdate()
   }
 
-  unloadScreen(forceUnload: boolean) {
+  unloadScreen(forceUnload?: boolean) {
     if (this.hasPersistedState && !forceUnload) return
 
     this.destroyLatestBroadcastedAccountOp()


### PR DESCRIPTION
If the Transfer popup is closed during signing or broadcasting, we don't want to show the tracking screen next time. Previously, the last account op was kept and shown, even after closing mid-process (mainCtrl.#broadcastSignedAccountOp). With shouldTrackLatestBroadcastedAccountOp, we can now prevent this and show a fresh form instead.

Linked PR: https://github.com/AmbireTech/ambire-app/pull/5166