### PR TITLE
Skip email vault tests

### DIFF
--- a/src/libs/emailVault/emailVault.test.ts
+++ b/src/libs/emailVault/emailVault.test.ts
@@ -38,7 +38,8 @@ const initEmailVaultTest = async () => {
   }
 }
 
-describe('happy cases email vault', () => {
+// Email vault test fail very frequently so we are skipping them for now
+describe.skip('happy cases email vault', () => {
   beforeAll(async () => {
     email = `unufri+${Wallet.createRandom().address.slice(12, 20)}@ambire.com`.toLowerCase()
     const result = await requestMagicLink(email, relayerUrl, fetch)


### PR DESCRIPTION
We agreed to do this in a meeting last week. The reason is that the tests fail randomly very often