### PR TITLE
Feature / 	Standardize personal message signing as a hex string

### DIFF
--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -1,20 +1,16 @@
-import { hexlify, isBytesLike, isHexString, toUtf8Bytes, Uint8Array } from 'ethers'
-import { HexString } from 'ethers/lib.commonjs/utils/data'
-import { Hex } from 'interfaces/hex'
-
 import EmittableError from '../../classes/EmittableError'
 import { Account } from '../../interfaces/account'
 import { ExternalSignerControllers, Key, KeystoreSignerInterface } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
-import { Message, PlainTextMessage } from '../../interfaces/userRequest'
+import { Message } from '../../interfaces/userRequest'
 import {
   getAppFormatted,
   getEIP712Signature,
   getPlainTextSignature,
   getVerifyMessageSignature,
-  isPlainTextMessage,
   verifyMessage
 } from '../../libs/signMessage/signMessage'
+import { isPlainTextMessage } from '../../libs/transfer/userRequest'
 import hexStringToUint8Array from '../../utils/hexStringToUint8Array'
 import { AccountsController } from '../accounts/accounts'
 import { SignedMessage } from '../activity/types'
@@ -94,23 +90,7 @@ export class SignMessageController extends EventEmitter {
 
     if (['message', 'typedMessage', 'authorization-7702'].includes(messageToSign.content.kind)) {
       if (dapp) this.dapp = dapp
-
       this.messageToSign = messageToSign
-
-      if (isPlainTextMessage(this.messageToSign.content)) {
-        const shouldConvertInComingPlainMessageToHex = !isHexString(
-          this.messageToSign.content.message
-        )
-
-        if (shouldConvertInComingPlainMessageToHex) {
-          this.messageToSign.content.message = (
-            this.messageToSign.content.message instanceof Uint8Array
-              ? hexlify(this.messageToSign.content.message)
-              : hexlify(toUtf8Bytes(this.messageToSign.content.message))
-          ) as Hex
-        }
-      }
-
       this.isInitialized = true
       this.emitUpdate()
     } else {

--- a/src/interfaces/userRequest.ts
+++ b/src/interfaces/userRequest.ts
@@ -19,7 +19,7 @@ export interface Calls {
 }
 export interface PlainTextMessage {
   kind: 'message'
-  message: string
+  message: Hex
 }
 
 export interface TypedMessage {

--- a/src/libs/humanizer/interfaces.ts
+++ b/src/libs/humanizer/interfaces.ts
@@ -14,7 +14,6 @@ export type HumanizerVisualization = (
         | 'danger'
         | 'deadline'
         | 'chain'
-        | 'message'
         | 'image'
         | 'link'
         | 'text'
@@ -24,7 +23,6 @@ export type HumanizerVisualization = (
       value?: bigint
       warning?: boolean
       chainId?: bigint
-      messageContent?: Uint8Array | string
     }
   | {
       type: 'token'

--- a/src/libs/humanizer/messageModules/legendsModule.ts
+++ b/src/libs/humanizer/messageModules/legendsModule.ts
@@ -1,5 +1,6 @@
 import { isHexString, toUtf8Bytes, toUtf8String } from 'ethers'
 
+import { Hex } from '../../../interfaces/hex'
 import { Message } from '../../../interfaces/userRequest'
 import { HumanizerTypedMessageModule } from '../interfaces'
 import { getAction, getAddressVisualization, getLabel } from '../utils'
@@ -7,7 +8,7 @@ import { getAction, getAddressVisualization, getLabel } from '../utils'
 export const legendsMessageModule: HumanizerTypedMessageModule = (message: Message) => {
   if (message.content.kind !== 'message' || typeof message.content.message !== 'string')
     return { fullVisualization: [] }
-  let messageAsText = message.content.message
+  let messageAsText: Hex | string = message.content.message
   if (isHexString(message.content.message) && message.content.message.length % 2 === 0) {
     messageAsText = toUtf8String(toUtf8Bytes(message.content.message))
   }

--- a/src/libs/humanizer/messageModules/zealyModule.ts
+++ b/src/libs/humanizer/messageModules/zealyModule.ts
@@ -1,5 +1,6 @@
 import { isHexString, toUtf8String } from 'ethers'
 
+import { Hex } from '../../../interfaces/hex'
 import { Message } from '../../../interfaces/userRequest'
 import { HumanizerTypedMessageModule } from '../interfaces'
 import { getAction, getLabel } from '../utils'
@@ -7,7 +8,7 @@ import { getAction, getLabel } from '../utils'
 export const zealyMessageModule: HumanizerTypedMessageModule = (message: Message) => {
   if (message.content.kind !== 'message' || typeof message.content.message !== 'string')
     return { fullVisualization: [] }
-  let messageAsText = message.content.message
+  let messageAsText: Hex | string = message.content.message
   if (isHexString(message.content.message) && message.content.message.length % 2 === 0) {
     messageAsText = toUtf8String(message.content.message)
   }

--- a/src/libs/signMessage/signMessage.test.ts
+++ b/src/libs/signMessage/signMessage.test.ts
@@ -18,6 +18,7 @@ import { Network } from '../../interfaces/network'
 import { Storage } from '../../interfaces/storage'
 import { TypedMessage } from '../../interfaces/userRequest'
 import { getRpcProvider } from '../../services/provider'
+import hexStringToUint8Array from '../../utils/hexStringToUint8Array'
 import { callToTuple, getSignableHash } from '../accountOp/accountOp'
 import { getAccountState } from '../accountState/accountState'
 import { KeystoreSigner } from '../keystoreSigner/keystoreSigner'
@@ -180,7 +181,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     const signer = await keystore.getSigner(eoaSigner.keyPublicAddress, 'internal')
 
     const signatureForPlainText = await getPlainTextSignature(
-      'test',
+      hexlify(toUtf8Bytes('test')) as Hex,
       ethereumNetwork,
       eoaAccount,
       accountStates[eoaAccount.addr][ethereumNetwork.chainId.toString()],
@@ -197,7 +198,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     expect(firstRes).toBe(true)
 
     const signatureForUint8Array = await getPlainTextSignature(
-      toUtf8Bytes('test'),
+      hexlify(toUtf8Bytes('test')) as Hex,
       ethereumNetwork,
       eoaAccount,
       accountStates[eoaAccount.addr][ethereumNetwork.chainId.toString()],
@@ -213,7 +214,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     expect(secondRes).toBe(true)
 
     const signatureForNumberAsString = await getPlainTextSignature(
-      '1',
+      hexlify(toUtf8Bytes('1')) as Hex,
       ethereumNetwork,
       eoaAccount,
       accountStates[eoaAccount.addr][ethereumNetwork.chainId.toString()],
@@ -233,7 +234,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     const signer = await keystore.getSigner(eoaSigner.keyPublicAddress, 'internal')
 
     const signatureForPlainText = await getPlainTextSignature(
-      'test',
+      hexlify(toUtf8Bytes('test')) as Hex,
       polygonNetwork,
       smartAccount,
       accountStates[smartAccount.addr][polygonNetwork.chainId.toString()],
@@ -260,7 +261,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     const accountStates = await getAccountsInfo([v1Account])
     const signer = await keystore.getSigner(v1siger.keyPublicAddress, 'internal')
 
-    const msg = `test for ${v1Account.addr}`
+    const msg = hexlify(toUtf8Bytes(`test for ${v1Account.addr}`)) as Hex
     const signatureForPlainText = await getPlainTextSignature(
       msg,
       polygonNetwork,
@@ -277,7 +278,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       provider,
       signer: v1Account.addr,
       signature: signatureForPlainText,
-      message: msg
+      message: hexStringToUint8Array(msg)
     })
     expect(res).toBe(true)
   })
@@ -287,7 +288,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
 
     try {
       await getPlainTextSignature(
-        'test',
+        hexlify(toUtf8Bytes('test')) as Hex,
         ethereumNetwork,
         v1Account,
         accountStates[v1Account.addr][ethereumNetwork.chainId.toString()],
@@ -309,7 +310,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     const accountState = accountStates[v1Account.addr][ethereumNetwork.chainId.toString()]
 
     const plaintextSigNoAddrInMessage = await getPlainTextSignature(
-      'test',
+      hexlify(toUtf8Bytes('test')) as Hex,
       ethereumNetwork,
       v1Account,
       accountState,
@@ -824,7 +825,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     const signer = await keystore.getSigner(eoaSigner.keyPublicAddress, 'internal')
 
     const signatureForPlainText = await getPlainTextSignature(
-      'test',
+      hexlify(toUtf8Bytes('test')) as Hex,
       polygonNetwork,
       smartAccount,
       v2AccountState,
@@ -940,7 +941,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: false', () => {
     const signer = await keystore.getSigner(eoaSigner.keyPublicAddress, 'internal')
 
     const signatureForPlainText = await getPlainTextSignature(
-      'test',
+      hexlify(toUtf8Bytes('test')) as Hex,
       polygonNetwork,
       smartAccount,
       accountStates[smartAccount.addr][polygonNetwork.chainId.toString()],

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-param-reassign */
 import {
   AbiCoder,
-  BytesLike,
   concat,
   encodeRlp,
   getAddress,
@@ -15,8 +14,7 @@ import {
   toBeHex,
   toNumber,
   toUtf8Bytes,
-  TypedDataDomain,
-  TypedDataField
+  TypedDataDomain
 } from 'ethers'
 
 import { MessageTypes, SignTypedDataVersion, TypedDataUtils } from '@metamask/eth-sig-util'
@@ -29,7 +27,7 @@ import { Hex } from '../../interfaces/hex'
 import { KeystoreSignerInterface } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
 import { EIP7702Signature } from '../../interfaces/signatures'
-import { Message, PlainTextMessage, TypedMessage } from '../../interfaces/userRequest'
+import { PlainTextMessage, TypedMessage } from '../../interfaces/userRequest'
 import hexStringToUint8Array from '../../utils/hexStringToUint8Array'
 import isSameAddr from '../../utils/isSameAddr'
 import { stripHexPrefix } from '../../utils/stripHexPrefix'
@@ -721,8 +719,14 @@ export function getAppFormatted(
   return signature as EIP7702Signature
 }
 
-export const isPlainTextMessage = (
-  messageContent: Message['content']
-): messageContent is PlainTextMessage => {
-  return messageContent.kind === 'message'
+/**
+ * Similarly to other wallets, try to convert the input to a hex string
+ * if it's not already a hex string. Some dapps send the message in plain text.
+ */
+export const toPersonalSignHex = (input: string | Uint8Array | Hex): Hex => {
+  if (typeof input === 'string') {
+    return isHexString(input) ? input : (hexlify(toUtf8Bytes(input)) as Hex)
+  }
+
+  return hexlify(input) as Hex
 }

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -720,8 +720,7 @@ export function getAppFormatted(
 }
 
 /**
- * Similarly to other wallets, try to convert the input to a hex string
- * if it's not already a hex string. Some dapps send the message in plain text.
+ * Tries to convert an input (from a dapp) to a hex string
  */
 export const toPersonalSignHex = (input: string | Uint8Array | Hex): Hex => {
   if (typeof input === 'string') {

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import {
   AbiCoder,
+  BytesLike,
   concat,
   encodeRlp,
   getAddress,
@@ -28,7 +29,7 @@ import { Hex } from '../../interfaces/hex'
 import { KeystoreSignerInterface } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
 import { EIP7702Signature } from '../../interfaces/signatures'
-import { TypedMessage } from '../../interfaces/userRequest'
+import { Message, PlainTextMessage, TypedMessage } from '../../interfaces/userRequest'
 import hexStringToUint8Array from '../../utils/hexStringToUint8Array'
 import isSameAddr from '../../utils/isSameAddr'
 import { stripHexPrefix } from '../../utils/stripHexPrefix'
@@ -497,7 +498,7 @@ export async function getExecuteSignature(
 }
 
 export async function getPlainTextSignature(
-  message: string | Uint8Array,
+  messageHex: PlainTextMessage['message'],
   network: Network,
   account: Account,
   accountState: AccountOnchainState,
@@ -505,15 +506,6 @@ export async function getPlainTextSignature(
   isOG = false
 ): Promise<string> {
   const dedicatedToOneSA = signer.key.dedicatedToOneSA
-
-  let messageHex
-  if (message instanceof Uint8Array) {
-    messageHex = hexlify(message)
-  } else if (!isHexString(message)) {
-    messageHex = hexlify(toUtf8Bytes(message))
-  } else {
-    messageHex = message
-  }
 
   if (!account.creation) {
     const signature = await signer.signMessage(messageHex)
@@ -524,13 +516,10 @@ export async function getPlainTextSignature(
     const lowercaseHexAddrWithout0x = hexlify(toUtf8Bytes(account.addr.toLowerCase().slice(2)))
     const checksummedHexAddrWithout0x = hexlify(toUtf8Bytes(account.addr.slice(2)))
     const asciiAddrLowerCase = account.addr.toLowerCase()
-    const humanReadableMsg = message instanceof Uint8Array ? hexlify(message) : message
 
-    const isAsciiAddressInMessage = humanReadableMsg.toLowerCase().includes(asciiAddrLowerCase)
-    const isLowercaseHexAddressInMessage = humanReadableMsg.includes(
-      lowercaseHexAddrWithout0x.slice(2)
-    )
-    const isChecksummedHexAddressInMessage = humanReadableMsg.includes(
+    const isAsciiAddressInMessage = messageHex.toLowerCase().includes(asciiAddrLowerCase)
+    const isLowercaseHexAddressInMessage = messageHex.includes(lowercaseHexAddrWithout0x.slice(2))
+    const isChecksummedHexAddressInMessage = messageHex.includes(
       checksummedHexAddrWithout0x.slice(2)
     )
 
@@ -730,4 +719,10 @@ export function getAppFormatted(
   if (isHexString(signature)) return getHexStringSignature(signature, account, accountState)
 
   return signature as EIP7702Signature
+}
+
+export const isPlainTextMessage = (
+  messageContent: Message['content']
+): messageContent is PlainTextMessage => {
+  return messageContent.kind === 'message'
 }

--- a/src/libs/transfer/userRequest.ts
+++ b/src/libs/transfer/userRequest.ts
@@ -6,7 +6,7 @@ import WETH from '../../../contracts/compiled/WETH.json'
 import { Session } from '../../classes/session'
 import { FEE_COLLECTOR, STK_WALLET, SUPPLY_CONTROLLER_ADDR } from '../../consts/addresses'
 import { networks } from '../../consts/networks'
-import { Calls, SignUserRequest } from '../../interfaces/userRequest'
+import { Calls, PlainTextMessage, SignUserRequest } from '../../interfaces/userRequest'
 import { PaymasterService } from '../erc7677/types'
 import { AddrVestingData, ClaimableRewardsData, TokenResult } from '../portfolio'
 import { getSanitizedAmount } from './amount'
@@ -200,4 +200,15 @@ function buildTransferUserRequest({
   }
 }
 
-export { buildClaimWalletRequest, buildMintVestingRequest, buildTransferUserRequest }
+const isPlainTextMessage = (
+  messageContent: SignUserRequest['action']
+): messageContent is PlainTextMessage => {
+  return messageContent.kind === 'message'
+}
+
+export {
+  buildClaimWalletRequest,
+  buildMintVestingRequest,
+  buildTransferUserRequest,
+  isPlainTextMessage
+}


### PR DESCRIPTION
Standardize personal message signing by ensuring message content is consistently handled as hex strings throughout the codebase. The change addresses inconsistent handling of message formats between plain text and hex strings.

- Added: A utility function `toPersonalSignHex` to convert different dapp input formats (plain text or Uint8Array) to hex strings
- Changed: Refactor message signing logic to use hex strings consistently and removed redundant conversion code.
- Changed: Remove obsolete HumanizerVisualization type (`message`) and it's prop (`messageContent`)