### PR TITLE
Feature / Set a timeout for the reverse ENS lookup logic

### DIFF
--- a/src/controllers/domains/domains.ts
+++ b/src/controllers/domains/domains.ts
@@ -89,8 +89,7 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
       return
 
     this.loadingAddresses.push(checksummedAddress)
-    // TODO: Maybe forgotten if check?
-    if (emitUpdate) this.emitUpdate()
+    this.emitUpdate()
 
     let ensName: string | null = null
 

--- a/src/controllers/domains/domains.ts
+++ b/src/controllers/domains/domains.ts
@@ -98,7 +98,7 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
       ensName = await withTimeout(() => reverseLookupEns(checksummedAddress, ethereumProvider))
     } catch (e: any) {
       // Fail silently with a console error, no biggie, since that would get retried
-      console.error('reverse ENS lookup failed', e)
+      console.warn('reverse ENS lookup failed', e)
     }
 
     this.domains[checksummedAddress] = {

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,0 +1,43 @@
+export const DEFAULT_TIMEOUT_MESSAGE = 'timed out, race timer resolved first'
+export const DEFAULT_TIMEOUT_MS = 5000
+
+/**
+ * Run an async task with a soft timeout using Promise.race. Notes:
+ * - By default, this utility does not cancel the underlying task. If the timeout wins the race,
+ *   the returned promise rejects, but the task may continue running in the background.
+ * - To also signal cancellation to the underlying operation, pass `{ useAbort: true }`.
+ *   In that case, a new `AbortController` is created, its `signal` is provided to the task,
+ *   and on timeout the controller is aborted.
+ * - Callers may ignore the signal if they don't support cancellation; behavior falls back to soft timeout.
+ */
+export async function withTimeout<T>(
+  task: (args?: { signal?: AbortSignal | null }) => Promise<T>,
+  options?: { timeoutMs?: number; message?: string; useAbort?: boolean }
+): Promise<T> {
+  const {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    message = DEFAULT_TIMEOUT_MESSAGE,
+    useAbort = false
+  } = options || {}
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const controller = useAbort ? new AbortController() : null
+
+  try {
+    return await Promise.race<T>([
+      task({ signal: controller?.signal ?? null }),
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => {
+          if (controller) controller.abort()
+          reject(new Error(message))
+        }, timeoutMs)
+      })
+    ])
+  } catch (err: unknown) {
+    const error = err as Error & { name?: string }
+    if (error && error.name === 'AbortError') throw new Error(message)
+    throw err as Error
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}


### PR DESCRIPTION
Sometimes, especially on crappy connection, reverse ENS lookup hangs and causes infinite loading skeletons on addresses everywhere. Especially bad on the AccountPicker, because user can't proceed until lookup gets resolved.

<img width="958" height="732" alt="Screenshot 2025-08-18 at 15 57 47" src="https://github.com/user-attachments/assets/15297422-aa50-4b98-862f-7e2c9c2ed3b6" />

So let a sensible timeout (5s) and fallback.

Also, introduce reusable `withTimeout` (that supports canceling the underlying operation via Abort controller).