### PR TITLE
Bug / Swap & Bridge race condition when changing a route and exiting the form

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2060,6 +2060,10 @@ export class SwapAndBridgeController extends EventEmitter {
    *
    * If the component re-renders or receives stale async events (e.g., an old estimation result),
    * this check prevents applying outdated data to the current form state.
+   *
+   * ⚠️ IMPORTANT: If you make changes here and they involve async operations,
+   * make sure to check `isQuoteIdObsoleteAfterAsyncOperation` afterwards
+   * to ensure you’re not acting on obsolete data.
    */
   async initSignAccountOpIfNeeded(quoteIdGuard: string) {
     // no updates if the user has committed

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2049,7 +2049,7 @@ export class SwapAndBridgeController extends EventEmitter {
   /**
    * Guard to ensure we only proceed with data that matches the latest active quote in `this.#updateQuoteId`.
    */
-  #validateUpdateQuoteIdAfterAsyncOperation(quoteIdGuard: string) {
+  #isQuoteIdObsoleteAfterAsyncOperation(quoteIdGuard: string) {
     return quoteIdGuard && quoteIdGuard !== this.#updateQuoteId
   }
 
@@ -2091,11 +2091,11 @@ export class SwapAndBridgeController extends EventEmitter {
       network.chainId
     )
 
-    if (this.#validateUpdateQuoteIdAfterAsyncOperation(quoteIdGuard)) return
+    if (this.#isQuoteIdObsoleteAfterAsyncOperation(quoteIdGuard)) return
 
     const userTxn = await this.getRouteStartUserTx()
 
-    if (this.#validateUpdateQuoteIdAfterAsyncOperation(quoteIdGuard)) return
+    if (this.#isQuoteIdObsoleteAfterAsyncOperation(quoteIdGuard)) return
 
     // if no txn is provided because of a route failure (large slippage),
     // auto select the next route and continue on
@@ -2121,7 +2121,7 @@ export class SwapAndBridgeController extends EventEmitter {
       accountState
     )
 
-    if (this.#validateUpdateQuoteIdAfterAsyncOperation(quoteIdGuard)) return
+    if (this.#isQuoteIdObsoleteAfterAsyncOperation(quoteIdGuard)) return
 
     const isBridge = this.fromChainId && this.toChainId && this.fromChainId !== this.toChainId
     const calls = !isBridge ? [...userRequestCalls, ...swapOrBridgeCalls] : [...swapOrBridgeCalls]

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1734,7 +1734,7 @@ export class SwapAndBridgeController extends EventEmitter {
       this.isAutoSelectRouteDisabled = isAutoSelectDisabled
     }
 
-    await this.initSignAccountOpIfNeeded()
+    await this.initSignAccountOpIfNeeded(this.#updateQuoteId)
     this.emitUpdate()
   }
 


### PR DESCRIPTION
Solves a race condition when changing a Swap & Bridge route and exiting the form - in this case `initSignAccountOpIfNeeded` was getting called without `quoteIdGuard` and the logic that was validating updateQuoteId after async operation didn't click. Crash report: https://monitor.ambire.com/organizations/ambire/issues/131

<img width="1224" height="336" alt="image" src="https://github.com/user-attachments/assets/9459ba47-aadb-459c-aefb-cf2b9f6b26c0" />

Also, refactors a bit the logic, so it is better understandable.