### PR TITLE
Filter bridges that require native if account doesn't have native

### DIFF
--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -430,7 +430,8 @@ export class LiFiAPI {
     userAddress,
     sort,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    isOG
+    isOG,
+    accountHasNative
   }: {
     fromAsset: TokenResult | null
     fromChainId: number
@@ -443,6 +444,7 @@ export class LiFiAPI {
     isSmartAccount: boolean
     sort: 'time' | 'output'
     isOG: InviteController['isOG']
+    accountHasNative: boolean
   }): Promise<SwapAndBridgeQuote> {
     if (!fromAsset)
       throw new SwapAndBridgeProviderApiError(
@@ -472,7 +474,11 @@ export class LiFiAPI {
         allowDestinationCall: 'false',
         allowSwitchChain: 'false',
         // LiFi fee is from 0 to 1, so normalize it by dividing by 100
-        fee: (FEE_PERCENT / 100).toString() as string | undefined
+        fee: (FEE_PERCENT / 100).toString() as string | undefined,
+        bridges: {
+          // filter out bridges that require native if the account doesn't have any
+          deny: !accountHasNative ? ['squid', 'stargateV2', 'stargateV2Bus'] : []
+        }
       }
     }
 

--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -291,6 +291,7 @@ export class SocketAPI {
     isSmartAccount: boolean
     sort: 'time' | 'output'
     isOG: InviteController['isOG']
+    accountHasNative: boolean
   }): Promise<SwapAndBridgeQuote> {
     const params = new URLSearchParams({
       fromChainId: fromChainId.toString(),


### PR DESCRIPTION
Filter out known bridges that require a native payment if that account doesn't have any native.
It's discussable whether we want to implement it this way, but:
* we check if the user has at least more than 2 cents of native
* if he doesnt', we filter the known routes that require native

Filtered bridges: stargateV2, stargateV2Bus, squid