### PR TITLE
Refactor/ Selected account errors

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -82,7 +82,7 @@ export class SelectedAccountController extends EventEmitter implements ISelected
    */
   #portfolioByNetworks: SelectedAccountPortfolioByNetworks = {}
 
-  portfolioStartedLoadingAtTimestamp: number | null = null
+  #portfolioLoadingTimeout: NodeJS.Timeout | null = null
 
   #isPortfolioLoadingFromScratch = true
 
@@ -248,7 +248,8 @@ export class SelectedAccountController extends EventEmitter implements ISelected
     this.#portfolioByNetworks = {}
     this.resetSelectedAccountPortfolio({ skipUpdate: true })
     this.dashboardNetworkFilter = null
-    this.portfolioStartedLoadingAtTimestamp = null
+    if (this.#portfolioLoadingTimeout) clearTimeout(this.#portfolioLoadingTimeout)
+    this.#portfolioLoadingTimeout = null
 
     if (!account) {
       await this.#storage.remove('selectedAccount')
@@ -319,19 +320,24 @@ export class SelectedAccountController extends EventEmitter implements ISelected
       latestStateSelectedAccount,
       pendingStateSelectedAccount,
       structuredClone(this.#portfolioByNetworks),
-      this.portfolioStartedLoadingAtTimestamp,
       defiPositionsAccountState,
+      this.portfolio.shouldShowPartialResult,
       this.#isPortfolioLoadingFromScratch
     )
 
     // Reset the loading timestamp if the portfolio is ready
-    if (this.portfolioStartedLoadingAtTimestamp && newSelectedAccountPortfolio.isAllReady) {
-      this.portfolioStartedLoadingAtTimestamp = null
+    if (this.#portfolioLoadingTimeout && newSelectedAccountPortfolio.isAllReady) {
+      clearTimeout(this.#portfolioLoadingTimeout)
+      this.#portfolioLoadingTimeout = null
     }
 
     // Set the loading timestamp when the portfolio starts loading
-    if (!this.portfolioStartedLoadingAtTimestamp && !newSelectedAccountPortfolio.isAllReady) {
-      this.portfolioStartedLoadingAtTimestamp = Date.now()
+    if (!this.#portfolioLoadingTimeout && !newSelectedAccountPortfolio.isAllReady) {
+      this.#portfolioLoadingTimeout = setTimeout(() => {
+        this.portfolio.shouldShowPartialResult = true
+        this.updateSelectedAccountPortfolio()
+        this.#portfolioLoadingTimeout = null
+      }, 5000)
     }
 
     // Reset isPortfolioLoadingFromScratch flag when the portfolio has finished the initial load

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -29,8 +29,7 @@ import { PositionsByProvider } from '../../libs/defiPositions/types'
 import { PortfolioGasTankResult } from '../../libs/portfolio/interfaces'
 import {
   getNetworksWithDeFiPositionsErrorErrors,
-  getNetworksWithFailedRPCErrors,
-  getNetworksWithPortfolioErrorErrors,
+  getNetworksWithErrors,
   SelectedAccountBalanceError
 } from '../../libs/selectedAccount/errors'
 import { calculateSelectedAccountPortfolio } from '../../libs/selectedAccount/selectedAccount'
@@ -498,20 +497,15 @@ export class SelectedAccountController extends EventEmitter implements ISelected
       return
     }
 
-    const networksWithFailedRPCBanners = getNetworksWithFailedRPCErrors({
-      providers: this.#providers.providers,
+    this.#portfolioErrors = getNetworksWithErrors({
       networks: this.#networks.networks,
-      networksWithAssets: this.#portfolio.getNetworksWithAssets(this.account.addr)
-    })
-
-    const errorBanners = getNetworksWithPortfolioErrorErrors({
-      networks: this.#networks.networks,
+      shouldShowPartialResult: this.portfolio.shouldShowPartialResult,
       selectedAccountLatest: this.portfolio.latest,
       isAllReady: this.portfolio.isAllReady,
-      providers: this.#providers.providers
+      accountState: this.#accounts.accountStates[this.account.addr] || {},
+      providers: this.#providers.providers,
+      networksWithAssets: this.#portfolio.getNetworksWithAssets(this.account.addr)
     })
-
-    this.#portfolioErrors = [...networksWithFailedRPCBanners, ...errorBanners]
 
     if (!skipUpdate) {
       this.emitUpdate()

--- a/src/interfaces/account.ts
+++ b/src/interfaces/account.ts
@@ -53,7 +53,8 @@ export interface AccountOnchainState {
   currentBlock: bigint
   isSmarterEoa: boolean
   delegatedContract: Hex | null
-  delegatedContractName: 'AMBIRE' | 'METAMASK' | 'UNKNOWN' | null
+  delegatedContractName: 'AMBIRE' | 'METAMASK' | 'UNKNOWN' | nully
+  updatedAt: number
 }
 
 export type AccountStates = {

--- a/src/interfaces/account.ts
+++ b/src/interfaces/account.ts
@@ -53,7 +53,7 @@ export interface AccountOnchainState {
   currentBlock: bigint
   isSmarterEoa: boolean
   delegatedContract: Hex | null
-  delegatedContractName: 'AMBIRE' | 'METAMASK' | 'UNKNOWN' | nully
+  delegatedContractName: 'AMBIRE' | 'METAMASK' | 'UNKNOWN' | null
   updatedAt: number
 }
 

--- a/src/libs/accountState/accountState.ts
+++ b/src/libs/accountState/accountState.ts
@@ -130,7 +130,8 @@ export async function getAccountState(
         account.associatedKeys.length > 0 && accResult.associatedKeyPrivileges.length === 0,
       isSmarterEoa,
       delegatedContract,
-      delegatedContractName
+      delegatedContractName,
+      updatedAt: Date.now()
     }
   })
 

--- a/src/libs/selectedAccount/errors.test.ts
+++ b/src/libs/selectedAccount/errors.test.ts
@@ -1,11 +1,82 @@
 import { networks } from '../../consts/networks'
 import { Network } from '../../interfaces/network'
-import { addPortfolioError, addRPCError, SelectedAccountBalanceError } from './errors'
+/* eslint-disable no-param-reassign */
+import { RPCProvider } from '../../interfaces/provider'
+import {
+  SelectedAccountPortfolio,
+  SelectedAccountPortfolioState
+} from '../../interfaces/selectedAccount'
+import { getRpcProvider } from '../../services/provider'
+import {
+  addPortfolioError,
+  addRPCError,
+  getNetworksWithErrors,
+  SelectedAccountBalanceError
+} from './errors'
 
 const mockNetworks = structuredClone(networks) as Network[]
 
 mockNetworks.find((n) => n.chainId === 137n)!.rpcUrls = ['rpc-1', 'rpc-2']
 mockNetworks.find((n) => n.chainId === 42161n)!.rpcUrls = ['rpc-1', 'rpc-2']
+
+const mockProviders = mockNetworks.reduce((acc, network) => {
+  acc[network.chainId.toString()] = getRpcProvider(
+    network.rpcUrls,
+    network.chainId,
+    network.selectedRpcUrl
+  )
+  acc[network.chainId.toString()]!.isWorking = true
+  return acc
+}, {} as Record<string, RPCProvider>)
+
+const mockAccountState = mockNetworks.reduce((acc, network) => {
+  acc[network.chainId.toString()] = {
+    updatedAt: Date.now()
+  }
+
+  return acc
+}, {} as any)
+
+const getMockSelectedAccountPortfolio = (params?: {
+  loadingChainIds?: bigint[]
+  notReadyChainIds?: bigint[]
+  criticalErrorChainIds?: bigint[]
+  freshDataChainIds?: bigint[]
+  nonCriticalErrorChainIds?: bigint[]
+}): SelectedAccountPortfolioState => {
+  const {
+    loadingChainIds,
+    notReadyChainIds,
+    nonCriticalErrorChainIds,
+    freshDataChainIds,
+    criticalErrorChainIds
+  } = params || {}
+
+  return networks.reduce((acc, network) => {
+    acc[network.chainId.toString()] = {
+      isLoading: !!loadingChainIds?.includes(network.chainId),
+      isReady: !!notReadyChainIds?.includes(network.chainId),
+      result: {
+        lastSuccessfulUpdate: !freshDataChainIds?.includes(network.chainId)
+          ? Date.now() - 60 * 60 * 1000
+          : Date.now() - 5 * 60 * 1000
+      } as any,
+      criticalError: criticalErrorChainIds?.includes(network.chainId)
+        ? new Error('Critical portfolio error')
+        : undefined,
+      errors: nonCriticalErrorChainIds?.includes(network.chainId)
+        ? [
+            {
+              message: "Some message, doesn't matter",
+              name: 'PriceFetchError',
+              level: 'warning'
+            }
+          ]
+        : []
+    }
+    return acc
+  }, {} as SelectedAccountPortfolio['latest'])
+}
 
 describe('selectedAccount errors', () => {
   describe('addRPCError', () => {
@@ -400,6 +471,244 @@ describe('selectedAccount errors', () => {
         expect(result).toHaveLength(1)
         expect(result[0].networkNames).toEqual(['Ethereum'])
       })
+    })
+  })
+  describe('getNetworksWithErrors', () => {
+    it('all providers are not working - no errors are returned because the user is offline', () => {
+      const providers = structuredClone(mockProviders)
+      Object.values(providers).forEach((p) => {
+        p.isWorking = false
+      })
+
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          criticalErrorChainIds: [1n, 137n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers,
+        accountState: mockAccountState,
+        networksWithAssets: {}
+      })
+
+      expect(errors).toHaveLength(0)
+    })
+    it('critical portfolio error', () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          criticalErrorChainIds: [1n, 137n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '137': true }
+      })
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].id).toBe('portfolio-critical')
+      expect(errors[0].networkNames).toEqual(['Ethereum', 'Polygon'])
+    })
+    it('rpc down errors are added in favour of portfolio errors', () => {
+      const providers = structuredClone(mockProviders)
+      providers['1'].isWorking = false
+      providers['56'].isWorking = false
+
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          criticalErrorChainIds: [1n, 56n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '56': true }
+      })
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].id).toBe('rpcs-down')
+      expect(errors[0].networkNames).toEqual(['Ethereum', 'BNB Smart Chain'])
+    })
+    it('no errors are added when the state is fresh (not Ethereum)', () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          freshDataChainIds: [56n, 137n],
+          criticalErrorChainIds: [56n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: { '56': true, '137': true }
+      })
+
+      expect(errors).toHaveLength(0)
+    })
+    it('errors are added even when the state is fresh (Ethereum)', () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          freshDataChainIds: [1n, 56n, 137n],
+          criticalErrorChainIds: [1n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '56': true, '137': true }
+      })
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].id).toBe('portfolio-critical')
+      expect(errors[0].networkNames).toEqual(['Ethereum'])
+    })
+    it('no errors are added when the portfolio is loading from scratch', () => {
+      const providers = structuredClone(mockProviders)
+      providers['1'].isWorking = false
+      providers['56'].isWorking = false
+
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          loadingChainIds: [1n, 56n],
+          criticalErrorChainIds: [1n, 56n]
+        }),
+        isAllReady: false,
+        shouldShowPartialResult: false,
+        providers,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '56': true }
+      })
+
+      expect(errors).toHaveLength(0)
+    })
+    it('critical portfolio error and the rpc is not working, but the user has no assets', () => {
+      const providers = structuredClone(mockProviders)
+      providers['137'].isWorking = false
+
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          criticalErrorChainIds: [137n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers,
+        accountState: mockAccountState,
+        networksWithAssets: { '137': false }
+      })
+
+      expect(errors).toHaveLength(0)
+    })
+    it("critical portfolio error, but we don't know if the user has assets", () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          criticalErrorChainIds: [137n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: {}
+      })
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].id).toBe('portfolio-critical')
+      expect(errors[0].networkNames).toEqual(['Polygon'])
+    })
+    it('non-critical portfolio errors', () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          nonCriticalErrorChainIds: [1n, 137n],
+          criticalErrorChainIds: [1n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '137': true }
+      })
+
+      expect(errors).toHaveLength(2)
+
+      expect(errors[0].id).toBe('portfolio-critical')
+      expect(errors[0].networkNames).toEqual(['Ethereum'])
+
+      expect(errors[1].id).toBe('PriceFetchError')
+      expect(errors[1].networkNames).toEqual(['Polygon'])
+    })
+    it('no errors are added for loading networks if (isAllReady=false)', () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          loadingChainIds: [1n, 56n],
+          criticalErrorChainIds: [1n, 56n]
+        }),
+        isAllReady: false,
+        shouldShowPartialResult: false,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '56': true }
+      })
+
+      expect(errors).toHaveLength(0)
+    })
+    it('errors are added for loading networks if (isAllReady=true)', () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          loadingChainIds: [1n, 56n],
+          criticalErrorChainIds: [1n, 56n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: false,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '56': true }
+      })
+
+      expect(errors).toHaveLength(1)
+
+      expect(errors[0].id).toBe('portfolio-critical')
+    })
+    it('loading-too-long error is added for loading networks if isAllReady=false and shouldShowPartialResult=true', () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          loadingChainIds: [1n, 56n]
+        }),
+        isAllReady: false,
+        shouldShowPartialResult: true,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '56': true }
+      })
+
+      expect(errors).toHaveLength(1)
+
+      expect(errors[0].id).toBe('loading-too-long')
+      expect(errors[0].networkNames).toEqual(['Ethereum', 'BNB Smart Chain'])
+    })
+    it('loading-too-long error is not added for loading networks if isAllReady=true and shouldShowPartialResult=true', () => {
+      const errors = getNetworksWithErrors({
+        networks: mockNetworks,
+        selectedAccountLatest: getMockSelectedAccountPortfolio({
+          loadingChainIds: [1n, 56n]
+        }),
+        isAllReady: true,
+        shouldShowPartialResult: true,
+        providers: mockProviders,
+        accountState: mockAccountState,
+        networksWithAssets: { '1': true, '56': true }
+      })
+
+      expect(errors).toHaveLength(0)
     })
   })
 })

--- a/src/libs/selectedAccount/errors.test.ts
+++ b/src/libs/selectedAccount/errors.test.ts
@@ -1,0 +1,405 @@
+import { networks } from '../../consts/networks'
+import { Network } from '../../interfaces/network'
+import { addPortfolioError, addRPCError, SelectedAccountBalanceError } from './errors'
+
+const mockNetworks = structuredClone(networks) as Network[]
+
+mockNetworks.find((n) => n.chainId === 137n)!.rpcUrls = ['rpc-1', 'rpc-2']
+mockNetworks.find((n) => n.chainId === 42161n)!.rpcUrls = ['rpc-1', 'rpc-2']
+
+describe('selectedAccount errors', () => {
+  describe('addRPCError', () => {
+    describe('when adding RPC error for network with single RPC URL', () => {
+      it('should add a new error when no existing errors', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addRPCError(errors, '1', mockNetworks)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'rpcs-down',
+          networkNames: ['Ethereum'],
+          type: 'error',
+          title: 'Failed to retrieve network data for Ethereum (RPC malfunction)',
+          text: 'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.',
+          actions: undefined
+        })
+      })
+
+      it('should add network to existing rpcs-down error', () => {
+        const existingErrors: SelectedAccountBalanceError[] = [
+          {
+            id: 'rpcs-down',
+            networkNames: ['Ethereum'],
+            type: 'error',
+            title: 'Failed to retrieve network data for Ethereum (RPC malfunction)',
+            text: 'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.'
+          }
+        ]
+        const result = addRPCError(existingErrors, '56', mockNetworks)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'rpcs-down',
+          networkNames: ['Ethereum', 'BNB Smart Chain'],
+          type: 'error',
+          title: 'Failed to retrieve network data for Ethereum, BNB Smart Chain (RPC malfunction)',
+          text: 'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.'
+        })
+      })
+
+      it('should not add duplicate network names to existing error', () => {
+        const existingErrors: SelectedAccountBalanceError[] = [
+          {
+            id: 'rpcs-down',
+            networkNames: ['Ethereum'],
+            type: 'error',
+            title: 'Failed to retrieve network data for Ethereum (RPC malfunction)',
+            text: 'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.'
+          }
+        ]
+        const result = addRPCError(existingErrors, '1', mockNetworks)
+
+        expect(result).toHaveLength(1)
+        expect(result[0].networkNames).toEqual(['Ethereum'])
+        expect(result[0].title).toBe(
+          'Failed to retrieve network data for Ethereum (RPC malfunction)'
+        )
+      })
+    })
+
+    describe('when adding RPC error for network with multiple RPC URLs', () => {
+      it('should add a new custom-rpcs-down error', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addRPCError(errors, '137', mockNetworks)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'custom-rpcs-down-137',
+          networkNames: ['Polygon'],
+          type: 'error',
+          title:
+            'Failed to retrieve network data for Polygon. You can try selecting another RPC URL',
+          text: 'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.',
+          actions: [
+            {
+              label: 'Select',
+              actionName: 'select-rpc-url',
+              meta: { network: mockNetworks[1] }
+            }
+          ]
+        })
+      })
+
+      it('should not modify existing custom-rpcs-down error for same network', () => {
+        const existingErrors: SelectedAccountBalanceError[] = [
+          {
+            id: 'custom-rpcs-down-137',
+            networkNames: ['Polygon'],
+            type: 'error',
+            title:
+              'Failed to retrieve network data for Polygon. You can try selecting another RPC URL',
+            text: 'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.',
+            actions: [
+              {
+                label: 'Select',
+                actionName: 'select-rpc-url',
+                meta: { network: mockNetworks[1] }
+              }
+            ]
+          }
+        ]
+        const result = addRPCError(existingErrors, '137', mockNetworks)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual(existingErrors[0])
+      })
+
+      it('should add separate custom-rpcs-down errors for different mockNetworks', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        let result = addRPCError(errors, '137', mockNetworks)
+        result = addRPCError(result, '42161', mockNetworks)
+
+        expect(result).toHaveLength(2)
+        expect(result[0].id).toBe('custom-rpcs-down-137')
+        expect(result[1].id).toBe('custom-rpcs-down-42161')
+        expect(result[1].networkNames).toEqual(['Arbitrum'])
+      })
+    })
+
+    describe('edge cases', () => {
+      it('should return an empty errors array when network is not found', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addRPCError(errors, '999', mockNetworks)
+
+        expect(result).toHaveLength(0)
+      })
+
+      it('should handle empty networks array', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addRPCError(errors, '1', [])
+
+        expect(result).toHaveLength(0)
+      })
+
+      it('should not modify original errors array', () => {
+        const originalErrors: SelectedAccountBalanceError[] = []
+        const result = addRPCError(originalErrors, '1', mockNetworks)
+
+        expect(result).not.toBe(originalErrors)
+        expect(originalErrors).toHaveLength(0)
+        expect(result).toHaveLength(1)
+        expect(result[0].networkNames).toEqual(['Ethereum'])
+      })
+    })
+
+    describe('mixed error scenarios', () => {
+      it('should handle both single and multiple RPC URL errors together', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        let result = addRPCError(errors, '1', mockNetworks) // Single RPC
+        result = addRPCError(result, '137', mockNetworks) // Multiple RPCs
+        result = addRPCError(result, '56', mockNetworks) // Single RPC
+
+        expect(result).toHaveLength(2)
+
+        // Should have one rpcs-down error with both single-RPC mockNetworks
+        const rpcsDownError = result.find((e) => e.id === 'rpcs-down')
+        expect(rpcsDownError).toBeDefined()
+        expect(rpcsDownError!.networkNames).toEqual(['Ethereum', 'BNB Smart Chain'])
+
+        // Should have one custom error for the multiple-RPC network
+        const customRpcError = result.find((e) => e.id === 'custom-rpcs-down-137')
+        expect(customRpcError).toBeDefined()
+        expect(customRpcError!.networkNames).toEqual(['Polygon'])
+      })
+    })
+  })
+
+  describe('addPortfolioError', () => {
+    describe('portfolio-critical error type', () => {
+      it('should add a new portfolio-critical error', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addPortfolioError(errors, 'Ethereum', 'portfolio-critical')
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'portfolio-critical',
+          networkNames: ['Ethereum'],
+          type: 'error',
+          title: 'Failed to retrieve the portfolio data',
+          text: 'Account balance and visible assets may be inaccurate.'
+        })
+      })
+
+      it('should add network to existing portfolio-critical error', () => {
+        const existingErrors: SelectedAccountBalanceError[] = [
+          {
+            id: 'portfolio-critical',
+            networkNames: ['Ethereum'],
+            type: 'error',
+            title: 'Failed to retrieve the portfolio data',
+            text: 'Account balance and visible assets may be inaccurate.'
+          }
+        ]
+        const result = addPortfolioError(existingErrors, 'Polygon', 'portfolio-critical')
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'portfolio-critical',
+          networkNames: ['Ethereum', 'Polygon'],
+          type: 'error',
+          title: 'Failed to retrieve the portfolio data on Ethereum, Polygon',
+          text: 'Account balance and visible assets may be inaccurate.'
+        })
+      })
+    })
+
+    describe('loading-too-long error type', () => {
+      it('should add a new loading-too-long error', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addPortfolioError(errors, 'BNB Smart Chain', 'loading-too-long')
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'loading-too-long',
+          networkNames: ['BNB Smart Chain'],
+          type: 'warning',
+          title: 'Loading is taking longer than expected',
+          text: 'Account balance and visible assets may be inaccurate.'
+        })
+      })
+
+      it('should add network to existing loading-too-long error', () => {
+        const existingErrors: SelectedAccountBalanceError[] = [
+          {
+            id: 'loading-too-long',
+            networkNames: ['BNB Smart Chain'],
+            type: 'warning',
+            title: 'Loading is taking longer than expected',
+            text: 'Account balance and visible assets may be inaccurate.'
+          }
+        ]
+        const result = addPortfolioError(existingErrors, 'Arbitrum', 'loading-too-long')
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'loading-too-long',
+          networkNames: ['BNB Smart Chain', 'Arbitrum'],
+          type: 'warning',
+          title: 'Loading is taking longer than expected on BNB Smart Chain, Arbitrum',
+          text: 'Account balance and visible assets may be inaccurate.'
+        })
+      })
+    })
+
+    describe('PORTFOLIO_LIB_ERROR_NAMES error types', () => {
+      it('should return new array for non-existent error type', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addPortfolioError(errors, 'Ethereum', 'NonCriticalApiHintsError')
+
+        expect(result).not.toBe(errors)
+        expect(result).toHaveLength(0)
+      })
+
+      it('should add PriceFetchError', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addPortfolioError(errors, 'Ethereum', 'PriceFetchError')
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'PriceFetchError',
+          networkNames: ['Ethereum'],
+          type: 'warning',
+          title: 'Failed to retrieve prices',
+          text: 'Account balance and asset prices may be inaccurate.'
+        })
+      })
+
+      it('should add NoApiHintsError', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addPortfolioError(errors, 'Polygon', 'NoApiHintsError')
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'NoApiHintsError',
+          networkNames: ['Polygon'],
+          type: 'error',
+          title: 'Automatic asset discovery is temporarily unavailable',
+          text: 'Your funds are safe, but your portfolio will be inaccurate. You can add assets manually or wait for the issue to be resolved.'
+        })
+      })
+
+      it('should add StaleApiHintsError', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addPortfolioError(errors, 'BNB Smart Chain', 'StaleApiHintsError')
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toEqual({
+          id: 'StaleApiHintsError',
+          networkNames: ['BNB Smart Chain'],
+          type: 'warning',
+          title: 'Automatic asset discovery is temporarily unavailable',
+          text: 'New assets may not be visible in your portfolio. You can add assets manually or wait for the issue to be resolved.'
+        })
+      })
+    })
+
+    describe('title formatting with multiple mockNetworks', () => {
+      it('should handle title that already contains " on " when adding mockNetworks', () => {
+        const existingErrors: SelectedAccountBalanceError[] = [
+          {
+            id: 'portfolio-critical',
+            networkNames: ['Ethereum'],
+            type: 'error',
+            title: 'Failed to retrieve the portfolio data on Ethereum',
+            text: 'Account balance and visible assets may be inaccurate.'
+          }
+        ]
+        const result = addPortfolioError(existingErrors, 'Polygon', 'portfolio-critical')
+
+        expect(result[0].title).toBe('Failed to retrieve the portfolio data on Ethereum, Polygon')
+      })
+
+      it('should handle title without " on " when adding mockNetworks', () => {
+        const existingErrors: SelectedAccountBalanceError[] = [
+          {
+            id: 'portfolio-critical',
+            networkNames: ['Ethereum'],
+            type: 'error',
+            title: 'Failed to retrieve the portfolio data',
+            text: 'Account balance and visible assets may be inaccurate.'
+          }
+        ]
+        const result = addPortfolioError(existingErrors, 'Polygon', 'portfolio-critical')
+
+        expect(result[0].title).toBe('Failed to retrieve the portfolio data on Ethereum, Polygon')
+      })
+
+      it('should handle multiple " on " occurrences correctly', () => {
+        const existingErrors: SelectedAccountBalanceError[] = [
+          {
+            id: 'loading-too-long',
+            networkNames: ['Network One'],
+            type: 'warning',
+            title: 'Something went wrong on Network One',
+            text: 'Test error'
+          }
+        ]
+        const result = addPortfolioError(existingErrors, 'Network Two', 'loading-too-long')
+
+        expect(result[0].title).toBe('Something went wrong on Network One, Network Two')
+      })
+    })
+
+    describe('different error types in same array', () => {
+      it('should handle multiple different error types', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        let result = addPortfolioError(errors, 'Ethereum', 'portfolio-critical')
+        result = addPortfolioError(result, 'Polygon', 'loading-too-long')
+        result = addPortfolioError(result, 'BNB Smart Chain', 'PriceFetchError')
+
+        expect(result).toHaveLength(3)
+        expect(result[0].id).toBe('portfolio-critical')
+        expect(result[1].id).toBe('loading-too-long')
+        expect(result[2].id).toBe('PriceFetchError')
+      })
+
+      it('should add to existing error of same type while having other types', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        let result = addPortfolioError(errors, 'Ethereum', 'portfolio-critical')
+        result = addPortfolioError(result, 'Polygon', 'loading-too-long')
+        result = addPortfolioError(result, 'BNB Smart Chain', 'portfolio-critical') // Same type as first
+
+        expect(result).toHaveLength(2)
+        expect(result[0].networkNames).toEqual(['Ethereum', 'BNB Smart Chain'])
+        expect(result[1].networkNames).toEqual(['Polygon'])
+      })
+    })
+
+    describe('edge cases and error handling', () => {
+      it('should handle empty network name', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        const result = addPortfolioError(errors, '', 'portfolio-critical')
+
+        expect(result).toHaveLength(1)
+        expect(result[0].networkNames).toEqual([''])
+      })
+
+      it('should create new array (function does not mutate input)', () => {
+        const originalErrors: SelectedAccountBalanceError[] = []
+        const result = addPortfolioError(originalErrors, 'Ethereum', 'portfolio-critical')
+
+        expect(result).not.toBe(originalErrors)
+        expect(originalErrors).toHaveLength(0)
+        expect(result).toHaveLength(1)
+      })
+      it('should handle adding same network multiple times to same error type', () => {
+        const errors: SelectedAccountBalanceError[] = []
+        let result = addPortfolioError(errors, 'Ethereum', 'portfolio-critical')
+        result = addPortfolioError(result, 'Ethereum', 'portfolio-critical')
+
+        expect(result).toHaveLength(1)
+        expect(result[0].networkNames).toEqual(['Ethereum'])
+      })
+    })
+  })
+})

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -208,7 +208,8 @@ export const getNetworksWithErrors = ({
 
   if (!Object.keys(selectedAccountLatest).length || areAllProvidersDown) return []
 
-  Object.keys(networks).forEach((chainId) => {
+  networks.forEach((network) => {
+    const chainId = network.chainId.toString()
     const portfolioForNetwork = selectedAccountLatest[chainId]
     const accountStateForNetwork = accountState?.[chainId]
     const criticalPortfolioError = portfolioForNetwork?.criticalError
@@ -216,7 +217,7 @@ export const getNetworksWithErrors = ({
     const lastSuccessfulPortfolioUpdate = portfolioForNetwork?.result?.lastSuccessfulUpdate
     const accountStateUpdatedAt = accountStateForNetwork?.updatedAt
     const networkName = getNetworkName(networks, chainId)
-    const isLoadingFromScratch = portfolioForNetwork?.isLoading && isAllReady
+    const isLoadingFromScratch = portfolioForNetwork?.isLoading && !isAllReady
 
     if (!networkName) {
       console.error('Network name not found for network in getNetworksWithErrors', chainId)
@@ -261,8 +262,7 @@ export const getNetworksWithErrors = ({
     // the user has never had assets on a network but expects to receive some?
     // I think we should simply increase the timeout above to a higher value (30 mins?)
     // but always display the error on manual reloads.
-    if (!Object.keys(networksWithAssets).includes(chainId) || networksWithAssets[chainId] === false)
-      return
+    if (networksWithAssets?.[chainId] === false) return
 
     if (!isRpcWorking) {
       // Add an RPC error if the RPC is not working

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -1,3 +1,4 @@
+import { AccountOnchainState } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
 import { RPCProvider, RPCProviders } from '../../interfaces/provider'
 import { SelectedAccountPortfolioState } from '../../interfaces/selectedAccount'
@@ -6,7 +7,6 @@ import {
   DeFiPositionsError,
   NetworksWithPositions
 } from '../defiPositions/types'
-import { getNetworksWithFailedRPC } from '../networks/networks'
 import { AccountAssetsState } from '../portfolio/interfaces'
 import { PORTFOLIO_LIB_ERROR_NAMES } from '../portfolio/portfolio'
 
@@ -35,78 +35,63 @@ export type SelectedAccountBalanceError = {
   actions?: Action[]
 }
 
-export const getNetworksWithFailedRPCErrors = ({
-  providers,
-  networks,
-  networksWithAssets
-}: {
-  providers: RPCProviders
+export const addRPCError = (
+  errors: SelectedAccountBalanceError[],
+  chainId: string,
   networks: Network[]
-  networksWithAssets: AccountAssetsState
-}): SelectedAccountBalanceError[] => {
-  const errors: SelectedAccountBalanceError[] = []
-  const chainIds = getNetworksWithFailedRPC({ providers }).filter(
-    (chainId) =>
-      (Object.keys(networksWithAssets).includes(chainId) && networksWithAssets[chainId] === true) ||
-      !Object.keys(networksWithAssets).includes(chainId)
-  )
+) => {
+  const newErrors = [...errors]
+  const network = networks.find((n) => n.chainId.toString() === chainId)
+  if (!network) return newErrors
 
-  // Show an error for networks with no RPC providers
-  networks.forEach((network) => {
-    if (providers[network.chainId.toString()]) return
+  const hasMultipleRpcUrls = network.rpcUrls && network.rpcUrls.length > 1
+  const errorId: `custom-rpcs-down-${string}` | 'rpcs-down' = hasMultipleRpcUrls
+    ? `custom-rpcs-down-${network.chainId.toString()}`
+    : 'rpcs-down'
+  const networkName = network.name
 
-    chainIds.push(network.chainId.toString())
-  })
+  const existingError = newErrors.find((error) => error.id === errorId)
 
-  const networksData = chainIds.map(
-    (id) => networks.find((n: Network) => n.chainId.toString() === id)!
-  )
+  if (existingError) {
+    if (!existingError.networkNames.includes(networkName) && !hasMultipleRpcUrls) {
+      existingError.networkNames.push(networkName)
+      existingError.title = `Failed to retrieve network data for ${existingError.networkNames.join(
+        ', '
+      )} (RPC malfunction)`
+    }
+  } else {
+    const text =
+      'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.'
+    let title = ''
+    let actions: Action[] | undefined
 
-  const allFailed = networksData.length === networks.length
-
-  const networksWithMultipleRpcUrls = allFailed
-    ? []
-    : networksData.filter((n) => n?.rpcUrls?.length > 1)
-
-  const networksToGroupInSingleBanner = allFailed
-    ? networksData
-    : networksData.filter((n) => n?.rpcUrls?.length <= 1)
-
-  if (!networksData.length) return errors
-
-  networksWithMultipleRpcUrls.forEach((n) => {
-    errors.push({
-      id: `custom-rpcs-down-${n.chainId}`,
-      networkNames: [n.name],
-      type: 'error',
-      title: `Failed to retrieve network data for ${n.name}. You can try selecting another RPC URL`,
-      text: 'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.',
-      actions: [
+    if (hasMultipleRpcUrls) {
+      title = `Failed to retrieve network data for ${networkName}. You can try selecting another RPC URL`
+      actions = [
         {
           label: 'Select',
           actionName: 'select-rpc-url',
-          meta: { network: n }
+          meta: { network }
         }
       ]
+    } else {
+      title = `Failed to retrieve network data for ${networkName} (RPC malfunction)`
+    }
+
+    newErrors.push({
+      id: errorId,
+      networkNames: [networkName],
+      type: 'error',
+      title,
+      text,
+      actions
     })
-  })
+  }
 
-  if (!networksToGroupInSingleBanner.length) return errors
-
-  errors.push({
-    id: 'rpcs-down',
-    networkNames: networksToGroupInSingleBanner.map((n) => n.name),
-    type: 'error',
-    title: `Failed to retrieve network data for ${networksToGroupInSingleBanner
-      .map((n) => n.name)
-      .join(', ')} (RPC malfunction)`,
-    text: 'Affected features: visible assets, DeFi positions, sign message/transaction, ENS domain resolving, add account.'
-  })
-
-  return errors
+  return newErrors
 }
 
-const addPortfolioError = (
+export const addPortfolioError = (
   errors: SelectedAccountBalanceError[],
   networkName: string,
   newError: keyof typeof PORTFOLIO_LIB_ERROR_NAMES | 'portfolio-critical' | 'loading-too-long'
@@ -115,7 +100,21 @@ const addPortfolioError = (
   const existingError = newErrors.find((error) => error.id === newError)
 
   if (existingError) {
-    existingError.networkNames.push(networkName)
+    if (!existingError.networkNames.includes(networkName)) {
+      existingError.networkNames.push(networkName)
+      const networkNames = existingError.networkNames
+
+      const lastIndexOfOn = existingError.title.lastIndexOf(' on ')
+
+      if (lastIndexOfOn !== -1) {
+        existingError.title = `${existingError.title.substring(
+          0,
+          lastIndexOfOn
+        )} on ${networkNames.join(', ')}`
+      } else {
+        existingError.title = `${existingError.title} on ${networkNames.join(', ')}`
+      }
+    }
   } else {
     let title = ''
     let text = ''
@@ -165,91 +164,119 @@ const addPortfolioError = (
   return newErrors
 }
 
-export const getNetworksWithPortfolioErrorErrors = ({
+const getNetworkName = (networks: Network[], chainId: string) => {
+  let networkName = networks.find((n) => n.chainId.toString() === chainId)?.name
+
+  if (chainId === 'gasTank') networkName = 'Gas Tank'
+  else if (chainId === 'rewards') networkName = 'Rewards'
+
+  return networkName
+}
+
+/**
+ * Cases:
+ * - All providers are not working - the user is offline and an error should not be displayed
+ * - Critical RPC error on Ethereum (displayed immediately, because many things depend on it)
+ * - Critical RPC error on other network - displayed after 10 mins of stale account state or portfolio state
+ * - Critical portfolio error on any network - displayed after 10 mins of stale portfolio state
+ * - Non-critical portfolio error on any network - displayed after 10 mins of stale portfolio state
+ */
+
+export const getNetworksWithErrors = ({
   networks,
   selectedAccountLatest,
   providers,
-  isAllReady
+  accountState,
+  shouldShowPartialResult,
+  isAllReady,
+  networksWithAssets
 }: {
   networks: Network[]
   selectedAccountLatest: SelectedAccountPortfolioState
   providers: RPCProviders
+  accountState: {
+    [chainId: string]: AccountOnchainState
+  }
   isAllReady: boolean
+  shouldShowPartialResult: boolean
+  networksWithAssets: AccountAssetsState
 }): SelectedAccountBalanceError[] => {
   let errors: SelectedAccountBalanceError[] = []
+  const areAllProvidersDown = Object.values(providers).every(
+    (provider) => provider?.isWorking === false
+  )
 
-  if (!Object.keys(selectedAccountLatest).length) return []
+  if (!Object.keys(selectedAccountLatest).length || areAllProvidersDown) return []
 
-  Object.keys(selectedAccountLatest).forEach((chainId) => {
+  Object.keys(networks).forEach((chainId) => {
     const portfolioForNetwork = selectedAccountLatest[chainId]
-    const criticalError = portfolioForNetwork?.criticalError
-    const lastSuccessfulUpdate = portfolioForNetwork?.result?.lastSuccessfulUpdate
-    let networkName = networks.find((n) => n.chainId.toString() === chainId)?.name
-
-    if (chainId === 'gasTank') networkName = 'Gas Tank'
-    else if (chainId === 'rewards') networkName = 'Rewards'
+    const accountStateForNetwork = accountState?.[chainId]
+    const criticalPortfolioError = portfolioForNetwork?.criticalError
+    const isRpcWorking = providers[chainId]?.isWorking !== false
+    const lastSuccessfulPortfolioUpdate = portfolioForNetwork?.result?.lastSuccessfulUpdate
+    const accountStateUpdatedAt = accountStateForNetwork?.updatedAt
+    const networkName = getNetworkName(networks, chainId)
+    const isLoadingFromScratch = portfolioForNetwork?.isLoading && isAllReady
 
     if (!networkName) {
-      console.error(
-        'Network name not found for network in getNetworksWithPortfolioErrorErrors',
-        chainId
-      )
+      console.error('Network name not found for network in getNetworksWithErrors', chainId)
       return
     }
 
-    if (portfolioForNetwork?.isLoading && !isAllReady) {
-      // Add an error if the network is preventing the portfolio from going ready
-      // The error is added, regardless of whether the loading is taking too long (> 5s)
-      // or not. This is determined in the UI. The error is added so the UI knows which networks
-      // are preventing the portfolio from going ready.
-      errors = addPortfolioError(errors, networkName, 'loading-too-long')
+    // No other errors should be displayed if the portfolio is still loading
+    // from scratch
+    if (isLoadingFromScratch) {
+      // The portfolio has been loading for longer than X seconds. The networks
+      // that are still loading are the slow ones, so we add a warning for them.
+      if (shouldShowPartialResult)
+        errors = addPortfolioError(errors, networkName, 'loading-too-long')
       return
     }
 
-    // Don't display an error banner if the last successful update was less than 10 minutes ago
-    if (typeof lastSuccessfulUpdate === 'number' && Date.now() - lastSuccessfulUpdate < TEN_MINUTES)
+    // Add portfolio non-critical errors if the portfolio and RPC are working
+    if (!criticalPortfolioError && isRpcWorking) {
+      portfolioForNetwork?.errors.forEach((err: any) => {
+        errors = addPortfolioError(errors, networkName as string, err.name)
+      })
       return
+    }
 
-    if (!portfolioForNetwork || !chainId) return
-    // Don't display an error banner if the RPC isn't working because an RPC error banner is already displayed.
-    // In case of additional networks don't check the RPC as there isn't one
-    const rpcProvider = providers[chainId]
-    // Don't display an error banner if the RPC isn't working because an RPC error banner is already displayed.
-    // Also, it may be the case that isWorking is not defined. In that case there will be no RPC error banner
-    // so we must display the portfolio error banner.
-    // We are purposely checking the RPC and not the RPC banners, because they are only displayed
-    // when the RPC is not working AND the user has balance on the network.
-    // Example: The user has no balance on Berachain and the RPC is not working.
-    // In this case there will be no RPC error banner and no portfolio error banner.
+    // Don't display an error banner if the last successful portfolio update was less than 10 minutes ago
+    // and the account state was updated less than 10 minutes ago
     if (
-      criticalError &&
-      (['gasTank', 'rewards'].includes(chainId) ||
-        typeof rpcProvider?.isWorking !== 'boolean' ||
-        rpcProvider.isWorking)
+      // Skip the 10 minute check for Ethereum as many things depend
+      // on the Ethereum RPC working
+      chainId !== '1' &&
+      typeof lastSuccessfulPortfolioUpdate === 'number' &&
+      Date.now() - lastSuccessfulPortfolioUpdate < TEN_MINUTES &&
+      accountStateUpdatedAt &&
+      Date.now() - accountStateUpdatedAt < TEN_MINUTES
     ) {
-      errors = addPortfolioError(errors, networkName, 'portfolio-critical')
       return
     }
 
-    portfolioForNetwork?.errors.forEach((err: any) => {
-      errors = addPortfolioError(errors, networkName as string, err.name)
-    })
-  })
+    // Don't display an error if the user has never had assets on this network
+    // but display one if we don't know whether the user has assets on this network
+    // Note @petromir: This logic is legacy and I no longer think it's correct. What if
+    // the user has never had assets on a network but expects to receive some?
+    // I think we should simply increase the timeout above to a higher value (30 mins?)
+    // but always display the error on manual reloads.
+    if (!Object.keys(networksWithAssets).includes(chainId) || networksWithAssets[chainId] === false)
+      return
 
-  return errors.map(({ title, networkNames, ...rest }) => {
-    const networkNamesString = networkNames.reduce((acc, name, index) => {
-      const isLast = index === networkNames.length - 1
-      const isOnly = networkNames.length === 1
+    if (!isRpcWorking) {
+      // Add an RPC error if the RPC is not working
+      errors = addRPCError(errors, chainId, networks)
+      return
+    }
 
-      return `${acc}${name}${isLast || isOnly ? '' : ', '}`
-    }, '')
-
-    return {
-      ...rest,
-      title: `${title} on ${networkNamesString}`,
-      networkNames
+    if (criticalPortfolioError) {
+      // Add portfolio critical banner
+      errors = addPortfolioError(errors, networkName as string, 'portfolio-critical')
     }
   })
+
+  return errors
 }
 
 export const getNetworksWithDeFiPositionsErrorErrors = ({

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -256,15 +256,15 @@ export const getNetworksWithErrors = ({
       return
     }
 
-    // Don't display an error if the user has never had assets on this network
-    // but display one if we don't know whether the user has assets on this network
-    // Note @petromir: This logic is legacy and I no longer think it's correct. What if
-    // the user has never had assets on a network but expects to receive some?
-    // I think we should simply increase the timeout above to a higher value (30 mins?)
-    // but always display the error on manual reloads.
-    if (networksWithAssets?.[chainId] === false) return
-
     if (!isRpcWorking) {
+      // Don't display an error if the user has never had assets on this network
+      // but display one if we don't know whether the user has assets on this network
+      // Note @petromir: This logic is legacy and I no longer think it's correct. What if
+      // the user has never had assets on a network but expects to receive some?
+      // I think we should simply increase the timeout above to a higher value (30 mins?)
+      // but always display the error on manual reloads.
+      if (networksWithAssets?.[chainId] === false) return
+
       // Add an RPC error if the RPC is not working
       errors = addRPCError(errors, chainId, networks)
       return

--- a/src/libs/selectedAccount/selectedAccount.test.ts
+++ b/src/libs/selectedAccount/selectedAccount.test.ts
@@ -314,8 +314,8 @@ describe('Selected Account lib', () => {
         clonedPortfolioLatestState,
         clonedPortfolioPendingState,
         {},
-        Date.now(),
         clonedDefiAccountState,
+        false,
         true
       )
 
@@ -330,7 +330,6 @@ describe('Selected Account lib', () => {
       const clonedPortfolioLatestState = structuredClone(PORTFOLIO_STATE) as AccountState
       const clonedPortfolioPendingState = structuredClone(PENDING_PORTFOLIO_STATE) as AccountState
       const clonedDefiAccountState = structuredClone(DEFI_STATE) as DefiAccountState
-      const portfolioStartedLoadingAtTimestamp = Date.now() - 6000
 
       clonedPortfolioLatestState['1']!.isLoading = true
       clonedPortfolioPendingState['1']!.isLoading = true
@@ -339,8 +338,8 @@ describe('Selected Account lib', () => {
         clonedPortfolioLatestState,
         clonedPortfolioPendingState,
         {},
-        portfolioStartedLoadingAtTimestamp,
         clonedDefiAccountState,
+        true,
         true
       )
 
@@ -359,8 +358,8 @@ describe('Selected Account lib', () => {
         clonedPortfolioLatestState,
         clonedPortfolioPendingState,
         {},
-        Date.now(),
         clonedDefiAccountState,
+        false,
         true
       )
 

--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -402,8 +402,8 @@ export function calculateSelectedAccountPortfolioByNetworks(
   latestStateSelectedAccount: AccountState,
   pendingStateSelectedAccount: AccountState,
   pastAccountPortfolioWithDefiPositions: SelectedAccountPortfolioByNetworks,
-  portfolioStartedLoadingAtTimestamp: number | null,
   defiPositionsAccountState: DefiPositionsAccountState,
+  shouldShowPartialResult: boolean,
   isLoadingFromScratch: boolean
 ): {
   selectedAccountPortfolioByNetworks: SelectedAccountPortfolioByNetworks
@@ -411,9 +411,6 @@ export function calculateSelectedAccountPortfolioByNetworks(
   isReadyToVisualize: boolean
   shouldShowPartialResult: boolean
 } {
-  const now = Date.now()
-  const shouldShowPartialResult =
-    !!portfolioStartedLoadingAtTimestamp && now - portfolioStartedLoadingAtTimestamp > 5000
   const newAccountPortfolioWithDefiPositions: SelectedAccountPortfolioByNetworks =
     pastAccountPortfolioWithDefiPositions
 
@@ -562,7 +559,7 @@ export function calculateSelectedAccountPortfolioByNetworks(
   }
 
   return {
-    shouldShowPartialResult,
+    shouldShowPartialResult: isAllReady ? false : shouldShowPartialResult,
     isReadyToVisualize,
     isAllReady,
     selectedAccountPortfolioByNetworks: newAccountPortfolioWithDefiPositions
@@ -578,8 +575,8 @@ export function calculateSelectedAccountPortfolio(
   latestStateSelectedAccount: AccountState,
   pendingStateSelectedAccount: AccountState,
   pastAccountPortfolioWithDefiPositions: SelectedAccountPortfolioByNetworks,
-  portfolioStartedLoadingAtTimestamp: number | null,
   defiPositionsAccountState: DefiPositionsAccountState,
+  prevShouldShowPartialResult: boolean,
   isLoadingFromScratch: boolean
 ): {
   selectedAccountPortfolio: SelectedAccountPortfolio
@@ -594,8 +591,8 @@ export function calculateSelectedAccountPortfolio(
     latestStateSelectedAccount,
     pendingStateSelectedAccount,
     pastAccountPortfolioWithDefiPositions,
-    portfolioStartedLoadingAtTimestamp,
     defiPositionsAccountState,
+    prevShouldShowPartialResult,
     isLoadingFromScratch
   )
 


### PR DESCRIPTION
## Changes:
- No longer displays an RPC error if the account state and portfolio were updated within the past 10 minutes (resolves https://github.com/AmbireTech/ambire-app/issues/5459), excluding manual reloads
- Refactors and simplifies the selected account portfolio and RPC error logic. The previous implementation relied on implicit assumptions and convoluted code paths. The current code follows a clear, logical flow and is well-documented
- Implements nearly 40 test cases (previously 0) covering this logic
- Fixes the `shouldShowPartialResult` flag. Previously, this flag was calculated by comparing the current timestamp with the timestamp of when the portfolio started loading. The issue was when it was calculated—only on emit updates. If all networks loaded in 1s except Ethereum (which takes 10s), there would be a 9s gap without any emit updates. This caused the flag to be true for only a split second instead of the intended 5s

Closes https://github.com/AmbireTech/ambire-app/issues/5459