### PR TITLE
Initial token balances / nfts retry mechanism

### DIFF
--- a/src/libs/deployless/deployless.ts
+++ b/src/libs/deployless/deployless.ts
@@ -236,7 +236,7 @@ export function fromDescriptor(
 
 async function mapError(
   callPromise: Promise<string>,
-  allowRetry: boolean,
+  allowRetry: boolean = false,
   retryCounter = 0
 ): Promise<string> {
   try {

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -130,7 +130,7 @@ export async function getNFTs(
           ),
           limits.erc721Tokens
         ],
-        deploylessOpts
+        { ...deploylessOpts, allowRetry: true }
       )
     )[0]
 
@@ -277,11 +277,10 @@ export async function getTokens(
   }
   const deploylessOpts = getDeploylessOpts(accountAddr, !network.rpcNoStateOverride, opts)
   if (!opts.simulation) {
-    const [results, blockNumber] = await deployless.call(
-      'getBalances',
-      [accountAddr, tokenAddrs],
-      deploylessOpts
-    )
+    const [results, blockNumber] = await deployless.call('getBalances', [accountAddr, tokenAddrs], {
+      ...deploylessOpts,
+      allowRetry: true
+    })
 
     return [
       results.map((token: any, i: number) => [token.error, mapToken(token, tokenAddrs[i])]),


### PR DESCRIPTION
Add: a retry mechanism in deployless to allow quick refetching of initial portfolio requests if they are failing (they should not on initial load)

---

Ran the failing tests locally, they pass