### PR TITLE
Fix: do not persist the portfolio update if it's overriding the latest simulation

### DIFF
--- a/src/controllers/activity/activity.test.ts
+++ b/src/controllers/activity/activity.test.ts
@@ -232,7 +232,8 @@ describe('Activity Controller ', () => {
       relayerUrl,
       velcroUrl,
       new BannerController(storageCtrl),
-      featureFlagsCtrl
+      featureFlagsCtrl,
+      () => {}
     )
 
     const autoLoginCtrl = new AutoLoginController(

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -49,7 +49,7 @@ import { ITransferController } from '../../interfaces/transfer'
 import { IUiController, UiManager, View } from '../../interfaces/ui'
 import { BenzinUserRequest, CallsUserRequest } from '../../interfaces/userRequest'
 import { getDefaultSelectedAccount } from '../../libs/account/account'
-import { AccountOp } from '../../libs/accountOp/accountOp'
+import { AccountOp, haveAccountOpsChanged } from '../../libs/accountOp/accountOp'
 import { getDappIdentifier, SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus, Call } from '../../libs/accountOp/types'
 import { HumanizerMeta } from '../../libs/humanizer/interfaces'
@@ -318,6 +318,9 @@ export class MainController extends EventEmitter implements IMainController {
       velcroUrl,
       this.banner,
       this.featureFlags,
+      (chainId: string, accountOps?: AccountOp[]) => {
+        return this.hasSimulationChanged(chainId, accountOps)
+      },
       eventEmitterRegistry
     )
     if (this.featureFlags.isFeatureEnabled('withEmailVaultController')) {
@@ -1420,6 +1423,22 @@ export class MainController extends EventEmitter implements IMainController {
     if (oldIsOffline !== this.isOffline) {
       this.emitUpdate()
     }
+  }
+
+  hasSimulationChanged(chainId: string, accountOps?: AccountOp[]): boolean {
+    if (!this.selectedAccount?.account) return false
+
+    const accountOpsToBeSimulatedByNetwork = getAccountOpsForSimulation(
+      this.selectedAccount.account,
+      this.requests.visibleUserRequests,
+      this.networks.networks
+    )
+    const latestAccOps = accountOpsToBeSimulatedByNetwork?.[chainId]
+
+    if (accountOps === undefined && latestAccOps === undefined) return false
+    if (accountOps === undefined && latestAccOps !== undefined) return true
+    if (accountOps !== undefined && latestAccOps === undefined) return true
+    return haveAccountOpsChanged(accountOps!, latestAccOps!)
   }
 
   async updateSelectedAccountPortfolio(opts?: {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -318,8 +318,8 @@ export class MainController extends EventEmitter implements IMainController {
       velcroUrl,
       this.banner,
       this.featureFlags,
-      (chainId: string, accountOps?: AccountOp[]) => {
-        return this.hasSimulationChanged(chainId, accountOps)
+      (accAddr: string, chainId: string, accountOps?: AccountOp[]) => {
+        return this.hasSimulationChanged(accAddr, chainId, accountOps)
       },
       eventEmitterRegistry
     )
@@ -1425,8 +1425,9 @@ export class MainController extends EventEmitter implements IMainController {
     }
   }
 
-  hasSimulationChanged(chainId: string, accountOps?: AccountOp[]): boolean {
-    if (!this.selectedAccount?.account) return false
+  hasSimulationChanged(accAddr: string, chainId: string, accountOps?: AccountOp[]): boolean {
+    if (!this.selectedAccount?.account || this.selectedAccount.account.addr !== accAddr)
+      return false
 
     const accountOpsToBeSimulatedByNetwork = getAccountOpsForSimulation(
       this.selectedAccount.account,

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -1,6 +1,5 @@
-import { ethers, Wallet, ZeroAddress } from 'ethers'
+import { getAddress, Interface, Wallet, ZeroAddress } from 'ethers'
 import fetch from 'node-fetch'
-import { getAddress } from 'viem'
 
 import { describe, expect, jest } from '@jest/globals'
 
@@ -21,7 +20,6 @@ import * as defiPricesLib from '../../libs/defiPositions/defiPrices'
 import { getProviderId } from '../../libs/defiPositions/helpers'
 import * as defiProviders from '../../libs/defiPositions/providers'
 import { DeFiPositionsError } from '../../libs/defiPositions/types'
-import { Portfolio } from '../../libs/portfolio'
 import {
   erc721CollectionToLearnedAssetKeys,
   learnedErc721sToHints
@@ -34,7 +32,7 @@ import {
   PortfolioNetworkResult,
   PreviousHintsStorage
 } from '../../libs/portfolio/interfaces'
-import { PORTFOLIO_LIB_ERROR_NAMES } from '../../libs/portfolio/portfolio'
+import { Portfolio, PORTFOLIO_LIB_ERROR_NAMES } from '../../libs/portfolio/portfolio'
 import { getRpcProvider } from '../../services/provider'
 import wait from '../../utils/wait'
 import { AccountsController } from '../accounts/accounts'
@@ -297,9 +295,13 @@ const getKeystoreKeys = (): StoredKey[] => {
 
 const { uiManager } = mockUiManager()
 const uiCtrl = new UiController({ uiManager })
-const prepareTest = async (
+const prepareTest = async ({
+  initialSetStorage,
+  hasSimulationChanged
+}: {
   initialSetStorage?: (storageCtrl: StorageController) => Promise<void>
-) => {
+  hasSimulationChanged?: Function
+} = {}) => {
   const storage = produceMemoryStore()
   const storageCtrl = new StorageController(storage)
   await storageCtrl.set('accounts', [
@@ -357,7 +359,7 @@ const prepareTest = async (
     velcroUrl,
     new BannerController(storageCtrl),
     featureFlagsCtrl,
-    () => {}
+    hasSimulationChanged ? hasSimulationChanged : () => {}
   )
 
   await accountsCtrl.initialLoadPromise
@@ -379,7 +381,7 @@ describe('Portfolio Controller ', () => {
   })
   async function getAccountOp() {
     const ABI = ['function transferFrom(address from, address to, uint256 tokenId)']
-    const iface = new ethers.Interface(ABI)
+    const iface = new Interface(ABI)
     const data = iface.encodeFunctionData('transferFrom', [
       '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
       '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
@@ -768,9 +770,9 @@ describe('Portfolio Controller ', () => {
         erc721s: {}
       }
 
-      const { controller, storageCtrl } = await prepareTest((storageC) =>
-        storageC.set('learnedAssets', startingLearnedAssets)
-      )
+      const { controller, storageCtrl } = await prepareTest({
+        initialSetStorage: (storageC) => storageC.set('learnedAssets', startingLearnedAssets)
+      })
 
       const nextBatchOf30 = generateRandomAddresses(30)
       const allCurrentlyOwned = [...firstBatchOf50.slice(0, 20), ...nextBatchOf30]
@@ -814,9 +816,9 @@ describe('Portfolio Controller ', () => {
         }
       }
 
-      const { controller, storageCtrl } = await prepareTest((storageC) =>
-        storageC.set('learnedAssets', startingLearnedAssets)
-      )
+      const { controller, storageCtrl } = await prepareTest({
+        initialSetStorage: (storageC) => storageC.set('learnedAssets', startingLearnedAssets)
+      })
 
       const nextRandomCollections = generateRandomAddresses(30).reduce(
         (acc, addr, index) => {
@@ -1254,8 +1256,10 @@ describe('Portfolio Controller ', () => {
           }
         }
       }
-      const { controller } = await prepareTest(async (storageCtrl) => {
-        await storageCtrl.set('learnedAssets', initialLearnedAssets)
+      const { controller } = await prepareTest({
+        initialSetStorage: async (storageCtrl) => {
+          await storageCtrl.set('learnedAssets', initialLearnedAssets)
+        }
       })
 
       // @ts-ignore
@@ -1425,9 +1429,9 @@ describe('Portfolio Controller ', () => {
         },
         fromExternalAPI: {}
       }
-      const { controller, storageCtrl } = await prepareTest((storage) =>
-        storage.set('previousHints', previousHints)
-      )
+      const { controller, storageCtrl } = await prepareTest({
+        initialSetStorage: (storage) => storage.set('previousHints', previousHints)
+      })
 
       const learnedAssets = await storageCtrl.get('learnedAssets', null)
       expect(learnedAssets).toBe(null)
@@ -1455,10 +1459,12 @@ describe('Portfolio Controller ', () => {
     test('Learned assets from view-only account are not returned', async () => {
       const learnedAssets = getMultipleAccountsLearnedAssets()
 
-      const { controller } = await prepareTest(async (storageController) => {
-        await storageController.set('learnedAssets', learnedAssets)
-        // Get rid of the second account's key (to make it view-only)
-        await storageController.set('keystoreKeys', getKeystoreKeys().slice(0, 1))
+      const { controller } = await prepareTest({
+        initialSetStorage: async (storageController) => {
+          await storageController.set('learnedAssets', learnedAssets)
+          // Get rid of the second account's key (to make it view-only)
+          await storageController.set('keystoreKeys', getKeystoreKeys().slice(0, 1))
+        }
       })
 
       // @ts-ignore
@@ -1473,10 +1479,12 @@ describe('Portfolio Controller ', () => {
     test('Learned assets from other imported accounts are not returned if the update is not manual', async () => {
       const learnedAssets = getMultipleAccountsLearnedAssets()
 
-      const { controller } = await prepareTest(async (storageController) => {
-        await storageController.set('learnedAssets', learnedAssets)
-        // Get rid of the second account's key (to make it view-only)
-        await storageController.set('keystoreKeys', getKeystoreKeys())
+      const { controller } = await prepareTest({
+        initialSetStorage: async (storageController) => {
+          await storageController.set('learnedAssets', learnedAssets)
+          // Get rid of the second account's key (to make it view-only)
+          await storageController.set('keystoreKeys', getKeystoreKeys())
+        }
       })
 
       // @ts-ignore
@@ -1491,10 +1499,12 @@ describe('Portfolio Controller ', () => {
     test('Learned assets are added from other imported accounts on a manual update', async () => {
       const learnedAssets = getMultipleAccountsLearnedAssets()
 
-      const { controller } = await prepareTest(async (storageController) => {
-        await storageController.set('learnedAssets', learnedAssets)
-        // Get rid of the second account's key (to make it view-only)
-        await storageController.set('keystoreKeys', getKeystoreKeys())
+      const { controller } = await prepareTest({
+        initialSetStorage: async (storageController) => {
+          await storageController.set('learnedAssets', learnedAssets)
+          // Get rid of the second account's key (to make it view-only)
+          await storageController.set('keystoreKeys', getKeystoreKeys())
+        }
       })
 
       // @ts-ignore
@@ -2090,5 +2100,49 @@ describe('Portfolio Controller ', () => {
     expect(hasItems(controller.getAccountPortfolioState(account.addr))).not.toBeTruthy()
     expect(hasItems(controller.getAccountPortfolioState(account.addr))).not.toBeTruthy()
     expect(Object.keys(controller.getNetworksWithAssets(account.addr)).length).toEqual(0)
+  })
+  test('should do a request with a simulation; then a second request without the simulation should come and it should not be allowed to persist', async () => {
+    const { controller } = await prepareTest({
+      hasSimulationChanged: (chainId: string, accountOps?: AccountOp[]) => {
+        if (accountOps) return false
+        return true
+      }
+    })
+    const ethereum = networks.find((n) => n.chainId === 1n)!
+    const accountOpsOnEthereum = await getAccountOp()
+    const accountStates = await getAccountsInfo([account])
+
+    // update and persist the simulation
+    await controller.updateSelectedAccount(
+      account.addr,
+      [ethereum],
+      {
+        accountOps: accountOpsOnEthereum,
+        states: accountStates[account.addr]!
+      },
+      { isManualUpdate: true, isSignAccountOpSimulation: true }
+    )
+    // make sure the simulation is there
+    const hasItems = (obj: any) => !!Object.keys(obj).length
+    const portfolioState = controller.getAccountPortfolioState(account.addr)
+    expect(hasItems(portfolioState)).toBeTruthy()
+    expect(portfolioState['1']).not.toBe(undefined)
+    const ethereumPortfolioState = portfolioState['1']!
+    expect(ethereumPortfolioState.accountOps).not.toBe(undefined)
+    expect(ethereumPortfolioState.accountOps).not.toBe(null)
+    expect(ethereumPortfolioState.accountOps).toStrictEqual(accountOpsOnEthereum['1'])
+
+    // update the selected account again and make sure this
+    // request doesn't get persisted
+    await controller.updateSelectedAccount(account.addr, [ethereum], undefined, {
+      isManualUpdate: true
+    })
+    const newPortfolioState = controller.getAccountPortfolioState(account.addr)
+    expect(hasItems(newPortfolioState)).toBeTruthy()
+    expect(newPortfolioState['1']).not.toBe(undefined)
+    const newEthereumPortfolioState = newPortfolioState['1']!
+    expect(newEthereumPortfolioState.accountOps).not.toBe(undefined)
+    expect(newEthereumPortfolioState.accountOps).not.toBe(null)
+    expect(newEthereumPortfolioState.accountOps).toStrictEqual(accountOpsOnEthereum['1'])
   })
 })

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -2103,7 +2103,7 @@ describe('Portfolio Controller ', () => {
   })
   test('should do a request with a simulation; then a second request without the simulation should come and it should not be allowed to persist', async () => {
     const { controller } = await prepareTest({
-      hasSimulationChanged: (chainId: string, accountOps?: AccountOp[]) => {
+      hasSimulationChanged: (accAddr: string, chainId: string, accountOps?: AccountOp[]) => {
         if (accountOps) return false
         return true
       }

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -356,7 +356,8 @@ const prepareTest = async (
     relayerUrl,
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl
+    featureFlagsCtrl,
+    () => {}
   )
 
   await accountsCtrl.initialLoadPromise

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -973,10 +973,26 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       accountState[network.chainId.toString()] = { isLoading: false, isReady: false, errors: [] }
     }
 
-    const canSkipUpdate = PortfolioController.#getCanSkipUpdate(
-      accountState[network.chainId.toString()],
-      maxDataAgeMs
-    )
+    // always persist the simulation if it's isSignAccountOpSimulation
+    // otherwise, check for race conditions as updates happen from wherever
+    // - if the latest account opts from visibleRequests are not those
+    // passed as portfolioProps?.simulation?.accountOps, do not persist
+    // the update as it is outdated!
+    // this often happened when doing approve + action but the dapp sends
+    // the second request action immediately after txn confirmation.
+    // at that time, all kinds of portfolio update request fly in the wallet
+    // and some of them might disturb the correct, final simulation
+    const hasSimalationChanged =
+      !isSignAccountOpSimulation &&
+      this.#hasSimulationChanged(
+        account.addr,
+        network.chainId,
+        portfolioProps?.simulation?.accountOps
+      )
+
+    const canSkipUpdate =
+      hasSimalationChanged ||
+      PortfolioController.#getCanSkipUpdate(accountState[network.chainId.toString()], maxDataAgeMs)
 
     if (canSkipUpdate) return [true, null]
 
@@ -1075,24 +1091,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       } else if (!hasError) {
         // Update the last successful update only if there are no critical errors.
         lastSuccessfulUpdate = Date.now()
-      }
-
-      // always persist the simulation if it's isSignAccountOpSimulation
-      // otherwise, check for race conditions as updates happen from wherever
-      // - if the latest account opts from visibleRequests are not those
-      // passed as portfolioProps?.simulation?.accountOps, do not persist
-      // the update as it is outdated!
-      // this often happened when doing approve + action but the dapp sends
-      // the second request action immediately after txn confirmation.
-      // at that time, all kinds of portfolio update request fly in the wallet
-      // and some of them might disturb the correct, final simulation
-      if (
-        !isSignAccountOpSimulation &&
-        this.#hasSimulationChanged(network.chainId, portfolioProps?.simulation?.accountOps)
-      ) {
-        this.#setNetworkLoading(account.addr, network.chainId.toString(), false)
-        this.emitUpdate()
-        return [true, discoveryData]
       }
 
       accountState[network.chainId.toString()] = {

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -22,6 +22,7 @@ import { isBasicAccount } from '../../libs/account/account'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 /* eslint-disable @typescript-eslint/no-shadow */
 import { AccountOp, isAccountOpsIntentEqual } from '../../libs/accountOp/accountOp'
+import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
 import {
   enhancePortfolioTokensWithDefiPositions,
@@ -80,7 +81,6 @@ import { PORTFOLIO_LIB_ERROR_NAMES } from '../../libs/portfolio/portfolio'
 import { BindedRelayerCall, relayerCall } from '../../libs/relayerCall/relayerCall'
 import { isInternalChain } from '../../libs/selectedAccount/selectedAccount'
 import EventEmitter from '../eventEmitter/eventEmitter'
-import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 
 /* eslint-disable @typescript-eslint/no-shadow */
 
@@ -205,6 +205,8 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
   defiPositionsCountOnDisabledNetworks: PositionCountOnDisabledNetworks = {}
 
+  #hasSimulationChanged: Function
+
   constructor(
     storage: IStorageController,
     fetch: Fetch,
@@ -216,6 +218,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     velcroUrl: string,
     banner: IBannerController,
     featureFlags: IFeatureFlagsController,
+    hasSimulationChanged: Function,
     eventEmitterRegistry?: IEventEmitterRegistryController
   ) {
     super(eventEmitterRegistry)
@@ -234,6 +237,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     this.temporaryTokens = {}
     this.#banner = banner
     this.#featureFlags = featureFlags
+    this.#hasSimulationChanged = hasSimulationChanged
     this.batchedPortfolioDiscovery = batcher(
       fetch,
       (queue) => {
@@ -945,10 +949,11 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     portfolioProps: Partial<GetOptions> & {
       maxDataAgeMs?: number
       isManualUpdate?: boolean
+      isSignAccountOpSimulation?: boolean
     },
     discoveryData: FormattedPortfolioDiscoveryResponse | null
   ): Promise<boolean> {
-    const { maxDataAgeMs, isManualUpdate } = portfolioProps
+    const { maxDataAgeMs, isManualUpdate, isSignAccountOpSimulation } = portfolioProps
     const accountState = this.#state[account.addr]
 
     // Can occur if the account is removed while updateSelectedAccount is in progress
@@ -1043,6 +1048,24 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       } else if (!hasError) {
         // Update the last successful update only if there are no critical errors.
         lastSuccessfulUpdate = Date.now()
+      }
+
+      // always persist the simulation if it's isSignAccountOpSimulation
+      // otherwise, check for race conditions as updates happen from wherever
+      // - if the latest account opts from visibleRequests are not those
+      // passed as portfolioProps?.simulation?.accountOps, do not persist
+      // the update as it is outdated!
+      // this often happened when doing approve + action but the dapp sends
+      // the second request action immediately after txn confirmation.
+      // at that time, all kinds of portfolio update request fly in the wallet
+      // and some of them might disturb the correct, final simulation
+      if (
+        !isSignAccountOpSimulation &&
+        this.#hasSimulationChanged(network.chainId, portfolioProps?.simulation?.accountOps)
+      ) {
+        this.#setNetworkLoading(account.addr, network.chainId.toString(), false)
+        this.emitUpdate()
+        return true
       }
 
       accountState[network.chainId.toString()] = {
@@ -1286,12 +1309,14 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       defiMaxDataAgeMs?: number
       maxDataAgeMsUnused?: number
       isManualUpdate?: boolean
+      isSignAccountOpSimulation?: boolean
     }
   ) {
     const {
       maxDataAgeMs: paramsMaxDataAgeMs = 0,
       maxDataAgeMsUnused: paramsMaxDataAgeMsUnused,
-      isManualUpdate
+      isManualUpdate,
+      isSignAccountOpSimulation
     } = opts || {}
     await this.#initialLoadPromise
     const selectedAccount = this.#accounts.accounts.find((x) => x.addr === accountId)
@@ -1385,6 +1410,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
                   }
                 }),
               disableAutoDiscovery: true,
+              isSignAccountOpSimulation,
               ...allHints
             },
             discoveryResponse
@@ -1874,7 +1900,9 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         }
       : undefined
 
-    return this.updateSelectedAccount(op.accountAddr, [network], simulation)
+    return this.updateSelectedAccount(op.accountAddr, [network], simulation, {
+      isSignAccountOpSimulation: true
+    })
   }
 
   async updateNetworksWithDefiPositions(

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -183,7 +183,8 @@ const prepareTest = async () => {
     relayerUrl,
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl
+    featureFlagsCtrl,
+    () => {}
   )
   const callRelayer = relayerCall.bind({ url: '', fetch })
   const safe = new SafeController({

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -171,7 +171,8 @@ const prepareTest = async () => {
     relayerUrl,
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl
+    featureFlagsCtrl,
+    () => {}
   )
 
   await accountsCtrl.initialLoadPromise

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -438,7 +438,8 @@ const init = async (
     'https://staging-relayer.ambire.com',
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl
+    featureFlagsCtrl,
+    () => {}
   )
   const phishing = new PhishingController({
     fetch,

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -143,7 +143,8 @@ const portfolioCtrl = new PortfolioController(
   relayerUrl,
   velcroUrl,
   new BannerController(storageCtrl),
-  featureFlagsCtrl
+  featureFlagsCtrl,
+  () => {}
 )
 
 const safe = new SafeController({

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -227,7 +227,8 @@ const prepareTest = async () => {
     relayerUrl,
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl
+    featureFlagsCtrl,
+    () => {}
   )
   const activity = new ActivityController(
     storageCtrl,

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -229,3 +229,36 @@ export function getSignableHash(
 export function accountOpSignableHash(op: AccountOp, chainId: bigint): Uint8Array {
   return getSignableHash(op.accountAddr, chainId, op.nonce ?? 0n, getSignableCalls(op))
 }
+
+export function haveCallsChanged(callsOne: AccountOp['calls'], callsTwo: AccountOp['calls']) {
+  const lengthDiff = callsOne.length !== callsTwo.length
+  if (lengthDiff) return true
+
+  // if some of their properties differ, then calls have changed
+  for (let i = 0; i < callsOne.length; i++) {
+    const callOne = callsOne[i]!
+    const callTwo = callsTwo[i]!
+    if (
+      callOne.to !== callTwo?.to ||
+      callOne.data !== callTwo?.data ||
+      callOne.value !== callTwo?.value ||
+      callOne.id !== callTwo?.id
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+export function haveAccountOpsChanged(accountOpsOne: AccountOp[], accountOpsTwo: AccountOp[]) {
+  const lengthDiff = accountOpsOne.length !== accountOpsTwo.length
+  if (lengthDiff) return true
+
+  for (let i = 0; i < accountOpsOne.length; i++) {
+    const oneOp = accountOpsOne[i]!
+    const twoOp = accountOpsTwo[i]!
+    if (haveCallsChanged(oneOp.calls, twoOp.calls)) return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## Explanation

A nasty race condition exists when two or more portfolio updates (`this.portfolio.updateSelectedAccount`) fire at the same time:
* one of them is from signAccountOp with the latest simulation
* other is from another place that constructs the simulation based on the visibleRequests and the above signAccountOp request might not be one of them

In that case, sometimes the signAccountOp simulation completes faster and gets overridden by the other portfolio requests, resulting in a "no balance changes detected" simulation for cases where you're actually depositing or losing assets.

## How to reproduce

Link:  
https://app.morpho.org/opmainnet/market/0x8e77af0efaf4a3d59f37126c77f6f0ee7b56bcb1363c0986b8f6087b93ba833e/wbtc-usdc

When borrowing in Morpho, they do 2 requests one after the other:
* approve your deposit
* do the deposit

I did a recording with the broken simulation:

https://github.com/user-attachments/assets/fdeea2be-4e5b-4e11-979a-7846f71d5211

And one with the fix:

https://github.com/user-attachments/assets/26529eed-eadb-4ebb-9939-0fd3f89c3633


