### PR TITLE
Fix/ Selected account isReadyToBeVisualized and error reporting bugs

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -508,8 +508,8 @@ export class SelectedAccountController extends EventEmitter {
     const errorBanners = getNetworksWithPortfolioErrorErrors({
       networks: this.#networks.networks,
       selectedAccountLatest: this.portfolio.latest,
-      providers: this.#providers.providers,
-      isAllReady: this.portfolio.isAllReady
+      isAllReady: this.portfolio.isAllReady,
+      providers: this.#providers.providers
     })
 
     this.#portfolioErrors = [...networksWithFailedRPCBanners, ...errorBanners]

--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -484,6 +484,12 @@ export function calculateSelectedAccountPortfolioByNetworks(
       newAccountPortfolioWithDefiPositions[network] =
         pastAccountPortfolioWithDefiPositionsNetworkState
 
+      if (!hasTokensWithAmount) {
+        hasTokensWithAmount = pastAccountPortfolioWithDefiPositionsNetworkState.tokens.some(
+          ({ amount }) => amount > 0n
+        )
+      }
+
       return
     }
 


### PR DESCRIPTION
## Fixes:
- `isReadyToVisualize` toggles between `true` and `false`, while its value must be true. This was because when we pulled the tokens from cache `hasTokensWithAmount` remained `false`
- Critical errors weren't displayed. You can read the code comments and reproduction steps to learn more

## Screenshots:
- An account with ~$350 balance. There are critical errors in the console, but nothing is displayed on the dashboard :skull: 
<img width="2280" height="1171" alt="image" src="https://github.com/user-attachments/assets/72996bef-bbd8-460e-a786-7a52c0310215" />

## How to reproduce the second bug:
- Reload the extension
- Set network throttling to 3G
- Set CPU throttling to > 6x (YOU MUST APPLY THIS AFTER EVERY SERVICE WORKER RESTART)
- Unlock the extension
- Load another account
- When the portfolio is done loading (can take >30s) close the popup
- Open it again. On `v2` there will be no errors (there must be)
