### PR TITLE
Fix / Portfolio unhandled error

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -593,6 +593,10 @@ export class PortfolioController extends EventEmitter {
     const blockTag = portfolioProps.blockTag
     const stateKeys = { latest: this.#latest, pending: this.#pending }
     const accountState = stateKeys[blockTag][accountId]
+
+    // Can occur if the account is removed while updateSelectedAccount is in progress
+    if (!accountState) return false
+
     if (!accountState[network.chainId.toString()]) {
       // isLoading must be false here, otherwise canSkipUpdate will return true
       // and portfolio will not be updated


### PR DESCRIPTION
There’s a race condition in the `updateSelectedAccount` function within the portfolio module. At the beginning of the function, we perform a check to ensure state[accountId] is defined. However, due to the asynchronous operations in the function (e.g., awaiting promises or handling callbacks), this initial check becomes insufficient. By the time we reach the call to `updatePortfolioState`, the account may have been removed from the portfolio state via the `removeAccountData` func, leading to a runtime error:
“Cannot read properties of undefined (reading ‘1’)”.
This occurs because we don’t re-validate the existence of state[accountId] immediately before invoking `updatePortfolioState`, allowing the state to change mid-execution.