### PR TITLE
Fix / Limit portfolio update to broadcasted chain

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -507,7 +507,8 @@ export class ActivityController extends EventEmitter implements IActivityControl
    */
   async updateAccountsOpsStatuses(): Promise<{
     shouldEmitUpdate: boolean
-    shouldUpdatePortfolio: boolean
+    // Which networks require a portfolio update?
+    chainsToUpdate: Network['chainId'][]
     updatedAccountsOps: SubmittedAccountOp[]
     newestOpTimestamp: number
   }> {
@@ -516,7 +517,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
     if (!this.#selectedAccount.account || !this.#accountsOps[this.#selectedAccount.account.addr])
       return {
         shouldEmitUpdate: false,
-        shouldUpdatePortfolio: false,
+        chainsToUpdate: [],
         updatedAccountsOps: [],
         newestOpTimestamp: 0
       }
@@ -525,7 +526,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
     // and optimizes the number of the emitted updates and storage/state updates.
     let shouldEmitUpdate = false
 
-    let shouldUpdatePortfolio = false
+    const chainsToUpdate = new Set<Network['chainId']>()
     const updatedAccountsOps: SubmittedAccountOp[] = []
 
     // Use this flag to make the auto-refresh slower with the passege of time.
@@ -638,7 +639,11 @@ export class ActivityController extends EventEmitter implements IActivityControl
                     if (updatedOpIfAny) updatedAccountsOps.push(updatedOpIfAny)
 
                     if (receipt.status) {
-                      shouldUpdatePortfolio = true
+                      chainsToUpdate.add(
+                        this.#accountsOps[selectedAccount][network.chainId.toString()][
+                          accountOpIndex
+                        ].chainId
+                      )
                     }
 
                     if (accountOp.isSingletonDeploy && receipt.status) {
@@ -716,7 +721,12 @@ export class ActivityController extends EventEmitter implements IActivityControl
       this.emitUpdate()
     }
 
-    return { shouldEmitUpdate, shouldUpdatePortfolio, updatedAccountsOps, newestOpTimestamp }
+    return {
+      shouldEmitUpdate,
+      chainsToUpdate: Array.from(chainsToUpdate),
+      updatedAccountsOps,
+      newestOpTimestamp
+    }
   }
 
   async addSignedMessage(signedMessage: SignedMessage, account: string) {

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -638,7 +638,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
                     )
                     if (updatedOpIfAny) updatedAccountsOps.push(updatedOpIfAny)
 
-                    if (receipt.status) {
+                    if (isSuccess && updatedOpIfAny) {
                       chainsToUpdate.add(
                         this.#accountsOps[selectedAccount][network.chainId.toString()][
                           accountOpIndex

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1182,14 +1182,18 @@ export class MainController extends EventEmitter implements IMainController {
   async updateAccountsOpsStatuses(): Promise<{ newestOpTimestamp: number }> {
     await this.#initialLoadPromise
 
-    const { shouldEmitUpdate, shouldUpdatePortfolio, updatedAccountsOps, newestOpTimestamp } =
+    const { shouldEmitUpdate, chainsToUpdate, updatedAccountsOps, newestOpTimestamp } =
       await this.activity.updateAccountsOpsStatuses()
 
     if (shouldEmitUpdate) {
       this.emitUpdate()
 
-      if (shouldUpdatePortfolio) {
-        this.updateSelectedAccountPortfolio({ forceUpdate: true })
+      if (chainsToUpdate.length) {
+        const networks = chainsToUpdate
+          ? this.networks.networks.filter((n) => chainsToUpdate.includes(n.chainId))
+          : undefined
+
+        this.updateSelectedAccountPortfolio({ forceUpdate: true, networks })
       }
     }
 


### PR DESCRIPTION
1. Fix: After a broadcast, update the portfolio only for the broadcasted transaction's network. Previously, it was updated for all networks, which caused a performance downgrade.
2. Fix: Portfolio updates (from activity status updates) now rely not only on receipt.status, but also on additional transaction confirmation logic, depending on whether the account operation is identified as a UserOperation or MultipleTxns.