### PR TITLE
Refactor/ DRY tests using a common helper to initialize controllers (makeMainController)

### DIFF
--- a/src/controllers/accountPicker/accountPicker.test.ts
+++ b/src/controllers/accountPicker/accountPicker.test.ts
@@ -1,14 +1,11 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { Wallet } from 'ethers'
-import fetch from 'node-fetch'
 
 /* eslint-disable no-new */
 import { describe, expect, test } from '@jest/globals'
 
-import { relayerUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
 import { suppressConsoleBeforeEach } from '../../../test/helpers/console'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import {
   BIP44_STANDARD_DERIVATION_TEMPLATE,
@@ -16,17 +13,9 @@ import {
   SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
 } from '../../consts/derivation'
 import { Account } from '../../interfaces/account'
-import { IProvidersController } from '../../interfaces/provider'
-import { Storage } from '../../interfaces/storage'
 import { isSmartAccount } from '../../libs/account/account'
 import { getPrivateKeyFromSeed, KeyIterator } from '../../libs/keyIterator/keyIterator'
 import wait from '../../utils/wait'
-import { AccountsController } from '../accounts/accounts'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { ProvidersController } from '../providers/providers'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
 import { AccountPickerController, DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from './accountPicker'
 
 const key1to11BasicAccPublicAddresses = Array.from(
@@ -64,61 +53,11 @@ const basicAccount: Account = {
 }
 
 const prepareTest = async () => {
-  const storage: Storage = produceMemoryStore()
-  let providersCtrl: IProvidersController
-  const storageCtrl = new StorageController(storage)
-  const networksCtrl = new NetworksController({
-    storage: storageCtrl,
-    fetch,
-    relayerUrl,
-    useTempProvider: (props, cb) => {
-      return providersCtrl.useTempProvider(props, cb)
-    },
-    onAddOrUpdateNetworks: () => {},
-    onReady: async () => {
-      await providersCtrl.init({ networks: networksCtrl.allNetworks })
-    }
-  })
-  const { uiManager } = mockUiManager()
-  const uiCtrl = new UiController({ uiManager })
-  providersCtrl = new ProvidersController({
-    storage: storageCtrl,
-    getNetworks: () => networksCtrl.allNetworks,
-    sendUiMessage: () => uiCtrl.message.sendUiMessage
-  })
-
-  const keystoreController = new KeystoreController('default', storageCtrl, {}, uiCtrl)
-
-  const accountsCtrl = new AccountsController(
-    storageCtrl,
-    providersCtrl,
-    networksCtrl,
-    keystoreController,
-    () => {},
-    () => {},
-    () => {},
-    relayerUrl,
-    fetch
-  )
-
-  await accountsCtrl.initialLoadPromise
-  await providersCtrl.initialLoadPromise
-  await networksCtrl.initialLoadPromise
-
-  const controller: AccountPickerController = new AccountPickerController({
-    accounts: accountsCtrl,
-    keystore: new KeystoreController('default', storageCtrl, {}, uiCtrl),
-    networks: networksCtrl,
-    providers: providersCtrl,
-    relayerUrl,
-    fetch,
-    externalSignerControllers: {},
-    onAddAccountsSuccessCallback: () => Promise.resolve()
-  })
+  const { mainCtrl } = await makeMainController()
 
   return {
-    controller,
-    storageCtrl
+    controller: mainCtrl.accountPicker as AccountPickerController,
+    storageCtrl: null
   }
 }
 

--- a/src/controllers/accountPicker/accountPicker.test.ts
+++ b/src/controllers/accountPicker/accountPicker.test.ts
@@ -16,7 +16,7 @@ import { Account } from '../../interfaces/account'
 import { isSmartAccount } from '../../libs/account/account'
 import { getPrivateKeyFromSeed, KeyIterator } from '../../libs/keyIterator/keyIterator'
 import wait from '../../utils/wait'
-import { AccountPickerController, DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from './accountPicker'
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from './accountPicker'
 
 const key1to11BasicAccPublicAddresses = Array.from(
   { length: 11 },
@@ -55,9 +55,10 @@ const basicAccount: Account = {
 const prepareTest = async () => {
   const { mainCtrl } = await makeMainController()
 
+  await mainCtrl.keystore.initialLoadPromise
+
   return {
-    controller: mainCtrl.accountPicker as AccountPickerController,
-    storageCtrl: null
+    controller: mainCtrl.accountPicker
   }
 }
 

--- a/src/controllers/accounts/accounts.test.ts
+++ b/src/controllers/accounts/accounts.test.ts
@@ -1,96 +1,51 @@
-import fetch from 'node-fetch'
-
 import { describe, expect, test } from '@jest/globals'
 
-import { relayerUrl } from '../../../test/config'
-import {
-  mockInternalKeys,
-  produceMemoryStore,
-  waitForAccountsCtrlFirstLoad
-} from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { mockInternalKeys } from '../../../test/helpers'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { IAccountsController } from '../../interfaces/account'
-import { IProvidersController } from '../../interfaces/provider'
-import { Storage } from '../../interfaces/storage'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { ProvidersController } from '../providers/providers'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
-import { AccountsController } from './accounts'
+
+const accounts = [
+  {
+    addr: '0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0',
+    associatedKeys: ['0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0'],
+    initialPrivileges: [],
+    creation: null,
+    preferences: {
+      label: DEFAULT_ACCOUNT_LABEL,
+      pfp: '0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0'
+    }
+  },
+  {
+    addr: '0x71c3D24a627f0416db45107353d8d0A5ae0401ae',
+    associatedKeys: ['0x71c3D24a627f0416db45107353d8d0A5ae0401ae'],
+    initialPrivileges: [],
+    creation: null,
+    preferences: {
+      label: DEFAULT_ACCOUNT_LABEL,
+      pfp: '0x71c3D24a627f0416db45107353d8d0A5ae0401ae'
+    }
+  }
+]
 
 describe('AccountsController', () => {
-  const storage: Storage = produceMemoryStore()
-  const accounts = [
-    {
-      addr: '0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0',
-      associatedKeys: ['0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0'],
-      initialPrivileges: [],
-      creation: null,
-      preferences: {
-        label: DEFAULT_ACCOUNT_LABEL,
-        pfp: '0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0'
-      }
-    },
-    {
-      addr: '0x71c3D24a627f0416db45107353d8d0A5ae0401ae',
-      associatedKeys: ['0x71c3D24a627f0416db45107353d8d0A5ae0401ae'],
-      initialPrivileges: [],
-      creation: null,
-      preferences: {
-        label: DEFAULT_ACCOUNT_LABEL,
-        pfp: '0x71c3D24a627f0416db45107353d8d0A5ae0401ae'
-      }
-    }
-  ]
-
-  const mockKeys = mockInternalKeys(accounts)
-
-  storage.set('keystoreKeys', mockKeys)
-
-  let providersCtrl: IProvidersController
-  const storageCtrl = new StorageController(storage)
-  const networksCtrl = new NetworksController({
-    storage: storageCtrl,
-    fetch,
-    relayerUrl,
-    useTempProvider: (props, cb) => {
-      return providersCtrl.useTempProvider(props, cb)
-    },
-    onAddOrUpdateNetworks: () => {},
-    onReady: async () => {
-      await providersCtrl.init({ networks: networksCtrl.allNetworks })
-    }
-  })
-  const { uiManager } = mockUiManager()
-  const uiCtrl = new UiController({ uiManager })
-  providersCtrl = new ProvidersController({
-    storage: storageCtrl,
-    getNetworks: () => networksCtrl.allNetworks,
-    sendUiMessage: () => uiCtrl.message.sendUiMessage
-  })
-
   let accountsCtrl: IAccountsController
-  test('should init AccountsController', async () => {
-    await storageCtrl.set('accounts', accounts)
-    await storageCtrl.set('selectedAccount', accounts[0]!.addr)
 
-    accountsCtrl = new AccountsController(
-      storageCtrl,
-      providersCtrl,
-      networksCtrl,
-      new KeystoreController('default', storageCtrl, {}, uiCtrl),
-      () => {},
-      () => {},
-      () => {},
-      relayerUrl,
-      fetch
+  test('should init AccountsController', async () => {
+    const mockKeys = mockInternalKeys(accounts)
+    const { mainCtrl } = await makeMainController(
+      async (storageCtrl) => {
+        await storageCtrl.set('accounts', accounts)
+        await storageCtrl.set('selectedAccount', accounts[0]!.addr)
+        await storageCtrl.set('keystoreKeys', mockKeys)
+      },
+      { skipAccountStateLoad: false }
     )
+
+    accountsCtrl = mainCtrl.accounts
 
     expect(accountsCtrl).toBeDefined()
 
-    await waitForAccountsCtrlFirstLoad(accountsCtrl)
     expect(accountsCtrl.areAccountStatesLoading).toBe(false)
   })
   test('update account preferences', async () => {
@@ -116,9 +71,9 @@ describe('AccountsController', () => {
     expect(Object.keys(accountsCtrl.accountStates).length).toBeGreaterThan(0)
     expect(accountsCtrl.areAccountStatesLoading).toBe(false)
 
-    await accountsCtrl.removeAccountData('0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0')
+    accountsCtrl.removeAccountData('0xAa0e9a1E2D2CcF2B867fda047bb5394BEF1883E0')
 
-    await accountsCtrl.removeAccountData('0x71c3D24a627f0416db45107353d8d0A5ae0401ae')
+    accountsCtrl.removeAccountData('0x71c3D24a627f0416db45107353d8d0A5ae0401ae')
 
     expect(accountsCtrl.accounts.length).toEqual(0)
     expect(Object.keys(accountsCtrl.accountStates).length).toEqual(0)

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -149,7 +149,7 @@ export class AccountsController extends EventEmitter implements IAccountsControl
     // NOTE: YOU MUST USE waitForAccountsCtrlFirstLoad IN TESTS
     // TO ENSURE ACCOUNT STATE IS LOADED
     // --------------------------------------------------
-    this.accountStateInitialLoadPromise = this.#updateAccountStates(
+    this.accountStateInitialLoadPromise = this.updateAccountStates(
       this.#getAccountsToUpdateAccountStatesInBackground(initialSelectedAccountAddr)
     ).finally(() => {
       this.accountStateInitialLoadPromise = undefined
@@ -180,10 +180,10 @@ export class AccountsController extends EventEmitter implements IAccountsControl
 
     const accountData = this.accounts.find((account) => account.addr === accountAddr)
     if (!accountData) return
-    await this.#updateAccountStates([accountData], blockTag, networks)
+    await this.updateAccountStates([accountData], blockTag, networks)
   }
 
-  async #updateAccountStates(
+  private async updateAccountStates(
     accounts: Account[],
     blockTag: string | number = 'latest',
     updateOnlyNetworksWithIds: bigint[] = []
@@ -307,7 +307,7 @@ export class AccountsController extends EventEmitter implements IAccountsControl
 
     // update the state of new accounts. Otherwise, the user needs to restart his extension
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.#updateAccountStates(newAccountsNotAddedYet)
+    this.updateAccountStates(newAccountsNotAddedYet)
 
     this.emitUpdate()
   }

--- a/src/controllers/activity/activity.test.ts
+++ b/src/controllers/activity/activity.test.ts
@@ -2,33 +2,12 @@ import fetch from 'node-fetch'
 
 import { describe, expect } from '@jest/globals'
 
-import { relayerUrl, velcroUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
-import { networks } from '../../consts/networks'
-import { IAccountsController } from '../../interfaces/account'
-import { INetworksController } from '../../interfaces/network'
-import { IPortfolioController } from '../../interfaces/portfolio'
-import { RPCProviders } from '../../interfaces/provider'
-import { ISelectedAccountController } from '../../interfaces/selectedAccount'
+import { IMainController } from '../../interfaces/main'
+import { IStorageController, Storage } from '../../interfaces/storage'
 import * as submittedAccountOp from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
-import { relayerCall } from '../../libs/relayerCall/relayerCall'
-import { getRpcProvider } from '../../services/provider'
-import { AccountsController } from '../accounts/accounts'
-import { AutoLoginController } from '../autoLogin/autoLogin'
-import { BannerController } from '../banner/banner'
-import { FeatureFlagsController } from '../featureFlags/featureFlags'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { PortfolioController } from '../portfolio/portfolio'
-import { ProvidersController } from '../providers/providers'
-import { SafeController } from '../safe/safe'
-import { SelectedAccountController } from '../selectedAccount/selectedAccount'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
 import { ActivityController } from './activity'
 import { SignedMessage } from './types'
 
@@ -116,44 +95,21 @@ const SIGNED_MESSAGE: SignedMessage = {
   chainId: 1n
 }
 
-const providers: RPCProviders = {}
-
-networks.forEach((network) => {
-  providers[network.chainId.toString()] = getRpcProvider(network.rpcUrls, network.chainId)
-  providers[network.chainId.toString()]!.isWorking = true
-})
-
-const callRelayer = relayerCall.bind({ url: '', fetch })
-
-let providersCtrl: ProvidersController
-let portfolioCtrl: IPortfolioController
-let accountsCtrl: IAccountsController
-let selectedAccountCtrl: ISelectedAccountController
-let networksCtrl: INetworksController
-
-const storage = produceMemoryStore()
-const storageCtrl = new StorageController(storage)
-
-const { uiManager } = mockUiManager()
-const uiCtrl = new UiController({ uiManager })
+let mainCtrl: IMainController
+let storageCtrl: IStorageController
+let storage: Storage
 
 const prepareTest = async () => {
-  const safe = new SafeController({
-    networks: networksCtrl,
-    providers: providersCtrl,
-    storage: storageCtrl,
-    accounts: accountsCtrl
-  })
   const controller = new ActivityController(
-    storageCtrl,
+    mainCtrl.storage,
     fetch,
-    callRelayer,
-    accountsCtrl,
-    selectedAccountCtrl,
-    providersCtrl,
-    networksCtrl,
-    portfolioCtrl,
-    safe,
+    mainCtrl.callRelayer,
+    mainCtrl.accounts,
+    mainCtrl.selectedAccount,
+    mainCtrl.providers,
+    mainCtrl.networks,
+    mainCtrl.portfolio,
+    mainCtrl.safe,
     () => Promise.resolve()
   )
 
@@ -169,22 +125,16 @@ const prepareTest = async () => {
 }
 
 const prepareSignedMessagesTest = async () => {
-  const safe = new SafeController({
-    networks: networksCtrl,
-    providers: providersCtrl,
-    storage: storageCtrl,
-    accounts: accountsCtrl
-  })
   const controller = new ActivityController(
-    storageCtrl,
+    mainCtrl.storage,
     fetch,
-    callRelayer,
-    accountsCtrl,
-    selectedAccountCtrl,
-    providersCtrl,
-    networksCtrl,
-    portfolioCtrl,
-    safe,
+    mainCtrl.callRelayer,
+    mainCtrl.accounts,
+    mainCtrl.selectedAccount,
+    mainCtrl.providers,
+    mainCtrl.networks,
+    mainCtrl.portfolio,
+    mainCtrl.safe,
     () => Promise.resolve()
   )
 
@@ -200,74 +150,10 @@ describe('Activity Controller ', () => {
   // Otherwise account states will be fetched in every tests and the RPC may timeout or throw
   // errors
   beforeAll(async () => {
-    await storageCtrl.set('accounts', ACCOUNTS)
-
-    networksCtrl = new NetworksController({
-      storage: storageCtrl,
-      fetch,
-      relayerUrl,
-      useTempProvider: (props, cb) => {
-        return providersCtrl.useTempProvider(props, cb)
-      },
-      onAddOrUpdateNetworks: (nets) => {
-        nets.forEach((n) => {
-          providersCtrl.setProvider(n)
-        })
-      },
-      onReady: async () => {
-        await providersCtrl.init({ networks: networksCtrl.allNetworks })
-      }
-    })
-    providersCtrl = new ProvidersController({
-      storage: storageCtrl,
-      getNetworks: () => networksCtrl.allNetworks,
-      sendUiMessage: () => uiCtrl.message.sendUiMessage
-    })
-
-    const keystore = new KeystoreController('default', storageCtrl, {}, uiCtrl)
-    accountsCtrl = new AccountsController(
-      storageCtrl,
-      providersCtrl,
-      networksCtrl,
-      keystore,
-      () => {},
-      () => {},
-      () => {},
-      relayerUrl,
-      fetch
-    )
-    const featureFlagsCtrl = new FeatureFlagsController({}, storageCtrl)
-    portfolioCtrl = new PortfolioController(
-      storageCtrl,
-      fetch,
-      providersCtrl,
-      networksCtrl,
-      accountsCtrl,
-      keystore,
-      relayerUrl,
-      velcroUrl,
-      new BannerController(storageCtrl),
-      featureFlagsCtrl,
-      () => {}
-    )
-
-    const autoLoginCtrl = new AutoLoginController(
-      storageCtrl,
-      keystore,
-      providersCtrl,
-      networksCtrl,
-      accountsCtrl,
-      {},
-      new InviteController({ relayerUrl, fetch, storage: storageCtrl })
-    )
-    selectedAccountCtrl = new SelectedAccountController({
-      storage: storageCtrl,
-      accounts: accountsCtrl,
-      autoLogin: autoLoginCtrl
-    })
-
-    await selectedAccountCtrl.initialLoadPromise
-    await selectedAccountCtrl.setAccount(ACCOUNTS[1]!)
+    ;({ mainCtrl, storageCtrl, storage } = await makeMainController(async (s) => {
+      await s.set('accounts', ACCOUNTS)
+    }))
+    await mainCtrl.selectedAccount.setAccount(ACCOUNTS[1]!)
   })
 
   // Clear activity storage after each test
@@ -767,7 +653,7 @@ describe('Activity Controller ', () => {
 
       expect(controllerAccountsOps1!.filter(({ chainId }) => chainId === 56n).length).toBe(5)
 
-      await networksCtrl.updateNetwork({ disabled: true }, 56n)
+      await mainCtrl.networks.updateNetwork({ disabled: true }, 56n)
 
       await controller.filterAccountsOps(sessionId, INIT_PARAMS, {
         fromPage: 0,
@@ -781,7 +667,7 @@ describe('Activity Controller ', () => {
           .length
       ).toBe(0)
 
-      await networksCtrl.updateNetwork({ disabled: false }, 56n)
+      await mainCtrl.networks.updateNetwork({ disabled: false }, 56n)
     })
 
     test('Keeps no more than 1000 items', async () => {
@@ -941,22 +827,16 @@ describe('Activity Controller ', () => {
     })
   })
   test('removeAccountData', async () => {
-    const safe = new SafeController({
-      networks: networksCtrl,
-      providers: providersCtrl,
-      storage: storageCtrl,
-      accounts: accountsCtrl
-    })
     const controller = new ActivityController(
-      storageCtrl,
+      mainCtrl.storage,
       fetch,
-      callRelayer,
-      accountsCtrl,
-      selectedAccountCtrl,
-      providersCtrl,
-      networksCtrl,
-      portfolioCtrl,
-      safe,
+      mainCtrl.callRelayer,
+      mainCtrl.accounts,
+      mainCtrl.selectedAccount,
+      mainCtrl.providers,
+      mainCtrl.networks,
+      mainCtrl.portfolio,
+      mainCtrl.safe,
       () => Promise.resolve()
     )
 

--- a/src/controllers/addressBook/addressBook.test.ts
+++ b/src/controllers/addressBook/addressBook.test.ts
@@ -1,27 +1,10 @@
-import fetch from 'node-fetch'
-
 import { expect, jest } from '@jest/globals'
 
-import { relayerUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { Account } from '../../interfaces/account'
-import { IProvidersController } from '../../interfaces/provider'
-import { Storage } from '../../interfaces/storage'
-import { AccountsController } from '../accounts/accounts'
-import { AutoLoginController } from '../autoLogin/autoLogin'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { ProvidersController } from '../providers/providers'
-import { SelectedAccountController } from '../selectedAccount/selectedAccount'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
-import { AddressBookController } from './addressBook'
-
-const storage: Storage = produceMemoryStore()
-const storageCtrl = new StorageController(storage)
+import { IAddressBookController } from '../../interfaces/addressBook'
+import { ISelectedAccountController } from '../../interfaces/selectedAccount'
 
 let errors = 0
 
@@ -61,72 +44,27 @@ const MOCK_ACCOUNTS: Account[] = [
   }
 ]
 
-storage.set('accounts', MOCK_ACCOUNTS)
-
 describe('AddressBookController', () => {
-  let providersCtrl: IProvidersController
-  const networksCtrl = new NetworksController({
-    storage: storageCtrl,
-    fetch,
-    relayerUrl,
-    useTempProvider: (props, cb) => {
-      return providersCtrl.useTempProvider(props, cb)
-    },
-    onAddOrUpdateNetworks: () => {},
-    onReady: async () => {
-      await providersCtrl.init({ networks: networksCtrl.allNetworks })
-    }
-  })
-  const { uiManager } = mockUiManager()
-  const uiCtrl = new UiController({ uiManager })
-  providersCtrl = new ProvidersController({
-    storage: storageCtrl,
-    getNetworks: () => networksCtrl.allNetworks,
-    sendUiMessage: () => uiCtrl.message.sendUiMessage
-  })
+  let addressBookController: IAddressBookController
+  let selectedAccountCtrl: ISelectedAccountController
 
-  const keystore = new KeystoreController('default', storageCtrl, {}, uiCtrl)
-  const accountsCtrl = new AccountsController(
-    storageCtrl,
-    providersCtrl,
-    networksCtrl,
-    keystore,
-    () => {},
-    () => {},
-    () => {},
-    relayerUrl,
-    fetch
-  )
-  const autoLoginCtrl = new AutoLoginController(
-    storageCtrl,
-    keystore,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    {},
-    new InviteController({ relayerUrl, fetch, storage: storageCtrl })
-  )
-  const selectedAccountCtrl = new SelectedAccountController({
-    storage: storageCtrl,
-    accounts: accountsCtrl,
-    autoLogin: autoLoginCtrl
+  beforeAll(async () => {
+    const { mainCtrl } = await makeMainController(async (storageCtrl) => {
+      await storageCtrl.set('accounts', MOCK_ACCOUNTS)
+    })
+    addressBookController = mainCtrl.addressBook
+    selectedAccountCtrl = mainCtrl.selectedAccount
+    // 'any' is on purpose, to override 'emitError' prop (which is protected)
+    ;(addressBookController as any).emitError = mockEmitError
   })
-  const addressBookController = new AddressBookController(
-    storageCtrl,
-    accountsCtrl,
-    selectedAccountCtrl
-  )
 
   const getContactFromName = (name: string) => {
     return addressBookController.contacts.find((contact) => contact.name === name)
   }
 
-  // 'any' is on purpose, to override 'emitError' prop (which is protected)
-  ;(addressBookController as any).emitError = mockEmitError
-
   it('wallet accounts are in contacts', async () => {
     await selectedAccountCtrl.initialLoadPromise
-    await selectedAccountCtrl.setAccount(MOCK_ACCOUNTS[0])
+    await selectedAccountCtrl.setAccount(MOCK_ACCOUNTS[0]!)
     expect(getContactFromName('Account 1')?.isWalletAccount).toBeTruthy()
     expect(getContactFromName('Account 1')?.address).toEqual(
       '0x66fE93c51726e6FD51668B0B0434ffcedD604d08'

--- a/src/controllers/autoLogin/autoLogin.test.ts
+++ b/src/controllers/autoLogin/autoLogin.test.ts
@@ -1,48 +1,13 @@
 import { hexlify, toUtf8Bytes, ZeroAddress } from 'ethers'
-import fetch from 'node-fetch'
 import { createSiweMessage, CreateSiweMessageParameters } from 'viem/siwe'
 
-import { relayerUrl } from '../../../test/config'
-import { mockInternalKeys, produceMemoryStore } from '../../../test/helpers'
+import { mockInternalKeys } from '../../../test/helpers'
 import { suppressConsoleBeforeEach } from '../../../test/helpers/console'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { AutoLoginPolicy, AutoLoginSettings } from '../../interfaces/autoLogin'
-import { IProvidersController } from '../../interfaces/provider'
-import { Storage } from '../../interfaces/storage'
-import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
-import { AccountsController } from '../accounts/accounts'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { ProvidersController } from '../providers/providers'
 import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
 import { AutoLoginController } from './autoLogin'
-
-const storage: Storage = produceMemoryStore()
-let providersCtrl: IProvidersController
-const storageCtrl = new StorageController(storage)
-const networksCtrl = new NetworksController({
-  storage: storageCtrl,
-  fetch,
-  relayerUrl,
-  useTempProvider: (props, cb) => {
-    return providersCtrl.useTempProvider(props, cb)
-  },
-  onAddOrUpdateNetworks: () => {},
-  onReady: async () => {
-    await providersCtrl.init({ networks: networksCtrl.allNetworks })
-  }
-})
-
-const { uiManager } = mockUiManager()
-const uiCtrl = new UiController({ uiManager })
-providersCtrl = new ProvidersController({
-  storage: storageCtrl,
-  getNetworks: () => networksCtrl.allNetworks,
-  sendUiMessage: () => uiCtrl.message.sendUiMessage
-})
 
 const EOA_ACC = {
   addr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
@@ -67,55 +32,14 @@ const prepareTest = async (
   initialSetStorage?: (storageCtrl: StorageController) => Promise<void>
 ) => {
   const mockEOAKeys = mockInternalKeys([EOA_ACC])
-  await storage.set('keystoreKeys', mockEOAKeys)
-  await storage.set('accounts', accounts)
-
-  const keystore = new KeystoreController(
-    'default',
-    storageCtrl,
-    { internal: KeystoreSigner },
-    uiCtrl
-  )
-
-  const accountsCtrl = new AccountsController(
-    storageCtrl,
-    providersCtrl,
-    networksCtrl,
-    keystore,
-    () => {},
-    () => {},
-    () => {},
-    relayerUrl,
-    fetch
-  )
-
-  await networksCtrl.initialLoadPromise
-  await accountsCtrl.initialLoadPromise
-  await keystore.initialLoadPromise
-  await providersCtrl.initialLoadPromise
-  if (initialSetStorage) await initialSetStorage(storageCtrl)
-
-  await accountsCtrl.addAccounts(accounts)
-
-  const autoLogin = new AutoLoginController(
-    storageCtrl,
-    keystore,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    {},
-    new InviteController({
-      relayerUrl,
-      fetch,
-      storage: storageCtrl
-    })
-  )
-
-  await autoLogin.initialLoadPromise
+  const { mainCtrl } = await makeMainController(async (storageCtrl) => {
+    await storageCtrl.set('keystoreKeys', mockEOAKeys)
+    await storageCtrl.set('accounts', accounts)
+    if (initialSetStorage) await initialSetStorage(storageCtrl)
+  })
 
   return {
-    storage,
-    controller: autoLogin
+    controller: mainCtrl.autoLogin
   }
 }
 

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -1,15 +1,10 @@
 /* eslint-disable no-await-in-loop */
-import fetch from 'node-fetch'
 
-/* eslint-disable prettier/prettier */
-import { relayerUrl, velcroUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
 import { suppressConsole } from '../../../test/helpers/console'
-import { mockUiManager } from '../../../test/helpers/ui'
+/* eslint-disable prettier/prettier */
+import { makeMainController } from '../../../test/helpers/mainController'
 import { waitForFnToBeCalledAndExecuted } from '../../../test/recurringTimeout'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
-import * as accountStateLib from '../../libs/accountState/accountState'
-import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
 import { SwapProviderParallelExecutor } from '../../services/swapIntegrators/swapProviderParallelExecutor'
 import wait from '../../utils/wait'
 import EventEmitter from '../eventEmitter/eventEmitter'
@@ -79,29 +74,14 @@ const submittedAccountOp = {
 } as SubmittedAccountOp
 
 const prepareTest = async () => {
-  const storage = produceMemoryStore()
-  await storage.set('accounts', accounts)
-  await storage.set('selectedAccount', '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
-
-  const uiManager = mockUiManager().uiManager
-  jest.spyOn(accountStateLib, 'getAccountState').mockImplementation(async () => {
-    return []
-  })
   jest.spyOn(SwapProviderParallelExecutor.prototype, 'getSupportedChains').mockResolvedValue([])
-  const mainCtrl = new MainController({
-    appVersion: '5.31.0',
-    platform: 'default',
-    storageAPI: storage,
-    fetch,
-    relayerUrl,
-    featureFlags: {},
-    liFiApiKey: '',
-    bungeeApiKey: '',
-    keystoreSigners: { internal: KeystoreSigner },
-    externalSignerControllers: {},
-    uiManager,
-    velcroUrl
-  })
+  const { mainCtrl } = await makeMainController(
+    async (storageCtrl) => {
+      await storageCtrl.set('accounts', accounts)
+      await storageCtrl.set('selectedAccount', '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
+    },
+    { skipContinuousUpdates: false, awaitInitialLoad: false }
+  )
   mainCtrl.portfolio.updateSelectedAccount = jest.fn().mockResolvedValue(undefined)
   mainCtrl.updateSelectedAccountPortfolio = jest.fn().mockImplementation(async () => {
     await wait(500)

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -150,11 +150,8 @@ describe('ContinuousUpdatesController intervals', () => {
       initialFnExecutionsCount + 1
     )
     const updateSelectedAccountCalledTimes = updateSelectedAccountPortfolioSpy.mock.calls.length
-    await mainCtrl.activity.addAccountOp(submittedAccountOp)
-    await jest.advanceTimersByTimeAsync(0)
-    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.updatePortfolioInterval)
     expect(mainCtrl.continuousUpdates!.updatePortfolioInterval.fnExecutionsCount).toBe(
-      initialFnExecutionsCount + 2
+      initialFnExecutionsCount + 1
     )
     expect(updateSelectedAccountPortfolioSpy).toHaveBeenCalledTimes(
       updateSelectedAccountCalledTimes
@@ -164,11 +161,11 @@ describe('ContinuousUpdatesController intervals', () => {
     expect(mainCtrl.continuousUpdates!.updatePortfolioInterval.restart).toHaveBeenCalledTimes(2)
     await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.updatePortfolioInterval)
     expect(mainCtrl.continuousUpdates!.updatePortfolioInterval.fnExecutionsCount).toBe(
-      initialFnExecutionsCount + 3
+      initialFnExecutionsCount + 2
     )
     await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.updatePortfolioInterval)
     expect(mainCtrl.continuousUpdates!.updatePortfolioInterval.fnExecutionsCount).toBe(
-      initialFnExecutionsCount + 4
+      initialFnExecutionsCount + 3
     )
   })
 

--- a/src/controllers/dapps/dapps.test.ts
+++ b/src/controllers/dapps/dapps.test.ts
@@ -4,6 +4,7 @@ import { expect } from '@jest/globals'
 
 import { relayerUrl } from '../../../test/config'
 import { produceMemoryStore } from '../../../test/helpers'
+import { suppressConsole } from '../../../test/helpers/console'
 import { mockUiManager } from '../../../test/helpers/ui'
 import { Session } from '../../classes/session'
 import { predefinedDapps } from '../../consts/dapps/dapps'
@@ -162,6 +163,7 @@ describe('DappsController', () => {
     expect(controller.dapps.some((d) => d.name === 'Lido')).toBe(false)
   })
   test('should retry on fetch and update fail', async () => {
+    const { restore } = suppressConsole()
     jest.useFakeTimers()
     const callCount: Record<string, number> = {}
     const { controller } = await prepareTest(
@@ -225,6 +227,7 @@ describe('DappsController', () => {
     expect(controller.dapps.length).toBeGreaterThan(predefinedDapps.length)
     jest.useRealTimers()
     jest.clearAllTimers()
+    restore()
   })
   test('should add dapp to connect and update blacklisted status', async () => {
     const MOCK_SESSION = new Session({ tabId: 1, url: 'https://test-dApp.com' })
@@ -235,7 +238,7 @@ describe('DappsController', () => {
       meta: { params: {} },
       dappPromises: [
         {
-          dapp: null,
+          id: '',
           resolve: () => {},
           reject: () => {},
           meta: {},

--- a/src/controllers/dapps/dapps.test.ts
+++ b/src/controllers/dapps/dapps.test.ts
@@ -2,93 +2,19 @@ import fetch from 'node-fetch'
 
 import { expect } from '@jest/globals'
 
-import { relayerUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
 import { suppressConsole } from '../../../test/helpers/console'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { Session } from '../../classes/session'
 import { predefinedDapps } from '../../consts/dapps/dapps'
 import mockChains from '../../consts/dapps/mockChains'
 import mockDapps from '../../consts/dapps/mockDapps'
-import { IProvidersController } from '../../interfaces/provider'
-import { IStorageController, Storage } from '../../interfaces/storage'
+import { IStorageController } from '../../interfaces/storage'
 import { DappConnectRequest } from '../../interfaces/userRequest'
-import { AccountsController } from '../accounts/accounts'
-import { AddressBookController } from '../addressBook/addressBook'
-import { AutoLoginController } from '../autoLogin/autoLogin'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { PhishingController } from '../phishing/phishing'
-import { ProvidersController } from '../providers/providers'
-import { SelectedAccountController } from '../selectedAccount/selectedAccount'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
-import { DappsController } from './dapps'
 
 const prepareTest = async (
   storageInit?: (storageController: IStorageController) => Promise<void>,
   getMockFetchImplementation?: (url: string, ...args: any) => Promise<any>
 ) => {
-  const storage: Storage = produceMemoryStore()
-  const storageCtrl = new StorageController(storage)
-
-  !!storageInit && (await storageInit(storageCtrl))
-
-  let providersCtrl: IProvidersController
-  const networksCtrl = new NetworksController({
-    storage: storageCtrl,
-    fetch,
-    relayerUrl,
-    useTempProvider: (props, cb) => {
-      return providersCtrl.useTempProvider(props, cb)
-    },
-    onAddOrUpdateNetworks: () => {},
-    onReady: async () => {
-      await providersCtrl.init({ networks: networksCtrl.allNetworks })
-    }
-  })
-  const { uiManager } = mockUiManager()
-  const uiCtrl = new UiController({ uiManager })
-  providersCtrl = new ProvidersController({
-    storage: storageCtrl,
-    getNetworks: () => networksCtrl.allNetworks,
-    sendUiMessage: () => uiCtrl.message.sendUiMessage
-  })
-  const keystore = new KeystoreController('default', storageCtrl, {}, uiCtrl)
-  const accountsCtrl = new AccountsController(
-    storageCtrl,
-    providersCtrl,
-    networksCtrl,
-    keystore,
-    () => {},
-    () => {},
-    () => {},
-    relayerUrl,
-    fetch
-  )
-  const autoLoginCtrl = new AutoLoginController(
-    storageCtrl,
-    keystore,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    {},
-    new InviteController({ relayerUrl, fetch, storage: storageCtrl })
-  )
-  const selectedAccountCtrl = new SelectedAccountController({
-    storage: storageCtrl,
-    accounts: accountsCtrl,
-    autoLogin: autoLoginCtrl
-  })
-  const addressBookCtrl = new AddressBookController(storageCtrl, accountsCtrl, selectedAccountCtrl)
-
-  const phishingCtrl = new PhishingController({
-    fetch,
-    storage: storageCtrl,
-    addressBook: addressBookCtrl
-  })
-
   const mockFetch = jest.fn()
 
   if (getMockFetchImplementation) {
@@ -114,14 +40,23 @@ const prepareTest = async (
       return fetch(url, ...args)
     })
   }
-  const controller = new DappsController({
-    fetch: mockFetch,
-    appVersion: '1.0.0',
-    storage: storageCtrl,
-    networks: networksCtrl,
-    phishing: phishingCtrl,
-    ui: uiCtrl
-  })
+
+  const { mainCtrl } = await makeMainController(
+    async (storageCtrl) => {
+      if (storageInit) {
+        await storageInit(storageCtrl)
+      }
+    },
+    {
+      awaitInitialLoad: false,
+      skipAppsFetchOnLoad: false,
+      overrides: {
+        fetch: mockFetch
+      }
+    }
+  )
+  const controller = mainCtrl.dapps
+
   await controller.initialLoadPromise
 
   return { controller }

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -1,18 +1,11 @@
-import fetch from 'node-fetch'
-
 import { describe, expect, test } from '@jest/globals'
 
-import { relayerUrl, velcroUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { BIP44_STANDARD_DERIVATION_TEMPLATE } from '../../consts/derivation'
 import { KeyIterator } from '../../libs/keyIterator/keyIterator'
-import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
 import wait from '../../utils/wait'
 import { MainController } from './main'
-
-const uiManager = mockUiManager().uiManager
 
 describe('Main Controller ', () => {
   const accounts = [
@@ -48,33 +41,12 @@ describe('Main Controller ', () => {
     }
   ]
 
-  const storage = produceMemoryStore()
-  const email = 'unufri@ambire.com'
-  storage.set('accounts', accounts)
   let controller: MainController
   test('Init controller', async () => {
-    controller = new MainController({
-      appVersion: '5.31.0',
-      platform: 'default',
-      storageAPI: storage,
-      fetch,
-      relayerUrl,
-      liFiApiKey: '',
-      bungeeApiKey: '',
-      featureFlags: {},
-      keystoreSigners: { internal: KeystoreSigner },
-      externalSignerControllers: {},
-      uiManager,
-      velcroUrl
+    const { mainCtrl } = await makeMainController(async (storageCtrl) => {
+      await storageCtrl.set('accounts', accounts)
     })
-    // eslint-disable-next-line no-promise-executor-return
-    await new Promise((resolve) => {
-      const unsubscribe = controller.onUpdate(() => {
-        unsubscribe()
-        resolve(null)
-      })
-    })
-    // console.dir(controller.accountStates, { depth: null })
+    controller = mainCtrl
     // @TODO
     // expect(states).to
   })
@@ -103,7 +75,7 @@ describe('Main Controller ', () => {
     // console.log(
     //   JSON.stringify(controller.emailVault.emailVaultStates[email].availableSecrets, null, 2)
     // )
-    controller.emailVault?.uploadKeyStoreSecret(email)
+    void controller.emailVault?.uploadKeyStoreSecret('unufri@ambire.com')
     // eslint-disable-next-line no-promise-executor-return
     await new Promise((resolve) => {
       if (controller.emailVault) {
@@ -135,19 +107,8 @@ describe('Main Controller ', () => {
   // })
 
   test('should add an account from the account picker and persist it in accounts', async () => {
-    controller = new MainController({
-      appVersion: '5.31.0',
-      platform: 'default',
-      storageAPI: storage,
-      fetch,
-      relayerUrl,
-      liFiApiKey: '',
-      bungeeApiKey: '',
-      featureFlags: {},
-      uiManager,
-      keystoreSigners: { internal: KeystoreSigner },
-      externalSignerControllers: {},
-      velcroUrl
+    const { mainCtrl: controller } = await makeMainController(async (storageCtrl) => {
+      await storageCtrl.set('accounts', accounts)
     })
 
     let retries = 0
@@ -197,20 +158,7 @@ describe('Main Controller ', () => {
   // FIXME: This test works when fired standalone, but it throws an error when
   // run with the rest of the tests. Figure out wtf.
   test.skip('should add accounts and merge the associated keys of the already added accounts', (done) => {
-    const mainCtrl = new MainController({
-      appVersion: '5.31.0',
-      platform: 'default',
-      storageAPI: storage,
-      fetch,
-      relayerUrl,
-      liFiApiKey: '',
-      bungeeApiKey: '',
-      featureFlags: {},
-      uiManager,
-      keystoreSigners: { internal: KeystoreSigner },
-      externalSignerControllers: {},
-      velcroUrl
-    })
+    const mainCtrl = new MainController({} as any)
 
     mainCtrl.accounts.accounts = [
       {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -375,12 +375,6 @@ export class MainController extends EventEmitter implements IMainController {
       addressBook: this.addressBook
     })
 
-    this.selectedAccount.initControllers({
-      portfolio: this.portfolio,
-      networks: this.networks,
-      providers: this.providers
-    })
-
     this.callRelayer = relayerCall.bind({ url: relayerUrl, fetch: this.fetch })
     this.activity = new ActivityController(
       this.storage,
@@ -651,6 +645,15 @@ export class MainController extends EventEmitter implements IMainController {
     await this.networks.initialLoadPromise
     await this.providers.initialLoadPromise
     await this.accounts.initialLoadPromise
+    await this.portfolio.initialLoadPromise
+    await this.keystore.initialLoadPromise
+
+    this.selectedAccount.initControllers({
+      portfolio: this.portfolio,
+      networks: this.networks,
+      providers: this.providers
+    })
+
     await this.selectedAccount.initialLoadPromise
 
     this.updateSelectedAccountPortfolio()

--- a/src/controllers/networks/networks.test.ts
+++ b/src/controllers/networks/networks.test.ts
@@ -1,19 +1,10 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
-import fetch from 'node-fetch'
-
 import { describe, expect, test } from '@jest/globals'
 
-import { relayerUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { networks as predefinedNetworks } from '../../consts/networks'
-import { ProvidersController } from '../../controllers/providers/providers'
-import { UiController } from '../../controllers/ui/ui'
 import { INetworksController } from '../../interfaces/network'
-import { IProvidersController } from '../../interfaces/provider'
-import { StorageController } from '../storage/storage'
-import { NetworksController } from './networks'
 
 describe('Networks Controller', () => {
   let networksController: INetworksController
@@ -22,31 +13,8 @@ describe('Networks Controller', () => {
   beforeEach(async () => {
     if (skipBeforeEach) return
 
-    const storage = produceMemoryStore()
-    const storageCtrl = new StorageController(storage)
-    let providersCtrl: IProvidersController
-
-    const { uiManager } = mockUiManager()
-    const uiCtrl = new UiController({ uiManager })
-
-    networksController = new NetworksController({
-      storage: storageCtrl,
-      fetch,
-      relayerUrl,
-      useTempProvider: (props, cb) => {
-        return providersCtrl.useTempProvider(props, cb)
-      },
-      onAddOrUpdateNetworks: () => {},
-      onReady: async () => {
-        await providersCtrl.init({ networks: networksController.allNetworks })
-      }
-    })
-    providersCtrl = new ProvidersController({
-      storage: storageCtrl,
-      getNetworks: () => networksController.allNetworks,
-      sendUiMessage: () => uiCtrl.message.sendUiMessage
-    })
-    await providersCtrl.initialLoadPromise
+    const { mainCtrl } = await makeMainController(undefined)
+    networksController = mainCtrl.networks
   })
 
   test('should initialize with predefined networks if storage is empty', async () => {
@@ -125,36 +93,13 @@ describe('Networks Controller', () => {
 
   test('should work in testnet mode', async () => {
     skipBeforeEach = true
-    const storage = produceMemoryStore()
-    const storageCtrl = new StorageController(storage)
-    let providersCtrl: IProvidersController
-
-    const testnetNetworksController = new NetworksController({
-      defaultNetworksMode: 'testnet',
-      storage: storageCtrl,
-      fetch,
-      relayerUrl,
-      useTempProvider: (props, cb) => {
-        return providersCtrl.useTempProvider(props, cb)
-      },
-      onAddOrUpdateNetworks: () => {},
-      onReady: async () => {
-        await providersCtrl.init({ networks: testnetNetworksController.allNetworks })
-      }
-    })
-    const { uiManager } = mockUiManager()
-    const uiCtrl = new UiController({ uiManager })
-    providersCtrl = new ProvidersController({
-      storage: storageCtrl,
-      getNetworks: () => testnetNetworksController.allNetworks,
-      sendUiMessage: () => uiCtrl.message.sendUiMessage
+    const { mainCtrl } = await makeMainController(undefined, {
+      overrides: { featureFlags: { testnetMode: true } }
     })
 
-    await testnetNetworksController.initialLoadPromise
-    expect(testnetNetworksController.networks.find((n) => n.chainId === 1n)).toBe(undefined)
-    expect(testnetNetworksController.networks.find((n) => n.chainId === 11155111n)).not.toBe(
-      undefined
-    )
+    await mainCtrl.networks.initialLoadPromise
+    expect(mainCtrl.networks.networks.find((n) => n.chainId === 1n)).toBe(undefined)
+    expect(mainCtrl.networks.networks.find((n) => n.chainId === 11155111n)).not.toBe(undefined)
   })
 
   // TODO: Refactor Fantom test as well

--- a/src/controllers/phishing/phishing.test.ts
+++ b/src/controllers/phishing/phishing.test.ts
@@ -1,105 +1,25 @@
-import fetch from 'node-fetch'
-
 import { expect } from '@jest/globals'
 
-import { relayerUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
-import { IProvidersController } from '../../interfaces/provider'
-import { Storage } from '../../interfaces/storage'
-import { AccountsController } from '../accounts/accounts'
-import { AddressBookController } from '../addressBook/addressBook'
-import { AutoLoginController } from '../autoLogin/autoLogin'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { ProvidersController } from '../providers/providers'
-import { SelectedAccountController } from '../selectedAccount/selectedAccount'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
-import { PhishingController } from './phishing'
+import { makeMainController } from '../../../test/helpers/mainController'
 
 const prepareTest = async () => {
-  const storage: Storage = produceMemoryStore()
-  const storageCtrl = new StorageController(storage)
-
-  await storageCtrl.set('domainsBlacklistedStatus', {
-    'foourmemez.com': {
-      status: 'BLACKLISTED',
-      updatedAt: Date.now()
-    },
-    'rewards.ambire.com': {
-      status: 'VERIFIED',
-      updatedAt: Date.now()
-    }
+  const { mainCtrl } = await makeMainController(async (storageCtrl) => {
+    await storageCtrl.set('domainsBlacklistedStatus', {
+      'foourmemez.com': { status: 'BLACKLISTED', updatedAt: Date.now() },
+      'rewards.ambire.com': { status: 'VERIFIED', updatedAt: Date.now() }
+    })
+    await storageCtrl.set('addressesBlacklistedStatus', {
+      '0x20a9ff01b49cd8967cdd8081c547236eed1d1a4e': {
+        status: 'BLACKLISTED',
+        updatedAt: Date.now()
+      },
+      '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45': {
+        status: 'VERIFIED',
+        updatedAt: Date.now()
+      }
+    })
   })
-  await storageCtrl.set('addressesBlacklistedStatus', {
-    '0x20a9ff01b49cd8967cdd8081c547236eed1d1a4e': {
-      status: 'BLACKLISTED',
-      updatedAt: Date.now()
-    },
-    '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45': {
-      status: 'VERIFIED',
-      updatedAt: Date.now()
-    }
-  })
-
-  let providersCtrl: IProvidersController
-  const networksCtrl = new NetworksController({
-    storage: storageCtrl,
-    fetch,
-    relayerUrl,
-    useTempProvider: (props, cb) => {
-      return providersCtrl.useTempProvider(props, cb)
-    },
-    onAddOrUpdateNetworks: () => {},
-    onReady: async () => {
-      await providersCtrl.init({ networks: networksCtrl.allNetworks })
-    }
-  })
-  const { uiManager } = mockUiManager()
-  const uiCtrl = new UiController({ uiManager })
-  providersCtrl = new ProvidersController({
-    storage: storageCtrl,
-    getNetworks: () => networksCtrl.allNetworks,
-    sendUiMessage: () => uiCtrl.message.sendUiMessage
-  })
-  const keystore = new KeystoreController('default', storageCtrl, {}, uiCtrl)
-  const accountsCtrl = new AccountsController(
-    storageCtrl,
-    providersCtrl,
-    networksCtrl,
-    keystore,
-    () => {},
-    () => {},
-    () => {},
-    relayerUrl,
-    fetch
-  )
-  const autoLoginCtrl = new AutoLoginController(
-    storageCtrl,
-    keystore,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    {},
-    new InviteController({ relayerUrl, fetch, storage: storageCtrl })
-  )
-  const selectedAccountCtrl = new SelectedAccountController({
-    storage: storageCtrl,
-    accounts: accountsCtrl,
-    autoLogin: autoLoginCtrl
-  })
-  const addressBookCtrl = new AddressBookController(storageCtrl, accountsCtrl, selectedAccountCtrl)
-
-  const controller = new PhishingController({
-    fetch,
-    storage: storageCtrl,
-    addressBook: addressBookCtrl
-  })
-  await controller.initialLoadPromise
-
-  return { controller }
+  return { controller: mainCtrl.phishing }
 }
 
 describe('PhishingController', () => {

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -203,7 +203,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
   #featureFlags: IFeatureFlagsController
 
   // Holds the initial load promise, so that one can wait until it completes
-  #initialLoadPromise?: Promise<void>
+  initialLoadPromise?: Promise<void>
 
   defiSessionIds: string[] = []
 
@@ -302,8 +302,8 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         dedupeByKeys: ['chainId', 'accountAddr']
       }
     )
-    this.#initialLoadPromise = this.#load().finally(() => {
-      this.#initialLoadPromise = undefined
+    this.initialLoadPromise = this.#load().finally(() => {
+      this.initialLoadPromise = undefined
     })
   }
 
@@ -417,7 +417,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     selectedAccountAddr?: string,
     shouldUpdatePortfolio?: boolean
   ) {
-    await this.#initialLoadPromise
+    await this.initialLoadPromise
     const isTokenAlreadyAdded = this.customTokens.some(
       ({ address, chainId }) =>
         address.toLowerCase() === customToken.address.toLowerCase() &&
@@ -440,7 +440,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     selectedAccountAddr?: string,
     shouldUpdatePortfolio?: boolean
   ) {
-    await this.#initialLoadPromise
+    await this.initialLoadPromise
     this.customTokens = this.customTokens.filter(
       (token) =>
         !(
@@ -470,7 +470,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     selectedAccountAddr?: string,
     shouldUpdatePortfolio?: boolean
   ) {
-    await this.#initialLoadPromise
+    await this.initialLoadPromise
 
     const existingPreference = this.tokenPreferences.find(
       ({ address, chainId }) =>
@@ -577,7 +577,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     accountId: AccountId,
     allNetworks: boolean = false
   ) {
-    await this.#initialLoadPromise
+    await this.initialLoadPromise
     if (this.validTokens.erc20[`${token.address}-${token.chainId}`]?.isValid === true) return
 
     const provider = this.#providers.providers[token.chainId.toString()]
@@ -1402,7 +1402,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       isManualUpdate,
       isSignAccountOpSimulation
     } = opts || {}
-    await this.#initialLoadPromise
+    await this.initialLoadPromise
     const selectedAccount = this.#accounts.accounts.find((x) => x.addr === accountId)
     if (!selectedAccount)
       throw new Error(
@@ -1795,7 +1795,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     key: `${string}:${string}`,
     chainId: bigint
   ): Promise<boolean> {
-    await this.#initialLoadPromise
+    await this.initialLoadPromise
     if (!tokensWithBalance) return false
 
     if (!this.#learnedAssets.erc20s[key]) this.#learnedAssets.erc20s[key] = {}
@@ -1851,7 +1851,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     accountAddr: string,
     chainId: bigint
   ): Promise<boolean> {
-    await this.#initialLoadPromise
+    await this.initialLoadPromise
     if (!nftsData?.length) return false
     const key = `${chainId.toString()}:${accountAddr}`
 

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -1,50 +1,27 @@
-import fetch from 'node-fetch'
+import { ZeroAddress } from 'ethers'
 
 import { describe, expect, test } from '@jest/globals'
 
-import { relayerUrl, velcroUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
+import { relayerUrl } from '../../../test/config'
+import { waitForAccountsCtrlFirstLoad } from '../../../test/helpers'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { mockUiManager } from '../../../test/helpers/ui'
 import { Session } from '../../classes/session'
-import humanizerInfo from '../../consts/humanizer/humanizerInfo.json'
-import { Account } from '../../interfaces/account'
-import { IRequestsController } from '../../interfaces/requests'
 import {
   BenzinUserRequest,
   CallsUserRequest,
   DappConnectRequest,
   UserRequest
 } from '../../interfaces/userRequest'
-import { HumanizerMeta } from '../../libs/humanizer/interfaces'
-import { relayerCall } from '../../libs/relayerCall/relayerCall'
-import { AccountsController } from '../accounts/accounts'
-import { ActivityController } from '../activity/activity'
-import { AddressBookController } from '../addressBook/addressBook'
-import { AutoLoginController } from '../autoLogin/autoLogin'
-import { BannerController } from '../banner/banner'
 import { EventEmitterRegistryController } from '../eventEmitterRegistry/eventEmitterRegistry'
-import { FeatureFlagsController } from '../featureFlags/featureFlags'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { PhishingController } from '../phishing/phishing'
-import { PortfolioController } from '../portfolio/portfolio'
-import { ProvidersController } from '../providers/providers'
-import { SafeController } from '../safe/safe'
-import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 import { SignAccountOpController } from '../signAccountOp/signAccountOp'
-import { StorageController } from '../storage/storage'
-import { SocketAPIMock } from '../swapAndBridge/socketApiMock'
-import { SwapAndBridgeController } from '../swapAndBridge/swapAndBridge'
-import { TransferController } from '../transfer/transfer'
-import { UiController } from '../ui/ui'
 import { RequestsController } from './requests'
 
 const { uiManager, getWindowId, eventEmitter: event } = mockUiManager()
 
 const MOCK_SESSION = new Session({ tabId: 1, url: 'https://test-dApp.com' })
 
-const accounts: Account[] = [
+const accounts = [
   {
     addr: '0xa07D75aacEFd11b425AF7181958F0F85c312f143',
     associatedKeys: ['0xd6e371526cdaeE04cd8AF225D42e37Bc14688D9E'],
@@ -92,164 +69,14 @@ const accounts: Account[] = [
   }
 ]
 
-const waitForAccountsCtrlFirstLoad = async (accountsCtrl: AccountsController) => {
-  return new Promise<void>((resolve) => {
-    const unsubscribe = accountsCtrl.onUpdate(() => {
-      if (
-        accountsCtrl.accounts.length &&
-        Object.keys(accountsCtrl.accountStates).length &&
-        !accountsCtrl.areAccountStatesLoading
-      ) {
-        unsubscribe()
-        resolve()
-      }
-    })
-  })
-}
-
 const prepareTest = async () => {
-  const storage = produceMemoryStore()
-  await storage.set('accounts', accounts)
-  await storage.set('selectedAccount', '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
-  const storageCtrl = new StorageController(storage)
-  const uiCtrl = new UiController({ uiManager })
-  const keystore = new KeystoreController('default', storageCtrl, {}, uiCtrl)
-  let providersCtrl: ProvidersController
-  const networksCtrl = new NetworksController({
-    storage: storageCtrl,
-    fetch,
-    relayerUrl,
-    useTempProvider: (props, cb) => {
-      return providersCtrl.useTempProvider(props, cb)
+  const { mainCtrl } = await makeMainController(
+    async (storageCtrl) => {
+      await storageCtrl.set('accounts', accounts)
+      await storageCtrl.set('selectedAccount', '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
     },
-    onAddOrUpdateNetworks: () => {},
-    onReady: async () => {
-      await providersCtrl.init({ networks: networksCtrl.allNetworks })
-    }
-  })
-  providersCtrl = new ProvidersController({
-    storage: storageCtrl,
-    getNetworks: () => networksCtrl.allNetworks,
-    sendUiMessage: () => uiCtrl.message.sendUiMessage
-  })
-  const accountsCtrl = new AccountsController(
-    storageCtrl,
-    providersCtrl,
-    networksCtrl,
-    keystore,
-    () => {},
-    () => {},
-    () => {},
-    relayerUrl,
-    fetch
+    { skipAccountStateLoad: false }
   )
-
-  const keystoreCtrl = new KeystoreController('default', storageCtrl, {}, uiCtrl)
-
-  const autoLoginCtrl = new AutoLoginController(
-    storageCtrl,
-    keystoreCtrl,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    {},
-    new InviteController({ relayerUrl, fetch, storage: storageCtrl })
-  )
-
-  const selectedAccountCtrl = new SelectedAccountController({
-    storage: storageCtrl,
-    accounts: accountsCtrl,
-    autoLogin: autoLoginCtrl
-  })
-
-  const addressBookCtrl = new AddressBookController(storageCtrl, accountsCtrl, selectedAccountCtrl)
-
-  await addressBookCtrl.initialLoadPromise
-
-  const phishingCtrl = new PhishingController({
-    fetch,
-    storage: storageCtrl,
-    addressBook: addressBookCtrl
-  })
-
-  const featureFlagsCtrl = new FeatureFlagsController({}, storageCtrl)
-  const portfolioCtrl = new PortfolioController(
-    storageCtrl,
-    fetch,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    keystore,
-    relayerUrl,
-    velcroUrl,
-    new BannerController(storageCtrl),
-    featureFlagsCtrl,
-    () => {}
-  )
-  const callRelayer = relayerCall.bind({ url: '', fetch })
-  const safe = new SafeController({
-    networks: networksCtrl,
-    providers: providersCtrl,
-    storage: storageCtrl,
-    accounts: accountsCtrl
-  })
-  const activityCtrl = new ActivityController(
-    storageCtrl,
-    fetch,
-    callRelayer,
-    accountsCtrl,
-    selectedAccountCtrl,
-    providersCtrl,
-    networksCtrl,
-    portfolioCtrl,
-    safe,
-    () => Promise.resolve()
-  )
-
-  const transferCtrl = new TransferController(
-    () => {},
-    storageCtrl,
-    humanizerInfo as HumanizerMeta,
-    selectedAccountCtrl,
-    networksCtrl,
-    addressBookCtrl,
-    accountsCtrl,
-    keystoreCtrl,
-    portfolioCtrl,
-    activityCtrl,
-    {},
-    providersCtrl,
-    phishingCtrl,
-    relayerUrl,
-    () => Promise.resolve(),
-    uiCtrl
-  )
-
-  const requestsController: IRequestsController = {} as IRequestsController
-
-  const swapAndBridgeCtrl = new SwapAndBridgeController({
-    callRelayer: () => {},
-    selectedAccount: selectedAccountCtrl,
-    networks: networksCtrl,
-    accounts: accountsCtrl,
-    activity: activityCtrl,
-    storage: storageCtrl,
-    swapProvider: new SocketAPIMock({ fetch, apiKey: '' }) as any,
-    keystore,
-    portfolio: portfolioCtrl,
-    providers: providersCtrl,
-    phishing: phishingCtrl,
-    externalSignerControllers: {},
-    relayerUrl,
-    getUserRequests: () => {
-      return requestsController?.userRequests || []
-    },
-    getVisibleUserRequests: () => {
-      return requestsController?.visibleUserRequests || []
-    },
-    onBroadcastSuccess: () => Promise.resolve(),
-    onBroadcastFailed: () => {}
-  })
 
   const eventEmitterRegistry = new EventEmitterRegistryController(() => null)
 
@@ -262,26 +89,25 @@ const prepareTest = async () => {
     chainId: bigint
     requestId: string
   }) => {
-    await accountsCtrl.initialLoadPromise
-    await waitForAccountsCtrlFirstLoad(accountsCtrl)
-    await networksCtrl.initialLoadPromise
-    const account = accountsCtrl.accounts.find((a) => a.addr === addr)!
-    const network = networksCtrl.networks.find((n) => n.chainId === chainId)!
+    await mainCtrl.accounts.initialLoadPromise
+    await mainCtrl.networks.initialLoadPromise
+    const account = mainCtrl.accounts.accounts.find((a) => a.addr === addr)!
+    const network = mainCtrl.networks.networks.find((n) => n.chainId === chainId)!
 
     return new SignAccountOpController({
       type: 'default',
-      callRelayer,
-      accounts: accountsCtrl,
-      networks: networksCtrl,
-      keystore: keystoreCtrl,
-      portfolio: portfolioCtrl,
+      callRelayer: mainCtrl.callRelayer,
+      accounts: mainCtrl.accounts,
+      networks: mainCtrl.networks,
+      keystore: mainCtrl.keystore,
+      portfolio: mainCtrl.portfolio,
       externalSignerControllers: {},
-      activity: activityCtrl,
+      activity: mainCtrl.activity,
       account,
       network,
       eventEmitterRegistry,
-      provider: providersCtrl.providers[network.chainId.toString()]!,
-      phishing: phishingCtrl,
+      provider: mainCtrl.providers.providers[network.chainId.toString()]!,
+      phishing: mainCtrl.phishing,
       fromRequestId: requestId,
       accountOp: {
         accountAddr: addr,
@@ -332,34 +158,37 @@ const prepareTest = async () => {
     } as CallsUserRequest
   }
 
+  const requestsController = new RequestsController({
+    relayerUrl,
+    callRelayer: mainCtrl.callRelayer,
+    portfolio: mainCtrl.portfolio,
+    externalSignerControllers: {},
+    activity: mainCtrl.activity,
+    phishing: mainCtrl.phishing,
+    accounts: mainCtrl.accounts,
+    networks: mainCtrl.networks,
+    providers: mainCtrl.providers,
+    selectedAccount: mainCtrl.selectedAccount,
+    keystore: mainCtrl.keystore,
+    transfer: mainCtrl.transfer,
+    swapAndBridge: mainCtrl.swapAndBridge,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ui: uiManager as any,
+    safe: mainCtrl.safe,
+    autoLogin: mainCtrl.autoLogin,
+    getDapp: async () => undefined,
+    updateSelectedAccountPortfolio: () => Promise.resolve(),
+    addTokensToBeLearned: () => {},
+    onSetCurrentUserRequest: () => {},
+    onBroadcastSuccess: async () => {},
+    onBroadcastFailed: () => {},
+    eventEmitterRegistry,
+    shouldSimulateAccountOps: false
+  })
+
   return {
-    selectedAccountCtrl,
-    controller: new RequestsController({
-      relayerUrl,
-      callRelayer,
-      portfolio: portfolioCtrl,
-      externalSignerControllers: {},
-      activity: activityCtrl,
-      phishing: phishingCtrl,
-      accounts: accountsCtrl,
-      networks: networksCtrl,
-      providers: providersCtrl,
-      selectedAccount: selectedAccountCtrl,
-      keystore: keystoreCtrl,
-      transfer: transferCtrl,
-      swapAndBridge: swapAndBridgeCtrl,
-      ui: uiCtrl,
-      safe,
-      autoLogin: autoLoginCtrl,
-      getDapp: async () => undefined,
-      updateSelectedAccountPortfolio: () => Promise.resolve(),
-      addTokensToBeLearned: () => {},
-      onSetCurrentUserRequest: () => {},
-      onBroadcastSuccess: async () => {},
-      onBroadcastFailed: () => {},
-      eventEmitterRegistry,
-      shouldSimulateAccountOps: false
-    }),
+    selectedAccountCtrl: mainCtrl.selectedAccount,
+    controller: requestsController,
     getSignAccountOp,
     getCallsRequest
   }
@@ -436,6 +265,7 @@ describe('RequestsController ', () => {
           name: 'Ether',
           chainId: 1n,
           decimals: 18,
+          marketDataIn: [],
           priceIn: [],
           flags: {
             onGasTank: false,

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -1,9 +1,6 @@
-import { ZeroAddress } from 'ethers'
-
 import { describe, expect, test } from '@jest/globals'
 
 import { relayerUrl } from '../../../test/config'
-import { waitForAccountsCtrlFirstLoad } from '../../../test/helpers'
 import { makeMainController } from '../../../test/helpers/mainController'
 import { mockUiManager } from '../../../test/helpers/ui'
 import { Session } from '../../classes/session'
@@ -16,8 +13,6 @@ import {
 import { EventEmitterRegistryController } from '../eventEmitterRegistry/eventEmitterRegistry'
 import { SignAccountOpController } from '../signAccountOp/signAccountOp'
 import { RequestsController } from './requests'
-
-const { uiManager, getWindowId, eventEmitter: event } = mockUiManager()
 
 const MOCK_SESSION = new Session({ tabId: 1, url: 'https://test-dApp.com' })
 
@@ -70,13 +65,39 @@ const accounts = [
 ]
 
 const prepareTest = async () => {
-  const { mainCtrl } = await makeMainController(
-    async (storageCtrl) => {
-      await storageCtrl.set('accounts', accounts)
-      await storageCtrl.set('selectedAccount', '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
-    },
-    { skipAccountStateLoad: false }
-  )
+  const { uiManager, getWindowId, eventEmitter: event } = mockUiManager()
+
+  const { mainCtrl } = await makeMainController(async (storageCtrl) => {
+    await storageCtrl.set('accounts', accounts)
+    await storageCtrl.set('selectedAccount', '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
+  })
+
+  // Mock account states for all accounts
+  for (const account of mainCtrl.accounts.accounts) {
+    mainCtrl.accounts.accountStates[account.addr] = {}
+    for (const network of mainCtrl.networks.networks) {
+      mainCtrl.accounts.accountStates[account.addr]![network.chainId.toString()] = {
+        accountAddr: account.addr,
+        isDeployed: true,
+        eoaNonce: null,
+        nonce: 0n,
+        erc4337Nonce: 0n,
+        associatedKeys: [],
+        importedAccountKeys: [],
+        balance: 0n,
+        isEOA: false,
+        isErc4337Enabled: false,
+        isErc4337Nonce: false,
+        isV2: true,
+        currentBlock: 0n,
+        isSmarterEoa: false,
+        delegatedContract: null,
+        delegatedContractName: null,
+        threshold: 1,
+        updatedAt: 0
+      } as any
+    }
+  }
 
   const eventEmitterRegistry = new EventEmitterRegistryController(() => null)
 
@@ -94,7 +115,7 @@ const prepareTest = async () => {
     const account = mainCtrl.accounts.accounts.find((a) => a.addr === addr)!
     const network = mainCtrl.networks.networks.find((n) => n.chainId === chainId)!
 
-    return new SignAccountOpController({
+    const signAccountOp = new SignAccountOpController({
       type: 'default',
       callRelayer: mainCtrl.callRelayer,
       accounts: mainCtrl.accounts,
@@ -132,6 +153,10 @@ const prepareTest = async () => {
       onBroadcastSuccess: async () => {},
       onBroadcastFailed: () => {}
     })
+    // Prevent the recurring estimation timer from reaching V1.getAvailableFeeOptions
+    // (which throws for accounts with no ETH on the test networks).
+    jest.spyOn(signAccountOp.estimation, 'estimate').mockResolvedValue(undefined)
+    return signAccountOp
   }
 
   const getCallsRequest = async ({ addr, chainId }: { addr: string; chainId: bigint }) => {
@@ -172,8 +197,7 @@ const prepareTest = async () => {
     keystore: mainCtrl.keystore,
     transfer: mainCtrl.transfer,
     swapAndBridge: mainCtrl.swapAndBridge,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ui: uiManager as any,
+    ui: uiManager as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     safe: mainCtrl.safe,
     autoLogin: mainCtrl.autoLogin,
     getDapp: async () => undefined,
@@ -190,7 +214,9 @@ const prepareTest = async () => {
     selectedAccountCtrl: mainCtrl.selectedAccount,
     controller: requestsController,
     getSignAccountOp,
-    getCallsRequest
+    getCallsRequest,
+    event,
+    getWindowId
   }
 }
 
@@ -442,7 +468,7 @@ describe('RequestsController ', () => {
     expect(controller.currentUserRequest).toBe(DAPP_CONNECT_REQUEST)
   })
   test('should focus out and then focus on the current request window', async () => {
-    const { controller } = await prepareTest()
+    const { controller, event, getWindowId } = await prepareTest()
 
     await controller.addUserRequests([DAPP_CONNECT_REQUEST])
     event.emit('windowFocusChange', 'random-window-id')

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -1,5 +1,3 @@
-import { generateUuid } from 'utils/uuid'
-
 import { describe, expect, test } from '@jest/globals'
 
 import { relayerUrl } from '../../../test/config'
@@ -12,6 +10,7 @@ import {
   DappConnectRequest,
   UserRequest
 } from '../../interfaces/userRequest'
+import { generateUuid } from '../../utils/uuid'
 import { EventEmitterRegistryController } from '../eventEmitterRegistry/eventEmitterRegistry'
 import { SignAccountOpController } from '../signAccountOp/signAccountOp'
 import { RequestsController } from './requests'

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -398,6 +398,10 @@ describe('SelectedAccount Controller', () => {
       selectedAccountCtrl.portfolio.portfolioState['137']!.criticalError = new Error('Mock error')
       await forceBannerRecalculation(providersCtrl)
 
+      if (selectedAccountCtrl.balanceAffectingErrors.length > 0) {
+        console.error('Balance affecting errors:', selectedAccountCtrl.balanceAffectingErrors)
+      }
+
       expect(selectedAccountCtrl.balanceAffectingErrors.length).toBe(0)
 
       // There is a critical error and lastSuccessfulUpdate is more than 10 minutes ago

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -1,33 +1,16 @@
-import fetch from 'node-fetch'
-
 import { expect } from '@jest/globals'
 
-import { relayerUrl, velcroUrl } from '../../../test/config'
-import { produceMemoryStore } from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { networks } from '../../consts/networks'
 import { IProvidersController } from '../../interfaces/provider'
-import { Storage } from '../../interfaces/storage'
+import { ISelectedAccountController } from '../../interfaces/selectedAccount'
 import { DeFiPositionsError } from '../../libs/defiPositions/types'
-import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
 import { PORTFOLIO_LIB_ERROR_NAMES } from '../../libs/portfolio/portfolio'
 import { stringify } from '../../libs/richJson/richJson'
 import { DEFAULT_SELECTED_ACCOUNT_PORTFOLIO } from '../../libs/selectedAccount/selectedAccount'
 import wait from '../../utils/wait'
-import { AccountsController } from '../accounts/accounts'
-import { AutoLoginController } from '../autoLogin/autoLogin'
-import { BannerController } from '../banner/banner'
 import EventEmitter from '../eventEmitter/eventEmitter'
-import { FeatureFlagsController } from '../featureFlags/featureFlags'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { PortfolioController } from '../portfolio/portfolio'
-import { ProvidersController } from '../providers/providers'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
-import { SelectedAccountController } from './selectedAccount'
 
 const accounts = [
   {
@@ -62,7 +45,7 @@ const accounts = [
   }
 ]
 
-const waitSelectedAccCtrlPortfolioAllReady = (selectedAccountCtrl: SelectedAccountController) => {
+const waitSelectedAccCtrlPortfolioAllReady = (selectedAccountCtrl: ISelectedAccountController) => {
   return new Promise((resolve) => {
     const unsubscribe = selectedAccountCtrl.onUpdate(() => {
       if (selectedAccountCtrl.portfolio.isAllReady) {
@@ -92,109 +75,21 @@ const waitNextControllerUpdate = (ctrl: EventEmitter) => {
 }
 
 const prepareTest = async () => {
-  const storage: Storage = produceMemoryStore()
-  let providersCtrl: IProvidersController
-  const storageCtrl = new StorageController(storage)
-  const networksCtrl = new NetworksController({
-    storage: storageCtrl,
-    fetch,
-    relayerUrl,
-    useTempProvider: (props, cb) => {
-      return providersCtrl.useTempProvider(props, cb)
+  const { mainCtrl } = await makeMainController(
+    async (storageCtrl) => {
+      await storageCtrl.set('accounts', accounts)
+      await storageCtrl.set('selectedAccount', accounts[0]!.addr)
     },
-    onAddOrUpdateNetworks: () => {},
-    onReady: async () => {
-      await providersCtrl.init({ networks: networksCtrl.allNetworks })
-    }
-  })
-
-  const { uiManager } = mockUiManager()
-  const uiCtrl = new UiController({ uiManager })
-
-  providersCtrl = new ProvidersController({
-    storage: storageCtrl,
-    getNetworks: () => networksCtrl.allNetworks,
-    sendUiMessage: () => uiCtrl.message.sendUiMessage
-  })
-
-  // Purposefully mocking these methods as they are not used
-  // and listeners result in a memory leak warning in tests
-  uiCtrl.addView = jest.fn()
-  uiCtrl.removeView = jest.fn()
-  uiCtrl.uiEvent.on = jest.fn()
-
-  const keystore = new KeystoreController(
-    'default',
-    storageCtrl,
-    { internal: KeystoreSigner },
-    uiCtrl
+    { awaitAccountStates: true, skipAccountStateLoad: false }
   )
-
-  await storageCtrl.set('accounts', accounts)
-  await storageCtrl.set('selectedAccount', accounts[0]!.addr)
-
-  const accountsCtrl = new AccountsController(
-    storageCtrl,
-    providersCtrl,
-    networksCtrl,
-    keystore,
-    () => {},
-    () => {},
-    () => {},
-    relayerUrl,
-    fetch
-  )
-
-  const autoLoginCtrl = new AutoLoginController(
-    storageCtrl,
-    keystore,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    {},
-    new InviteController({ relayerUrl, fetch, storage: storageCtrl })
-  )
-
-  const selectedAccountCtrl = new SelectedAccountController({
-    storage: storageCtrl,
-    accounts: accountsCtrl,
-    autoLogin: autoLoginCtrl
-  })
-  const featureFlagsCtrl = new FeatureFlagsController({}, storageCtrl)
-  const portfolioCtrl = new PortfolioController(
-    storageCtrl,
-    fetch,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    keystore,
-    relayerUrl,
-    velcroUrl,
-    new BannerController(storageCtrl),
-    featureFlagsCtrl,
-    () => {}
-  )
-
-  await accountsCtrl.initialLoadPromise
-  await accountsCtrl.accountStateInitialLoadPromise
-  await networksCtrl.initialLoadPromise
-  await providersCtrl.initialLoadPromise
-  await autoLoginCtrl.initialLoadPromise
-  await selectedAccountCtrl.initialLoadPromise
-
-  selectedAccountCtrl.initControllers({
-    portfolio: portfolioCtrl,
-    networks: networksCtrl,
-    providers: providersCtrl
-  })
 
   return {
-    selectedAccountCtrl,
-    portfolioCtrl,
-    providersCtrl,
-    autoLoginCtrl,
-    accountsCtrl,
-    storage
+    selectedAccountCtrl: mainCtrl.selectedAccount,
+    portfolioCtrl: mainCtrl.portfolio,
+    providersCtrl: mainCtrl.providers,
+    autoLoginCtrl: mainCtrl.autoLogin,
+    accountsCtrl: mainCtrl.accounts,
+    storage: mainCtrl.storage
   }
 }
 
@@ -523,9 +418,9 @@ describe('SelectedAccount Controller', () => {
 
       expect(selectedAccountCtrl.balanceAffectingErrors.length).toBe(0)
       // Mock an error
-      jest.spyOn(portfolioCtrl, 'getAccountPortfolioState').mockImplementation(() => ({
+      jest.spyOn(portfolioCtrl, 'getAccountPortfolioState').mockImplementation((() => ({
         '1': mockEthereumDefiErrorState
-      }))
+      })) as any)
       jest.spyOn(portfolioCtrl, 'getNetworksWithDefiPositions').mockImplementation(() => ({
         '1': ['AAVE v3', 'Uniswap V3']
       }))
@@ -552,9 +447,9 @@ describe('SelectedAccount Controller', () => {
 
       expect(selectedAccountCtrl.balanceAffectingErrors.length).toBe(0)
       // Mock an error
-      jest.spyOn(portfolioCtrl, 'getAccountPortfolioState').mockImplementation(() => ({
+      jest.spyOn(portfolioCtrl, 'getAccountPortfolioState').mockImplementation((() => ({
         '1': mockEthereumDefiErrorState
-      }))
+      })) as any)
       // This mocks the case where we have fetched the positions but the user has none
       // and there is a critical error but we don't want to show the banner
       jest.spyOn(portfolioCtrl, 'getNetworksWithDefiPositions').mockImplementation(() => ({
@@ -583,9 +478,9 @@ describe('SelectedAccount Controller', () => {
 
       expect(selectedAccountCtrl.balanceAffectingErrors.length).toBe(0)
       // Mock an error
-      jest.spyOn(portfolioCtrl, 'getAccountPortfolioState').mockImplementation(() => ({
+      jest.spyOn(portfolioCtrl, 'getAccountPortfolioState').mockImplementation((() => ({
         '1': mockEthereumDefiErrorState
-      }))
+      })) as any)
       // This mocks the case where we have never fetched the positions
       // and there is a critical error but we don't want to show the banner
       jest.spyOn(portfolioCtrl, 'getNetworksWithDefiPositions').mockImplementation(() => ({}))

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -75,13 +75,14 @@ const waitNextControllerUpdate = (ctrl: EventEmitter) => {
 }
 
 const prepareTest = async () => {
-  const { mainCtrl } = await makeMainController(
-    async (storageCtrl) => {
-      await storageCtrl.set('accounts', accounts)
-      await storageCtrl.set('selectedAccount', accounts[0]!.addr)
-    },
-    { awaitAccountStates: true, skipAccountStateLoad: false }
-  )
+  const { mainCtrl } = await makeMainController(async (storageCtrl) => {
+    await storageCtrl.set('accounts', accounts)
+    await storageCtrl.set('selectedAccount', accounts[0]!.addr)
+  })
+
+  await mainCtrl.selectedAccount.initialLoadPromise
+  await mainCtrl.autoLogin.initialLoadPromise
+  await mainCtrl.portfolio.initialLoadPromise
 
   return {
     selectedAccountCtrl: mainCtrl.selectedAccount,

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -389,18 +389,22 @@ describe('SelectedAccount Controller', () => {
       ).toBeDefined()
     })
     it('Portfolio error banner lastSuccessfulUpdate logic is working properly', async () => {
-      const { selectedAccountCtrl, portfolioCtrl, providersCtrl } = await prepareTest()
+      const { selectedAccountCtrl, portfolioCtrl, providersCtrl, accountsCtrl } =
+        await prepareTest()
       selectedAccountCtrl.resetSelectedAccountPortfolio()
       await portfolioCtrl.updateSelectedAccount(accountAddr)
       await waitSelectedAccCtrlPortfolioAllReady(selectedAccountCtrl)
 
+      // Mock account state
+      accountsCtrl.accountStates[accountAddr] = {
+        '137': {
+          updatedAt: Date.now()
+        } as any
+      }
+
       // There is a critical error but lastSuccessfulUpdate is less than 10 minutes ago
       selectedAccountCtrl.portfolio.portfolioState['137']!.criticalError = new Error('Mock error')
       await forceBannerRecalculation(providersCtrl)
-
-      if (selectedAccountCtrl.balanceAffectingErrors.length > 0) {
-        console.error('Balance affecting errors:', selectedAccountCtrl.balanceAffectingErrors)
-      }
 
       expect(selectedAccountCtrl.balanceAffectingErrors.length).toBe(0)
 

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -1,13 +1,10 @@
 /* eslint-disable class-methods-use-this */
 
 import { hexlify, randomBytes } from 'ethers'
-import fetch from 'node-fetch'
 
 import { describe, expect, jest, test } from '@jest/globals'
 
-import { relayerUrl } from '../../../test/config'
-import { produceMemoryStore, waitForAccountsCtrlFirstLoad } from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { Account, IAccountsController } from '../../interfaces/account'
 import { Hex } from '../../interfaces/hex'
@@ -17,13 +14,6 @@ import { INetworksController } from '../../interfaces/network'
 import { IProvidersController } from '../../interfaces/provider'
 import { ISignMessageController } from '../../interfaces/signMessage'
 import { Message } from '../../interfaces/userRequest'
-import { AccountsController } from '../accounts/accounts'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { ProvidersController } from '../providers/providers'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
 import { SignMessageController } from './signMessage'
 
 class InternalSigner {
@@ -96,50 +86,18 @@ describe('SignMessageController', () => {
   let inviteCtrl: IInviteController
 
   beforeAll(async () => {
-    const storage = produceMemoryStore()
-    const storageCtrl = new StorageController(storage)
-    await storageCtrl.set('accounts', [account])
-    await storageCtrl.set('selectedAccount', account.addr)
-    const { uiManager } = mockUiManager()
-    const uiCtrl = new UiController({ uiManager })
-    keystoreCtrl = new KeystoreController(
-      'default',
-      storageCtrl,
-      { internal: InternalSigner },
-      uiCtrl
-    )
-    networksCtrl = new NetworksController({
-      storage: storageCtrl,
-      fetch,
-      relayerUrl,
-      useTempProvider: (props, cb) => {
-        return providersCtrl.useTempProvider(props, cb)
+    const { mainCtrl } = await makeMainController(
+      async (storageCtrl) => {
+        await storageCtrl.set('accounts', [account])
+        await storageCtrl.set('selectedAccount', account.addr)
       },
-      onAddOrUpdateNetworks: () => {},
-      onReady: async () => {
-        await providersCtrl.init({ networks: networksCtrl.allNetworks })
-      }
-    })
-    providersCtrl = new ProvidersController({
-      storage: storageCtrl,
-      getNetworks: () => networksCtrl.allNetworks,
-      sendUiMessage: () => uiCtrl.message.sendUiMessage
-    })
-
-    accountsCtrl = new AccountsController(
-      storageCtrl,
-      providersCtrl,
-      networksCtrl,
-      keystoreCtrl,
-      () => {},
-      () => {},
-      () => {},
-      relayerUrl,
-      fetch
+      { skipAccountStateLoad: false, overrides: { keystoreSigners: { internal: InternalSigner } } }
     )
-    inviteCtrl = new InviteController({ relayerUrl, fetch, storage: storageCtrl })
-
-    await waitForAccountsCtrlFirstLoad(accountsCtrl)
+    keystoreCtrl = mainCtrl.keystore
+    networksCtrl = mainCtrl.networks
+    providersCtrl = mainCtrl.providers
+    accountsCtrl = mainCtrl.accounts
+    inviteCtrl = mainCtrl.invite
   })
 
   beforeEach(async () => {

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -1,43 +1,15 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-floating-promises */
-/* eslint-disable class-methods-use-this */
-/* eslint-disable @typescript-eslint/no-useless-constructor */
-/* eslint-disable max-classes-per-file */
 
-import { hexlify, randomBytes } from 'ethers'
 import fetch from 'node-fetch'
 
 import { expect } from '@jest/globals'
 
-import { relayerUrl, velcroUrl } from '../../../test/config'
-import { mockInternalKeys, produceMemoryStore } from '../../../test/helpers'
-import { mockUiManager } from '../../../test/helpers/ui'
+import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { FEE_COLLECTOR } from '../../consts/addresses'
-import humanizerInfo from '../../consts/humanizer/humanizerInfo.json'
 import { networks } from '../../consts/networks'
-import { Account } from '../../interfaces/account'
-import { Hex } from '../../interfaces/hex'
-import { Key, KeystoreSignerInterface } from '../../interfaces/keystore'
-import { HumanizerMeta } from '../../libs/humanizer/interfaces'
 import { TokenResult } from '../../libs/portfolio'
-import { relayerCall } from '../../libs/relayerCall/relayerCall'
-import { AccountsController } from '../accounts/accounts'
-import { ActivityController } from '../activity/activity'
-import { AddressBookController } from '../addressBook/addressBook'
-import { AutoLoginController } from '../autoLogin/autoLogin'
-import { BannerController } from '../banner/banner'
-import { FeatureFlagsController } from '../featureFlags/featureFlags'
-import { InviteController } from '../invite/invite'
-import { KeystoreController } from '../keystore/keystore'
-import { NetworksController } from '../networks/networks'
-import { PhishingController } from '../phishing/phishing'
-import { PortfolioController } from '../portfolio/portfolio'
-import { ProvidersController } from '../providers/providers'
-import { SafeController } from '../safe/safe'
-import { SelectedAccountController } from '../selectedAccount/selectedAccount'
-import { StorageController } from '../storage/storage'
-import { UiController } from '../ui/ui'
 import { TransferController } from './transfer'
 
 const ethereum = networks.find((x) => x.chainId === 1n)
@@ -66,220 +38,20 @@ const account = {
   }
 }
 
-// TODO - this mocks are being duplicated across the tests. Should reuse it.
-class InternalSigner {
-  key
-
-  privKey
-
-  constructor(_key: Key, _privKey?: string) {
-    this.key = _key
-    this.privKey = _privKey
-  }
-
-  signRawTransaction() {
-    return Promise.resolve('')
-  }
-
-  signTypedData() {
-    return Promise.resolve('')
-  }
-
-  signMessage() {
-    return Promise.resolve('')
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  sign7702: KeystoreSignerInterface['sign7702'] = async (s) => {
-    return {
-      yParity: '0x00',
-      r: hexlify(randomBytes(32)) as Hex,
-      s: hexlify(randomBytes(32)) as Hex
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  signTransactionTypeFour: KeystoreSignerInterface['signTransactionTypeFour'] = async (s) => {
-    throw new Error('not supported')
-  }
-}
-
-class LedgerSigner {
-  key
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  constructor(_key: Key) {
-    this.key = _key
-  }
-
-  signRawTransaction() {
-    return Promise.resolve('')
-  }
-
-  signTypedData() {
-    return Promise.resolve('')
-  }
-
-  signMessage() {
-    return Promise.resolve('')
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  sign7702: KeystoreSignerInterface['sign7702'] = async (s) => {
-    return {
-      yParity: '0x00',
-      r: hexlify(randomBytes(32)) as Hex,
-      s: hexlify(randomBytes(32)) as Hex
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  signTransactionTypeFour: KeystoreSignerInterface['signTransactionTypeFour'] = async (s) => {
-    throw new Error('not supported')
-  }
-}
-
-const { uiManager } = mockUiManager()
-
 const getTokens = () => {
   return structuredClone(ETHEREUM_TOKENS.concat(POLYGON_TOKENS))
 }
 
 const prepareTest = async () => {
-  const storage = produceMemoryStore()
-  const storageCtrl = new StorageController(storage)
-
-  const accounts = [account]
-
-  const mockKeys = mockInternalKeys(accounts as Account[])
-
-  storage.set('keystoreKeys', mockKeys)
-
-  storageCtrl.set('accounts', accounts)
-
-  let providersCtrl: any
-
-  const networksCtrl = new NetworksController({
-    storage: storageCtrl,
-    fetch,
-    relayerUrl,
-    useTempProvider: (props, cb) => {
-      return providersCtrl.useTempProvider(props, cb)
-    },
-    onAddOrUpdateNetworks: () => {},
-    onReady: async () => {
-      await providersCtrl.init({ networks: networksCtrl.allNetworks })
-    }
+  const { mainCtrl } = await makeMainController(async (storageCtrl) => {
+    await storageCtrl.set('accounts', [account])
+    await storageCtrl.set('selectedAccount', account.addr)
   })
-
-  const uiCtrl = new UiController({ uiManager })
-  providersCtrl = new ProvidersController({
-    storage: storageCtrl,
-    getNetworks: () => networksCtrl.allNetworks,
-    sendUiMessage: () => uiCtrl.message.sendUiMessage
-  })
-
-  const keystoreSigners = { internal: InternalSigner, ledger: LedgerSigner }
-  const keystoreController = new KeystoreController('default', storageCtrl, keystoreSigners, uiCtrl)
-
-  const accountsCtrl = new AccountsController(
-    storageCtrl,
-    providersCtrl,
-    networksCtrl,
-    keystoreController,
-    () => {},
-    () => {},
-    () => {},
-    relayerUrl,
-    fetch
-  )
-  const autoLoginCtrl = new AutoLoginController(
-    storageCtrl,
-    keystoreController,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    {},
-    new InviteController({ relayerUrl, fetch, storage: storageCtrl })
-  )
-
-  const selectedAccountCtrl = new SelectedAccountController({
-    storage: storageCtrl,
-    accounts: accountsCtrl,
-    autoLogin: autoLoginCtrl
-  })
-
-  const addressBookController = new AddressBookController(
-    storageCtrl,
-    accountsCtrl,
-    selectedAccountCtrl
-  )
-
-  const callRelayer = relayerCall.bind({ url: '', fetch })
-
-  const featureFlagsCtrl = new FeatureFlagsController({}, storageCtrl)
-  const portfolioController = new PortfolioController(
-    storageCtrl,
-    fetch,
-    providersCtrl,
-    networksCtrl,
-    accountsCtrl,
-    keystoreController,
-    relayerUrl,
-    velcroUrl,
-    new BannerController(storageCtrl),
-    featureFlagsCtrl,
-    () => {}
-  )
-  const safe = new SafeController({
-    networks: networksCtrl,
-    providers: providersCtrl,
-    storage: storageCtrl,
-    accounts: accountsCtrl
-  })
-  const activity = new ActivityController(
-    storageCtrl,
-    fetch,
-    callRelayer,
-    accountsCtrl,
-    selectedAccountCtrl,
-    providersCtrl,
-    networksCtrl,
-    portfolioController,
-    safe,
-    () => Promise.resolve()
-  )
-
-  const phishing = new PhishingController({
-    fetch,
-    storage: storageCtrl,
-    addressBook: addressBookController
-  })
-
-  const transferController = new TransferController(
-    () => {},
-    storageCtrl,
-    humanizerInfo as HumanizerMeta,
-    selectedAccountCtrl,
-    networksCtrl,
-    addressBookController,
-    accountsCtrl,
-    keystoreController,
-    portfolioController,
-    activity,
-    {},
-    providersCtrl,
-    phishing,
-    relayerUrl,
-    () => Promise.resolve(),
-    uiCtrl
-  )
-
-  await selectedAccountCtrl.initialLoadPromise
-  await selectedAccountCtrl.setAccount(account)
+  await mainCtrl.selectedAccount.setAccount(account)
+  mainCtrl.transfer.resetForm()
 
   return {
-    transferController,
+    transferController: mainCtrl.transfer as TransferController,
     tokens: getTokens()
   }
 }
@@ -463,7 +235,8 @@ const ETHEREUM_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 2694.55 }]
+    priceIn: [{ baseCurrency: 'usd', price: 2694.55 }],
+    marketDataIn: []
   },
   {
     amount: 0n,
@@ -480,7 +253,8 @@ const ETHEREUM_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 0.01605456 }]
+    priceIn: [{ baseCurrency: 'usd', price: 0.01605456 }],
+    marketDataIn: []
   },
   {
     amount: 0n,
@@ -497,7 +271,8 @@ const ETHEREUM_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 0.32798689176900603 }]
+    priceIn: [{ baseCurrency: 'usd', price: 0.32798689176900603 }],
+    marketDataIn: []
   },
   {
     amount: 58316260607759458104900n,
@@ -514,7 +289,8 @@ const ETHEREUM_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 0.01565007 }]
+    priceIn: [{ baseCurrency: 'usd', price: 0.01565007 }],
+    marketDataIn: []
   }
 ]
 
@@ -534,6 +310,7 @@ const POLYGON_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 0.177387 }]
+    priceIn: [{ baseCurrency: 'usd', price: 0.177387 }],
+    marketDataIn: []
   }
 ]

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -374,6 +374,7 @@ export const validateERC20Token = async (
   let type: 'network' | 'validation' | null = null
 
   const handleERC20Error = (e: any, operation: string) => {
+    console.error('Error during ERC20 validation operation:', operation, e)
     if (isNetworkError(e)) {
       hasNetworkError = true
       isValid = false

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -1,5 +1,5 @@
 import { getAddress, parseUnits } from 'ethers'
-import isEmail from 'validator/es/lib/isEmail'
+import isEmail from 'validator/lib/isEmail'
 
 import { TokenResult } from '../../libs/portfolio'
 import { getTokenAmount } from '../../libs/portfolio/helpers'

--- a/test/helpers/mainController.ts
+++ b/test/helpers/mainController.ts
@@ -1,0 +1,131 @@
+import fetch from 'node-fetch'
+
+import { MainController } from '../../src/controllers/main/main'
+import { StorageController } from '../../src/controllers/storage/storage'
+import * as accountStateLib from '../../src/libs/accountState/accountState'
+import { KeystoreSigner } from '../../src/libs/keystoreSigner/keystoreSigner'
+import { relayerUrl, velcroUrl } from '../config'
+import { produceMemoryStore } from '../helpers'
+import { mockUiManager } from './ui'
+
+import type { FeatureFlags } from '../../src/consts/featureFlags'
+import type {
+  ExternalSignerControllers,
+  Key,
+  KeystoreSignerType
+} from '../../src/interfaces/keystore'
+import type { Platform } from '../../src/interfaces/platform'
+import type { Storage } from '../../src/interfaces/storage'
+
+export interface MakeMainControllerOpts {
+  /** Mock `getAccountState` to return `[]`, skipping real RPC calls. Default: `true`. */
+  skipAccountStateLoad?: boolean
+  /** Don't instantiate `ContinuousUpdatesController`, avoiding lingering timers. Default: `true`. */
+  skipContinuousUpdates?: boolean
+  /**
+   * Await `mainCtrl.initialLoadPromise` before returning. Set to `false` when
+   * using fake timers so you can apply post-construction mocks first. Default: `true`.
+   */
+  awaitInitialLoad?: boolean
+  /** Also await `accounts.accountStateInitialLoadPromise` (ignored when `skipAccountStateLoad` is true). Default: `false`. */
+  awaitAccountStates?: boolean
+  /** Mock `portfolio.updateSelectedAccount` to a no-op, preventing real network calls on load. Default: `true`. */
+  skipPortfolioUpdateOnLoad?: boolean
+  /** Mock `domains.reverseLookup` to a no-op, preventing real domain resolution on load. Default: `true`. */
+  skipDomainsResolveOnLoad?: boolean
+  /** Override any `MainController` constructor params. */
+  overrides?: {
+    appVersion?: string
+    platform?: Platform
+    featureFlags?: Partial<FeatureFlags>
+    liFiApiKey?: string
+    bungeeApiKey?: string
+    externalSignerControllers?: ExternalSignerControllers
+    keystoreSigners?: Partial<{ [key in Key['type']]: KeystoreSignerType }>
+    relayerUrl?: string
+    velcroUrl?: string
+  }
+}
+
+export interface MakeMainControllerResult {
+  mainCtrl: MainController
+  storage: Storage
+  /** The `StorageController` passed to `initialSetStorage`. Note: `mainCtrl.storage` is a separate instance wrapping the same underlying map. */
+  storageCtrl: StorageController
+  /** Restores spies set up by the factory. Call in `afterEach`, or use `jest.restoreAllMocks()`. */
+  restore: () => void
+}
+
+export const makeMainController = async (
+  initialSetStorage?: (storageCtrl: StorageController) => Promise<void> | void,
+  opts: MakeMainControllerOpts = {}
+): Promise<MakeMainControllerResult> => {
+  const {
+    skipAccountStateLoad = true,
+    skipContinuousUpdates = true,
+    awaitInitialLoad = true,
+    awaitAccountStates = true,
+    skipPortfolioUpdateOnLoad = true,
+    skipDomainsResolveOnLoad = true,
+    overrides = {}
+  } = opts
+
+  const storage: Storage = produceMemoryStore()
+
+  // Wrap in StorageController so the caller can pre-seed data via the high-level API.
+  // We pass the same raw instance to MainController so both see the same data.
+  const storageCtrl = new StorageController(storage)
+  if (initialSetStorage) await initialSetStorage(storageCtrl)
+
+  // Must be set up before MainController is constructed since AccountsController.#load()
+  // fires from the constructor and unconditionally calls getAccountState.
+  let accountStateSpy: jest.SpyInstance | undefined
+  if (skipAccountStateLoad) {
+    accountStateSpy = jest.spyOn(accountStateLib, 'getAccountState').mockResolvedValue([])
+  }
+
+  const featureFlags: Partial<FeatureFlags> = {
+    withContinuousUpdatesController: !skipContinuousUpdates,
+    ...overrides.featureFlags
+  }
+
+  const { uiManager } = mockUiManager()
+  const mainCtrl = new MainController({
+    appVersion: overrides.appVersion ?? '5.31.0',
+    platform: overrides.platform ?? 'default',
+    storageAPI: storage,
+    fetch,
+    relayerUrl: overrides.relayerUrl ?? relayerUrl,
+    velcroUrl: overrides.velcroUrl ?? velcroUrl,
+    liFiApiKey: overrides.liFiApiKey ?? '',
+    bungeeApiKey: overrides.bungeeApiKey ?? '',
+    featureFlags,
+    keystoreSigners: overrides.keystoreSigners ?? { internal: KeystoreSigner },
+    externalSignerControllers: overrides.externalSignerControllers ?? {},
+    uiManager
+  })
+
+  // Applied synchronously before any async callbacks run, so the initial load
+  // will use the mocked versions.
+  if (skipPortfolioUpdateOnLoad) {
+    mainCtrl.portfolio.updateSelectedAccount = jest.fn().mockResolvedValue(undefined)
+  }
+  if (skipDomainsResolveOnLoad) {
+    mainCtrl.domains.reverseLookup = jest.fn().mockResolvedValue(undefined)
+  }
+
+  if (awaitInitialLoad) {
+    await mainCtrl.initialLoadPromise
+  }
+
+  if (awaitAccountStates && !skipAccountStateLoad) {
+    await mainCtrl.accounts.accountStateInitialLoadPromise
+  }
+
+  return {
+    mainCtrl,
+    storage,
+    storageCtrl,
+    restore: () => accountStateSpy?.mockRestore()
+  }
+}

--- a/test/helpers/mainController.ts
+++ b/test/helpers/mainController.ts
@@ -1,7 +1,10 @@
 import fetch from 'node-fetch'
 
 import { AccountsController } from '../../src/controllers/accounts/accounts'
+import { DappsController } from '../../src/controllers/dapps/dapps'
 import { MainController } from '../../src/controllers/main/main'
+import { NetworksController } from '../../src/controllers/networks/networks'
+import { PhishingController } from '../../src/controllers/phishing/phishing'
 import { PortfolioController } from '../../src/controllers/portfolio/portfolio'
 import { StorageController } from '../../src/controllers/storage/storage'
 import { KeystoreSigner } from '../../src/libs/keystoreSigner/keystoreSigner'
@@ -32,6 +35,8 @@ export interface MakeMainControllerOpts {
   skipPortfolioUpdateOnLoad?: boolean
   /** Mock `domains.reverseLookup` to a no-op, preventing real domain resolution on load. Default: `true`. */
   skipDomainsResolveOnLoad?: boolean
+  /** Whether to update the app catalog on load. Default: `true`. */
+  skipAppsFetchOnLoad?: boolean
   /** Override any `MainController` constructor params. */
   overrides?: {
     appVersion?: string
@@ -63,6 +68,7 @@ export const makeMainController = async (
     awaitInitialLoad = true,
     skipPortfolioUpdateOnLoad = true,
     skipDomainsResolveOnLoad = true,
+    skipAppsFetchOnLoad = true,
     overrides = {}
   } = opts
 
@@ -84,6 +90,8 @@ export const makeMainController = async (
       })
   }
 
+  // Stop all continuous updates to prevent interference with tests and avoid lingering timers after tests complete
+
   jest
     .spyOn(AccountsController.prototype, 'setViewOnlyAccountIdentitiesIfNeeded')
     .mockImplementation(async () => {
@@ -99,6 +107,22 @@ export const makeMainController = async (
   jest.spyOn(PortfolioController.prototype, 'updateExchangeList').mockImplementation(async () => {
     await wait(1)
   })
+
+  if (skipAppsFetchOnLoad) {
+    jest.spyOn(DappsController.prototype, 'fetchAndUpdateDapps').mockImplementation(async () => {
+      await wait(1)
+    })
+  }
+
+  jest.spyOn(NetworksController.prototype, 'synchronizeNetworks').mockImplementation(async () => {
+    await wait(1)
+  })
+
+  jest
+    .spyOn(PhishingController.prototype, 'continuouslyUpdatePhishing')
+    .mockImplementation(async () => {
+      await wait(1)
+    })
 
   const featureFlags: Partial<FeatureFlags> = {
     withContinuousUpdatesController: !skipContinuousUpdates,

--- a/test/helpers/mainController.ts
+++ b/test/helpers/mainController.ts
@@ -48,6 +48,7 @@ export interface MakeMainControllerOpts {
     keystoreSigners?: Partial<{ [key in Key['type']]: KeystoreSignerType }>
     relayerUrl?: string
     velcroUrl?: string
+    fetch?: any
   }
 }
 
@@ -131,10 +132,10 @@ export const makeMainController = async (
 
   const { uiManager } = mockUiManager()
   const mainCtrl = new MainController({
-    appVersion: overrides.appVersion ?? '5.31.0',
-    platform: overrides.platform ?? 'default',
+    appVersion: overrides.appVersion ?? '1.0.0',
+    platform: overrides.platform ?? 'browser-webkit',
     storageAPI: storage,
-    fetch,
+    fetch: overrides.fetch ?? fetch,
     relayerUrl: overrides.relayerUrl ?? relayerUrl,
     velcroUrl: overrides.velcroUrl ?? velcroUrl,
     liFiApiKey: overrides.liFiApiKey ?? '',

--- a/test/helpers/mainController.ts
+++ b/test/helpers/mainController.ts
@@ -1,9 +1,11 @@
 import fetch from 'node-fetch'
 
+import { AccountsController } from '../../src/controllers/accounts/accounts'
 import { MainController } from '../../src/controllers/main/main'
+import { PortfolioController } from '../../src/controllers/portfolio/portfolio'
 import { StorageController } from '../../src/controllers/storage/storage'
-import * as accountStateLib from '../../src/libs/accountState/accountState'
 import { KeystoreSigner } from '../../src/libs/keystoreSigner/keystoreSigner'
+import wait from '../../src/utils/wait'
 import { relayerUrl, velcroUrl } from '../config'
 import { produceMemoryStore } from '../helpers'
 import { mockUiManager } from './ui'
@@ -16,7 +18,6 @@ import type {
 } from '../../src/interfaces/keystore'
 import type { Platform } from '../../src/interfaces/platform'
 import type { Storage } from '../../src/interfaces/storage'
-
 export interface MakeMainControllerOpts {
   /** Mock `getAccountState` to return `[]`, skipping real RPC calls. Default: `true`. */
   skipAccountStateLoad?: boolean
@@ -27,8 +28,6 @@ export interface MakeMainControllerOpts {
    * using fake timers so you can apply post-construction mocks first. Default: `true`.
    */
   awaitInitialLoad?: boolean
-  /** Also await `accounts.accountStateInitialLoadPromise` (ignored when `skipAccountStateLoad` is true). Default: `false`. */
-  awaitAccountStates?: boolean
   /** Mock `portfolio.updateSelectedAccount` to a no-op, preventing real network calls on load. Default: `true`. */
   skipPortfolioUpdateOnLoad?: boolean
   /** Mock `domains.reverseLookup` to a no-op, preventing real domain resolution on load. Default: `true`. */
@@ -52,8 +51,6 @@ export interface MakeMainControllerResult {
   storage: Storage
   /** The `StorageController` passed to `initialSetStorage`. Note: `mainCtrl.storage` is a separate instance wrapping the same underlying map. */
   storageCtrl: StorageController
-  /** Restores spies set up by the factory. Call in `afterEach`, or use `jest.restoreAllMocks()`. */
-  restore: () => void
 }
 
 export const makeMainController = async (
@@ -64,7 +61,6 @@ export const makeMainController = async (
     skipAccountStateLoad = true,
     skipContinuousUpdates = true,
     awaitInitialLoad = true,
-    awaitAccountStates = true,
     skipPortfolioUpdateOnLoad = true,
     skipDomainsResolveOnLoad = true,
     overrides = {}
@@ -77,12 +73,32 @@ export const makeMainController = async (
   const storageCtrl = new StorageController(storage)
   if (initialSetStorage) await initialSetStorage(storageCtrl)
 
-  // Must be set up before MainController is constructed since AccountsController.#load()
-  // fires from the constructor and unconditionally calls getAccountState.
+  // Must be set up before MainController is constructed
   let accountStateSpy: jest.SpyInstance | undefined
   if (skipAccountStateLoad) {
-    accountStateSpy = jest.spyOn(accountStateLib, 'getAccountState').mockResolvedValue([])
+    accountStateSpy = jest
+      // @ts-ignore
+      .spyOn(AccountsController.prototype, 'updateAccountStates')
+      .mockImplementation(async () => {
+        await wait(1)
+      })
   }
+
+  jest
+    .spyOn(AccountsController.prototype, 'setViewOnlyAccountIdentitiesIfNeeded')
+    .mockImplementation(async () => {
+      await wait(1)
+    })
+
+  jest
+    .spyOn(AccountsController.prototype, 'createSmartAccountIdentitiesIfNeeded')
+    .mockImplementation(async () => {
+      await wait(1)
+    })
+
+  jest.spyOn(PortfolioController.prototype, 'updateExchangeList').mockImplementation(async () => {
+    await wait(1)
+  })
 
   const featureFlags: Partial<FeatureFlags> = {
     withContinuousUpdatesController: !skipContinuousUpdates,
@@ -108,7 +124,7 @@ export const makeMainController = async (
   // Applied synchronously before any async callbacks run, so the initial load
   // will use the mocked versions.
   if (skipPortfolioUpdateOnLoad) {
-    mainCtrl.portfolio.updateSelectedAccount = jest.fn().mockResolvedValue(undefined)
+    mainCtrl.updateSelectedAccountPortfolio = jest.fn().mockResolvedValue(undefined)
   }
   if (skipDomainsResolveOnLoad) {
     mainCtrl.domains.reverseLookup = jest.fn().mockResolvedValue(undefined)
@@ -118,14 +134,13 @@ export const makeMainController = async (
     await mainCtrl.initialLoadPromise
   }
 
-  if (awaitAccountStates && !skipAccountStateLoad) {
-    await mainCtrl.accounts.accountStateInitialLoadPromise
-  }
+  await mainCtrl.accounts.accountStateInitialLoadPromise
+
+  accountStateSpy?.mockRestore()
 
   return {
     mainCtrl,
     storage,
-    storageCtrl,
-    restore: () => accountStateSpy?.mockRestore()
+    storageCtrl
   }
 }


### PR DESCRIPTION
Initialize a main controller instead of copy pasting the same logic to initialize controllers. The initialized controller doesn't do any background requests/async operations unless specified using params.

<img width="577" height="433" alt="image" src="https://github.com/user-attachments/assets/a1e6124a-c3a4-48e1-beb7-00343ba640b1" />
