### PR TITLE
Fixes / ContinuousUpdatesController tests

### DIFF
--- a/src/classes/recurringTimeout/recurringTimeout.ts
+++ b/src/classes/recurringTimeout/recurringTimeout.ts
@@ -67,6 +67,7 @@ export class RecurringTimeout implements IRecurringTimeout {
   }
 
   stop() {
+    this.startScheduled = false
     this.#reset()
   }
 
@@ -76,8 +77,6 @@ export class RecurringTimeout implements IRecurringTimeout {
   }
 
   async #loop() {
-    if (this.promise) return // prevents multiple executions in one tick
-
     try {
       this.promise = this.#fn()
       this.fnExecutionsCount += 1
@@ -117,6 +116,8 @@ export class RecurringTimeout implements IRecurringTimeout {
 
       if (newTimeout) this.updateTimeout({ timeout: newTimeout })
 
+      if (this.promise) return // prevents multiple executions in one tick
+
       if (runImmediately) {
         this.#loop()
       } else {
@@ -127,8 +128,6 @@ export class RecurringTimeout implements IRecurringTimeout {
 
   #reset() {
     this.running = false
-    this.promise = undefined
-    this.startScheduled = false
     this.startedRunningAt = 0
 
     if (this.#timeoutId) {

--- a/src/classes/recurringTimeout/recurringTimeout.ts
+++ b/src/classes/recurringTimeout/recurringTimeout.ts
@@ -12,6 +12,7 @@ export interface IRecurringTimeout {
   updateTimeout: (options: { timeout: number }) => void
   running: boolean
   sessionId: number
+  fnExecutionsCount: number
   startedRunningAt: number
   currentTimeout: number
   promise: Promise<void> | undefined
@@ -29,6 +30,8 @@ export class RecurringTimeout implements IRecurringTimeout {
 
   // used mainly for testing how many times the fn was called
   sessionId: number = 0
+
+  fnExecutionsCount: number = 0
 
   running = false
 
@@ -77,6 +80,7 @@ export class RecurringTimeout implements IRecurringTimeout {
 
     try {
       this.promise = this.#fn()
+      this.fnExecutionsCount += 1
       await this.promise
     } catch (err: any) {
       if (!this.promise) return

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -49,6 +49,9 @@ export class AccountsController extends EventEmitter implements IAccountsControl
   // Holds the initial load promise, so that one can wait until it completes
   initialLoadPromise?: Promise<void>
 
+  // Tracks the initial load of account states. Unlike `initialLoadPromise`,
+  // this one isn’t awaited during the AccountsController initial load, so it’s the only
+  // reliable way to know when account states are fully loaded.
   accountStatesInitialLoadPromise?: Promise<void>
 
   constructor(

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -49,6 +49,8 @@ export class AccountsController extends EventEmitter implements IAccountsControl
   // Holds the initial load promise, so that one can wait until it completes
   initialLoadPromise?: Promise<void>
 
+  accountStatesInitialLoadPromise?: Promise<void>
+
   constructor(
     storage: IStorageController,
     providers: IProvidersController,
@@ -100,9 +102,11 @@ export class AccountsController extends EventEmitter implements IAccountsControl
     // NOTE: YOU MUST USE waitForAccountsCtrlFirstLoad IN TESTS
     // TO ENSURE ACCOUNT STATE IS LOADED
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.#updateAccountStates(
+    this.accountStatesInitialLoadPromise = this.#updateAccountStates(
       this.#getAccountsToUpdateAccountStatesInBackground(initialSelectedAccountAddr)
-    )
+    ).finally(() => {
+      this.accountStatesInitialLoadPromise = undefined
+    })
   }
 
   async updateAccountStates(

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -259,18 +259,18 @@ describe('ContinuousUpdatesController intervals', () => {
     mainCtrl.providers.providers = mockedProviders
     jest.spyOn(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout, 'start')
     jest.spyOn(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout, 'restart')
-    jest
-      .spyOn(mainCtrl.continuousUpdates.accountStateLatestInterval, 'restart')
-      .mockImplementation(() => {})
-    jest
-      .spyOn(mainCtrl.continuousUpdates.accountStatePendingInterval, 'start')
-      .mockImplementation(() => {})
-    jest
-      .spyOn(mainCtrl.continuousUpdates.accountStatePendingInterval, 'restart')
-      .mockImplementation(() => {})
-    jest
-      .spyOn(mainCtrl.continuousUpdates.accountStatePendingInterval, 'start')
-      .mockImplementation(() => {})
+    mainCtrl.continuousUpdates.accountStateLatestInterval.start = jest
+      .fn()
+      .mockResolvedValue(undefined)
+    mainCtrl.continuousUpdates.accountStateLatestInterval.restart = jest
+      .fn()
+      .mockResolvedValue(undefined)
+    mainCtrl.continuousUpdates.accountStatePendingInterval.start = jest
+      .fn()
+      .mockResolvedValue(undefined)
+    mainCtrl.continuousUpdates.accountStatePendingInterval.restart = jest
+      .fn()
+      .mockResolvedValue(undefined)
 
     const fastAccountStateReFetchMock = jest.spyOn(
       mainCtrl.continuousUpdates,

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -239,9 +239,6 @@ describe('ContinuousUpdatesController intervals', () => {
       ) as RPCProviders
     }
     mainCtrl.providers.providers = filterProviders(mainCtrl.providers.providers)
-    // ensure that all providers are working
-    mainCtrl.providers.providers[1].isWorking = true
-    mainCtrl.providers.providers[137].isWorking = true
     jest.spyOn(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout, 'start')
     jest.spyOn(mainCtrl.continuousUpdates, 'updateAccountStateLatest')
     jest.spyOn(mainCtrl.continuousUpdates, 'updateAccountStatePending')
@@ -251,13 +248,13 @@ describe('ContinuousUpdatesController intervals', () => {
       'fastAccountStateReFetch'
     )
 
+    // ensure there is at least one provider that is not working
+    mainCtrl.providers.providers[1].isWorking = false
+    mainCtrl.providers.providers[137].isWorking = true
     mainCtrl.ui.addView({ id: '1', type: 'popup', currentRoute: 'dashboard', isReady: true })
     await jest.advanceTimersByTimeAsync(0)
     expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.start).toHaveBeenCalledTimes(1)
     expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(0)
-    // ensure there is at least one provider that is not working
-    mainCtrl.providers.providers[1].isWorking = false
-    mainCtrl.providers.providers[137].isWorking = true
     await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout)
     expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(1)
     await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout)

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -275,7 +275,6 @@ describe('ContinuousUpdatesController intervals', () => {
     mainCtrl.providers.providers[1].isWorking = false
     mainCtrl.providers.providers[137].isWorking = true
     mainCtrl.ui.addView({ id: '1', type: 'popup', currentRoute: 'dashboard', isReady: true })
-    await jest.advanceTimersByTimeAsync(1000000)
     const initialFnExecutionsCount =
       mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.fnExecutionsCount
     expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.start).toHaveBeenCalledTimes(1)

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -159,28 +159,52 @@ describe('ContinuousUpdatesController intervals', () => {
     mainCtrl.providers.providers = mockedProviders
 
     jest.spyOn(mainCtrl.continuousUpdates.updatePortfolioInterval, 'restart')
-    const updatePortfolioSpy = jest.spyOn(mainCtrl.continuousUpdates, 'updatePortfolio')
     mainCtrl.ui.addView({ id: '1', type: 'popup', currentRoute: 'dashboard', isReady: true })
     await jest.advanceTimersByTimeAsync(0)
     expect(mainCtrl.continuousUpdates.updatePortfolioInterval.restart).toHaveBeenCalled()
     const updateSelectedAccountPortfolioSpy = jest.spyOn(mainCtrl, 'updateSelectedAccountPortfolio')
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.updatePortfolioInterval)
-    expect(updatePortfolioSpy).toHaveBeenCalledTimes(1)
+    const initialFnExecutionsCount =
+      mainCtrl.continuousUpdates.updatePortfolioInterval.fnExecutionsCount
+    const { fnExecutionsCount: fnExecutionsCountFirstCall } = await waitForFnToBeCalledAndExecuted(
+      mainCtrl.continuousUpdates.updatePortfolioInterval
+    )
+    expect(mainCtrl.continuousUpdates.updatePortfolioInterval.fnExecutionsCount).toBe(
+      initialFnExecutionsCount + fnExecutionsCountFirstCall
+    )
     const updateSelectedAccountCalledTimes = updateSelectedAccountPortfolioSpy.mock.calls.length
     await mainCtrl.activity.addAccountOp(submittedAccountOp)
     await jest.advanceTimersByTimeAsync(0)
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.updatePortfolioInterval)
-    expect(updatePortfolioSpy).toHaveBeenCalledTimes(2)
+    const { fnExecutionsCount: fnExecutionsCountSecondCall } = await waitForFnToBeCalledAndExecuted(
+      mainCtrl.continuousUpdates.updatePortfolioInterval
+    )
+    expect(mainCtrl.continuousUpdates.updatePortfolioInterval.fnExecutionsCount).toBe(
+      initialFnExecutionsCount + fnExecutionsCountFirstCall + fnExecutionsCountSecondCall
+    )
     expect(updateSelectedAccountPortfolioSpy).toHaveBeenCalledTimes(
       updateSelectedAccountCalledTimes
     ) // tests the branching in the updatePortfolio func
     mainCtrl.ui.removeView('1')
     await jest.advanceTimersByTimeAsync(0)
     expect(mainCtrl.continuousUpdates.updatePortfolioInterval.restart).toHaveBeenCalledTimes(2)
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.updatePortfolioInterval)
-    expect(updatePortfolioSpy).toHaveBeenCalledTimes(3)
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.updatePortfolioInterval)
-    expect(updatePortfolioSpy).toHaveBeenCalledTimes(4)
+    const { fnExecutionsCount: fnExecutionsCountThirdCall } = await waitForFnToBeCalledAndExecuted(
+      mainCtrl.continuousUpdates.updatePortfolioInterval
+    )
+    expect(mainCtrl.continuousUpdates.updatePortfolioInterval.fnExecutionsCount).toBe(
+      initialFnExecutionsCount +
+        fnExecutionsCountFirstCall +
+        fnExecutionsCountSecondCall +
+        fnExecutionsCountThirdCall
+    )
+    const { fnExecutionsCount: fnExecutionsCountFourthCall } = await waitForFnToBeCalledAndExecuted(
+      mainCtrl.continuousUpdates.updatePortfolioInterval
+    )
+    expect(mainCtrl.continuousUpdates.updatePortfolioInterval.fnExecutionsCount).toBe(
+      initialFnExecutionsCount +
+        fnExecutionsCountFirstCall +
+        fnExecutionsCountSecondCall +
+        fnExecutionsCountThirdCall +
+        fnExecutionsCountFourthCall
+    )
   })
 
   test('should run accountsOpsStatusesInterval', async () => {
@@ -189,18 +213,26 @@ describe('ContinuousUpdatesController intervals', () => {
 
     jest.spyOn(mainCtrl.continuousUpdates.accountsOpsStatusesInterval, 'start')
     jest.spyOn(mainCtrl.continuousUpdates.accountsOpsStatusesInterval, 'stop')
-    const updateAccountsOpsStatuses = jest.spyOn(
-      mainCtrl.continuousUpdates,
-      'updateAccountsOpsStatuses'
-    )
 
     await mainCtrl.activity.addAccountOp(submittedAccountOp)
     await jest.advanceTimersByTimeAsync(0)
+
+    const initialFnExecutionsCount =
+      mainCtrl.continuousUpdates.accountsOpsStatusesInterval.fnExecutionsCount
+
     expect(mainCtrl.continuousUpdates.accountsOpsStatusesInterval.start).toHaveBeenCalled()
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.accountsOpsStatusesInterval)
-    expect(updateAccountsOpsStatuses).toHaveBeenCalledTimes(1)
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.accountsOpsStatusesInterval)
-    expect(updateAccountsOpsStatuses).toHaveBeenCalledTimes(2)
+    const { fnExecutionsCount: fnExecutionsCountFirstCall } = await waitForFnToBeCalledAndExecuted(
+      mainCtrl.continuousUpdates.accountsOpsStatusesInterval
+    )
+    expect(mainCtrl.continuousUpdates.accountsOpsStatusesInterval.fnExecutionsCount).toBe(
+      initialFnExecutionsCount + fnExecutionsCountFirstCall
+    )
+    const { fnExecutionsCount: fnExecutionsCountSecondCall } = await waitForFnToBeCalledAndExecuted(
+      mainCtrl.continuousUpdates.accountsOpsStatusesInterval
+    )
+    expect(mainCtrl.continuousUpdates.accountsOpsStatusesInterval.fnExecutionsCount).toBe(
+      initialFnExecutionsCount + fnExecutionsCountFirstCall + fnExecutionsCountSecondCall
+    )
     jest.spyOn(mainCtrl.activity, 'broadcastedButNotConfirmed', 'get').mockReturnValue([])
     // @ts-ignore
     mainCtrl.activity.emitUpdate()
@@ -214,21 +246,22 @@ describe('ContinuousUpdatesController intervals', () => {
     jest.spyOn(mainCtrl.continuousUpdates.accountStateLatestInterval, 'restart')
     jest.spyOn(mainCtrl.continuousUpdates.accountStatePendingInterval, 'start')
     jest.spyOn(mainCtrl.continuousUpdates.accountStatePendingInterval, 'stop')
-    const updateAccountStateLatestMock = jest.spyOn(
-      mainCtrl.continuousUpdates,
-      'updateAccountStateLatest'
-    )
-    const updateAccountStatePendingMock = jest.spyOn(
-      mainCtrl.continuousUpdates,
-      'updateAccountStatePending'
-    )
 
     await waitForContinuousUpdatesCtrlReady(mainCtrl)
 
+    const initialAccountStateLatestFnExecutionsCount =
+      mainCtrl.continuousUpdates.accountStateLatestInterval.fnExecutionsCount
+
+    const initialAccountStatePendingFnExecutionsCount =
+      mainCtrl.continuousUpdates.accountStateLatestInterval.fnExecutionsCount
+
     expect(mainCtrl.continuousUpdates.accountStateLatestInterval.running).toBe(true)
     expect(mainCtrl.continuousUpdates.accountStatePendingInterval.running).toBe(false)
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.accountStateLatestInterval)
-    expect(updateAccountStateLatestMock).toHaveBeenCalledTimes(1)
+    const { fnExecutionsCount: accountStateLatestFnExecutionsCountFirstCall } =
+      await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.accountStateLatestInterval)
+    expect(mainCtrl.continuousUpdates.accountStateLatestInterval.fnExecutionsCount).toBe(
+      initialAccountStateLatestFnExecutionsCount + accountStateLatestFnExecutionsCountFirstCall
+    )
     mainCtrl.statuses.signAndBroadcastAccountOp = 'SUCCESS'
     // @ts-ignore
     mainCtrl.emitUpdate()
@@ -240,8 +273,11 @@ describe('ContinuousUpdatesController intervals', () => {
     expect(mainCtrl.continuousUpdates.accountStatePendingInterval.currentTimeout).toBe(
       ACCOUNT_STATE_PENDING_INTERVAL / 2
     )
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.accountStatePendingInterval)
-    expect(updateAccountStatePendingMock).toHaveBeenCalledTimes(1)
+    const { fnExecutionsCount: accountStatePendingFnExecutionsCountFirstCall } =
+      await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.accountStatePendingInterval)
+    expect(mainCtrl.continuousUpdates.accountStatePendingInterval.fnExecutionsCount).toBe(
+      initialAccountStatePendingFnExecutionsCount + accountStatePendingFnExecutionsCountFirstCall
+    )
     expect(mainCtrl.continuousUpdates.accountStateLatestInterval.restart).toHaveBeenCalledTimes(2)
     expect(mainCtrl.continuousUpdates.accountStatePendingInterval.stop).toHaveBeenCalledTimes(1)
   })
@@ -281,17 +317,17 @@ describe('ContinuousUpdatesController intervals', () => {
     expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.fnExecutionsCount).toBe(
       initialFnExecutionsCount
     )
-    const { fnCalledCount: fnCalledCountFirstCall } = await waitForFnToBeCalledAndExecuted(
+    const { fnExecutionsCount: fnExecutionsCountFirstCall } = await waitForFnToBeCalledAndExecuted(
       mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout
     )
     expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.fnExecutionsCount).toBe(
-      initialFnExecutionsCount + fnCalledCountFirstCall
+      initialFnExecutionsCount + fnExecutionsCountFirstCall
     )
-    const { fnCalledCount: fnCalledCountSecondCall } = await waitForFnToBeCalledAndExecuted(
+    const { fnExecutionsCount: fnExecutionsCountSecondCall } = await waitForFnToBeCalledAndExecuted(
       mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout
     )
     expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.fnExecutionsCount).toBe(
-      initialFnExecutionsCount + fnCalledCountFirstCall + fnCalledCountSecondCall
+      initialFnExecutionsCount + fnExecutionsCountFirstCall + fnExecutionsCountSecondCall
     )
   })
 })

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -137,6 +137,7 @@ describe('ContinuousUpdatesController intervals', () => {
     const { mainCtrl } = await prepareTest()
     await waitForContinuousUpdatesCtrlReady(mainCtrl)
     jest.spyOn(mainCtrl.continuousUpdates.updatePortfolioInterval, 'restart')
+    // Mock `fastAccountStateReFetchTimeout.restart` so it doesn’t interfere with this test
     const fastAccountStateReFetchTimeoutMock = jest
       .spyOn(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout, 'restart')
       .mockImplementation(() => {})

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -258,7 +258,6 @@ describe('ContinuousUpdatesController intervals', () => {
     mockedProviders[137].isWorking = true
     mainCtrl.providers.providers = mockedProviders
     jest.spyOn(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout, 'start')
-    jest.spyOn(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout, 'restart')
     mainCtrl.continuousUpdates.accountStateLatestInterval.start = jest
       .fn()
       .mockResolvedValue(undefined)
@@ -272,37 +271,28 @@ describe('ContinuousUpdatesController intervals', () => {
       .fn()
       .mockResolvedValue(undefined)
 
-    const fastAccountStateReFetchMock = jest.spyOn(
-      mainCtrl.continuousUpdates,
-      'fastAccountStateReFetch'
-    )
-
     // ensure there is at least one provider that is not working
     mainCtrl.providers.providers[1].isWorking = false
     mainCtrl.providers.providers[137].isWorking = true
     mainCtrl.ui.addView({ id: '1', type: 'popup', currentRoute: 'dashboard', isReady: true })
-    await jest.advanceTimersByTimeAsync(0)
+    await jest.advanceTimersByTimeAsync(1000000)
+    const initialFnExecutionsCount =
+      mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.fnExecutionsCount
     expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.start).toHaveBeenCalledTimes(1)
-    let providersEmitCount = 0
-    mainCtrl.providers.onUpdate(() => {
-      providersEmitCount += 1
-    })
-
-    expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(providersEmitCount)
+    expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.fnExecutionsCount).toBe(
+      initialFnExecutionsCount
+    )
     const { fnCalledCount: fnCalledCountFirstCall } = await waitForFnToBeCalledAndExecuted(
       mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout
     )
-    expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(
-      providersEmitCount + fnCalledCountFirstCall
+    expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.fnExecutionsCount).toBe(
+      initialFnExecutionsCount + fnCalledCountFirstCall
     )
     const { fnCalledCount: fnCalledCountSecondCall } = await waitForFnToBeCalledAndExecuted(
       mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout
     )
-    expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(
-      providersEmitCount + fnCalledCountFirstCall + fnCalledCountSecondCall
-    )
-    expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.restart).toHaveBeenCalledTimes(
-      providersEmitCount
+    expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.fnExecutionsCount).toBe(
+      initialFnExecutionsCount + fnCalledCountFirstCall + fnCalledCountSecondCall
     )
   })
 })

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -1,13 +1,13 @@
 /* eslint-disable no-await-in-loop */
-import { RPCProviders } from 'interfaces/provider'
-/* eslint-disable prettier/prettier */
 import fetch from 'node-fetch'
 
+/* eslint-disable prettier/prettier */
 import { relayerUrl, velcroUrl } from '../../../test/config'
 import { produceMemoryStore } from '../../../test/helpers'
 import { mockUiManager } from '../../../test/helpers/ui'
 import { waitForFnToBeCalledAndExecuted } from '../../../test/recurringTimeout'
 import { ACCOUNT_STATE_PENDING_INTERVAL } from '../../consts/intervals'
+import { RPCProviders } from '../../interfaces/provider'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
 import { MainController } from '../main/main'

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -289,10 +289,18 @@ describe('ContinuousUpdatesController intervals', () => {
     })
 
     expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(providersEmitCount)
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout)
-    expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(providersEmitCount + 1)
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout)
-    expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(providersEmitCount + 2)
+    const { fnCalledCount: fnCalledCountFirstCall } = await waitForFnToBeCalledAndExecuted(
+      mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout
+    )
+    expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(
+      providersEmitCount + fnCalledCountFirstCall
+    )
+    const { fnCalledCount: fnCalledCountSecondCall } = await waitForFnToBeCalledAndExecuted(
+      mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout
+    )
+    expect(fastAccountStateReFetchMock).toHaveBeenCalledTimes(
+      providersEmitCount + fnCalledCountFirstCall + fnCalledCountSecondCall
+    )
     expect(mainCtrl.continuousUpdates.fastAccountStateReFetchTimeout.restart).toHaveBeenCalledTimes(
       providersEmitCount
     )

--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -136,7 +136,7 @@ export class ContinuousUpdatesController extends EventEmitter {
      *  update is just now, retry in 8s. If it's a repeated failure, retry in 20s.
      */
     this.#fastAccountStateReFetchTimeout = new RecurringTimeout(
-      async () => this.fastAccountStateReFetch(),
+      this.#fastAccountStateReFetch.bind(this),
       8000,
       this.emitError.bind(this),
       'fastAccountStateReFetchTimeout'
@@ -150,7 +150,7 @@ export class ContinuousUpdatesController extends EventEmitter {
     }, 'continuous-update')
 
     this.#main.providers.onUpdate(() => {
-      this.#fastAccountStateReFetchTimeout.restart()
+      // this.#fastAccountStateReFetchTimeout.restart()
     }, 'continuous-update')
 
     this.#main.activity.onUpdate(() => {
@@ -191,6 +191,7 @@ export class ContinuousUpdatesController extends EventEmitter {
 
   async updateAccountStateLatest() {
     await this.initialLoadPromise
+    await this.#main.accounts.accountStatesInitialLoadPromise
 
     if (!this.#main.selectedAccount.account) {
       console.error('No selected account to latest state')
@@ -222,6 +223,7 @@ export class ContinuousUpdatesController extends EventEmitter {
 
   async updateAccountStatePending() {
     await this.initialLoadPromise
+    await this.#main.accounts.accountStatesInitialLoadPromise
 
     if (!this.#main.selectedAccount.account) {
       console.error('No selected account to update pending state')
@@ -257,7 +259,7 @@ export class ContinuousUpdatesController extends EventEmitter {
     this.#accountStatePendingInterval.updateTimeout({ timeout: interval })
   }
 
-  async fastAccountStateReFetch() {
+  async #fastAccountStateReFetch() {
     await this.initialLoadPromise
 
     const failedChainIds: string[] = getNetworksWithFailedRPC({

--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -150,7 +150,7 @@ export class ContinuousUpdatesController extends EventEmitter {
     }, 'continuous-update')
 
     this.#main.providers.onUpdate(() => {
-      // this.#fastAccountStateReFetchTimeout.restart()
+      this.#fastAccountStateReFetchTimeout.restart()
     }, 'continuous-update')
 
     this.#main.activity.onUpdate(() => {

--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -87,7 +87,7 @@ export class ContinuousUpdatesController extends EventEmitter {
     // 6. Gotcha: If the user forcefully updates the portfolio, we will also lose the simulation.
     //    However, this is not a frequent case, and we can make a compromise here.
     this.#updatePortfolioInterval = new RecurringTimeout(
-      () => this.updatePortfolio(),
+      this.#updatePortfolio.bind(this),
       INACTIVE_EXTENSION_PORTFOLIO_UPDATE_INTERVAL,
       this.emitError.bind(this)
     )
@@ -113,20 +113,20 @@ export class ContinuousUpdatesController extends EventEmitter {
      * Updates the account state for the selected account. Doesn't update the state for networks with failed RPC as this is handled by a different interval.
      */
     this.#accountStateLatestInterval = new RecurringTimeout(
-      async () => this.updateAccountStateLatest(),
+      this.#updateAccountStateLatest.bind(this),
       ACCOUNT_STATE_STAND_BY_INTERVAL,
       this.emitError.bind(this)
     )
 
     this.#accountStatePendingInterval = new RecurringTimeout(
-      async () => this.updateAccountStatePending(),
+      this.#updateAccountStatePending.bind(this),
       ACCOUNT_STATE_PENDING_INTERVAL,
       this.emitError.bind(this),
       'accountStatePendingInterval'
     )
 
     this.#accountsOpsStatusesInterval = new RecurringTimeout(
-      async () => this.updateAccountsOpsStatuses(),
+      this.#updateAccountsOpsStatuses.bind(this),
       ACTIVITY_REFRESH_INTERVAL,
       this.emitError.bind(this)
     )
@@ -172,14 +172,14 @@ export class ContinuousUpdatesController extends EventEmitter {
     this.#accountStateLatestInterval.start()
   }
 
-  async updatePortfolio() {
+  async #updatePortfolio() {
     await this.initialLoadPromise
 
     if (this.#main.activity.broadcastedButNotConfirmed.length) return
     await this.#main.updateSelectedAccountPortfolio()
   }
 
-  async updateAccountsOpsStatuses() {
+  async #updateAccountsOpsStatuses() {
     await this.initialLoadPromise
 
     const { newestOpTimestamp } = await this.#main.updateAccountsOpsStatuses()
@@ -189,7 +189,7 @@ export class ContinuousUpdatesController extends EventEmitter {
     this.#accountsOpsStatusesInterval.updateTimeout({ timeout: interval })
   }
 
-  async updateAccountStateLatest() {
+  async #updateAccountStateLatest() {
     await this.initialLoadPromise
     await this.#main.accounts.accountStatesInitialLoadPromise
 
@@ -221,7 +221,7 @@ export class ContinuousUpdatesController extends EventEmitter {
     )
   }
 
-  async updateAccountStatePending() {
+  async #updateAccountStatePending() {
     await this.initialLoadPromise
     await this.#main.accounts.accountStatesInitialLoadPromise
 

--- a/test/recurringTimeout.ts
+++ b/test/recurringTimeout.ts
@@ -5,7 +5,8 @@ export const waitForFnToBeCalledAndExecuted = async (
   recurringTimeout: IRecurringTimeout,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   id: string = '' // for testing
-) => {
+): Promise<{ fnCalledCount: number }> => {
+  const initialSessionId = recurringTimeout.sessionId
   while (recurringTimeout.startScheduled) {
     await jest.advanceTimersByTimeAsync(1)
   }
@@ -27,4 +28,6 @@ export const waitForFnToBeCalledAndExecuted = async (
     }
   expect(recurringTimeout.promise).toBe(undefined)
   await Promise.resolve()
+
+  return { fnCalledCount: 1 + recurringTimeout.sessionId - initialSessionId }
 }

--- a/test/recurringTimeout.ts
+++ b/test/recurringTimeout.ts
@@ -5,8 +5,7 @@ export const waitForFnToBeCalledAndExecuted = async (
   recurringTimeout: IRecurringTimeout,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   id: string = '' // for testing
-): Promise<{ fnExecutionsCount: number }> => {
-  const initialFnExecutionsCount = recurringTimeout.fnExecutionsCount
+): Promise<void> => {
   while (recurringTimeout.startScheduled) {
     await jest.advanceTimersByTimeAsync(1)
   }
@@ -28,6 +27,4 @@ export const waitForFnToBeCalledAndExecuted = async (
     }
   expect(recurringTimeout.promise).toBe(undefined)
   await Promise.resolve()
-
-  return { fnExecutionsCount: recurringTimeout.fnExecutionsCount - initialFnExecutionsCount }
 }

--- a/test/recurringTimeout.ts
+++ b/test/recurringTimeout.ts
@@ -5,8 +5,8 @@ export const waitForFnToBeCalledAndExecuted = async (
   recurringTimeout: IRecurringTimeout,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   id: string = '' // for testing
-): Promise<{ fnCalledCount: number }> => {
-  const initialSessionId = recurringTimeout.sessionId
+): Promise<{ fnExecutionsCount: number }> => {
+  const initialFnExecutionsCount = recurringTimeout.fnExecutionsCount
   while (recurringTimeout.startScheduled) {
     await jest.advanceTimersByTimeAsync(1)
   }
@@ -29,5 +29,5 @@ export const waitForFnToBeCalledAndExecuted = async (
   expect(recurringTimeout.promise).toBe(undefined)
   await Promise.resolve()
 
-  return { fnCalledCount: 1 + recurringTimeout.sessionId - initialSessionId }
+  return { fnExecutionsCount: recurringTimeout.fnExecutionsCount - initialFnExecutionsCount }
 }


### PR DESCRIPTION
* Fixed RecurringTimeout bug where restarting the timeout in the same tick caused multiple function calls, and the function’s promise was not awaited in the correct place, allowing a new execution to start before the previous one had finished.
* ContinuousUpdatesController tests refactoring and fixes to improve stability