### PR TITLE
Fix/ Handle undefined provider errors

### DIFF
--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -99,6 +99,7 @@ export class NetworksController extends EventEmitter {
     const uniqueNetworksByChainId = Object.values(this.#networks)
       .sort((a, b) => +b.predefined - +a.predefined) // first predefined
       .filter((item, index, self) => self.findIndex((i) => i.chainId === item.chainId) === index) // unique by chainId (predefined with priority)
+
     return uniqueNetworksByChainId.map((network) => {
       // eslint-disable-next-line no-param-reassign
       network.features = getFeaturesByNetworkProperties(
@@ -526,7 +527,7 @@ export class NetworksController extends EventEmitter {
 
   async #updateNetworks(network: Partial<Network>, chainIds: ChainId[]) {
     await Promise.all(chainIds.map((chainId) => this.#updateNetwork(network, chainId, true)))
-    this.#onAddOrUpdateNetworks(this.networks.filter((n) => chainIds.includes(n.chainId)))
+    this.#onAddOrUpdateNetworks(this.allNetworks.filter((n) => chainIds.includes(n.chainId)))
     this.emitUpdate()
   }
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -381,7 +381,11 @@ export class PortfolioController extends EventEmitter {
     this.emitUpdate()
   }
 
-  initializePortfolioLibIfNeeded(accountId: AccountId, chainId: bigint, network: Network) {
+  initializePortfolioLibIfNeeded(
+    accountId: AccountId,
+    chainId: bigint,
+    network: Network
+  ): Portfolio | null {
     const providers = this.#providers.providers
     const key = `${chainId}:${accountId}`
     // Initialize a new Portfolio lib if:
@@ -393,16 +397,20 @@ export class PortfolioController extends EventEmitter {
         // eslint-disable-next-line no-underscore-dangle
         providers[network.chainId.toString()]?._getConnection().url
     ) {
-      this.#portfolioLibs.set(
-        key,
-        new Portfolio(
-          this.#fetch,
-          providers[network.chainId.toString()],
-          network,
-          this.#velcroUrl,
-          this.#batchedVelcroDiscovery
+      try {
+        this.#portfolioLibs.set(
+          key,
+          new Portfolio(
+            this.#fetch,
+            providers[network.chainId.toString()],
+            network,
+            this.#velcroUrl,
+            this.#batchedVelcroDiscovery
+          )
         )
-      )
+      } catch (e: any) {
+        return null
+      }
     }
     return this.#portfolioLibs.get(key)!
   }
@@ -431,6 +439,12 @@ export class PortfolioController extends EventEmitter {
     this.emitUpdate()
 
     try {
+      if (!portfolioLib) {
+        throw new Error(
+          `a portfolio library is not initialized for ${network.name} (${network.chainId})`
+        )
+      }
+
       const result = await portfolioLib.get(accountId, {
         priceRecency: 60000 * 5,
         additionalErc20Hints: [additionalHint, ...temporaryTokensToFetch.map((x) => x.address)],
@@ -489,6 +503,7 @@ export class PortfolioController extends EventEmitter {
       const banner = res.data.banner
 
       const formattedBanner: Banner = {
+        // eslint-disable-next-line no-underscore-dangle
         id: banner.id || banner._id,
         type: banner.type,
         params: {
@@ -585,7 +600,7 @@ export class PortfolioController extends EventEmitter {
   protected async updatePortfolioState(
     accountId: string,
     network: Network,
-    portfolioLib: Portfolio,
+    portfolioLib: Portfolio | null,
     portfolioProps: Partial<GetOptions> & { blockTag: 'latest' | 'pending' },
     forceUpdate: boolean,
     maxDataAgeMs?: number
@@ -622,6 +637,11 @@ export class PortfolioController extends EventEmitter {
     ).some(Boolean)
 
     try {
+      if (!portfolioLib)
+        throw new Error(
+          `a portfolio library is not initialized for ${network.name} (${network.chainId})`
+        )
+
       const result = await portfolioLib.get(accountId, {
         priceRecency: 60000 * 5,
         priceCache: state.result?.priceCache,

--- a/src/controllers/providers/providers.ts
+++ b/src/controllers/providers/providers.ts
@@ -31,7 +31,7 @@ export class ProvidersController extends EventEmitter {
 
   async #load() {
     await this.#networks.initialLoadPromise
-    this.#networks.networks.forEach((n) => this.setProvider(n))
+    this.#networks.allNetworks.forEach((n) => this.setProvider(n))
     this.emitUpdate()
   }
 

--- a/src/libs/deployless/deployless.ts
+++ b/src/libs/deployless/deployless.ts
@@ -87,11 +87,16 @@ export class Deployless {
       !abi.includes((x: any) => x.type === 'constructor'),
       'contract cannot have a constructor, as it is not supported in state override mode'
     )
+    assert.ok(!!provider, 'provider must be provided')
     this.contractBytecode = code
     this.provider = provider
-    // eslint-disable-next-line no-underscore-dangle
-    this.isProviderInvictus = (provider as any)._getConnection().url.includes('invictus')
     this.iface = new Interface(abi)
+
+    if (provider && provider instanceof JsonRpcProvider) {
+      // eslint-disable-next-line no-underscore-dangle
+      this.isProviderInvictus = provider._getConnection().url.includes('invictus')
+    }
+
     if (codeAtRuntime !== undefined) {
       assert.ok(codeAtRuntime.startsWith('0x'), 'contract code (runtime) must start with 0x')
       this.stateOverrideSupported = true

--- a/src/libs/networks/networks.ts
+++ b/src/libs/networks/networks.ts
@@ -403,6 +403,9 @@ export function getValidNetworks(networksInStorage: { [key: string]: Network }):
       // Attempt to replace broken network with predefined version, if available
       const predefinedNetwork = predefinedNetworks.find((n) => n.chainId === network.chainId)
       if (predefinedNetwork) validNetworks[network.chainId.toString()] = predefinedNetwork
+      else {
+        console.error(`Invalid network found in storage for chainId ${network.chainId}`, network)
+      }
     }
   })
 

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -1,5 +1,5 @@
 import { Network } from '../../interfaces/network'
-import { RPCProviders } from '../../interfaces/provider'
+import { RPCProvider, RPCProviders } from '../../interfaces/provider'
 import { SelectedAccountPortfolioState } from '../../interfaces/selectedAccount'
 import {
   AccountState as DefiPositionsAccountState,
@@ -265,7 +265,7 @@ export const getNetworksWithDeFiPositionsErrorErrors = ({
 
     const networkState = currentAccountState[chainId]
     const network = networks.find((n) => n.chainId.toString() === chainId)
-    const rpcProvider = providers[chainId]
+    const rpcProvider: RPCProvider | undefined = providers[chainId]
     const lastSuccessfulUpdate = networkState.updatedAt
 
     if (
@@ -274,7 +274,7 @@ export const getNetworksWithDeFiPositionsErrorErrors = ({
       (typeof lastSuccessfulUpdate === 'number' &&
         Date.now() - lastSuccessfulUpdate < TEN_MINUTES) ||
       // Don't display an error banner if the RPC isn't working because an RPC error banner is already displayed.
-      (typeof rpcProvider.isWorking === 'boolean' && !rpcProvider.isWorking)
+      (rpcProvider && typeof rpcProvider.isWorking === 'boolean' && !rpcProvider.isWorking)
     )
       return
 

--- a/src/services/provider/getRpcProvider.ts
+++ b/src/services/provider/getRpcProvider.ts
@@ -23,6 +23,10 @@ const getRpcProvider = (
     if (prefUrl) rpcUrl = prefUrl
   }
 
+  if (!rpcUrl) {
+    throw new Error('Invalid RPC URL provided')
+  }
+
   if (chainId) {
     const staticNetwork = Network.from(Number(chainId))
 


### PR DESCRIPTION
## Fixes:
- Errors from `initializePortfolioLibIfNeeded` were never caught and bubbled up to whatever method was calling `portfolio.updateSelectedAccount`
- An error was emitted from the `selectedAccount` controller when the provider of a network is undefined
- Invalid networks weren't logged before removal. This could hide real problems (`console.error` should be detected by sentry)
- `getRpcProvider` wasn't throwing an error when there are no valid rpc urls