### PR TITLE
Config/ change source url ambire logo sponsored swap

### DIFF
--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -63,7 +63,7 @@ function getSwapSponsorshipEstimationData(): PaymasterEstimationData {
     ...paymasterData,
     sponsor: {
       name: 'Ambire Wallet',
-      icon: 'https://velcro.ambire.com/public/ambire-logos/symbol-color.svg'
+      icon: 'https://cena.ambire.com/public/ambire-logos/symbol-color.svg'
     }
   }
 }


### PR DESCRIPTION
## Reason
We are deprecating the veelcro, public images are moved to cena

<img width="597" height="603" alt="image" src="https://github.com/user-attachments/assets/f839a62f-bf53-4d02-9c0a-eb79419b58f3" />
