### PR TITLE
Fix: disabled network crash in activity banner

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -654,9 +654,8 @@ export class ActivityController extends EventEmitter {
     if (!recentlyBroadcastedAccountOps.length) return []
 
     return recentlyBroadcastedAccountOps.map((accountOp) => {
-      const network = this.#networks.networks.find((n) => n.chainId === accountOp.chainId)!
       const url = `https://explorer.ambire.com/${getBenzinUrlParams({
-        chainId: network.chainId,
+        chainId: accountOp.chainId,
         txnId: accountOp.txnId,
         identifiedBy: accountOp.identifiedBy
       })}`


### PR DESCRIPTION
Fix: pass the chain id from the accountOp directly to prevent the case where a disabled network breaks the whole extension