### PR TITLE
Bug / Filter out networks coming from the extension storage with invalid or bad required properties

### DIFF
--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -50,6 +50,10 @@ export interface NetworkFeature {
   level: 'success' | 'danger' | 'warning' | 'loading' | 'initial'
 }
 
+/**
+ * If you add a new mandatory property, make sure to adjust accordingly
+ * `sanityCheckImportantNetworkProperties` function, if needed
+ */
 export interface Network {
   chainId: bigint
   name: string

--- a/src/libs/networks/networks.ts
+++ b/src/libs/networks/networks.ts
@@ -361,3 +361,28 @@ export function hasRelayerSupport(network: Network) {
     network.hasRelayer || !!relayerAdditionalNetworks.find((net) => net.chainId === network.chainId)
   )
 }
+
+/**
+ * Validates networks coming from the storage, filtering out the invalid ones.
+ * This prevents crashes when networks have missing or invalid mandatory properties.
+ */
+export function getValidNetworks(networksInStorage: { [key: string]: Network }): {
+  [key: string]: Network
+} {
+  const validNetworks: { [key: string]: Network } = {}
+
+  Object.values(networksInStorage).forEach((network) => {
+    // Based on the crash reports received, it turned out there are users with
+    // messed-up networks in storage. Filter in only the networks with valid properties.
+    const hasValidNetworkProperties =
+      network &&
+      typeof network?.chainId === 'bigint' &&
+      Array.isArray(network?.rpcUrls) &&
+      network?.selectedRpcUrl &&
+      network?.explorerUrl
+
+    if (hasValidNetworkProperties) validNetworks[network.chainId.toString()] = network
+  })
+
+  return validNetworks
+}


### PR DESCRIPTION
Based on the crash reports received, it turned out there are users with messed-up networks in storage. So with this change, we filter in only the networks with valid properties. Also:

- Added: If network with bad props is detected in storage, try to replace it with a predefined network, if one exists

Crash report: https://monitor.ambire.com/organizations/ambire/issues/129