### PR TITLE
Portoflio: separate batched velcro request for multiple addresses

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -145,9 +145,14 @@ export class PortfolioController extends EventEmitter {
       fetch,
       (queue) => {
         const baseCurrencies = [...new Set(queue.map((x) => x.data.baseCurrency))]
-        return baseCurrencies.map((baseCurrency) => {
-          const queueSegment = queue.filter((x) => x.data.baseCurrency === baseCurrency)
-
+        const accountAddrs = [...new Set(queue.map((x) => x.data.accountAddr))]
+        const pairs = baseCurrencies
+          .map((baseCurrency) => accountAddrs.map((accountAddr) => ({ baseCurrency, accountAddr })))
+          .flat()
+        return pairs.map(({ baseCurrency, accountAddr }) => {
+          const queueSegment = queue.filter(
+            (x) => x.data.baseCurrency === baseCurrency && x.data.accountAddr === accountAddr
+          )
           const url = `${velcroUrl}/multi-hints?networks=${queueSegment
             .map((x) => x.data.chainId)
             .join(',')}&accounts=${queueSegment


### PR DESCRIPTION
## Problem
We have a batching function in the velcro controller that batches multiple chains into a single velcro request for a specific account. The problem is that, **_hypothetically_**,  if a user times it exactly, we might make a single request with multiple addresses. Which is a privacy issues. 

## Change
This PR simply stops the batching function from merging queue elements from different accounts.

Performance-wise should be absolutely the same.

## To test:
- go in the code and add `batchDebounce: 10000` as option in the batcher function (this is simply to increase the chances to hit this)
- click reload on the dashboard for some account and during those 10 seconds that are awaited for debouncing
- switch to another account

In the old version of the code you should be able to see a single `multi-hints` request for both accounts.
In this PR you should see 2 requests. 