### PR TITLE
Update/ Humanize aave estimation error 0x6679996d

### DIFF
--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -146,6 +146,10 @@ const BROADCAST_OR_ESTIMATION_ERRORS: ErrorHumanizerError[] = [
   {
     reasons: ['TRANSFER_FROM_FAILED'],
     message: 'Insufficient token amount'
+  },
+  {
+    reasons: ['0x6679996d'],
+    message: 'your health factor will drop below the liquidation threshold.'
   }
 ]
 


### PR DESCRIPTION
The error occurs when you attempt to send a significant amount of a collateral token while you have a borrow position.