### PR TITLE
Fix/ `getOrFetchAccountOnChainState` account state typeerror

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -296,6 +296,10 @@ export class AccountsController extends EventEmitter {
   // This ensures production doesn't blow up and it 99.9% of cases it
   // should not call the promise
   async getOrFetchAccountOnChainState(addr: string, chainId: bigint): Promise<AccountOnchainState> {
+    if (!this.accountStates[addr]) {
+      this.accountStates[addr] = {}
+    }
+
     if (!this.accountStates[addr][chainId.toString()])
       await this.updateAccountState(addr, 'latest', [chainId])
 


### PR DESCRIPTION
Error:
https://monitor.ambire.com/organizations/ambire/issues/115?project=3

<img width="901" height="623" alt="image" src="https://github.com/user-attachments/assets/950a122c-ffa0-40e6-be9b-4493e73f0b73" />

The user request was added from the extension UI, and somehow, the account had no key in the account state object. This is weird because we are always fetching the account state for the selected account and all other accounts (except view-only ones). View-only accounts don't have transaction history, so the user can't do this:
https://goodmorning-dev.slack.com/archives/C0644227TAP/p1753867839538629

This fixes the error, but I still have no explanation as to how it happened :thinking: 
