### PR TITLE
Move signAccountOp re-estimate inside the controller

### DIFF
--- a/src/controllers/estimation/estimation.ts
+++ b/src/controllers/estimation/estimation.ts
@@ -3,7 +3,6 @@ import { ZeroAddress } from 'ethers'
 /* eslint-disable class-methods-use-this */
 import ErrorHumanizerError from '../../classes/ErrorHumanizerError'
 import { IAccountsController } from '../../interfaces/account'
-import { IActivityController } from '../../interfaces/activity'
 import { ErrorRef } from '../../interfaces/eventEmitter'
 import { IKeystoreController } from '../../interfaces/keystore'
 import { INetworksController } from '../../interfaces/network'
@@ -50,8 +49,6 @@ export class EstimationController extends EventEmitter {
 
   #bundlerSwitcher: BundlerSwitcher
 
-  #activity: IActivityController
-
   #notFatalBundlerError?: Error
 
   constructor(
@@ -60,7 +57,6 @@ export class EstimationController extends EventEmitter {
     networks: INetworksController,
     provider: RPCProvider,
     portfolio: IPortfolioController,
-    activity: IActivityController,
     bundlerSwitcher: BundlerSwitcher
   ) {
     super()
@@ -69,7 +65,6 @@ export class EstimationController extends EventEmitter {
     this.#networks = networks
     this.#provider = provider
     this.#portfolio = portfolio
-    this.#activity = activity
     this.#bundlerSwitcher = bundlerSwitcher
   }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -707,7 +707,6 @@ export class MainController extends EventEmitter implements IMainController {
         this.networks,
         this.keystore,
         this.portfolio,
-        this.activity,
         this.#externalSignerControllers,
         this.selectedAccount.account,
         network,
@@ -717,6 +716,7 @@ export class MainController extends EventEmitter implements IMainController {
         () => {
           return this.isSignRequestStillActive
         },
+        true,
         true,
         (ctrl: ISignAccountOpController) => {
           this.traceCall(ctrl)

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -24,7 +24,6 @@ import { FullEstimationSummary } from '../../libs/estimate/interfaces'
 import { GasRecommendation } from '../../libs/gasPrice/gasPrice'
 import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
 import { TokenResult } from '../../libs/portfolio'
-import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import {
   adaptTypedMessageForMetaMaskSigUtil,
   getTypedData
@@ -32,7 +31,6 @@ import {
 import { BundlerSwitcher } from '../../services/bundlers/bundlerSwitcher'
 import { getRpcProvider } from '../../services/provider'
 import { AccountsController } from '../accounts/accounts'
-import { ActivityController } from '../activity/activity'
 import { BannerController } from '../banner/banner'
 import { EstimationController } from '../estimation/estimation'
 import { EstimationStatus } from '../estimation/types'
@@ -41,7 +39,6 @@ import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
 import { PortfolioController } from '../portfolio/portfolio'
 import { ProvidersController } from '../providers/providers'
-import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 import { StorageController } from '../storage/storage'
 import { getFeeSpeedIdentifier } from './helper'
 import { FeeSpeed, SigningStatus } from './signAccountOp'
@@ -455,23 +452,6 @@ const init = async (
   const bundlerSwitcher = new BundlerSwitcher(network, () => {
     return false
   })
-  const callRelayer = relayerCall.bind({ url: '', fetch })
-  const selectedAccountCtrl = new SelectedAccountController({
-    storage: storageCtrl,
-    accounts: accountsCtrl,
-    keystore
-  })
-  const activity = new ActivityController(
-    storageCtrl,
-    fetch,
-    callRelayer,
-    accountsCtrl,
-    selectedAccountCtrl,
-    providersCtrl,
-    networksCtrl,
-    portfolio,
-    () => Promise.resolve()
-  )
   const baseAccount = getBaseAccount(
     account,
     accountsCtrl.accountStates[account.addr][network.chainId.toString()],
@@ -484,7 +464,6 @@ const init = async (
     networksCtrl,
     providers,
     portfolio,
-    activity,
     bundlerSwitcher
   )
   estimationController.estimation = estimationOrMock
@@ -510,7 +489,6 @@ const init = async (
     networksCtrl,
     keystore,
     portfolio,
-    activity,
     {},
     account,
     network,

--- a/src/controllers/signAccountOp/signAccountOpTester.ts
+++ b/src/controllers/signAccountOp/signAccountOpTester.ts
@@ -1,6 +1,5 @@
 import { Account, IAccountsController } from '../../interfaces/account'
 import { AccountOpAction } from '../../interfaces/actions'
-import { IActivityController } from '../../interfaces/activity'
 import { ExternalSignerControllers, IKeystoreController } from '../../interfaces/keystore'
 import { INetworksController, Network } from '../../interfaces/network'
 import { IPortfolioController } from '../../interfaces/portfolio'
@@ -16,7 +15,6 @@ export class SignAccountOpTesterController extends SignAccountOpController {
     networks: INetworksController,
     keystore: IKeystoreController,
     portfolio: IPortfolioController,
-    activity: IActivityController,
     externalSignerControllers: ExternalSignerControllers,
     account: Account,
     network: Network,
@@ -34,7 +32,6 @@ export class SignAccountOpTesterController extends SignAccountOpController {
       networks,
       keystore,
       portfolio,
-      activity,
       externalSignerControllers,
       account,
       network,

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2195,7 +2195,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       this.#networks,
       this.#keystore,
       this.#portfolio,
-      this.#activity,
       this.#externalSignerControllers,
       this.#selectedAccount.account,
       network,
@@ -2212,6 +2211,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
         // identifiable
         return !!this.#signAccountOpController
       },
+      false,
       false,
       undefined
     )

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -639,7 +639,6 @@ export class TransferController extends EventEmitter implements ITransferControl
       this.#networks,
       this.#keystore,
       this.#portfolio,
-      this.#activity,
       this.#externalSignerControllers,
       this.#selectedAccountData.account,
       network,
@@ -647,6 +646,7 @@ export class TransferController extends EventEmitter implements ITransferControl
       randomId(), // the account op and the action are fabricated
       accountOp,
       () => true,
+      false,
       false,
       undefined
     )


### PR DESCRIPTION
We're moving the logic inside the controller and this allows us to easily start the 30s reestimation after the initial one has concluded (as discussed in qa-extension).

It also allows us better control over when to continue re-estimating, when to stop, should we simulate or not