### PR TITLE
Fix / Patch elliptic

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "elliptic": "^6.6.1"
   }
 }


### PR DESCRIPTION
Fix: Override **elliptic** package to always resolve to ^6.6.1, as in the previous versions there is a critical issues regarding signing and private key exposing.