### PR TITLE
Hotfix / Avoid waiting for the dapp broadcast to resolve

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1579,7 +1579,7 @@ export class MainController extends EventEmitter implements IMainController {
       shouldUpdateAccount: false
     })
 
-    await this.resolveDappBroadcast(submittedAccountOp, dappHandlers)
+    this.resolveDappBroadcast(submittedAccountOp, dappHandlers)
 
     this.emitUpdate()
   }


### PR DESCRIPTION
Fix: Avoid waiting for the dapp broadcast to resolve, as it can block the main controller from completing its broadcasting process.