### PR TITLE
Hotfix/ rpc-timeout error prefixed as invictus 2XX error

### DIFF
--- a/src/classes/ProviderError.test.ts
+++ b/src/classes/ProviderError.test.ts
@@ -46,4 +46,17 @@ describe('ProviderError', () => {
     expect(providerError.message).toContain('Doomsday')
     expect(providerError.isProviderInvictus).toBe(true)
   })
+  it('rpc-timeout errors are not prefixed with Invictus message', () => {
+    const error = new Error('rpc-timeout. Rpc: https://invictus.ambire.com/ethereum') as Error & {
+      [key: string]: any
+    }
+
+    const providerError = new ProviderError({
+      originalError: error,
+      providerUrl: 'https://invictus.ambire.com/ethereum'
+    })
+
+    expect(providerError.message).toBe('rpc-timeout. Rpc: https://invictus.ambire.com/ethereum')
+    expect(providerError.isProviderInvictus).toBe(true)
+  })
 })

--- a/src/classes/ProviderError.ts
+++ b/src/classes/ProviderError.ts
@@ -26,6 +26,8 @@ export class ProviderError extends Error {
     if (
       isProviderInvictus &&
       typeof message === 'string' &&
+      !message.startsWith('rpc-timeout') &&
+      !message.startsWith('Failed to fetch') &&
       !message.startsWith(INVICTUS_ERROR_PREFIX) &&
       !message.startsWith(INVICTUS_200_ERROR_PREFIX)
     ) {


### PR DESCRIPTION
There are two problems:
- There is logic in the extension that expects rpc timeout errors to always start with `rpc-timeout`
- Sentry is littered with invictus 2XX errors that are actually timeouts