### PR TITLE
Fix: #abortHWTransactionSign logic

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -807,7 +807,10 @@ export class MainController extends EventEmitter {
     const isAwaitingHWSignature =
       (signAccountOp.accountOp.signingKeyType !== 'internal' &&
         this.statuses.signAndBroadcastAccountOp === 'SIGNING') ||
-      (this.feePayerKey?.type !== 'internal' &&
+      // this.feePayerKey should be set before checking if it's type is internal
+      // if it's not, we are not waiting for a hw sig
+      (this.feePayerKey &&
+        this.feePayerKey.type !== 'internal' &&
         this.statuses.signAndBroadcastAccountOp === 'BROADCASTING')
 
     // Reset these flags only if we were awaiting a HW signature


### PR DESCRIPTION
Long story short, this fixes the reported "AA25 invalid nonce" errors.

Fix: #abortHWTransactionSign logic was missing a check for a set fee payer key. We are not setting a fee payer key when broadcasting with the relayer / 4337.  
This caused `this.#signAndBroadcastCallId` to be set to null which in turn makes `mainCtrl.statuses.signAndBroadcastAccountOp` to never reach its success state. That on the other hand meant the account state refetch in the background process didn't activate upon a successful broadcast resulting in a "AA25 invalid nonce error" when trying to broadcast quickly another user op.  