### PR TITLE
No bundler lottery on ethereum, just fallbacks

### DIFF
--- a/src/services/bundlers/etherspot.ts
+++ b/src/services/bundlers/etherspot.ts
@@ -40,9 +40,7 @@ export class Etherspot extends Bundler {
     const provider = this.getProvider(network)
 
     const status = await provider.send('eth_getUserOperationByHash', [userOpHash]).catch((e) => {
-      console.log('etherspot eth_getUserOperationByHash returned an error')
-      console.log(e)
-
+      // etherspot throws an error when the userOpHash is not found
       return null
     })
 

--- a/src/services/bundlers/getBundler.ts
+++ b/src/services/bundlers/getBundler.ts
@@ -29,9 +29,6 @@ export function getDefaultBundlerName(
   network: Network,
   opts: { canDelegate: boolean } = { canDelegate: false }
 ): BUNDLER {
-  // hardcode biconomy for Sonic as it's not supported by pimlico
-  if (network.chainId === 146n) return BICONOMY
-
   // use pimlico on all 7702 accounts that don't have a set delegation
   if (opts.canDelegate) return PIMLICO
 
@@ -42,6 +39,13 @@ export function getDefaultBundlerName(
   // if there are no availableBundlers declared for the network, proceed
   // to load the defaultBundler settings
   if (!availableBundlers.length || availableBundlers.length === 1) {
+    return network.erc4337.defaultBundler && allBundlers.includes(network.erc4337.defaultBundler)
+      ? network.erc4337.defaultBundler
+      : PIMLICO
+  }
+
+  // use the defaultBundler on ethereum if defined OR PIMLICO on ethereum, not loterry
+  if (network.chainId === 1n) {
     return network.erc4337.defaultBundler && allBundlers.includes(network.erc4337.defaultBundler)
       ? network.erc4337.defaultBundler
       : PIMLICO


### PR DESCRIPTION
Add: hardcode the default bundler on ethereum to be the default one chosen by the relayer, not a lottery system