### PR TITLE
Instead of emitting an error, do not proceed with gas calculations if `this.selectedOption` is not set

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -452,7 +452,13 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
   }
 
   #setGasFeePayment() {
-    if (this.isInitialized && this.paidBy && this.selectedFeeSpeed && this.feeTokenResult) {
+    if (
+      this.isInitialized &&
+      this.paidBy &&
+      this.selectedFeeSpeed &&
+      this.feeTokenResult &&
+      this.selectedOption
+    ) {
       this.accountOp.gasFeePayment = this.#getGasFeePayment()
     }
   }


### PR DESCRIPTION
Instead of emitting an error, do not proceed with gas calculations if `this.selectedOption` is not set.

This is trying to fix this error:  
https://monitor.ambire.com/organizations/ambire/issues/230/?alert_rule_id=4&alert_type=issue&notification_uuid=9f253e89-688a-405f-9a71-6838a5d3d19a&project=3&referrer=slack

Without the selectedOption set, we cannot calculate the gas prices. The selectedOption is set on the FE and dispatched later so it's a race condition error