### PR TITLE
Fix: safe debug trace call, safe messages, silent error

### DIFF
--- a/src/classes/recurringTimeout/recurringTimeout.test.ts
+++ b/src/classes/recurringTimeout/recurringTimeout.test.ts
@@ -250,7 +250,7 @@ describe('RecurringTimeout', () => {
     await Promise.resolve() // this await the promise of the fn to run its .then/.catch/.finally
 
     expect(emitError).toHaveBeenCalledWith(
-      expect.objectContaining({ error: err, message: 'Recurring task failed', level: 'minor' })
+      expect.objectContaining({ error: err, message: 'Recurring task failed', level: 'silent' })
     )
 
     // after failure, next run still schedules

--- a/src/classes/recurringTimeout/recurringTimeout.ts
+++ b/src/classes/recurringTimeout/recurringTimeout.ts
@@ -108,8 +108,10 @@ export class RecurringTimeout implements IRecurringTimeout {
     } catch (err: any) {
       if (!this.promise) return
       console.error('Recurring task error:', err)
-      if (this.#emitError)
-        this.#emitError({ error: err, message: 'Recurring task failed', level: 'minor' })
+      if (this.#emitError) {
+        // set level to silent as we don't want the user to see 'Recurring task failed'
+        this.#emitError({ error: err, message: 'Recurring task failed', level: 'silent' })
+      }
     } finally {
       // If fnExecutionsCount has changed, it means `restart` was called during the execution of fn,
       // so we shouldn't schedule the next loop here.

--- a/src/controllers/safe/safe.ts
+++ b/src/controllers/safe/safe.ts
@@ -294,7 +294,7 @@ export class SafeController extends EventEmitter implements ISafeController {
     for (let i = 0; i < data.length; i++) {
       const entry = data[i]!
       const msg = await getMessage(entry).catch((e) => e)
-      if (msg instanceof Error) continue
+      if (!msg || msg instanceof Error) continue
       messages.push(msg)
     }
     return messages

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -13,11 +13,9 @@ import {
   isBytesLike,
   keccak256,
   toBeHex,
+  toUtf8Bytes,
   ZeroAddress
 } from 'ethers'
-
-/* eslint-disable @typescript-eslint/no-floating-promises */
-import { utf8ToBytes } from '@noble/hashes/utils'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireAccount7702 from '../../../contracts/compiled/AmbireAccount7702.json'
@@ -1760,7 +1758,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       const stateDiff = !!this.account.safeCreation
         ? {
             [privSlot(
-              keccak256(utf8ToBytes('ambire.smart.contracts.storage')),
+              keccak256(toUtf8Bytes('ambire.smart.contracts.storage')),
               'uint256',
               this.account.associatedKeys[0],
               'bytes32'

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -11,14 +11,17 @@ import {
   Interface,
   isAddress,
   isBytesLike,
+  keccak256,
   toBeHex,
   ZeroAddress
 } from 'ethers'
 
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { utf8ToBytes } from '@noble/hashes/utils'
+
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireAccount7702 from '../../../contracts/compiled/AmbireAccount7702.json'
 import ERC20 from '../../../contracts/compiled/IERC20.json'
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import EmittableError from '../../classes/EmittableError'
 import ExternalSignerError from '../../classes/ExternalSignerError'
 import {
@@ -103,6 +106,7 @@ import { HumanizerWarning, IrCall } from '../../libs/humanizer/interfaces'
 import { hasRelayerSupport, relayerAdditionalNetworks } from '../../libs/networks/networks'
 import { AbstractPaymaster } from '../../libs/paymaster/abstractPaymaster'
 import { GetOptions, TokenResult } from '../../libs/portfolio'
+import { privSlot } from '../../libs/proxyDeploy/deploy'
 import {
   confirm,
   getAlreadySignedOwners,
@@ -1749,11 +1753,29 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       // TODO: how to handle this case?
       if (!state) return
 
+      // if the account is a safe,
+      // add an additional state override that gives privileges to the assKey;
+      // also, we changed privs storage slot to ambire.smart.contracts.storage
+      // so privs no longer override slot number 0
+      const stateDiff = !!this.account.safeCreation
+        ? {
+            [privSlot(
+              keccak256(utf8ToBytes('ambire.smart.contracts.storage')),
+              'uint256',
+              this.account.associatedKeys[0],
+              'bytes32'
+            )]: '0x0000000000000000000000000000000000000000000000000000000000000002'
+          }
+        : undefined
+
+      // add stateOverride when using a safe as well
       const stateOverride =
-        this.accountOp.calls.length > 1 && isBasicAccount(this.account, state)
+        !!this.account.safeCreation ||
+        (this.accountOp.calls.length > 1 && isBasicAccount(this.account, state))
           ? {
               [this.account.addr]: {
-                code: AmbireAccount7702.binRuntime
+                code: AmbireAccount7702.binRuntime,
+                stateDiff
               }
             }
           : undefined


### PR DESCRIPTION
Fixes:
* set the correct state override when using debug trace call for safe accounts
* exclude null messages from safe messages array
* do not show "Recurring task failed" error to the user