### PR TITLE
Use original bundler gas price

### DIFF
--- a/src/services/bundlers/biconomy.ts
+++ b/src/services/bundlers/biconomy.ts
@@ -85,4 +85,8 @@ export class Biconomy extends Bundler {
   public getName(): BUNDLER {
     return BICONOMY
   }
+
+  public shouldReestimateBeforeBroadcast(): boolean {
+    return false
+  }
 }

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -49,6 +49,12 @@ export abstract class Bundler {
   public abstract getName(): BUNDLER
 
   /**
+   * Each bundler should declare the conditions upon a reestimate before
+   * broadcast is needed
+   */
+  public abstract shouldReestimateBeforeBroadcast(network: Network): boolean
+
+  /**
    * Get the bundler RPC
    *
    * @param network

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -20,11 +20,6 @@ import { GasSpeeds, UserOpStatus } from './types'
 
 require('dotenv').config()
 
-function addExtra(gasInWei: bigint, percentageIncrease: bigint): Hex {
-  const percent = 100n / percentageIncrease
-  return toBeHex(gasInWei + gasInWei / percent) as Hex
-}
-
 export abstract class Bundler {
   /**
    * The default pollWaitTime. This is used to determine
@@ -172,25 +167,7 @@ export abstract class Bundler {
       return this.fetchGasPrices(network, errorCallback, increment)
     }
 
-    const results = response as GasSpeeds
-    return {
-      slow: {
-        maxFeePerGas: addExtra(BigInt(results.slow.maxFeePerGas), 5n),
-        maxPriorityFeePerGas: addExtra(BigInt(results.slow.maxPriorityFeePerGas), 5n)
-      },
-      medium: {
-        maxFeePerGas: addExtra(BigInt(results.medium.maxFeePerGas), 7n),
-        maxPriorityFeePerGas: addExtra(BigInt(results.medium.maxPriorityFeePerGas), 7n)
-      },
-      fast: {
-        maxFeePerGas: addExtra(BigInt(results.fast.maxFeePerGas), 10n),
-        maxPriorityFeePerGas: addExtra(BigInt(results.fast.maxPriorityFeePerGas), 10n)
-      },
-      ape: {
-        maxFeePerGas: addExtra(BigInt(results.ape.maxFeePerGas), 20n),
-        maxPriorityFeePerGas: addExtra(BigInt(results.ape.maxPriorityFeePerGas), 20n)
-      }
-    }
+    return response as GasSpeeds
   }
 
   // used when catching errors from bundler requests

--- a/src/services/bundlers/gelato.ts
+++ b/src/services/bundlers/gelato.ts
@@ -59,4 +59,8 @@ export class Gelato extends Bundler {
   public getName(): BUNDLER {
     return GELATO
   }
+
+  public shouldReestimateBeforeBroadcast(network: Network): boolean {
+    return !!network.isOptimistic
+  }
 }

--- a/src/services/bundlers/pimlico.ts
+++ b/src/services/bundlers/pimlico.ts
@@ -27,4 +27,8 @@ export class Pimlico extends Bundler {
   public getName(): BUNDLER {
     return PIMLICO
   }
+
+  public shouldReestimateBeforeBroadcast(): boolean {
+    return false
+  }
 }


### PR DESCRIPTION
```
/**
   * What is a good UX?
   * In the 4337 broadcast model, fee speeds don't make sense. That is
   * because it doesn't matter if you choose slow or fast, if the bundler
   * accepts the userOp, he is obliged to broadcast it as soon as possible.
   * Also, some bundlers return a single value for gas prices, meaning all
   * speed options should have the same cost
   *
   * But Ethereum UX doesn't work like this.
   * Users expect to see a broadcast speed in the wallet itself and if
   * it's not present, they will find it strange.
   *
   * The soluiton here is to create the illusion of speeds in the 4337
   * broadcast model by increasing them only for the user payment but
   * using the original, bundler provided ones for broadcast.
   * That way we get a better bundler userOp acceptance rate and a
   * normal, intuitive UX
 */
 ```

At a side note, we're adding a `shouldReestimateBeforeBroadcast` flag to each bundler and setting gelato to true if the network is optimistic. Gelato is currently not doing as well as pimlico/biconomy on L2s as the gas price it provides can change in a matter of 1-2s and even though we've fetched the gas price just before broadcast, gelato might reject the userOp, resulting in a terrible UX.
For the time being, we're disabling gelato on optimism on the relayer