### PR TITLE
Refactor/ Portfolio lib hints and prices logic

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -667,7 +667,7 @@ describe('Portfolio Controller ', () => {
   })
 
   describe('Hints- token/nft learning, external api hints and temporary tokens', () => {
-    test('Zero balance token is fetched after being learned', async () => {
+    test('Zero balance token from learned tokens is filtered out', async () => {
       const BANANA_TOKEN_ADDR = '0x94e496474F1725f1c1824cB5BDb92d7691A4F03a'
       const { controller } = prepareTest()
 
@@ -681,7 +681,7 @@ describe('Portfolio Controller ', () => {
         .getLatestPortfolioState(account.addr)
         ['1']?.result?.tokens.find((tk) => tk.address === BANANA_TOKEN_ADDR)
 
-      expect(token).toBeTruthy()
+      expect(token).toBeFalsy()
     })
 
     test('Learned tokens to avoid persisting non-ERC20 tokens', async () => {

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -845,11 +845,12 @@ export class PortfolioController extends EventEmitter {
   }
 
   addTokensToBeLearned(tokenAddresses: string[], chainId: bigint) {
-    if (!tokenAddresses.length) return false
-    if (!this.#toBeLearnedTokens[chainId.toString()])
-      this.#toBeLearnedTokens[chainId.toString()] = []
+    const chainIdString = chainId.toString()
 
-    let networkToBeLearnedTokens = this.#toBeLearnedTokens[chainId.toString()]
+    if (!tokenAddresses.length) return false
+    if (!this.#toBeLearnedTokens[chainIdString]) this.#toBeLearnedTokens[chainIdString] = []
+
+    let networkToBeLearnedTokens = this.#toBeLearnedTokens[chainIdString]
 
     const alreadyLearned = networkToBeLearnedTokens.map((addr) => getAddress(addr))
 
@@ -868,7 +869,7 @@ export class PortfolioController extends EventEmitter {
 
     networkToBeLearnedTokens = [...tokensToLearn, ...networkToBeLearnedTokens]
 
-    this.#toBeLearnedTokens[chainId.toString()] = networkToBeLearnedTokens
+    this.#toBeLearnedTokens[chainIdString] = networkToBeLearnedTokens
     return true
   }
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -894,6 +894,14 @@ export class PortfolioController extends EventEmitter {
       if (alreadyLearned.includes(getAddress(address))) return acc
 
       acc[address] = acc[address] || null // Keep the timestamp of all learned tokens
+
+      if (this.#toBeLearnedTokens[chainId.toString()]) {
+        // Remove the token from toBeLearnedTokens if it will be learned
+        this.#toBeLearnedTokens[chainId.toString()] = this.#toBeLearnedTokens[
+          chainId.toString()
+        ].filter((addr) => addr !== address)
+      }
+
       return acc
     }, {})
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -770,7 +770,8 @@ export class PortfolioController extends EventEmitter {
           const allHints = {
             previousHintsFromExternalAPI,
             additionalErc20Hints,
-            additionalErc721Hints
+            additionalErc721Hints,
+            specialErc20Hints
           }
 
           const [isSuccessfulLatestUpdate] = await Promise.all([
@@ -781,8 +782,7 @@ export class PortfolioController extends EventEmitter {
               portfolioLib,
               {
                 blockTag: 'latest',
-                ...allHints,
-                specialErc20Hints
+                ...allHints
               },
               forceUpdate,
               opts?.maxDataAgeMs
@@ -801,8 +801,7 @@ export class PortfolioController extends EventEmitter {
                       state
                     }
                   }),
-                ...allHints,
-                specialErc20Hints
+                ...allHints
               },
               forceUpdate,
               opts?.maxDataAgeMs

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -235,6 +235,26 @@ export async function getTokens(
       )
     }
 
+    const tokenFlags: TokenResult['flags'] = getFlags(
+      {},
+      network.chainId.toString(),
+      network.chainId,
+      address
+    )
+
+    if (opts.specialErc20Hints && opts.specialErc20Hints[address]) {
+      const value = opts.specialErc20Hints[address]
+
+      if (value === 'custom') {
+        tokenFlags.isCustom = true
+      } else if (value === 'hidden') {
+        tokenFlags.isHidden = true
+      } else if (value === 'hidden-custom') {
+        tokenFlags.isHidden = true
+        tokenFlags.isCustom = true
+      }
+    }
+
     return {
       amount: token.amount,
       chainId: network.chainId,
@@ -248,7 +268,7 @@ export async function getTokens(
           ? network.nativeAssetSymbol
           : symbol,
       address,
-      flags: getFlags({}, network.chainId.toString(), network.chainId, address)
+      flags: tokenFlags
     } as TokenResult
   }
   const deploylessOpts = getDeploylessOpts(accountAddr, !network.rpcNoStateOverride, opts)

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -368,9 +368,10 @@ export const tokenFilter = (
   // It mimics the native POL token (same symbol, same amount) and is shown twice in the Dashboard.
   // From a user's perspective, the token is duplicated and counted twice in the balance.
   const isERC20NativeRepresentation =
-    (token.symbol === nativeToken?.symbol ||
+    !!nativeToken &&
+    (token.symbol === nativeToken.symbol ||
       network.oldNativeAssetSymbols?.includes(token.symbol)) &&
-    token.amount === nativeToken?.amount &&
+    token.amount === nativeToken.amount &&
     token.address !== ZeroAddress
 
   if (isERC20NativeRepresentation) return false

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -3,13 +3,13 @@ import { Contract, formatUnits, ZeroAddress } from 'ethers'
 import IERC20 from '../../../contracts/compiled/IERC20.json'
 import gasTankFeeTokens from '../../consts/gasTankFeeTokens'
 import { PINNED_TOKENS } from '../../consts/pinnedTokens'
-import { AccountId } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
 import { RPCProvider } from '../../interfaces/provider'
 import { CustomToken, TokenPreference } from './customToken'
 import {
   AccountState,
   AdditionalPortfolioNetworkResult,
+  GetOptions,
   NetworkState,
   PortfolioGasTankResult,
   PreviousHintsStorage,
@@ -37,11 +37,16 @@ export function overrideSymbol(address: string, chainId: bigint, symbol: string)
   return symbol
 }
 
-export function getFlags(networkData: any, chainId: string, tokenChainId: bigint, address: string) {
+export function getFlags(
+  networkData: any,
+  chainId: string,
+  tokenChainId: bigint,
+  address: string
+): TokenResult['flags'] {
   const isRewardsOrGasTank = ['gasTank', 'rewards'].includes(chainId)
   const onGasTank = chainId === 'gasTank'
 
-  let rewardsType = null
+  let rewardsType: TokenResult['flags']['rewardsType'] = null
   if (networkData?.stkWalletClaimableBalance?.address.toLowerCase() === address.toLowerCase())
     rewardsType = 'wallet-rewards'
   if (networkData?.walletClaimableBalance?.address.toLowerCase() === address.toLowerCase())
@@ -53,7 +58,7 @@ export function getFlags(networkData: any, chainId: string, tokenChainId: bigint
       (isRewardsOrGasTank ? t.chainId === tokenChainId : t.chainId.toString() === chainId)
   )
 
-  const canTopUpGasTank = foundFeeToken && !foundFeeToken?.disableGasTankDeposit && !rewardsType
+  const canTopUpGasTank = !!foundFeeToken && !foundFeeToken?.disableGasTankDeposit && !rewardsType
   const isFeeToken =
     address === ZeroAddress ||
     // disable if not in gas tank
@@ -64,7 +69,8 @@ export function getFlags(networkData: any, chainId: string, tokenChainId: bigint
     onGasTank,
     rewardsType,
     canTopUpGasTank,
-    isFeeToken
+    isFeeToken,
+    isHidden: false
   }
 }
 
@@ -168,60 +174,6 @@ export const getAccountPortfolioTotal = (
 
     return acc + networkTotalAmountUSD
   }, 0)
-}
-
-export const getPinnedGasTankTokens = (
-  availableGasTankAssets: TokenResult[],
-  hasNonZeroTokens: boolean,
-  accountId: AccountId,
-  gasTankTokens: TokenResult[]
-) => {
-  if (!availableGasTankAssets) return []
-  // Don't set pinnedGasTankTokens if the user has > 1 non-zero tokens
-  if (hasNonZeroTokens) return []
-
-  return availableGasTankAssets.reduce((acc: TokenResult[], token: any) => {
-    const isGasTankToken = !!gasTankTokens.find(
-      (gasTankToken: TokenResult) =>
-        gasTankToken.symbol.toLowerCase() === token.symbol.toLowerCase()
-    )
-    const isAlreadyPinned = !!acc.find(
-      (accToken) => accToken.symbol.toLowerCase() === token.symbol.toLowerCase()
-    )
-
-    if (isGasTankToken || isAlreadyPinned) return acc
-
-    const correspondingPinnedToken = PINNED_TOKENS.find(
-      (pinnedToken) =>
-        (!('accountId' in pinnedToken) || pinnedToken.accountId === accountId) &&
-        pinnedToken.address === token.address &&
-        pinnedToken.chainId.toString() === token.chainId.toString()
-    )
-
-    if (correspondingPinnedToken && correspondingPinnedToken.onGasTank) {
-      acc.push({
-        address: token.address,
-        symbol: token.symbol.toUpperCase(),
-        name: token.name,
-        amount: 0n,
-        chainId: correspondingPinnedToken.chainId,
-        decimals: token.decimals,
-        priceIn: [
-          {
-            baseCurrency: 'usd',
-            price: token.price
-          }
-        ],
-        flags: {
-          rewardsType: null,
-          canTopUpGasTank: true,
-          isFeeToken: true,
-          onGasTank: true
-        }
-      })
-    }
-    return acc
-  }, [])
 }
 
 export const stripExternalHintsAPIResponse = (
@@ -365,22 +317,50 @@ export function getUpdatedHints(
   }
 }
 
-export const getTokensReadyToLearn = (toBeLearnedTokens: string[], resultTokens: TokenResult[]) => {
-  if (!toBeLearnedTokens || !resultTokens || !toBeLearnedTokens.length || !resultTokens.length)
-    return []
+export const getSpecialHints = (
+  chainId: Network['chainId'],
+  customTokens: CustomToken[],
+  tokenPreferences: TokenPreference[],
+  toBeLearnedTokens: {
+    [chainId: string]: string[]
+  }
+) => {
+  // The order is important here.
+  // Learned tokens are first because they can be overridden by custom or hidden tokens.
+  // Custom tokens are second because they can become hidden-custom
+  // Hidden tokens are last because they can become hidden-custom if a custom token with the same address exists.
+  const specialErc20Hints: GetOptions['specialErc20Hints'] = {}
 
-  return toBeLearnedTokens.filter((address) =>
-    resultTokens.find((resultToken) => resultToken.address === address && resultToken.amount > 0n)
-  )
+  if (toBeLearnedTokens && toBeLearnedTokens[chainId.toString()]) {
+    toBeLearnedTokens[chainId.toString()].forEach((token) => {
+      specialErc20Hints[token] = 'learn'
+    })
+  }
+
+  customTokens.forEach((token) => {
+    if (token.chainId === chainId && token.standard === 'ERC20') {
+      specialErc20Hints[token.address] = 'custom'
+    }
+  })
+
+  tokenPreferences.forEach((token) => {
+    if (token.chainId === chainId && token.isHidden) {
+      if (specialErc20Hints[token.address]) {
+        specialErc20Hints[token.address] = 'hidden-custom'
+      } else {
+        specialErc20Hints[token.address] = 'hidden'
+      }
+    }
+  })
+
+  return specialErc20Hints
 }
 
 export const tokenFilter = (
   token: TokenResult,
-  nativeToken: TokenResult,
   network: Network,
-  hasNonZeroTokens: boolean,
-  additionalHints: string[] | undefined,
-  isTokenPreference: boolean
+  shouldIncludePinned?: boolean,
+  nativeToken?: TokenResult
 ): boolean => {
   // Never add ERC20 tokens that represent the network's native token.
   // For instance, on Polygon, we have this token: `0x0000000000000000000000000000000000001010`.
@@ -389,13 +369,13 @@ export const tokenFilter = (
   const isERC20NativeRepresentation =
     (token.symbol === nativeToken?.symbol ||
       network.oldNativeAssetSymbols?.includes(token.symbol)) &&
-    token.amount === nativeToken.amount &&
+    token.amount === nativeToken?.amount &&
     token.address !== ZeroAddress
 
   if (isERC20NativeRepresentation) return false
 
   // always include tokens added as a preference
-  if (isTokenPreference) return true
+  if (token.flags.isHidden || token.flags.isCustom) return true
 
   // always include > 0 amount and native token
   if (token.amount > 0 || token.address === ZeroAddress) return true
@@ -404,61 +384,11 @@ export const tokenFilter = (
     return pinnedToken.chainId === network.chainId && pinnedToken.address === token.address
   })
 
-  // make the comparison to lowercase as otherwise, it doesn't work
-  const hintsLowerCase = additionalHints
-    ? additionalHints.map((hint) => hint.toLowerCase())
-    : undefined
-  const isInAdditionalHints = hintsLowerCase?.includes(token.address.toLowerCase())
-
   // if the amount is 0
   // return the token if it's pinned and requested
-  const pinnedRequested = isPinned && !hasNonZeroTokens
+  const pinnedRequested = isPinned && !!shouldIncludePinned
 
-  return isInAdditionalHints || pinnedRequested
-}
-
-/**
- * Filter the TokenResult[] by certain criteria (please refer to `tokenFilter` for more details)
- * and set the token.flags.isHidden flag.
- */
-export const processTokens = (
-  tokenResults: TokenResult[],
-  network: Network,
-  hasNonZeroTokens: boolean,
-  additionalHints: string[] | undefined,
-  tokenPreferences: TokenPreference[],
-  customTokens: CustomToken[]
-): TokenResult[] => {
-  // We need to know the native token in order to execute our filtration logic in tokenFilter.
-  // For performance reasons, we define it here once, instead of during every single iteration in the reduce method.
-  const nativeToken = tokenResults.find((token) => token.address === ZeroAddress)
-
-  return tokenResults.reduce((tokens, tokenResult) => {
-    const token = { ...tokenResult }
-    const isGasTankOrRewards = token.flags.onGasTank || token.flags.rewardsType
-
-    const preference = tokenPreferences?.find((tokenPreference) => {
-      return (
-        tokenPreference.address === token.address && tokenPreference.chainId === network.chainId
-      )
-    })
-
-    if (preference) {
-      token.flags.isHidden = preference.isHidden
-    }
-
-    token.flags.isCustom =
-      !isGasTankOrRewards &&
-      !!customTokens.find(
-        (customToken) =>
-          customToken.address === token.address && customToken.chainId === network.chainId
-      )
-
-    if (tokenFilter(token, nativeToken!, network, hasNonZeroTokens, additionalHints, !!preference))
-      tokens.push(token)
-
-    return tokens
-  }, [] as TokenResult[])
+  return pinnedRequested
 }
 
 export const isPortfolioGasTankResult = (

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -359,7 +359,8 @@ export const getSpecialHints = (
 export const tokenFilter = (
   token: TokenResult,
   network: Network,
-  shouldIncludePinned?: boolean,
+  isToBeLearned: boolean,
+  shouldIncludePinned: boolean,
   nativeToken?: TokenResult
 ): boolean => {
   // Never add ERC20 tokens that represent the network's native token.
@@ -375,7 +376,7 @@ export const tokenFilter = (
   if (isERC20NativeRepresentation) return false
 
   // always include tokens added as a preference
-  if (token.flags.isHidden || token.flags.isCustom) return true
+  if (token.flags.isHidden || token.flags.isCustom || isToBeLearned) return true
 
   // always include > 0 amount and native token
   if (token.amount > 0 || token.address === ZeroAddress) return true

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -74,9 +74,21 @@ export type ExternalHintsAPIResponse = Hints & {
   networkId: string
   chainId: number
   accountAddr: string
+  /**
+   * When hasHints is false and the list is generated from a top X list,
+   * the prices are coming together with the hints as the response contains
+   * prices for all tokens in the hints. In this case the extension should
+   * not make separate requests for prices.
+   */
   prices: {
     [addr: string]: Price
   }
+  /**
+   * When true, either the account is empty and static hints are returned,
+   * or the hints are coming from a top X list of tokens, sorted by market cap.
+   * In both cases, the hints are not user-specific so they must be learned
+   * and saved in the extension.
+   */
   hasHints: boolean
   /**
    * When true, prevents external API hints from overriding locally saved hints
@@ -111,6 +123,10 @@ export interface PortfolioLibGetResult {
   priceCache: PriceCache
   tokens: TokenResult[]
   feeTokens: TokenResult[]
+  toBeLearned: {
+    erc20s: Hints['erc20s']
+    erc721s: Hints['erc721s']
+  }
   tokenErrors: { error: string; address: string }[]
   collections: CollectionResult[]
   hintsFromExternalAPI: StrippedExternalHintsAPIResponse | null
@@ -216,6 +232,18 @@ export interface GetOptions {
   priceRecencyOnFailure?: number
   previousHintsFromExternalAPI?: StrippedExternalHintsAPIResponse | null
   fetchPinned: boolean
+  /**
+   * Hints for ERC20 tokens with a type
+   * custom, hidden and pinned are fetched and returned
+   * by the library regardless of their balance.
+   * `learn` type hints are returned only if the token has a non-zero balance
+   * and added to `toBeLearned`.
+   * !!! If passed the portfolio lib will filter out tokens based on specific
+   * conditions, such as balance and flags.
+   */
+  specialErc20Hints?: {
+    [address: string]: 'custom' | 'hidden' | 'hidden-custom' | 'learn'
+  }
   additionalErc20Hints?: Hints['erc20s']
   additionalErc721Hints?: Hints['erc721s']
   disableAutoDiscovery?: boolean

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -320,12 +320,20 @@ export class Portfolio {
         )
       })
       .map(([, result]: [any, TokenResult]) => {
+        if (
+          !result.amount ||
+          result.flags.isCustom ||
+          result.flags.isHidden ||
+          toBeLearned.erc20s.includes(result.address)
+        ) {
+          return result
+        }
+
         // Add tokens proposed by the controller to toBeLearned
         if (
           opts.specialErc20Hints &&
           opts.specialErc20Hints[result.address] &&
-          opts.specialErc20Hints[result.address] === 'learn' &&
-          result.amount > 0
+          opts.specialErc20Hints[result.address] === 'learn'
         ) {
           toBeLearned.erc20s.push(result.address)
           // Add tokens proposed by the external API to toBeLearned
@@ -334,10 +342,7 @@ export class Portfolio {
         } else if (
           hintsFromExternalAPI &&
           !hintsFromExternalAPI.hasHints &&
-          !hintsFromExternalAPI.skipOverrideSavedHints &&
-          !result.flags.isCustom &&
-          !result.flags.isHidden &&
-          result.amount > 0
+          !hintsFromExternalAPI.skipOverrideSavedHints
         ) {
           toBeLearned.erc20s.push(result.address)
         }

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -14,7 +14,7 @@ import { Deployless, fromDescriptor } from '../deployless/deployless'
 import batcher from './batcher'
 import { geckoRequestBatcher, geckoResponseIdentifier } from './gecko'
 import { getNFTs, getTokens } from './getOnchainBalances'
-import { stripExternalHintsAPIResponse } from './helpers'
+import { stripExternalHintsAPIResponse, tokenFilter } from './helpers'
 import {
   CollectionResult,
   ExternalHintsAPIResponse,
@@ -125,6 +125,10 @@ export class Portfolio {
   async get(accountAddr: string, opts: Partial<GetOptions> = {}): Promise<PortfolioLibGetResult> {
     const errors: PortfolioLibGetResult['errors'] = []
     const localOpts = { ...defaultOptions, ...opts }
+    const toBeLearned: PortfolioLibGetResult['toBeLearned'] = {
+      erc20s: [],
+      erc721s: {}
+    }
     const disableAutoDiscovery = localOpts.disableAutoDiscovery || false
     const { baseCurrency } = localOpts
     if (localOpts.simulation && localOpts.simulation.account.addr !== accountAddr)
@@ -218,6 +222,9 @@ export class Portfolio {
     // add the fee tokens
     hints.erc20s = [
       ...hints.erc20s,
+      ...Object.keys(localOpts.specialErc20Hints || {}),
+      ...(localOpts.additionalErc20Hints || []),
+      ...(localOpts.fetchPinned ? PINNED_TOKENS.map((x) => x.address) : []),
       ...gasTankFeeTokens.filter((x) => x.chainId === this.network.chainId).map((x) => x.address)
     ]
 
@@ -285,14 +292,49 @@ export class Portfolio {
       return isStale ? null : eligible
     }
 
-    const tokenFilter = ([error, result]: [TokenError, TokenResult]): boolean =>
-      error === '0x' && !!result.symbol
+    const nativeToken = tokensWithErrResult.find(
+      ([, result]) => result.address === ZeroAddress
+    )?.[1]
+
+    const isValidToken = (error: TokenError, token: TokenResult): boolean =>
+      error === '0x' && !!token.symbol
 
     const tokensWithoutPrices = tokensWithErrResult
-      .filter((_tokensWithErrResult: [TokenError, TokenResult]) =>
-        tokenFilter(_tokensWithErrResult)
-      )
-      .map(([, result]: [any, TokenResult]) => result)
+      .filter((_tokensWithErrResult: [TokenError, TokenResult]) => {
+        if (!isValidToken(_tokensWithErrResult[0], _tokensWithErrResult[1])) return false
+
+        // Don't filter by balance/custom/hidden etc. if this param isn't passed
+        // The portfolio lib is used outside the controller, in which case we want to
+        // fetch all tokens regardless of their balance or type
+        if (!localOpts.specialErc20Hints) return true
+
+        return tokenFilter(_tokensWithErrResult[1], this.network, opts.fetchPinned, nativeToken)
+      })
+      .map(([, result]: [any, TokenResult]) => {
+        // Add tokens proposed by the controller to toBeLearned
+        if (
+          opts.specialErc20Hints &&
+          opts.specialErc20Hints[result.address] &&
+          opts.specialErc20Hints[result.address] === 'learn' &&
+          result.amount > 0
+        ) {
+          toBeLearned.erc20s.push(result.address)
+          // Add tokens proposed by the external API to toBeLearned
+          // if the response API is static. That is because the static
+          // response may change and the user may stop seeing the token
+        } else if (
+          hintsFromExternalAPI &&
+          !hintsFromExternalAPI.hasHints &&
+          !hintsFromExternalAPI.skipOverrideSavedHints &&
+          !result.flags.isCustom &&
+          !result.flags.isHidden &&
+          result.amount > 0
+        ) {
+          toBeLearned.erc20s.push(result.address)
+        }
+
+        return result
+      })
 
     const unfilteredCollections = collectionsWithErrResult.map(([error, x], i) => {
       const address = collectionsHints[i][0] as unknown as string
@@ -307,7 +349,7 @@ export class Portfolio {
     })
 
     const collections = unfilteredCollections
-      .filter((preFilterCollection) => tokenFilter(preFilterCollection))
+      .filter((preFilterCollection) => isValidToken(preFilterCollection[0], preFilterCollection[1]))
       .map(([, collection]) => collection)
 
     const oracleCallDone = Date.now()
@@ -382,6 +424,7 @@ export class Portfolio {
     const priceUpdateDone = Date.now()
 
     return {
+      toBeLearned,
       hintsFromExternalAPI: stripExternalHintsAPIResponse(hintsFromExternalAPI),
       errors,
       updateStarted: start,

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -308,7 +308,16 @@ export class Portfolio {
         // fetch all tokens regardless of their balance or type
         if (!localOpts.specialErc20Hints) return true
 
-        return tokenFilter(_tokensWithErrResult[1], this.network, opts.fetchPinned, nativeToken)
+        const isToBeLearned =
+          localOpts.specialErc20Hints[_tokensWithErrResult[1].address] === 'learn'
+
+        return tokenFilter(
+          _tokensWithErrResult[1],
+          this.network,
+          isToBeLearned,
+          !!opts.fetchPinned,
+          nativeToken
+        )
       })
       .map(([, result]: [any, TokenResult]) => {
         // Add tokens proposed by the controller to toBeLearned


### PR DESCRIPTION
## Changes:
- Adjust the logic in the portfolio lib and controller so tokens can be filtered in the lib. This is needed so we don't fetch prices and map 0 value tokens that aren't needed
- Remove tokens from `toBeLearned` after learning them
- Makes the lib return a new property- `toBeLearned` that includes tokens that have to be learned by the controller. These tokens can be non-zero `toBeLearned` tokens passed from the controller or tokens on networks that don't support velcro discovery or have limited support. (On some networks, velcro returns a list of the top 100-200 tokens by marketcap, and as this list may change in the future, we have to learn non-zero tokens from it)

## Results:
Testing with `0xd8F3676A7567842295170B3f6AE4Bd466A878374` and filtering the network requests by URL `https://cena.ambire.com/api/v3/simple/`, we reduced the network requests for prices from ~120 to ~50