### PR TITLE
Fix/ Execution failed error (undefined provider)

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -445,7 +445,7 @@ export class SelectedAccountController extends EventEmitter {
         func()
       } catch (error: any) {
         this.emitError({
-          level: 'minor',
+          level: 'silent',
           message: `The execution of ${funcName} in SelectedAccountController failed`,
           error
         })

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -226,11 +226,12 @@ export const getNetworksWithPortfolioErrorErrors = ({
     // We are purposely checking the RPC and not the RPC banners, because they are only displayed
     // when the RPC is not working AND the user has balance on the network.
     // Example: The user has no balance on Berachain and the RPC is not working.
-    // In this case there will be no RPC error banner and no portfolio error banner.
-    const isRpcWorkingOrNotChecked =
-      typeof rpcProvider.isWorking !== 'boolean' || rpcProvider.isWorking
-
-    if (criticalError && (['gasTank', 'rewards'].includes(chainId) || isRpcWorkingOrNotChecked)) {
+    if (
+      criticalError &&
+      (['gasTank', 'rewards'].includes(chainId) ||
+        typeof rpcProvider.isWorking !== 'boolean' ||
+        rpcProvider.isWorking)
+    ) {
       errors = addPortfolioError(errors, networkName, 'portfolio-critical')
       return
     }


### PR DESCRIPTION
`rpcProvider` is undefined for gasTank and rewards. The selectedAccount error appears only when the portfolio additional call fails
Fixes the following problem https://monitor.ambire.com/organizations/ambire/issues/199/?project=3&referrer=issue-stream&stream_index=8