### PR TITLE
Change wallet_sendCalls: disallow wallet_sendCalls with 0 calls

### DIFF
--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -567,6 +567,11 @@ export class RequestsController extends EventEmitter {
       const isWalletSendCalls = !!request.params[0].calls
       const accountAddr = getAddress(request.params[0].from)
 
+      if (isWalletSendCalls && !request.params[0].calls.length)
+        throw ethErrors.provider.unsupportedMethod({
+          message: 'Request rejected - empty calls array not allowed!'
+        })
+
       const calls: Calls['calls'] = isWalletSendCalls
         ? request.params[0].calls
         : [request.params[0]]


### PR DESCRIPTION
We had bug in legends that resulted in empty array of calls to be requested to the wallet. 

That revealed that we are not able to properly display, simulate and reject actions where we have not calls. Displayed and explained here https://ambiretech.slack.com/archives/C08482RND39/p1753782464672869

This PR disallows dapp request of `wallet_sendCalls` with empty calls array