### PR TITLE
Cut off bundler gas failures

### DIFF
--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -45,7 +45,7 @@ async function fetchBundlerGasPrice(
   const prices = await Promise.race([
     fetchGas,
     new Promise((_resolve, reject) => {
-      setTimeout(() => reject(new Error('bundler gas request too slow')), 3000)
+      setTimeout(() => reject(new Error('bundler gas request too slow')), 4000)
     })
   ]).catch(() => {
     // eslint-disable-next-line no-console

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -184,7 +184,6 @@ export async function bundlerEstimate(
   while (true) {
     // estimate
     const estimations = await estimate(baseAcc, network, userOp, switcher, errorCallback)
-    const bundler = switcher.getBundler()
 
     // if no errors, return the results and get on with life
     if (!(estimations.estimation instanceof Error)) {


### PR DESCRIPTION
Wait a max of 4s for the bundler gas prices in the gas price controller.  
Switch the bundler if fetching gas prices from it is slow (4s max)