### PR TITLE
Fix/ Account op discrepancy between signAccountOp and requests controller

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -145,6 +145,15 @@ export class AccountsController extends EventEmitter implements IAccountsControl
   ) {
     if (!accounts.length) return
 
+    console.log(
+      'Debug: #updateAccountStates called for',
+      accounts,
+      'for tag',
+      blockTag,
+      'networks',
+      updateOnlyNetworksWithIds
+    )
+
     // if any, update the account state only for the passed networks; else - all
     const updateOnlyPassedNetworks = updateOnlyNetworksWithIds.length
     const networksToUpdate = this.#networks.networks.filter((network) => {

--- a/src/controllers/actions/actions.ts
+++ b/src/controllers/actions/actions.ts
@@ -1,6 +1,7 @@
 import EmittableError from '../../classes/EmittableError'
 import { Account } from '../../interfaces/account'
 import {
+  AccountOpAction,
   Action,
   ActionExecutionType,
   ActionPosition,
@@ -211,6 +212,18 @@ export class ActionsController extends EventEmitter {
     } else {
       this.emitUpdate()
     }
+  }
+
+  updateAccountOpAction(updatedAccountOp: AccountOpAction['accountOp']) {
+    const { accountAddr, chainId } = updatedAccountOp
+    const accountOpAction = this.actionsQueue.find(
+      (a) => a.type === 'accountOp' && a.id === `${accountAddr}-${chainId}`
+    )
+
+    if (!accountOpAction || accountOpAction.type !== 'accountOp') return
+
+    accountOpAction.accountOp = updatedAccountOp
+    this.emitUpdate()
   }
 
   async removeActions(actionIds: Action['id'][], shouldOpenNextAction: boolean = true) {

--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -202,6 +202,7 @@ export class ContinuousUpdatesController extends EventEmitter {
   }
 
   async #updateAccountStatePending() {
+    return
     await this.initialLoadPromise
     await this.#main.accounts.accountStatesInitialLoadPromise
 

--- a/src/controllers/estimation/estimation.ts
+++ b/src/controllers/estimation/estimation.ts
@@ -208,9 +208,11 @@ export class EstimationController extends EventEmitter {
     if (
       this.estimation &&
       (this.estimation.flags.hasNonceDiscrepancy || this.estimation.flags.has4337NonceDiscrepancy)
-    )
+    ) {
+      console.log('Debug: nonce discrepancy, updating account state for estimation', op.nonce)
       // silenly continuing on error here as the flags are more like app helpers
       this.#accounts.updateAccountState(op.accountAddr, 'pending', [op.chainId]).catch((e) => e)
+    }
 
     this.hasEstimated = true
     this.emitUpdate()

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -740,6 +740,9 @@ export class MainController extends EventEmitter implements IMainController {
         },
         true,
         true,
+        (updatedAccountOp: AccountOp) => {
+          this.requests.actions.updateAccountOpAction(updatedAccountOp)
+        },
         (ctrl: ISignAccountOpController) => {
           this.traceCall(ctrl)
         }

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -1250,6 +1250,8 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           states: await this.#accounts.getOrFetchAccountStates(op.accountAddr)
         }
       : undefined
+
+    console.log('Debug: simulating account op', op.nonce)
     return this.updateSelectedAccount(op.accountAddr, [network], simulation)
   }
 

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -17,6 +17,7 @@ import { Banner } from '../../interfaces/banner'
 import { DappProviderRequest, IDappsController } from '../../interfaces/dapp'
 import { Statuses } from '../../interfaces/eventEmitter'
 import { IKeystoreController } from '../../interfaces/keystore'
+import { StatusesWithCustom } from '../../interfaces/main'
 import { INetworksController, Network } from '../../interfaces/network'
 import { IProvidersController } from '../../interfaces/provider'
 import { BuildRequest, IRequestsController } from '../../interfaces/requests'
@@ -33,6 +34,7 @@ import { IUiController } from '../../interfaces/ui'
 import { Calls, DappUserRequest, SignUserRequest, UserRequest } from '../../interfaces/userRequest'
 import { isBasicAccount, isSmartAccount } from '../../libs/account/account'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
+import { AccountOp } from '../../libs/accountOp/accountOp'
 import { Call } from '../../libs/accountOp/types'
 import {
   dappRequestMethodToActionKind,
@@ -61,7 +63,6 @@ import { ActionsController } from '../actions/actions'
 import EventEmitter from '../eventEmitter/eventEmitter'
 import { SignAccountOpUpdateProps } from '../signAccountOp/signAccountOp'
 import { SwapAndBridgeFormStatus } from '../swapAndBridge/swapAndBridge'
-import { StatusesWithCustom } from '../../interfaces/main'
 
 const STATUS_WRAPPED_METHODS = {
   buildSwapAndBridgeUserRequest: 'INITIAL'
@@ -346,6 +347,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           userRequests: this.userRequests,
           actionsQueue: this.actions.actionsQueue
         })
+        console.log('Debug: nonce in requests ctrl', accountOpAction.accountOp.nonce)
 
         actionsToAdd.push(accountOpAction)
 

--- a/src/libs/estimate/ambireEstimation.ts
+++ b/src/libs/estimate/ambireEstimation.ts
@@ -111,6 +111,8 @@ export async function ambireEstimateGas(
   const nonceError = getNonceDiscrepancyFailure(opNonce, outcomeNonce)
   const flags: EstimationFlags = {}
   flags.hasInitialGasLimitFailed = accountOp.initialGasLimitFailed
+
+  console.log('Debug: ambireEstimateGas', nonceError, op.nonce, outcomeNonce)
   if (nonceError) {
     flags.hasNonceDiscrepancy = true
   }

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -253,6 +253,10 @@ export async function getTokens(
       : BigInt(EOA_SIMULATION_NONCE) + BigInt(idx),
     calls: calls.map(toSingletonCall).map(callToTuple)
   }))
+  console.log(
+    'Debug: simulation accountOps',
+    accountOps.map((op) => op.nonce)
+  )
   const [factory, factoryCalldata] = getAccountDeployParams(account)
   const [before, after, simulationErr, , blockNumber, deltaAddressesMapping] =
     await deployless.call(


### PR DESCRIPTION
This PR contains logs and purposefully disables account state pending updates, to make it easier to reproduce on Polygon.

Note 1: I was not able to reproduce this on 4337 networks
Note 2: Ethereum gas was like $2 per txn yesterday, which is why I tried Polygon

## How to reproduce:
1. Select a SA
2. Open Aave and switch to polygon
3. Borrow any asset
4. Sign the transaction, quickly close the action window, the borrow modal and borrow again
5. Try with `this.#onAccountOpUpdate(this.#accountOp)` commented out. 

## Why:
The simulation doesn't work, because the nonce in the requests controller is the old nonce. `getAccountOpsForSimulation` that is called in main is reading the account ops from the requests controller, so we must make sure they are identical.

Closes https://github.com/AmbireTech/ambire-app/issues/5638