### PR TITLE
Improve activity search for user operations

### DIFF
--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -16,7 +16,7 @@ import { BundlerEstimateResult, BundlerStateOverride } from '../../libs/estimate
 import { UserOperation } from '../../libs/userOperation/types'
 import { getCleanUserOp } from '../../libs/userOperation/userOperation'
 import { getRpcProvider } from '../provider'
-import { GasSpeeds, UserOpStatus } from './types'
+import { BundlerTransactionReceipt, GasSpeeds, UserOpStatus } from './types'
 
 require('dotenv').config()
 
@@ -121,7 +121,10 @@ export abstract class Bundler {
    * @param userOperationHash
    * @returns Receipt | null
    */
-  async getReceipt(userOperationHash: string, network: Network) {
+  async getReceipt(
+    userOperationHash: string,
+    network: Network
+  ): Promise<BundlerTransactionReceipt> {
     const provider = this.getProvider(network)
     return provider.send('eth_getUserOperationReceipt', [userOperationHash])
   }

--- a/src/services/bundlers/bundlerSwitcher.ts
+++ b/src/services/bundlers/bundlerSwitcher.ts
@@ -40,7 +40,7 @@ export class BundlerSwitcher {
     return this.bundler
   }
 
-  canSwitch(baseAcc: BaseAccount): boolean {
+  canSwitch(baseAcc?: BaseAccount): boolean {
     // don't switch the bundler if the account op is in a state of signing
     if (this.hasControllerForbiddenUpdates()) return false
 
@@ -54,7 +54,7 @@ export class BundlerSwitcher {
 
     // only pimlico can do txn type 4 and if pimlico is
     // not working, we have nothing to fallback to
-    if (baseAcc.shouldSignAuthorization(BROADCAST_OPTIONS.byBundler)) return false
+    if (baseAcc && baseAcc.shouldSignAuthorization(BROADCAST_OPTIONS.byBundler)) return false
 
     return true
   }

--- a/src/services/bundlers/types.ts
+++ b/src/services/bundlers/types.ts
@@ -1,3 +1,4 @@
+import { Log } from 'ethers'
 import { Hex } from '../../interfaces/hex'
 
 export interface Gas {
@@ -23,4 +24,20 @@ export interface UserOpStatus {
     | 'failed'
     | 'queued'
   transactionHash?: Hex
+}
+
+export interface BundlerTransactionReceipt {
+  success: boolean
+  sender: string
+  actualGasUsed: string
+  actualGasCost: string
+  logs: ReadonlyArray<Log>
+  receipt: {
+    status?: string | number
+    transactionHash: string
+    blockHash: string
+    logs: ReadonlyArray<Log>
+    blockNumber: string
+    gasUsed: string
+  }
 }


### PR DESCRIPTION
Change log:
* declare a txn stuck if not confirmed in 5 mins, not 15 (no need to wait that long);
* 3 mins after broadcast, ask for the receipt from the bundler when searching for the tx id