### PR TITLE
Allow build in swap retry on hw

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1735,7 +1735,10 @@ export class MainController extends EventEmitter {
         // if a batch of 5 txn is sent to Ledger for sign but the user reject
         // #3, #1 and #2 are already broadcast. Reduce the accountOp's call
         // to #1 and #2 and create a submittedAccountOp
-        if (multipleTxnsBroadcastRes.length) {
+        //
+        // unless it's the build-in swap - we want to throw an error and
+        // allow the user to retry in this case
+        if (multipleTxnsBroadcastRes.length && type !== SIGN_ACCOUNT_OP_SWAP) {
           transactionRes = {
             nonce,
             identifiedBy: {


### PR DESCRIPTION
Describing the bug:
* build-in swap, approve + swap with a hardware wallet
* the user broadcasts the approve successfully
* the user reject the swap on his hardware wallet device
* the swap moves on and shows the user the success screen which is clearly wrong

Last step changed to:
* keep the user on the one click sign page and allow him to retry to reject the whole swap

