### PR TITLE
Update / Transfer Field Validation Messages

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -223,15 +223,12 @@ export class ActivityController extends EventEmitter implements IActivityControl
   async hasAccountOpsSentTo(toAddress: string, accountId: AccountId): Promise<boolean> {
     await this.#initialLoadPromise
     const accounts = accountId ? [accountId] : Object.keys(this.#accountsOps)
-    console.log('Checking hasAccountOpsSentTo for address:', toAddress, 'and accounts:', accounts)
     return accounts.some((account) => {
       if (!this.#accountsOps[account]) return false
 
       const networks = Object.keys(this.#accountsOps[account])
-      console.log('Checking account:', account, 'networks:', networks)
       return networks.some((network) => {
         if (!this.#accountsOps[account][network]) return false
-        console.log('Checking ops for account/network:', this.#accountsOps[account][network])
         // Return true as soon as we find any operation sent to the target address
         return this.#accountsOps[account][network].some((op) =>
           op.calls.some((call) => call.to.toLowerCase() === toAddress.toLowerCase())

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -214,6 +214,32 @@ export class ActivityController extends EventEmitter implements IActivityControl
     this.emitUpdate()
   }
 
+  /**
+   * Checks if there are any account operations that were sent to a specific address
+   * @param toAddress The address to check for received transactions
+   * @param accountId The account ID to filter operations from
+   * @returns A boolean indicating whether any operations were sent to the specified address
+   */
+  async hasAccountOpsSentTo(toAddress: string, accountId: AccountId): Promise<boolean> {
+    await this.#initialLoadPromise
+    const accounts = accountId ? [accountId] : Object.keys(this.#accountsOps)
+    console.log('Checking hasAccountOpsSentTo for address:', toAddress, 'and accounts:', accounts)
+    return accounts.some((account) => {
+      if (!this.#accountsOps[account]) return false
+
+      const networks = Object.keys(this.#accountsOps[account])
+      console.log('Checking account:', account, 'networks:', networks)
+      return networks.some((network) => {
+        if (!this.#accountsOps[account][network]) return false
+        console.log('Checking ops for account/network:', this.#accountsOps[account][network])
+        // Return true as soon as we find any operation sent to the target address
+        return this.#accountsOps[account][network].some((op) =>
+          op.calls.some((call) => call.to.toLowerCase() === toAddress.toLowerCase())
+        )
+      })
+    })
+  }
+
   async filterAccountsOps(
     sessionId: string,
     filters: Filters,

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -643,11 +643,6 @@ export class TransferController extends EventEmitter implements ITransferControl
       this.recipientAddress,
       this.#selectedAccountData.account.addr
     )
-    console.log(
-      '[TransferController] Checking recipient address',
-      'previousTransactionExists',
-      previousTransactionExists
-    )
 
     // Update state based on whether there are previous transactions to this address
     this.isRecipientAddressFirstTimeSend =

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -652,7 +652,6 @@ export class TransferController extends EventEmitter implements ITransferControl
     // Update state based on whether there are previous transactions to this address
     this.isRecipientAddressFirstTimeSend =
       !previousTransactionExists &&
-      this.isRecipientAddressUnknown &&
       this.recipientAddress.toLowerCase() !== FEE_COLLECTOR.toLowerCase()
     this.signAccountOpController = new SignAccountOpController(
       this.#accounts,

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -114,6 +114,8 @@ export class TransferController extends EventEmitter implements ITransferControl
 
   #relayerUrl: string
 
+  isRecipientAddressFirstTimeSend: boolean = false
+
   signAccountOpController: ISignAccountOpController | null = null
 
   /**
@@ -299,7 +301,8 @@ export class TransferController extends EventEmitter implements ITransferControl
         isEnsAddress,
         this.addressState.isDomainResolving,
         this.isSWWarningVisible,
-        this.isSWWarningAgreed
+        this.isSWWarningAgreed,
+        this.isRecipientAddressFirstTimeSend
       )
     }
 
@@ -635,6 +638,22 @@ export class TransferController extends EventEmitter implements ITransferControl
       }
     }
 
+    // Check if the address has been used previously for transactions
+    const previousTransactionExists = await this.#activity.hasAccountOpsSentTo(
+      this.recipientAddress,
+      this.#selectedAccountData.account.addr
+    )
+    console.log(
+      '[TransferController] Checking recipient address',
+      'previousTransactionExists',
+      previousTransactionExists
+    )
+
+    // Update state based on whether there are previous transactions to this address
+    this.isRecipientAddressFirstTimeSend =
+      !previousTransactionExists &&
+      this.isRecipientAddressUnknown &&
+      this.recipientAddress.toLowerCase() !== FEE_COLLECTOR.toLowerCase()
     this.signAccountOpController = new SignAccountOpController(
       this.#accounts,
       this.#networks,

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -55,9 +55,9 @@ const validateAddAuthSignerAddress = (address: string, selectedAcc: any): Valida
 const NOT_IN_ADDRESS_BOOK_MESSAGE =
   "This address isn't in your Address Book. Double-check the details before confirming."
 const FIRST_TIME_SEND_MESSAGE =
-  "You're trying to send to an address you've never sent funds to before. Double-check before confirming."
+  "You're trying to send to an address you've never sent funds to before (this history is stored only in your current browser). Double-check before confirming."
 const FIRST_TIME_SEND_IN_ADDRESS_BOOK_MESSAGE =
-  'Bear in mind you have not send to this address before, but it is in your Address Book.'
+  'Bear in mind you have not sent to this address before (this history is stored only in your current browser), but it is in your Address Book.'
 const validateSendTransferAddress = (
   address: string,
   selectedAcc: string,

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -54,6 +54,10 @@ const validateAddAuthSignerAddress = (address: string, selectedAcc: any): Valida
 
 const NOT_IN_ADDRESS_BOOK_MESSAGE =
   "This address isn't in your Address Book. Double-check the details before confirming."
+const FIRST_TIME_SEND_MESSAGE =
+  "You're trying to send to an address you've never sent funds to before. Double-check before confirming."
+const FIRST_TIME_SEND_IN_ADDRESS_BOOK_MESSAGE =
+  'Bear in mind you have not send to this address before, but it is in your Address Book.'
 const validateSendTransferAddress = (
   address: string,
   selectedAcc: string,
@@ -63,7 +67,8 @@ const validateSendTransferAddress = (
   isEnsAddress: boolean,
   isRecipientDomainResolving: boolean,
   isSWWarningVisible?: boolean,
-  isSWWarningAgreed?: boolean
+  isSWWarningAgreed?: boolean,
+  isRecipientAddressFirstTimeSend?: boolean
 ): ValidateReturnType => {
   // Basic validation is handled in the AddressInput component and we don't want to overwrite it.
   if (!isValidAddress(address) || isRecipientDomainResolving) {
@@ -87,8 +92,22 @@ const validateSendTransferAddress = (
     }
   }
 
+  if (isRecipientAddressFirstTimeSend) {
+    if (isRecipientAddressUnknown) {
+      return {
+        success: false,
+        message: FIRST_TIME_SEND_MESSAGE
+      }
+    }
+    return {
+      success: false,
+      message: FIRST_TIME_SEND_IN_ADDRESS_BOOK_MESSAGE
+    }
+  }
+
   if (
     isRecipientAddressUnknown &&
+    isRecipientAddressFirstTimeSend &&
     !addressConfirmed &&
     !isEnsAddress &&
     !isRecipientDomainResolving
@@ -101,6 +120,7 @@ const validateSendTransferAddress = (
 
   if (
     isRecipientAddressUnknown &&
+    isRecipientAddressFirstTimeSend &&
     !addressConfirmed &&
     isEnsAddress &&
     !isRecipientDomainResolving


### PR DESCRIPTION
Check if there are any account operations that were sent to a specific address with helper function in activity controller

Display messages in 3 stages 
1. User has not interacted with the given address -   "You're trying to send to an address you've never sent funds to before (this history is stored only in your current browser). Double-check before confirming."
2. User has not interacted, but address is in Address Book -  "Bear in mind you have not sent to this address before (this history is stored only in your current browser), but it is in your Address Book.'
3. This message stays as before - "This address isn't in your Address Book. Double-check the details before confirming."

Do not display message if:
- User has interacted before, but address is not in Address Book

Closes #927

