### PR TITLE
Fix / AAVE protocol console error

### DIFF
--- a/src/controllers/providers/providers.ts
+++ b/src/controllers/providers/providers.ts
@@ -31,7 +31,7 @@ export class ProvidersController extends EventEmitter {
 
   async #load() {
     await this.#networks.initialLoadPromise
-    this.#networks.networks.forEach((n) => this.setProvider(n))
+    this.#networks.allNetworks.forEach((n) => this.setProvider(n))
     this.emitUpdate()
   }
 


### PR DESCRIPTION
Resolves:
<img width="944" height="488" alt="Screenshot 2025-08-05 at 13 46 12" src="https://github.com/user-attachments/assets/f12682a4-119b-4e38-8cfa-ff20d234b693" />
This resolves the issue by initializing providers for both enabled and disabled networks, instead of only initializing them for enabled networks. This will also help us for the development of the tokens discovery on disabled networks