### PR TITLE
Config / Tweak a bit Swap & Bridge service provider error messages (toasts)

### DIFF
--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -375,7 +375,7 @@ export class LiFiAPI {
       const fallbackMessage =
         // Upstream error coming from LiFi, that must be the most accurate
         upstreamMessage && upstreamCode
-          ? `${upstreamMessage} (code: ${upstreamCode})`
+          ? `${upstreamMessage} Reference: ${upstreamCode}`
           : upstreamMessage || JSON.stringify(responseBody).slice(0, 200)
 
       const error = `${errorPrefix} Our service provider LiFi responded: <${fallbackMessage}>`

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -1,12 +1,13 @@
 import {
   ExtendedChain as LiFiExtendedChain,
-  Step as LiFiIncludedStep,
+  LiFiStep,
   Route as LiFiRoute,
   RoutesResponse as LiFiRoutesResponse,
   StatusResponse as LiFiRouteStatusResponse,
-  LiFiStep,
+  Step as LiFiIncludedStep,
   Token as LiFiToken,
-  TokensResponse as LiFiTokensResponse
+  TokensResponse as LiFiTokensResponse,
+  ToolError
 } from '@lifi/types'
 
 import SwapAndBridgeProviderApiError from '../../classes/SwapAndBridgeProviderApiError'
@@ -342,14 +343,14 @@ export class LiFiAPI {
 
       const message = e?.message || 'no message'
       const status = e?.status ? `, status: <${e.status}>` : ''
-      const error = `${errorPrefix} Upstream error: <${message}>${status}`
+      const error = `${errorPrefix} Our service provider LiFi could not be reached: <${message}>${status}`
       throw new SwapAndBridgeProviderApiError(error)
     }
 
     if (response.status === 429) {
       this.activateApiKey()
       const error =
-        'Our service provider received too many requests, temporarily preventing your request from being processed.'
+        'Our service provider LiFi received too many requests, temporarily preventing your request from being processed.'
       throw new SwapAndBridgeProviderApiError(error, 'Rate limit reached, try again later.')
     }
 
@@ -357,7 +358,7 @@ export class LiFiAPI {
     try {
       responseBody = await response.json()
     } catch (e: any) {
-      const error = 'Our service provider is temporarily unavailable.'
+      const error = 'Our service provider LiFi is temporarily unavailable.'
       throw new SwapAndBridgeProviderApiError(error)
     }
 
@@ -368,8 +369,16 @@ export class LiFiAPI {
         throw new SwapAndBridgeProviderApiError(humanizedMessage)
       }
 
-      const fallbackMessage = JSON.stringify(responseBody)
-      const error = `${errorPrefix} Our service provider upstream error: <${fallbackMessage}>`
+      const upstreamMessage = (responseBody as ToolError)?.message
+      const upstreamCode = (responseBody as ToolError)?.code
+
+      const fallbackMessage =
+        // Upstream error coming from LiFi, that must be the most accurate
+        upstreamMessage && upstreamCode
+          ? `${upstreamMessage} (code: ${upstreamCode})`
+          : upstreamMessage || JSON.stringify(responseBody).slice(0, 200)
+
+      const error = `${errorPrefix} Our service provider LiFi responded: <${fallbackMessage}>`
       throw new SwapAndBridgeProviderApiError(error)
     }
 


### PR DESCRIPTION
So that:

- Changed: Explicitly mention error coming from LiFi (our service provider) and beautify a tiny bit LiFi "tool" errors (instead of always displaying them as stringified JSON). These may help a bit with the confusion in some recent bizarre errors like:
  Before:
  <img width="611" height="226" alt="Screenshot 2025-08-25 at 18 13 06" src="https://github.com/user-attachments/assets/f1f64c34-5323-4853-8f05-dac96bd91cfc" />
  After 
  <img width="610" height="217" alt="Screenshot 2025-08-29 at 19 25 02" src="https://github.com/user-attachments/assets/6d9fb0a5-7ca8-47bd-a22a-56139507ab8d" />
- Fixed: trim the raw error (`responseBody`) to prevent huge toasts
  <img width="616" height="268" alt="Screenshot 2025-08-29 at 19 19 19" src="https://github.com/user-attachments/assets/5fdce22d-1499-457e-b92d-355d4520c1c5" />