### PR TITLE
Config / Reverse lookup timeout

### DIFF
--- a/src/services/ensDomains/ensDomains.ts
+++ b/src/services/ensDomains/ensDomains.ts
@@ -68,7 +68,12 @@ function getBip44Items(coinTicker: string) {
 }
 
 async function reverseLookupEns(address: string, provider: RPCProvider) {
-  return provider.lookupAddress(address)
+  const lookup = provider.lookupAddress(address)
+  const lookupTimeout = new Promise<null>((resolve) => {
+    setTimeout(() => resolve(null), 10000)
+  })
+
+  return Promise.race([lookup, lookupTimeout])
 }
 
 export { resolveENSDomain, getBip44Items, reverseLookupEns }


### PR DESCRIPTION
Sometimes the reverse lookup hangs (simulate slow connection) for a long while, causing this loading skeleton on the AccountPicker:

<img width="1004" height="929" alt="Screenshot 2025-08-11 at 17 21 11" src="https://github.com/user-attachments/assets/3042f287-2585-4b5a-b466-f9adb0d9841c" />

So add 10s timeout.