### PR TITLE
User op nonce check optimizations

### DIFF
--- a/src/controllers/estimation/estimation.ts
+++ b/src/controllers/estimation/estimation.ts
@@ -243,7 +243,6 @@ export class EstimationController extends EventEmitter {
       })
     }
 
-    // TODO: test this
     if (
       this.estimation?.bundlerEstimation?.nonFatalErrors?.find(
         (err) => err.cause === '4337_ESTIMATION'

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -710,6 +710,7 @@ export class MainController extends EventEmitter implements IMainController {
         this.#externalSignerControllers,
         this.selectedAccount.account,
         network,
+        this.activity,
         this.providers.providers[network.chainId.toString()],
         actionId,
         accountOp,

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -24,6 +24,7 @@ import { FullEstimationSummary } from '../../libs/estimate/interfaces'
 import { GasRecommendation } from '../../libs/gasPrice/gasPrice'
 import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
 import { TokenResult } from '../../libs/portfolio'
+import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import {
   adaptTypedMessageForMetaMaskSigUtil,
   getTypedData
@@ -31,6 +32,7 @@ import {
 import { BundlerSwitcher } from '../../services/bundlers/bundlerSwitcher'
 import { getRpcProvider } from '../../services/provider'
 import { AccountsController } from '../accounts/accounts'
+import { ActivityController } from '../activity/activity'
 import { BannerController } from '../banner/banner'
 import { EstimationController } from '../estimation/estimation'
 import { EstimationStatus } from '../estimation/types'
@@ -39,6 +41,7 @@ import { KeystoreController } from '../keystore/keystore'
 import { NetworksController } from '../networks/networks'
 import { PortfolioController } from '../portfolio/portfolio'
 import { ProvidersController } from '../providers/providers'
+import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 import { StorageController } from '../storage/storage'
 import { getFeeSpeedIdentifier } from './helper'
 import { FeeSpeed, SigningStatus } from './signAccountOp'
@@ -458,13 +461,31 @@ const init = async (
     keystore.keys.filter((key) => account.associatedKeys.includes(key.addr)),
     network
   )
+  const selectedAccountCtrl = new SelectedAccountController({
+    storage: storageCtrl,
+    accounts: accountsCtrl,
+    keystore
+  })
+  const callRelayer = relayerCall.bind({ url: '', fetch })
+  const activity = new ActivityController(
+    storageCtrl,
+    fetch,
+    callRelayer,
+    accountsCtrl,
+    selectedAccountCtrl,
+    providersCtrl,
+    networksCtrl,
+    portfolio,
+    () => Promise.resolve()
+  )
   const estimationController = new EstimationController(
     keystore,
     accountsCtrl,
     networksCtrl,
     providers,
     portfolio,
-    bundlerSwitcher
+    bundlerSwitcher,
+    activity
   )
   estimationController.estimation = estimationOrMock
   estimationController.hasEstimated = true
@@ -492,6 +513,7 @@ const init = async (
     {},
     account,
     network,
+    activity,
     provider,
     1,
     op,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -54,6 +54,7 @@ import {
 import { getContractImplementation } from '../../libs/7702/7702'
 import { isAmbireV1LinkedAccount, isSmartAccount } from '../../libs/account/account'
 /* eslint-disable no-restricted-syntax */
+import { IActivityController } from '../../interfaces/activity'
 import { BaseAccount } from '../../libs/account/BaseAccount'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { AccountOp, GasFeePayment, getSignableCalls } from '../../libs/accountOp/accountOp'
@@ -272,6 +273,8 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
   #stopRefetching: boolean = false
 
+  #activity: IActivityController
+
   constructor(
     accounts: IAccountsController,
     networks: INetworksController,
@@ -280,6 +283,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     externalSignerControllers: ExternalSignerControllers,
     account: Account,
     network: Network,
+    activity: IActivityController,
     provider: RPCProvider,
     fromActionId: AccountOpAction['id'],
     accountOp: AccountOp,
@@ -302,6 +306,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       network
     )
     this.#network = network
+    this.#activity = activity
     this.fromActionId = fromActionId
     this.accountOp = structuredClone(accountOp)
     this.#isSignRequestStillActive = isSignRequestStillActive
@@ -323,7 +328,8 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       networks,
       provider,
       portfolio,
-      this.bundlerSwitcher
+      this.bundlerSwitcher,
+      this.#activity
     )
     const emptyFunc = () => {}
     this.#traceCall = traceCall ?? emptyFunc

--- a/src/controllers/signAccountOp/signAccountOpTester.ts
+++ b/src/controllers/signAccountOp/signAccountOpTester.ts
@@ -1,5 +1,6 @@
 import { Account, IAccountsController } from '../../interfaces/account'
 import { AccountOpAction } from '../../interfaces/actions'
+import { IActivityController } from '../../interfaces/activity'
 import { ExternalSignerControllers, IKeystoreController } from '../../interfaces/keystore'
 import { INetworksController, Network } from '../../interfaces/network'
 import { IPortfolioController } from '../../interfaces/portfolio'
@@ -18,11 +19,13 @@ export class SignAccountOpTesterController extends SignAccountOpController {
     externalSignerControllers: ExternalSignerControllers,
     account: Account,
     network: Network,
+    activity: IActivityController,
     provider: RPCProvider,
     fromActionId: AccountOpAction['id'],
     accountOp: AccountOp,
     isSignRequestStillActive: Function,
     shouldSimulate: boolean,
+    shouldReestimate: boolean,
     traceCall: Function,
     estimateController: EstimationController,
     gasPriceController: GasPriceController
@@ -35,11 +38,13 @@ export class SignAccountOpTesterController extends SignAccountOpController {
       externalSignerControllers,
       account,
       network,
+      activity,
       provider,
       fromActionId,
       accountOp,
       isSignRequestStillActive,
       shouldSimulate,
+      shouldReestimate,
       traceCall
     )
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2198,6 +2198,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       this.#externalSignerControllers,
       this.#selectedAccount.account,
       network,
+      this.#activity,
       provider,
       randomId(), // the account op and the action are fabricated
       accountOp,

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -642,6 +642,7 @@ export class TransferController extends EventEmitter implements ITransferControl
       this.#externalSignerControllers,
       this.#selectedAccountData.account,
       network,
+      this.#activity,
       provider,
       randomId(), // the account op and the action are fabricated
       accountOp,

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -1,4 +1,5 @@
 import { BaseAccount } from '../account/BaseAccount'
+import { SubmittedAccountOp } from '../accountOp/submittedAccountOp'
 
 import { AccountOnchainState } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
@@ -30,7 +31,8 @@ export async function getEstimation(
   feeTokens: TokenResult[],
   nativeToCheck: string[],
   switcher: BundlerSwitcher,
-  errorCallback: Function
+  errorCallback: Function,
+  pendingUserOp?: SubmittedAccountOp
 ): Promise<FullEstimation | Error> {
   const ambireEstimation = ambireEstimateGas(
     baseAcc,
@@ -50,7 +52,8 @@ export async function getEstimation(
     provider,
     switcher,
     errorCallback,
-    undefined
+    undefined,
+    pendingUserOp
   )
   const providerEstimation = providerEstimateGas(
     baseAcc.getAccount(),

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -17,6 +17,8 @@ import { paymasterFactory } from '../../services/paymaster'
 import wait from '../../utils/wait'
 import { BaseAccount } from '../account/BaseAccount'
 import { AccountOp, getSignableCalls } from '../accountOp/accountOp'
+import { SubmittedAccountOp } from '../accountOp/submittedAccountOp'
+import { AccountOpStatus } from '../accountOp/types'
 import { PaymasterEstimationData } from '../erc7677/types'
 import { getHumanReadableEstimationError } from '../errorHumanizer'
 import { TokenResult } from '../portfolio'
@@ -66,7 +68,8 @@ async function estimate(
   network: Network,
   userOp: UserOperation,
   switcher: BundlerSwitcher,
-  errorCallback: Function
+  errorCallback: Function,
+  pendingUserOp?: SubmittedAccountOp
 ): Promise<{
   gasPrice: GasSpeeds | Error
   estimation: any
@@ -83,6 +86,24 @@ async function estimate(
       // if gas prices couldn't be fetched, it means there's an internal error
       estimation: getHumanReadableEstimationError(decodedError),
       nonFatalErrors: []
+    }
+  }
+
+  // if there's a pending userOp in the activity
+  // and it has the same userOp nonce as this txn,
+  // resolve the bundler estimation with a failure
+  if (
+    pendingUserOp &&
+    pendingUserOp.asUserOperation &&
+    pendingUserOp.status === AccountOpStatus.BroadcastedButNotConfirmed &&
+    BigInt(pendingUserOp.asUserOperation.nonce) === BigInt(userOp.nonce)
+  ) {
+    const error = new Error('4337 invalid account nonce', { cause: '4337_INVALID_NONCE' })
+    return {
+      gasPrice,
+      // if gas prices couldn't be fetched, it means there's an internal error
+      estimation: error,
+      nonFatalErrors: [error]
     }
   }
 
@@ -140,7 +161,8 @@ export async function bundlerEstimate(
   provider: RPCProvider,
   switcher: BundlerSwitcher,
   errorCallback: Function,
-  eip7702Auth?: EIP7702Auth
+  eip7702Auth?: EIP7702Auth,
+  pendingUserOp?: SubmittedAccountOp
 ): Promise<Erc4337GasLimits | Error | null> {
   if (!baseAcc.supportsBundlerEstimation()) return null
 
@@ -182,7 +204,14 @@ export async function bundlerEstimate(
   const flags: EstimationFlags = {}
   while (true) {
     // estimate
-    const estimations = await estimate(baseAcc, network, userOp, switcher, errorCallback)
+    const estimations = await estimate(
+      baseAcc,
+      network,
+      userOp,
+      switcher,
+      errorCallback,
+      pendingUserOp
+    )
 
     // if no errors, return the results and get on with life
     if (!(estimations.estimation instanceof Error)) {
@@ -211,14 +240,14 @@ export async function bundlerEstimate(
         return estimations.nonFatalErrors.find((err) => err.cause === '4337_INVALID_NONCE')!
       }
 
+      // wait a bit to allow the state to sync
+      await wait(2000)
       const ep = new Contract(ERC_4337_ENTRYPOINT, entryPointAbi, provider)
       const accountNonce = await ep
         .getNonce(account.addr, 0, { blockTag: 'pending' })
         .catch(() => null)
       if (!accountNonce) continue
       userOp.nonce = toBeHex(accountNonce)
-      // wait a bit to allow the bundler to configure it's state correctly
-      await wait(1000)
       continue
     }
 

--- a/src/services/bundlers/gelato.ts
+++ b/src/services/bundlers/gelato.ts
@@ -61,6 +61,6 @@ export class Gelato extends Bundler {
   }
 
   public shouldReestimateBeforeBroadcast(network: Network): boolean {
-    return !!network.isOptimistic
+    return true
   }
 }

--- a/src/services/bundlers/gelato.ts
+++ b/src/services/bundlers/gelato.ts
@@ -61,6 +61,6 @@ export class Gelato extends Bundler {
   }
 
   public shouldReestimateBeforeBroadcast(network: Network): boolean {
-    return true
+    return !!network.isOptimistic
   }
 }


### PR DESCRIPTION
### Problem

When an impatient user comes and tries to broadcast a couple of userOps in quick succession, depending on the chain and bundler used, it could end up in an error, too many unnecessary requests fired, or a horror story.

The problem for this is very simple - `userOp` nonce reuse. Different bundlers handle that differently, some better than others. We don't want that, we want a unified solution where we make sure the nonce is up-to-date

### Solution

We are making sure that either the blockchain or our internal state is synced before allowing the bundler broadcast to happen. This is how it works in a few steps:
- we get the last `broadcastedButNotConfirmed` userOp for this chain, account
- we check if the nonce is the same as the new userOp's nonce
- if it is, we return an error for the bundler estimation without firing an `estimate` request as... it's useless as it will either return a "nonce error" or worse - end up completing successfully which will bring other problems down the line

After returning a nonce error, it's handled in two different ways depending whether we are on Ethereum or not

#### Ethereum
<img width="716" height="678" alt="Screenshot 2025-08-19 at 12 05 39" src="https://github.com/user-attachments/assets/d55dccd6-9ecd-477c-9421-6ca7d13a2b89" />

#### Other chains
On other chains, we wait 2s before fetching the newest userOp pending nonce and retry the estimate() function. If either the nonce has incremented OR the last `broadcastedButNotConfirmed` userOp has confirmed and it's no longer present, we do a bundler estimate request. It's important to ignore the last `broadcastedButNotConfirmed` userOp if it's already confirmed on the blockchain as that would mean the RPCs will handle the nonce sync better than us (as a failed bundler broadcast might mean that the userOp has not incremented

---

In this process, we skip a few bundler requests and get a unified solution handler regardless of the bundler

As a side note to this, when using gelato, we ask for a re-estimate just before broadcast always, on any chain, so we have consistent results with the bundler without hitting gas price errors