### PR TITLE
Fix / Wallet Connect EIP-6963 connection

### DIFF
--- a/src/classes/session.ts
+++ b/src/classes/session.ts
@@ -64,10 +64,12 @@ export class Session {
     this.tabId = tabId || Date.now()
     this.windowId = windowId
 
+    // Track requestIds per providerId, since we inject an EthereumProvider into all frames for the same session
     this.lastHandledRequestIds = new Proxy(
       {},
       {
         get: (target: { [providerId: string]: number }, prop: string) => {
+          // When accessing an unknown providerId, initialize it with the default requestId = -1
           if (!(prop in target)) {
             // eslint-disable-next-line no-param-reassign
             target[prop] = -1

--- a/src/classes/session.ts
+++ b/src/classes/session.ts
@@ -43,8 +43,7 @@ export class Session {
 
   messenger?: Messenger
 
-  // requestIds start from 0 but the default val should not be the fist req
-  lastHandledRequestId: number = -1
+  lastHandledRequestIds: { [providerId: string]: number }
 
   isWeb3App: boolean = false
 
@@ -64,6 +63,19 @@ export class Session {
     this.origin = origin || 'internal'
     this.tabId = tabId || Date.now()
     this.windowId = windowId
+
+    this.lastHandledRequestIds = new Proxy(
+      {},
+      {
+        get: (target: { [providerId: string]: number }, prop: string) => {
+          if (!(prop in target)) {
+            // eslint-disable-next-line no-param-reassign
+            target[prop] = -1
+          }
+          return target[prop]
+        }
+      }
+    )
   }
 
   setMessenger(messenger: Messenger) {

--- a/src/controllers/dapps/dapps.ts
+++ b/src/controllers/dapps/dapps.ts
@@ -101,9 +101,16 @@ export class DappsController extends EventEmitter implements IDappsController {
     this.dappSessions[sessionId].setMessenger(messenger)
   }
 
-  setSessionLastHandledRequestsId = (sessionId: string, id: number, isWeb3AppRequest?: boolean) => {
-    if (id > this.dappSessions[sessionId].lastHandledRequestId) {
-      this.dappSessions[sessionId].lastHandledRequestId = id
+  setSessionLastHandledRequestsId = (
+    sessionId: string,
+    providerId: number,
+    id: number,
+    isWeb3AppRequest?: boolean
+  ) => {
+    if (!this.dappSessions[sessionId]) return
+
+    if (id > this.dappSessions[sessionId].lastHandledRequestIds[providerId]) {
+      this.dappSessions[sessionId].lastHandledRequestIds[providerId] = id
       if (isWeb3AppRequest && !this.dappSessions[sessionId].isWeb3App) {
         this.dappSessions[sessionId].isWeb3App = true
         this.emitUpdate()
@@ -111,8 +118,14 @@ export class DappsController extends EventEmitter implements IDappsController {
     }
   }
 
-  resetSessionLastHandledRequestsId = (sessionId: string) => {
-    this.dappSessions[sessionId].lastHandledRequestId = -1
+  resetSessionLastHandledRequestsId = (sessionId: string, providerId?: number) => {
+    if (providerId) {
+      this.dappSessions[sessionId].lastHandledRequestIds[providerId] = -1
+    } else {
+      Object.keys(this.dappSessions[sessionId].lastHandledRequestIds).forEach((key) => {
+        this.dappSessions[sessionId].lastHandledRequestIds[key] = -1
+      })
+    }
   }
 
   setSessionProp = (sessionId: string, props: SessionProp) => {


### PR DESCRIPTION
* Change the lastHandledRequestId prop on the session to lastHandledRequestIds, so it can track the currentRequestId for multiple providers. The idea is that in a single dApp session, multiple providers might send requests to the extension, each with its own requestId. This happens because a dApp can have multiple frames, and we inject the provider into all of them, so requests can come from any of those frames.