### PR TITLE
Change: gas price fetch, refetch, when to use the bundler for gas prices and when not to

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -16,6 +16,7 @@ import { EOA_SIMULATION_NONCE } from '../../consts/deployless'
 import { networks } from '../../consts/networks'
 import { Account } from '../../interfaces/account'
 import { Storage } from '../../interfaces/storage'
+import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { AccountOp, accountOpSignableHash } from '../../libs/accountOp/accountOp'
 import { BROADCAST_OPTIONS } from '../../libs/broadcast/broadcast'
 import { FullEstimationSummary } from '../../libs/estimate/interfaces'
@@ -470,6 +471,12 @@ const init = async (
     portfolio,
     () => Promise.resolve()
   )
+  const baseAccount = getBaseAccount(
+    account,
+    accountsCtrl.accountStates[account.addr][network.chainId.toString()],
+    keystore.keys.filter((key) => account.associatedKeys.includes(key.addr)),
+    network
+  )
   const estimationController = new EstimationController(
     keystore,
     accountsCtrl,
@@ -485,11 +492,17 @@ const init = async (
   estimationController.availableFeeOptions = estimationOrMock.ambireEstimation
     ? estimationOrMock.ambireEstimation.feePaymentOptions
     : estimationOrMock.providerEstimation!.feePaymentOptions
-  const gasPriceController = new GasPriceController(network, provider, bundlerSwitcher, () => ({
-    estimation: estimationController,
-    readyToSign: true,
-    isSignRequestStillActive: () => true
-  }))
+  const gasPriceController = new GasPriceController(
+    network,
+    provider,
+    baseAccount,
+    bundlerSwitcher,
+    () => ({
+      estimation: estimationController,
+      readyToSign: true,
+      isSignRequestStillActive: () => true
+    })
+  )
   gasPriceController.gasPrices = gasPricesOrMock
   const controller = new SignAccountOpTesterController(
     accountsCtrl,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -318,11 +318,17 @@ export class SignAccountOpController extends EventEmitter {
     )
     const emptyFunc = () => {}
     this.#traceCall = traceCall ?? emptyFunc
-    this.gasPrice = new GasPriceController(network, provider, this.bundlerSwitcher, () => ({
-      estimation: this.estimation,
-      readyToSign: this.readyToSign,
-      isSignRequestStillActive
-    }))
+    this.gasPrice = new GasPriceController(
+      network,
+      provider,
+      this.baseAccount,
+      this.bundlerSwitcher,
+      () => ({
+        estimation: this.estimation,
+        readyToSign: this.readyToSign,
+        isSignRequestStillActive
+      })
+    )
     this.#shouldSimulate = shouldSimulate
 
     this.#load(shouldSimulate)


### PR DESCRIPTION
### Problem:  
The 4337 broadcast model is very monolith in a sense as some properties that usually should be independent (like gas limit estimations) are actually dependent on the gas price estimation. This is because the property `preVerificationGas` is returned in the gas limit request. The reason for this is simple - it depends on knowing the calldata, paymasterData, and gas price data.

The unfortunate part is the gas price data. The entry point is coded in a way that the higher gas price it receives, the more `preVerificationGas` it demands from the user. This is especially true on L2s.

But our codebase continues to treat gas price and gas limit requests in the 4337 broadcast model as independent. This leads to the following scenario:
- we start a `signAccountOp` request on `Optimism`
- a gas price request to the bundler is fired in the `GasPriceController`
- a gas price request from the bundler is awaited and a gas limit estimation request is fired in the `EstimationController`. The gas limit request must await the gas price request as it uses them. Otherwise, gas values will be wrong and a "Estimation confirmation failed" error will be thrown
- in `signAccountOp`, we have a race between the `GasPriceController` and the `EstimationController` for the bundler gas price. **Whoever completes last**, will get its gas price data recorded in `signAccountOp`
- each 12s, we have a gas price data refetch. It updates `signAccountOp`

The above example I believe makes the problem clearly visible. If the `GasPriceController` completes last OR 12s pass and a new gas price data from the bundler is fetched, that data does not then do a re-estimate request, leaving gas price and limit data out of sync. This does not lead to a request denial all of the time - if lucky, the bundler will still accept the out of sync data. But clearly, this is the incorrect way of implementing the 4337 broadcast model

### Solution:  
Stop fetching gas prices from the bundler in the gas price controller and stop refetching them every 12s. That will stop bundler gas price updates without following an estimation, thus removing the problem of causing data going out of sync.  
Re-estimation continues to happen every 30s. During that re-estimation, bundler gas prices will be fetched and passed on to the estimation, making them in sync.  
Finally, gas price data for accounts that do not use the 4337 broadcast model remains unchanged. An EOA / V1 account / V2 relayer account will continue requesting gas prices every 12s and they will continue asking the bundler for better gas price estimations every 12s as 1) bundler price estimations are better than ours 2) they are independent in non-4337 broadcast models