### PR TITLE
Fix: invalid account nonce trigger

### DIFF
--- a/src/libs/errorDecoder/handlers/bundler.ts
+++ b/src/libs/errorDecoder/handlers/bundler.ts
@@ -6,10 +6,11 @@ class BundlerErrorHandler implements ErrorHandler {
     const { message } = error?.error || error || {}
 
     return (
-      message.includes('UserOperation reverted during simulation with reason:') ||
+      message.includes('UserOperation reverted during simulation') ||
       message.includes('pimlico_getUserOperationGasPrice') ||
-      message.includes('UserOperation failed validation with reason:') ||
-      message.includes('UserOperation reverted with reason:')
+      message.includes('UserOperation failed validation') ||
+      message.includes('UserOperation reverted') ||
+      message.includes('invalid account nonce')
     )
   }
 
@@ -20,26 +21,9 @@ class BundlerErrorHandler implements ErrorHandler {
     if (message.includes('pimlico_getUserOperationGasPrice')) {
       reason = 'pimlico_getUserOperationGasPrice'
     } else {
-      const userOperationSimulationRegex =
-        /UserOperation reverted during simulation with reason:\s*/i
-      const userOperationValidationRegex = /UserOperation failed validation with reason:\s*/i
-      const userOperationRevertedRegex = /UserOperation reverted with reason:\s*/i
-      const regexes = [
-        userOperationSimulationRegex,
-        userOperationValidationRegex,
-        userOperationRevertedRegex
-      ]
-
-      for (let i = 0; i < regexes.length; i++) {
-        const regex = regexes[i]
-        if (regex.test(message)) {
-          const EntryPointErrorCode = /AA[0-9]{1,2}\s?/
-          reason = message.replace(regex, '')
-          // Remove error codes like AA1, AA2, etc. and the space after them
-          reason = reason.replace(EntryPointErrorCode, '')
-          break
-        }
-      }
+      const EntryPointErrorCode = /AA[0-9]{1,2}\s?/
+      // Remove error codes like AA1, AA2, etc. and the space after them
+      reason = reason.replace(EntryPointErrorCode, '')
     }
 
     return {

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -105,7 +105,10 @@ async function estimate(
     // fatal (at estimate.ts -> estimate4337)
     nonFatalErrors.push(new Error('Bundler estimation failed', { cause: '4337_ESTIMATION' }))
 
-    if (decodedError.reason && decodedError.reason.indexOf('invalid account nonce') !== -1) {
+    if (
+      e.message.indexOf('invalid account nonce') !== -1 ||
+      (decodedError.reason && decodedError.reason.indexOf('invalid account nonce') !== -1)
+    ) {
       nonFatalErrors.push(new Error('4337 invalid account nonce', { cause: '4337_INVALID_NONCE' }))
     }
 

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -101,14 +101,10 @@ async function estimate(
     const decodedError = bundler.decodeBundlerError(e)
 
     // if the bundler estimation fails, add a nonFatalError so we can react to
-    // it on the FE. The BE at a later stage decides if this error is actually
-    // fatal (at estimate.ts -> estimate4337)
+    // it on the FE. The BE at a later stage decides if this error is actually fatal
     nonFatalErrors.push(new Error('Bundler estimation failed', { cause: '4337_ESTIMATION' }))
 
-    if (
-      e.message.indexOf('invalid account nonce') !== -1 ||
-      (decodedError.reason && decodedError.reason.indexOf('invalid account nonce') !== -1)
-    ) {
+    if (e.message.indexOf('invalid account nonce') !== -1) {
       nonFatalErrors.push(new Error('4337 invalid account nonce', { cause: '4337_INVALID_NONCE' }))
     }
 


### PR DESCRIPTION
Problem:
* the invalid account nonce trigger during estimation was handled only if the bundler was pimlico as it relied on the decoded error

Solution:
* use the original error to perform the invalid account nonce check