### PR TITLE
Error: insufficient native on swap & bridge

### DIFF
--- a/src/interfaces/account.ts
+++ b/src/interfaces/account.ts
@@ -54,6 +54,7 @@ export interface AccountOnchainState {
   isSmarterEoa: boolean
   delegatedContract: Hex | null
   delegatedContractName: 'AMBIRE' | 'METAMASK' | 'UNKNOWN' | null
+  hasEoaWithNative: boolean
 }
 
 export type AccountStates = {

--- a/src/libs/account/BaseAccount.ts
+++ b/src/libs/account/BaseAccount.ts
@@ -86,6 +86,16 @@ export abstract class BaseAccount {
    */
   abstract getNonceId(): string
 
+  /**
+   * Can the account pay with tokens the transaction fee
+   */
+  abstract canPayWithTokens(): boolean
+
+  /**
+   * Can the account pay with tokens the transaction fee
+   */
+  abstract canPayWithEOA(): boolean
+
   // this is specific for v2 accounts, hardcoding a false for all else
   shouldIncludeActivatorCall(broadcastOption: string) {
     return false

--- a/src/libs/account/EOA.ts
+++ b/src/libs/account/EOA.ts
@@ -117,4 +117,12 @@ export class EOA extends BaseAccount {
     // EOAs have only an execution layer nonce
     return this.accountState.eoaNonce!.toString()
   }
+
+  canPayWithTokens(): boolean {
+    return false
+  }
+
+  canPayWithEOA(): boolean {
+    return false
+  }
 }

--- a/src/libs/account/EOA7702.ts
+++ b/src/libs/account/EOA7702.ts
@@ -3,6 +3,7 @@ import { Interface } from 'ethers'
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireAccount7702 from '../../../contracts/compiled/AmbireAccount7702.json'
 import { Hex } from '../../interfaces/hex'
+import { has7702 } from '../7702/7702'
 import { AccountOp, getSignableCalls } from '../accountOp/accountOp'
 import { BROADCAST_OPTIONS } from '../broadcast/broadcast'
 import {
@@ -196,5 +197,13 @@ export class EOA7702 extends BaseAccount {
   getNonceId(): string {
     // 7702 accounts have an execution layer nonce and an entry point nonce
     return `${this.accountState.eoaNonce!.toString()}-${this.accountState.erc4337Nonce.toString()}`
+  }
+
+  canPayWithTokens(): boolean {
+    return has7702(this.network) && this.network.erc4337.hasPaymaster
+  }
+
+  canPayWithEOA(): boolean {
+    return false
   }
 }

--- a/src/libs/account/V1.ts
+++ b/src/libs/account/V1.ts
@@ -98,4 +98,12 @@ export class V1 extends BaseAccount {
     // v1 accounts can only have an ambire smart contract nonce
     return this.accountState.nonce.toString()
   }
+
+  canPayWithTokens(): boolean {
+    return this.network.hasRelayer
+  }
+
+  canPayWithEOA(): boolean {
+    return this.accountState.hasEoaWithNative
+  }
 }

--- a/src/libs/account/V2.ts
+++ b/src/libs/account/V2.ts
@@ -173,4 +173,16 @@ export class V2 extends BaseAccount {
     // v2 accounts have two nonces: ambire smart account & entry point nonce
     return `${this.accountState.nonce.toString()}-${this.accountState.erc4337Nonce.toString()}`
   }
+
+  canPayWithTokens(): boolean {
+    if (this.network.erc4337.enabled) {
+      return this.network.erc4337.hasPaymaster
+    }
+
+    return this.network.hasRelayer
+  }
+
+  canPayWithEOA(): boolean {
+    return this.accountState.hasEoaWithNative
+  }
 }

--- a/src/libs/accountState/accountState.ts
+++ b/src/libs/accountState/accountState.ts
@@ -73,6 +73,7 @@ export async function getAccountState(
     getEOAsCode(eoas)
   ])
 
+  const hasEoaWithNative = !!accountStateResult.find((res: any) => res.isEOA && res.balance > 0)
   const result: AccountOnchainState[] = accountStateResult.map((accResult: any, index: number) => {
     const associatedKeys = accResult.associatedKeyPrivileges.map(
       (privilege: string, keyIndex: number) => {
@@ -130,7 +131,8 @@ export async function getAccountState(
         account.associatedKeys.length > 0 && accResult.associatedKeyPrivileges.length === 0,
       isSmarterEoa,
       delegatedContract,
-      delegatedContractName
+      delegatedContractName,
+      hasEoaWithNative
     }
   })
 


### PR DESCRIPTION
Scenario:
* you are either with an EOA without any native or a 7702 EOA but on a chain that doesn't support 7702 (and you don't know about this) and don't have any native
* you go to swap & bridge
* we inform you of this predicament

<img width="599" height="591" alt="Screenshot 2025-09-05 at 17 14 55" src="https://github.com/user-attachments/assets/ba73da5a-ada1-4d8c-985b-71670f1a677f" />

We can also ditch this code and safely allow the user to continue - he will find quotes, choose a route, but he won't be able to sign/broadcast the transactions because of insufficient native.

This PR aims to alarm the user before that happens. Whether that's a pros or a cons is debatable.

One cons we have here is calculating this logic in the swapErrors() getter. We should debate whether the trade-off is worth it (even if it's not so computational expensive)