### PR TITLE
Fix: increased bundler gas prices for v2 accounts as well

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1295,9 +1295,10 @@ export class SignAccountOpController extends EventEmitter {
         // the bundler does a better job than us for gas price estimations
         // so we prioritize their estimation over ours if there's any
         if (this.bundlerGasPrices) {
+          const increasedGasPrices = this.#getIncreasedBundlerGasPrices()!
           const name = gasRecommendation.name as keyof GasSpeeds
-          maxPriorityFeePerGas = BigInt(this.bundlerGasPrices[name].maxPriorityFeePerGas)
-          gasPrice = BigInt(this.bundlerGasPrices[name].maxFeePerGas)
+          maxPriorityFeePerGas = BigInt(increasedGasPrices[name].maxPriorityFeePerGas)
+          gasPrice = BigInt(increasedGasPrices[name].maxFeePerGas)
         }
 
         // EOA OR 7702: pays with native by itself


### PR DESCRIPTION
Fix: increase the bundler gas prices received by the bundler for better visual representation in signAccountOp for account that don't use 4337 for broadcast