### PR TITLE
Remove the activity nonce check

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1520,22 +1520,13 @@ export class SignAccountOpController extends EventEmitter {
       }
     }
 
-    // if broadcast but not confirmed for this network and an userOp,
-    // check if the nonces match. If they do, increment the current nonce
-    const notConfirmedUserOp = this.#activity.broadcastedButNotConfirmed.find(
-      (accOp) =>
-        accOp.chainId === this.#network.chainId &&
-        accOp.gasFeePayment &&
-        accOp.gasFeePayment.broadcastOption === BROADCAST_OPTIONS.byBundler
-    )
     const userOperation = getUserOperation(
       this.account,
       accountState,
       this.accountOp,
       this.bundlerSwitcher.getBundler().getName(),
       this.accountOp.meta?.entryPointAuthorization,
-      eip7702Auth,
-      notConfirmedUserOp?.asUserOperation
+      eip7702Auth
     )
 
     userOperation.preVerificationGas = erc4337Estimation.preVerificationGas

--- a/src/libs/userOperation/userOperation.ts
+++ b/src/libs/userOperation/userOperation.ts
@@ -123,16 +123,11 @@ export function getUserOperation(
   accountOp: AccountOp,
   bundler: BUNDLER,
   entryPointSig?: string,
-  eip7702Auth?: EIP7702Auth,
-  activityUserOp?: UserOperation
+  eip7702Auth?: EIP7702Auth
 ): UserOperation {
-  const accountStateNonce = toBeHex(accountState.erc4337Nonce)
   const userOp: UserOperation = {
     sender: accountOp.accountAddr,
-    nonce:
-      activityUserOp && accountStateNonce === activityUserOp.nonce
-        ? toBeHex(accountState.erc4337Nonce + 1n)
-        : accountStateNonce,
+    nonce: toBeHex(accountState.erc4337Nonce),
     callData: '0x',
     callGasLimit: toBeHex(0),
     verificationGasLimit: toBeHex(0),


### PR DESCRIPTION
Always use the nonce from the account state.

Remove the activity nonce check that we implemented before - the core issue for this was the account state not being refetched after a txn broadcast when interacting with an app