### PR TITLE
scripts: update contract compilation script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ We follow a lightweight Git branching model:
 
 ## Compiling
 
-This package **does not** include compiled output in the repository.
+### JS and TS
+
+This package **does not** include compiled **JS and TS** output in the repository.
 
 Each Ambire app compiles it individually as needed.
 
@@ -52,6 +54,16 @@ tsc src/libs/portfolio/getOnchainBalances.ts \
   --sourceMap true \
   --resolveJsonModule true \
   --outDir ./dist
+```
+
+### Contracts
+
+This package contains all of the contracts that are used within ambire-common, as well as contracts that are used in projects that have ambire-common as dependency. Do not delete compiled contracts unless you are sure they are not used in the Ambire web wallet, mobile wallet and relayer.
+
+To compile specific set of contracts, simply list the **contract names** in the command `compile:contracts` like so:
+
+```bash
+npm run compile:contracts WALLETSupplyController LegendsNFTImplementation
 ```
 
 ## Rules

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "humanizer:update:metamaskContactMetadata": "node scripts/updateHumanizerInfoWithMetaMaskContactMetadata.js",
     "humanizer:generate:combineHumanizerJsons": "node scripts/combineHumanizerJsons.js",
-    "compile:contracts": "ts-node scripts/compileContracts.js",
+    "compile:contracts": "npx hardhat compile && ts-node scripts/compileContracts.js",
     "hardhat": "npx hardhat compile; npx hardhat test",
     "jest": "node runTests.js",
     "build": "tsc src/libs/deployless/deployless.ts -t es5",

--- a/scripts/compileContracts.js
+++ b/scripts/compileContracts.js
@@ -1,56 +1,75 @@
-const fs = require('fs')
+/* eslint-disable no-console */
+/* eslint-disable no-continue */
+/* eslint-disable no-await-in-loop */
+const fs = require('fs').promises
 const path = require('path')
-const { compile } = require('../src/libs/deployless/compile')
 
 const rootDir = path.resolve(__dirname, '..')
-const contractsDirs = [`${rootDir}/contracts`, `${rootDir}/contracts/deployless`]
+const startDir = `${rootDir}/artifacts/contracts`
 const outputDir = `${rootDir}/contracts/compiled`
+let contractsToCompile = []
 
-// Extract all file paths from a `dir` in a flat way.
-// It doesn't support child folders, as we don't need it for now.
-async function walk(dir) {
-  let files = await fs.promises.readdir(dir)
-  files = await Promise.all(
-    files.map(async (file) => {
-      const filePath = path.join(dir, file)
-      return filePath
-    })
-  )
+async function moveContractsFromDir(dir) {
+  console.log('🕛 Searching in', dir)
 
-  return files.filter((file) => file.slice(-4) === '.sol')
-}
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  for (let i = 0; i < entries.length; i++) {
+    if (!contractsToCompile.length) return
+    const entry = entries[i]
+    const { name, path: folderPath } = entry
 
-let done = false
-
-async function compileFolder(contractsDir) {
-  const files = await walk(contractsDir)
-
-  console.log('📜 Contracts found: ', files)
-
-  let done = false
-
-  files.forEach((file) => {
-    let contractName = file.split('/').slice(-1)[0]
-    // it removes .sol from contract name
-    contractName = contractName.slice(0, contractName.length - 4)
-
-    if (process.argv[2] === contractName || !process.argv[2]) {
-      const output = compile(contractName, {
-        contractsFolder: contractsDir
-      })
-      fs.writeFileSync(`${outputDir}/${contractName}.json`, JSON.stringify(output))
-
-      console.log(`✅ ${contractName} compiled successfully!`)
-      done = true
+    if (!name.endsWith('.sol') && entry.isDirectory()) {
+      await moveContractsFromDir(entry.path)
+      continue
     }
-  })
+    if (!name.endsWith('.sol') || !entry.isDirectory()) continue
 
-  if (!done) console.log(`Contract ${process.argv[2]} not found.`)
+    const filesInFolder = await fs.readdir(folderPath, { withFileTypes: true })
+    for (let j = 0; j < filesInFolder.length; j++) {
+      const f = filesInFolder[j]
+
+      if (f.isDirectory()) continue
+      if (f.name.endsWith('.dbg.json') || !f.name.endsWith('.json')) continue
+
+      const { abi, bytecode, deployedBytecode } = await fs
+        .readFile(f.path, 'utf-8')
+        .then(JSON.parse)
+
+      const outputFile = `${outputDir}/${f.name}`
+      const dataToWrite = JSON.stringify(
+        { abi, bin: bytecode, binRuntime: deployedBytecode },
+        null,
+        4
+      )
+      const pureFilename = f.name.split('.json')[0]
+
+      if (contractsToCompile.includes(pureFilename)) {
+        await fs.writeFile(outputFile, dataToWrite)
+
+        const indexOfRequestedContract = contractsToCompile.indexOf(pureFilename)
+        contractsToCompile.splice(indexOfRequestedContract, 1)
+
+        console.log(`📜 Wrote ${f.name}`, pureFilename)
+      }
+    }
+  }
 }
 
-async function run() {
-  await Promise.all(contractsDirs.map((contractsDir) => compileFolder(contractsDir)).flat())
-  if (!done) console.log(`Contract ${process.argv[2]} not found.`)
+async function main() {
+  if (process.argv.length < 3) {
+    console.log(
+      '❗❗❗ No contract name passed for compilation. You should pass at least one as argument to the script!'
+    )``
+    return
+  }
+
+  contractsToCompile = process.argv.slice(2)
+
+  await moveContractsFromDir(startDir)
+
+  if (contractsToCompile.length)
+    console.log(`❌ Failed to find ${contractsToCompile.length} contracts: `, contractsToCompile)
+  else console.log('✅ Done')
 }
 
-run()
+main().catch(console.error)


### PR DESCRIPTION
Resolves: https://github.com/AmbireTech/ambire-app/issues/2876

Updates the script for compiling contracts. Now it uses the projects' `npx hardhat compile` instead of `solc` lib

Also improves reliability and usability for openzepelin contracts