### PR TITLE
Fix: always fetch the latest safe nonce before signing

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -110,6 +110,7 @@ import {
   getAlreadySignedOwners,
   getDefaultOwners,
   getImportedSignersThatHaveNotSigned,
+  getNonce,
   getSafeTxn,
   getSafeTxnHash,
   getSigs,
@@ -2539,6 +2540,24 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       ) {
         // all's good, proceed to broadcast
       } else if (this.account.safeCreation) {
+        // if the safe txn is not already signed, fetch the latest nonce
+        // as we don't have a mechanism for fixing nonces for safe accounts
+        // during the estimation phase itself
+        if (!this.accountOp.safeTx) {
+          const latestNonce = await getNonce(this.accountOp.accountAddr, this.provider).catch(
+            (e) => {
+              console.log('failed to retrieve the latest nonce for safe')
+              console.log(e)
+              return null
+            }
+          )
+          if (latestNonce) {
+            this.#updateAccountOp({
+              nonce: latestNonce
+            })
+          }
+        }
+
         const prevSignedSigs = getSigs(this.accountOp.signature)
         const nowSignedSigs: Hex[] = []
         const signers = this.accountOp.signers!

--- a/src/libs/safe/safe.ts
+++ b/src/libs/safe/safe.ts
@@ -29,6 +29,7 @@ import {
   SafeMultisigTransactionResponse
 } from '@safe-global/types-kit'
 
+import SafeAbi from '../../../contracts/compiled/Safe.json'
 import { execTransactionAbi, multiSendAddr } from '../../consts/safe'
 import { AccountOnchainState } from '../../interfaces/account'
 import { Hex } from '../../interfaces/hex'
@@ -695,4 +696,9 @@ export async function fetchExecutedTransactions(
   }
 
   return results
+}
+
+export async function getNonce(safeAddr: string, provider: RPCProvider): Promise<bigint> {
+  const safeInterface = new Contract(safeAddr, SafeAbi, provider) as any
+  return safeInterface.nonce()
 }


### PR DESCRIPTION
Closes https://github.com/AmbireTech/ambire-app/issues/6688

The issue with this is that for safe accounts, we don't have an auto nonce fix mechanism (like for v2 accounts) during estimation as we're using state overrides for the estimation. So, just before signing, fetch the latest nonce to make sure they are no issues