### PR TITLE
Feature/ Controller crash reporting

### DIFF
--- a/src/classes/EmittableError.ts
+++ b/src/classes/EmittableError.ts
@@ -5,13 +5,21 @@ export default class EmittableError extends Error {
 
   message: ErrorRef['message']
 
-  error: Error
+  error: ErrorRef['error']
 
-  constructor(errorRef: { message: ErrorRef['message']; level: ErrorRef['level']; error?: Error }) {
+  sendCrashReport?: ErrorRef['sendCrashReport']
+
+  constructor(errorRef: {
+    message: ErrorRef['message']
+    level: ErrorRef['level']
+    error?: ErrorRef['error']
+    sendCrashReport?: ErrorRef['sendCrashReport']
+  }) {
     super()
     this.message = errorRef.message
     this.name = 'EmittableError'
     this.level = errorRef.level
+    this.sendCrashReport = errorRef.sendCrashReport
 
     if (!errorRef.error) {
       this.error = new Error(errorRef.message)

--- a/src/classes/ExternalSignerError.ts
+++ b/src/classes/ExternalSignerError.ts
@@ -1,7 +1,19 @@
+import { ErrorRef } from '../controllers/eventEmitter/eventEmitter'
+
 export default class ExternalSignerError extends Error {
-  constructor(message: string) {
+  sendCrashReport?: ErrorRef['sendCrashReport']
+
+  constructor(
+    message: string,
+    params?: {
+      sendCrashReport?: ErrorRef['sendCrashReport']
+    }
+  ) {
     super()
+    const { sendCrashReport = false } = params || {}
     this.name = 'ExternalSignerError'
     this.message = message
+    // Don't send crash reports by default
+    this.sendCrashReport = sendCrashReport
   }
 }

--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -839,7 +839,7 @@ export class AccountPickerController extends EventEmitter {
           level: 'major',
           message:
             'Error when adding accounts on the Ambire Relayer. Please try again later or contact support if the problem persists.',
-          error: new Error(e?.message)
+          error: e
         })
 
         this.addAccountsStatus = 'INITIAL'

--- a/src/controllers/addressBook/addressBook.ts
+++ b/src/controllers/addressBook/addressBook.ts
@@ -106,8 +106,7 @@ export class AddressBookController extends EventEmitter {
       this.emitError({
         message: 'Invalid address',
         level: 'minor',
-        error: new Error('Address Book: invalid address'),
-        sendCrashReport: false
+        error: new Error('Address Book: invalid address')
       })
       return ''
     }

--- a/src/controllers/addressBook/addressBook.ts
+++ b/src/controllers/addressBook/addressBook.ts
@@ -106,7 +106,8 @@ export class AddressBookController extends EventEmitter {
       this.emitError({
         message: 'Invalid address',
         level: 'minor',
-        error: new Error('Address Book: invalid address')
+        error: new Error('Address Book: invalid address'),
+        sendCrashReport: false
       })
       return ''
     }

--- a/src/controllers/emailVault/emailVault.ts
+++ b/src/controllers/emailVault/emailVault.ts
@@ -359,6 +359,7 @@ export class EmailVaultController extends EventEmitter {
       this.emitError({
         message: 'Email key not confirmed',
         level: 'minor',
+        sendCrashReport: false,
         error: new Error('uploadKeyStoreSecret: not confirmed magic link key')
       })
 
@@ -395,7 +396,7 @@ export class EmailVaultController extends EventEmitter {
     if (!state.email[email].availableSecrets[uid]) {
       this.emitError({
         message: `Resetting the password on this device is not enabled for ${email}.`,
-        level: 'major',
+        level: 'expected',
         error: new Error('Keystore recovery: no keystore secret for this device')
       })
       return
@@ -403,7 +404,7 @@ export class EmailVaultController extends EventEmitter {
     if (state.email[email].availableSecrets[uid].type !== SecretType.KeyStore) {
       this.emitError({
         message: `Resetting the password on this device is not enabled for ${email}.`,
-        level: 'major',
+        level: 'expected',
         error: new Error(`Keystore recovery: no keystore secret for email ${email}`)
       })
       return
@@ -415,7 +416,7 @@ export class EmailVaultController extends EventEmitter {
     const emitExpiredMagicLinkError = () => {
       this.emitError({
         message: `The time allotted for changing your password has expired for ${email}. Please verify your email again!`,
-        level: 'major',
+        level: 'expected',
         error: new Error(`Keystore recovery: magic link expired for ${email}`)
       })
 

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -10,7 +10,7 @@ export type ErrorRef = {
   message: string
   /**
    * Logged in the console - all
-   * Displayed as a banner - display, major
+   * Displayed as a banner - expected, major
    * Reported to the error tracking service by default - all, except `expected`
    */
   level: 'expected' | 'minor' | 'silent' | 'major'

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -87,10 +87,7 @@ export default class EventEmitter {
   }
 
   protected emitError(error: ErrorRef) {
-    this.#errors.push({
-      ...error,
-      sendCrashReport: error.sendCrashReport ?? error.level !== 'expected'
-    })
+    this.#errors.push(error)
     this.#trimErrorsIfNeeded()
     console.log(
       `[Еmitted error in controller ${this.constructor.name}] ${error.message}`,

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -4,11 +4,25 @@ import wait from '../../utils/wait'
 const LIMIT_ON_THE_NUMBER_OF_ERRORS = 100
 
 export type ErrorRef = {
-  // user-friendly message, ideally containing call to action
+  /**
+   * User-friendly message, ideally containing call to action
+   */
   message: string
-  // error level, used for filtering
-  level: 'fatal' | 'major' | 'minor' | 'silent'
-  // error containing technical details and stack trace
+  /**
+   * Logged in the console - all
+   * Displayed as a banner - display, major
+   * Reported to the error tracking service by default - all, except `expected`
+   */
+  level: 'expected' | 'minor' | 'silent' | 'major'
+
+  /**
+   * Whether the error be reported to the error tracking service (e.g. Sentry).
+   * The default value depends on the error level. See the `level` property for more info.
+   */
+  sendCrashReport?: boolean
+  /**
+   * The original error, containing technical details and stack trace
+   */
   error: Error
 }
 
@@ -73,7 +87,10 @@ export default class EventEmitter {
   }
 
   protected emitError(error: ErrorRef) {
-    this.#errors.push(error)
+    this.#errors.push({
+      ...error,
+      sendCrashReport: error.sendCrashReport ?? error.level !== 'expected'
+    })
     this.#trimErrorsIfNeeded()
     console.log(
       `[Еmitted error in controller ${this.constructor.name}] ${error.message}`,

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -296,7 +296,7 @@ export class KeystoreController extends EventEmitter {
     if (this.#keystoreSecrets.find((x) => x.id === secretId))
       throw new EmittableError({
         message: KEYSTORE_UNEXPECTED_ERROR_MESSAGE,
-        level: 'expected',
+        level: 'major',
         error: new Error(`keystore: trying to add duplicate secret ${secretId}`)
       })
 

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -296,7 +296,7 @@ export class KeystoreController extends EventEmitter {
     if (this.#keystoreSecrets.find((x) => x.id === secretId))
       throw new EmittableError({
         message: KEYSTORE_UNEXPECTED_ERROR_MESSAGE,
-        level: 'major',
+        level: 'expected',
         error: new Error(`keystore: trying to add duplicate secret ${secretId}`)
       })
 
@@ -443,7 +443,7 @@ export class KeystoreController extends EventEmitter {
     if (!Mnemonic.isValidMnemonic(seed)) {
       throw new EmittableError({
         message: 'You are trying to store an invalid seed phrase.',
-        level: 'major',
+        level: 'expected',
         error: new Error('keystore: trying to add an invalid seed phrase')
       })
     }

--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -338,7 +338,7 @@ export class NetworksController extends EventEmitter {
     if (chainIds.indexOf(BigInt(network.chainId)) !== -1) {
       throw new EmittableError({
         message: 'The network you are trying to add has already been added.',
-        level: 'major',
+        level: 'expected',
         error: new Error('settings: addNetwork chain already added (duplicate id/chainId)')
       })
     }

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -249,7 +249,14 @@ export class SignMessageController extends EventEmitter {
       const message =
         e?.message || 'Something went wrong while signing the message. Please try again.'
 
-      return Promise.reject(new EmittableError({ level: 'major', message, error }))
+      return Promise.reject(
+        new EmittableError({
+          level: 'major',
+          message,
+          error,
+          sendCrashReport: e && 'sendCrashReport' in e ? e.sendCrashReport : undefined
+        })
+      )
     }
   }
 

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -1,4 +1,5 @@
 import EmittableError from '../../classes/EmittableError'
+import ExternalSignerError from '../../classes/ExternalSignerError'
 import { Account } from '../../interfaces/account'
 import { ExternalSignerControllers, Key, KeystoreSignerInterface } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
@@ -192,9 +193,12 @@ export class SignMessageController extends EventEmitter {
           signature = this.#signer.sign7702(this.messageToSign.content.message)
         }
       } catch (error: any) {
-        throw new Error(
+        throw new ExternalSignerError(
           error?.message ||
-            'Something went wrong while signing the message. Please try again later or contact support if the problem persists.'
+            'Something went wrong while signing the message. Please try again later or contact support if the problem persists.',
+          {
+            sendCrashReport: error?.sendCrashReport
+          }
         )
       }
 
@@ -254,7 +258,7 @@ export class SignMessageController extends EventEmitter {
           level: 'major',
           message,
           error,
-          sendCrashReport: e && 'sendCrashReport' in e ? e.sendCrashReport : undefined
+          sendCrashReport: e?.sendCrashReport
         })
       )
     }

--- a/src/libs/estimate/estimateWithRetries.ts
+++ b/src/libs/estimate/estimateWithRetries.ts
@@ -72,7 +72,7 @@ export async function estimateWithRetries<T>(
   if (error) {
     if (error.cause === 'ConnectivityError') {
       errorCallback({
-        level: 'major',
+        level: 'expected',
         message: 'Estimating the transaction failed because of a network error.',
         error
       })


### PR DESCRIPTION
Implements a mechanism that reports errors from the controllers to Sentry. 
To be able to report errors granularly, this PR updates `ErrorRef` and `EmittableError` as follows: 
- adds a new error type - `expected` - these are validation errors that will be displayed as toasts to the users, but won't be reported
- adds a new error property - `sendCrashReport` - it's true by default for all errors, except `expected`. Some errors aren't `expected`, but still shouldn't be reported. In this case, `sendCrashReport` should be passed as false

## App PR:
https://github.com/AmbireTech/ambire-app/pull/5270