### PR TITLE
Bug / Refine test that ensures the Networks controller initializes with predefined networks when storage is empty

### DIFF
--- a/src/controllers/networks/networks.test.ts
+++ b/src/controllers/networks/networks.test.ts
@@ -32,7 +32,10 @@ describe('Networks Controller', () => {
   test('should initialize with predefined networks if storage is empty', async () => {
     await networksController.initialLoadPromise // Wait for load to complete
 
-    expect(networksController.networks.length).toEqual(predefinedNetworks.length)
+    const actualChainIds = networksController.networks.map((n) => n.chainId)
+    const expectedChainIds = predefinedNetworks.map((n) => n.chainId)
+
+    expect(actualChainIds).toEqual(expect.arrayContaining(expectedChainIds))
   })
 
   test('should merge relayer networks correctly, including custom "unichain" network', async () => {


### PR DESCRIPTION
To handle cases where the Relayer adds new networks before the predefined config is updated, refine the test to ensure the NetworksController always initializes with predefined networks when storage is empty (no matter if more are incoming).