### PR TITLE
Fix/ defi position value mistakenly excluded in selectedAccount lib

### DIFF
--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -189,6 +189,10 @@ export const calculateDefiPositions = (
             )
           }
 
+          // If the token or asset don't have a value we MUST! not compare them
+          // by value as that would lead to false positives
+          if (!tokenBalanceUSD || !a.value) return false
+
           // If there is no protocol asset we have to fallback to finding the token
           // by symbol and chainId. In that case we must ensure that the value of the two
           // assets is similar


### PR DESCRIPTION
Fixes https://github.com/AmbireTech/ambire-common/pull/1627#issuecomment-3127245558

## How to reproduce:
1. Make sure you don't have xWALLET in the portfolio
2. Import `0xa07D75aacEFd11b425AF7181958F0F85c312f143` as view only
3. The balance should be ~250k USD
4. Add `0x47cd7e91c3cbaaf266369fe8518345fc4fc12935` xWALLET as a custom token on Ethereum
5. The balance will become significantly lower (the uni v3 position will be excluded)