### PR TITLE
Hotfix/ Update lifi #requestTimeoutMs to 10s from 5s

### DIFF
--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -221,7 +221,7 @@ export class LiFiAPI {
 
   #headers: RequestInitWithCustomHeaders['headers']
 
-  #requestTimeoutMs = 5000
+  #requestTimeoutMs = 10000
 
   isHealthy: boolean | null = null
 


### PR DESCRIPTION
Updates the timeout to 10 seconds as users with slow internet connections were experiencing many request timeouts.