### PR TITLE
Config / Enhance the Swap & Bridge parallel executor error handling

### DIFF
--- a/src/services/swapIntegrators/swapProviderParallelExecutor.ts
+++ b/src/services/swapIntegrators/swapProviderParallelExecutor.ts
@@ -48,12 +48,38 @@ export class SwapProviderParallelExecutor {
       )
     )
     const resultsWithoutErrors = apiResponses.filter((r) => !(r instanceof Error))
-    if (!resultsWithoutErrors.length) {
-      const errMsg = 'Swap providers are currently not working. Please try again later'
-      throw new SwapAndBridgeProviderApiError(errMsg, errMsg)
+    if (resultsWithoutErrors.length) return resultsWithoutErrors.flat() as T
+
+    const errors = apiResponses.filter((r): r is Error => r instanceof Error)
+    if (!errors.length) {
+      const errMsg = 'Our service providers are currently unavailable. Please try again later.'
+      throw new SwapAndBridgeProviderApiError(errMsg)
     }
 
-    return resultsWithoutErrors.flat() as T
+    // Use the first error (LiFi) as base message, since the bets are that's the the most accurate
+    const baseMessage = errors[0].message || 'Unknown error'
+
+    // Extract technical details from all errors (that's the content between < and >)
+    const technicalDetails = errors
+      .map((error) => {
+        const message = error.message || ''
+        const match = message.match(/<([^>]+)>/)
+        return match ? match[1] : null
+      })
+      .filter(Boolean)
+
+    // Modify the base message to indicate multiple providers
+    let combinedMessage = baseMessage
+      .replace(/\bLiFi\b/g, 'LiFi and Socket')
+      .replace(/\bservice provider\b/g, 'service providers')
+
+    // Replace the technical details with combined ones
+    if (technicalDetails.length > 0) {
+      const combinedDetails = technicalDetails.join('> and <')
+      combinedMessage = combinedMessage.replace(/<[^>]+>/, `<${combinedDetails}>`)
+    }
+
+    throw new SwapAndBridgeProviderApiError(combinedMessage)
   }
 
   async #routeTo<T, M extends keyof SwapProvider>(


### PR DESCRIPTION
For the unhappy path when all (both) service providers are unavailable, enhance the generic error fallback with informative messages with more details what went wrong (by combining the technical details from all errors).

Before:

<img width="607" height="177" alt="Screenshot 2025-09-16 at 16 39 49" src="https://github.com/user-attachments/assets/87db5e3b-e2cb-4f85-b6d9-afff313dc3fd" />

After:

<img width="613" height="218" alt="Screenshot 2025-09-16 at 16 35 14" src="https://github.com/user-attachments/assets/bb1b6e64-74c2-4706-98d7-b1dd81eebba9" />


