### PR TITLE
Fix/ Portfolio simulation race conditions

### DIFF
--- a/src/controllers/activity/activity.test.ts
+++ b/src/controllers/activity/activity.test.ts
@@ -247,8 +247,7 @@ describe('Activity Controller ', () => {
       relayerUrl,
       velcroUrl,
       new BannerController(storageCtrl),
-      featureFlagsCtrl,
-      () => {}
+      featureFlagsCtrl
     )
 
     const autoLoginCtrl = new AutoLoginController(

--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -208,10 +208,6 @@ export class ContinuousUpdatesController extends EventEmitter {
   async #updatePortfolio() {
     await this.initialLoadPromise
 
-    const selectedAccountBroadcastedButNotConfirmed = this.#main.selectedAccount.account
-      ? this.#main.activity.broadcastedButNotConfirmed[this.#main.selectedAccount.account.addr]
-      : []
-    if (selectedAccountBroadcastedButNotConfirmed?.length) return
     await this.#main.updateSelectedAccountPortfolio({
       maxDataAgeMs: 60 * 1000,
       maxDataAgeMsUnused: 60 * 60 * 1000

--- a/src/controllers/estimation/estimation.ts
+++ b/src/controllers/estimation/estimation.ts
@@ -10,7 +10,7 @@ import { SignAccountOpError, Warning } from '../../interfaces/signAccountOp'
 import { isSmartAccount } from '../../libs/account/account'
 import { BaseAccount } from '../../libs/account/BaseAccount'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
-import { AccountOp, AccountOpWithId } from '../../libs/accountOp/accountOp'
+import { AccountOp } from '../../libs/accountOp/accountOp'
 import { getEstimation, getEstimationSummary } from '../../libs/estimate/estimate'
 import { FeePaymentOption, FullEstimationSummary } from '../../libs/estimate/interfaces'
 import { isPortfolioGasTankResult } from '../../libs/portfolio/helpers'
@@ -92,7 +92,7 @@ export class EstimationController extends EventEmitter {
     )
   }
 
-  async estimate(op: AccountOpWithId) {
+  async estimate(op: AccountOp) {
     this.status = EstimationStatus.Loading
     this.emitUpdate()
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -49,12 +49,11 @@ import { ITransferController } from '../../interfaces/transfer'
 import { IUiController, UiManager, View } from '../../interfaces/ui'
 import { BenzinUserRequest, CallsUserRequest } from '../../interfaces/userRequest'
 import { getDefaultSelectedAccount } from '../../libs/account/account'
-import { AccountOp, haveAccountOpsChanged } from '../../libs/accountOp/accountOp'
+import { AccountOp } from '../../libs/accountOp/accountOp'
 import { getDappIdentifier, SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus, Call } from '../../libs/accountOp/types'
 import { HumanizerMeta } from '../../libs/humanizer/interfaces'
 import { KeyIterator } from '../../libs/keyIterator/keyIterator'
-import { getAccountOpsForSimulation } from '../../libs/main/main'
 import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import { SafeResults, toCallsUserRequest, toSigMessageUserRequests } from '../../libs/safe/safe'
 import { isNetworkReady } from '../../libs/selectedAccount/selectedAccount'
@@ -318,9 +317,6 @@ export class MainController extends EventEmitter implements IMainController {
       velcroUrl,
       this.banner,
       this.featureFlags,
-      (accAddr: string, chainId: string, accountOps?: AccountOp[]) => {
-        return this.hasSimulationChanged(accAddr, chainId, accountOps)
-      },
       eventEmitterRegistry
     )
     if (this.featureFlags.isFeatureEnabled('withEmailVaultController')) {
@@ -1167,7 +1163,8 @@ export class MainController extends EventEmitter implements IMainController {
       chainsToUpdate,
       portfoliosToUpdate,
       newestOpTimestamp,
-      shouldFetchSafeTxns
+      shouldFetchSafeTxns,
+      updatedAccountsOps
     } = updatedAccountsOpsForSelectedAccount
 
     if (shouldEmitUpdate) {
@@ -1188,7 +1185,13 @@ export class MainController extends EventEmitter implements IMainController {
             networks?.map((net) => net.chainId)
           )
 
-          await this.updateSelectedAccountPortfolio({ networks })
+          const finalizedAccountOps = updatedAccountsOps.filter(
+            (op) =>
+              op.status !== AccountOpStatus.Pending &&
+              op.status !== AccountOpStatus.BroadcastedButNotConfirmed
+          )
+
+          await this.portfolio.discardSimulation(finalizedAccountOps)
 
           // Reports to Sentry if the portfolio was not updated after a confirmed AccountOp
           this.portfolio.reportMissedPortfolioUpdateAfterUpdatedAccountOp(
@@ -1449,23 +1452,6 @@ export class MainController extends EventEmitter implements IMainController {
     }
   }
 
-  hasSimulationChanged(accAddr: string, chainId: string, accountOps?: AccountOp[]): boolean {
-    if (!this.selectedAccount?.account || this.selectedAccount.account.addr !== accAddr)
-      return false
-
-    const accountOpsToBeSimulatedByNetwork = getAccountOpsForSimulation(
-      this.selectedAccount.account,
-      this.requests.visibleUserRequests,
-      this.networks.networks
-    )
-    const latestAccOps = accountOpsToBeSimulatedByNetwork?.[chainId]
-
-    if (accountOps === undefined && latestAccOps === undefined) return false
-    if (accountOps === undefined && latestAccOps !== undefined) return true
-    if (accountOps !== undefined && latestAccOps === undefined) return true
-    return haveAccountOpsChanged(accountOps!, latestAccOps!)
-  }
-
   async updateSelectedAccountPortfolio(opts?: {
     networks?: Network[]
     isManualUpdate?: boolean
@@ -1485,21 +1471,10 @@ export class MainController extends EventEmitter implements IMainController {
     const canUpdateSignAccountOp = !signAccountOp || signAccountOp.canUpdate()
     if (!canUpdateSignAccountOp) return
 
-    const accountOpsToBeSimulatedByNetwork = getAccountOpsForSimulation(
-      this.selectedAccount.account,
-      this.requests.visibleUserRequests,
-      this.networks.networks
-    )
-
     await this.portfolio.updateSelectedAccount(
       this.selectedAccount.account.addr,
       networks,
-      accountOpsToBeSimulatedByNetwork
-        ? {
-            accountOps: accountOpsToBeSimulatedByNetwork,
-            states: await this.accounts.getOrFetchAccountStates(this.selectedAccount.account.addr)
-          }
-        : undefined,
+      undefined,
       { maxDataAgeMs, maxDataAgeMsUnused, defiMaxDataAgeMs, isManualUpdate }
     )
     this.#updateIsOffline()
@@ -1585,7 +1560,6 @@ export class MainController extends EventEmitter implements IMainController {
 
     if (safeRequests.length) {
       await this.requests.removeUserRequests(safeRequests, {
-        shouldUpdateAccount: false,
         shouldRejectSafeRequests: false
       })
     }
@@ -1603,13 +1577,7 @@ export class MainController extends EventEmitter implements IMainController {
     })
 
     await this.requests.removeUserRequests([accountOpRequest.id], {
-      shouldRemoveSwapAndBridgeRoute: false,
-      // Since `resolveAccountOpAction` is invoked only when we broadcast a transaction,
-      // we don't want to update the account portfolio immediately, as we would lose the simulation.
-      // The simulation is required to calculate the pending badges (see: calculatePendingAmounts()).
-      // Once the transaction is confirmed, delayed, or the user manually refreshes the portfolio,
-      // the account will be updated automatically.
-      shouldUpdateAccount: false
+      shouldRemoveSwapAndBridgeRoute: false
     })
 
     this.resolveDappBroadcast(submittedAccountOp, dappHandlers)

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -14,7 +14,12 @@ import { Account, AccountStates } from '../../interfaces/account'
 import { StoredKey } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
 import { RPCProviders } from '../../interfaces/provider'
-import { AccountOp } from '../../libs/accountOp/accountOp'
+import {
+  AccountOp,
+  AccountOpWithId,
+  areAccountOpsEqual,
+  getAccountOpId
+} from '../../libs/accountOp/accountOp'
 import { getAccountState } from '../../libs/accountState/accountState'
 import * as defiPricesLib from '../../libs/defiPositions/defiPrices'
 import { getProviderId } from '../../libs/defiPositions/helpers'
@@ -53,6 +58,8 @@ networks.forEach((network) => {
   providers[network.chainId.toString()] = getRpcProvider(network.rpcUrls, network.chainId)
   providers[network.chainId.toString()]!.isWorking = true
 })
+
+const ethereum = networks.find((network) => network.chainId === 1n)!
 
 const getAccountsInfo = async (accounts: Account[]): Promise<AccountStates> => {
   const result = await Promise.all(
@@ -296,11 +303,9 @@ const getKeystoreKeys = (): StoredKey[] => {
 const { uiManager } = mockUiManager()
 const uiCtrl = new UiController({ uiManager })
 const prepareTest = async ({
-  initialSetStorage,
-  hasSimulationChanged
+  initialSetStorage
 }: {
   initialSetStorage?: (storageCtrl: StorageController) => Promise<void>
-  hasSimulationChanged?: Function
 } = {}) => {
   const storage = produceMemoryStore()
   const storageCtrl = new StorageController(storage)
@@ -314,6 +319,15 @@ const prepareTest = async ({
     accountWithManyAssets,
     DEFI_TEST_ACCOUNT
   ])
+  await storageCtrl.set('learnedAssets', {
+    erc20s: {},
+    erc721s: {
+      '1:0xB674F3fd5F43464dB0448a57529eAF37F04cceA5': {
+        '0x932261f9Fc8DA46C4a22e31B45c4De60623848bF:39118': Date.now(),
+        '0xcF30DEf37DcB65d244F14E075Dc0ce875ccFa065:2442': Date.now()
+      }
+    }
+  })
   if (initialSetStorage) await initialSetStorage(storageCtrl)
 
   const keystore = new KeystoreController('default', storageCtrl, {}, uiCtrl)
@@ -358,8 +372,7 @@ const prepareTest = async ({
     relayerUrl,
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl,
-    hasSimulationChanged ? hasSimulationChanged : () => {}
+    featureFlagsCtrl
   )
 
   await accountsCtrl.initialLoadPromise
@@ -371,7 +384,7 @@ const prepareTest = async ({
     await wait(500)
   }
 
-  return { storageCtrl, controller, networksCtrl }
+  return { storageCtrl, controller, networksCtrl, accountsCtrl }
 }
 
 describe('Portfolio Controller ', () => {
@@ -379,32 +392,40 @@ describe('Portfolio Controller ', () => {
     jest.restoreAllMocks()
     jest.clearAllMocks()
   })
-  async function getAccountOp() {
+  async function getAccountOp(
+    collectibleAddress: string = '0xcf30def37dcb65d244f14e075dc0ce875ccfa065',
+    tokenId: number = 2442
+  ) {
     const ABI = ['function transferFrom(address from, address to, uint256 tokenId)']
     const iface = new Interface(ABI)
     const data = iface.encodeFunctionData('transferFrom', [
       '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
       '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
-      137
+      tokenId
     ])
 
     const nonce = await getNonce('0xB674F3fd5F43464dB0448a57529eAF37F04cceA5', providers['1']!)
-    const calls = [{ to: '0x18Ce9CF7156584CDffad05003410C3633EFD1ad0', value: BigInt(0), data }]
+    const calls = [{ to: collectibleAddress, value: BigInt(0), data }]
+
+    const op = {
+      accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
+      signingKeyAddr: '0x5Be214147EA1AE3653f289E17fE7Dc17A73AD175',
+      gasLimit: null,
+      gasFeePayment: null,
+      chainId: 1n,
+      nonce,
+      signature: '0x',
+      calls
+    } as AccountOp
 
     return {
       '1': [
         {
-          accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
-          signingKeyAddr: '0x5Be214147EA1AE3653f289E17fE7Dc17A73AD175',
-          gasLimit: null,
-          gasFeePayment: null,
-          chainId: 1n,
-          nonce,
-          signature: '0x',
-          calls
-        } as AccountOp
+          id: getAccountOpId(op),
+          ...op
+        }
       ]
-    }
+    } as Record<string, AccountOpWithId[]>
   }
 
   test('Account updates (by account and network, updateSelectedAccount()) are queued and executed sequentially to avoid race conditions', async () => {
@@ -602,7 +623,7 @@ describe('Portfolio Controller ', () => {
 
       const accountOp2 = await getAccountOp()
       // Change the address
-      accountOp2['1'][0]!.accountAddr = '0xB674F3fd5F43464dB0448a57529eAF37F04cceA4'
+      accountOp2['1']![0]!.accountAddr = '0xB674F3fd5F43464dB0448a57529eAF37F04cceA4'
 
       await controller.updateSelectedAccount(account.addr, undefined, {
         accountOps: accountOp2,
@@ -613,6 +634,175 @@ describe('Portfolio Controller ', () => {
       )['1']!
 
       expect(state2.result?.updateStarted).toBeGreaterThan(state1.result?.updateStarted!)
+    })
+  })
+
+  describe('Simulation discarding', () => {
+    const getEthereumPortfolioState = (controller: PortfolioController) =>
+      controller.getAccountPortfolioState(account.addr)['1']!
+
+    const getSimulatedCollection = (
+      controller: PortfolioController,
+      address: string = '0xcf30def37dcb65d244f14e075dc0ce875ccfa065'
+    ) =>
+      getEthereumPortfolioState(controller).result?.collections?.find(
+        (collection: CollectionResult) => collection.address.toLowerCase() === address
+      )
+
+    test('overrideSimulationResults removes the current simulation result and stored accountOps', async () => {
+      const { controller } = await prepareTest()
+      const accountOp = await getAccountOp()
+      const accountStates = await getAccountsInfo([account])
+
+      await controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: accountOp,
+        states: accountStates[account.addr]!
+      })
+
+      const stateBefore = getEthereumPortfolioState(controller)
+      const collectionBefore = getSimulatedCollection(controller)
+
+      expect(areAccountOpsEqual(stateBefore.accountOps!, accountOp['1']!)).toBe(true)
+      expect(collectionBefore?.amountPostSimulation).toBe(0n)
+
+      controller.overrideSimulationResults(accountOp['1']![0]!)
+
+      const stateAfter = getEthereumPortfolioState(controller)
+      const collectionAfter = getSimulatedCollection(controller)
+
+      expect(stateAfter.accountOps).toBeUndefined()
+      expect(collectionAfter).toBeTruthy()
+      expect(collectionAfter?.amountPostSimulation).toBeUndefined()
+      expect(collectionAfter?.postSimulation).toBeUndefined()
+      expect(collectionAfter?.simulationAmount).toBeUndefined()
+      expect(
+        stateAfter.result?.tokens.some(
+          (token) =>
+            token.amountPostSimulation !== undefined || token.simulationAmount !== undefined
+        )
+      ).toBe(false)
+    })
+
+    test('overrideSimulationResults is a no-op when there is no matching simulated state', async () => {
+      const { controller } = await prepareTest()
+      const accountOp = await getAccountOp()
+
+      expect(() => controller.overrideSimulationResults(accountOp['1']![0]!)).not.toThrow()
+      expect(controller.getAccountPortfolioState(account.addr)).toEqual({})
+    })
+
+    test('discardSimulation removes the matching simulated account op and refreshes the portfolio', async () => {
+      const { controller } = await prepareTest()
+      const accountOp = await getAccountOp()
+      const accountStates = await getAccountsInfo([account])
+
+      await controller.updateSelectedAccount(account.addr, undefined, {
+        accountOps: accountOp,
+        states: accountStates[account.addr]!
+      })
+
+      const stateBefore = getEthereumPortfolioState(controller)
+      expect(stateBefore.accountOps).toStrictEqual(accountOp['1'])
+      expect(getSimulatedCollection(controller)?.amountPostSimulation).toBe(0n)
+
+      await controller.discardSimulation(accountOp['1']!)
+
+      const stateAfter = getEthereumPortfolioState(controller)
+
+      expect(stateAfter.accountOps).toBeUndefined()
+      expect(stateAfter.result?.updateStarted).toBeGreaterThan(stateBefore.result?.updateStarted!)
+      expect(getSimulatedCollection(controller)?.amountPostSimulation).toBeUndefined()
+      expect(stateAfter.accountOps).toBeUndefined()
+    })
+
+    test('discardSimulation is a no-op when the account op is not part of the current simulation', async () => {
+      const { controller } = await prepareTest()
+      const accountOp = await getAccountOp()
+      const accountStates = await getAccountsInfo([account])
+
+      await controller.updateSelectedAccount(account.addr, undefined, {
+        accountOps: accountOp,
+        states: accountStates[account.addr]!
+      })
+
+      const updateSelectedAccountSpy = jest.spyOn(controller, 'updateSelectedAccount')
+      const nonMatchingAccountOp = structuredClone(accountOp['1']![0]!)
+      nonMatchingAccountOp.accountAddr = account2.addr
+
+      await controller.discardSimulation([nonMatchingAccountOp])
+
+      expect(updateSelectedAccountSpy).not.toHaveBeenCalled()
+      expect(getEthereumPortfolioState(controller).accountOps).toStrictEqual(accountOp['1'])
+      expect(getSimulatedCollection(controller)?.amountPostSimulation).toBe(0n)
+    })
+
+    test('discardSimulation does not affect a different account op, even if they are called together', async () => {
+      const { controller } = await prepareTest()
+      const ethereum = networks.find((network) => network.chainId === 1n)!
+      const oldAccountOp = await getAccountOp()
+      const toBeDiscardedAccountOp = await getAccountOp(
+        '0x932261f9fc8da46c4a22e31b45c4de60623848bf',
+        39118
+      )
+      const accountStates = await getAccountsInfo([account])
+
+      const updatePromise = controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: oldAccountOp,
+        states: accountStates[account.addr]!
+      })
+
+      const discardPromise = controller.discardSimulation(toBeDiscardedAccountOp['1']!)
+
+      await Promise.all([updatePromise, discardPromise])
+
+      const stateAfter = getEthereumPortfolioState(controller)
+
+      expect(areAccountOpsEqual(stateAfter.accountOps!, oldAccountOp['1']!)).toBe(true)
+    })
+
+    test('discardSimulation does not discard a newer simulation when it is queued first', async () => {
+      const { controller } = await prepareTest()
+      const ethereum = networks.find((network) => network.chainId === 1n)!
+      const oldAccountOp = await getAccountOp()
+      const newAccountOp = await getAccountOp('0x932261f9fc8da46c4a22e31b45c4de60623848bf', 39118)
+      const accountStates = await getAccountsInfo([account])
+
+      await controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: oldAccountOp,
+        states: accountStates[account.addr]!
+      })
+
+      const discardPromise = controller.discardSimulation(oldAccountOp['1']!)
+      const updatePromise = controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: newAccountOp,
+        states: accountStates[account.addr]!
+      })
+
+      await Promise.all([discardPromise, updatePromise])
+
+      const stateAfter = getEthereumPortfolioState(controller)
+
+      expect(areAccountOpsEqual(stateAfter.accountOps!, newAccountOp['1']!)).toBe(true)
+    })
+    test('discardSimulation is not affected by account op nonces being updated in between', async () => {
+      const { controller } = await prepareTest()
+      const ethereum = networks.find((network) => network.chainId === 1n)!
+      const accountOp = await getAccountOp()
+      const accountStates = await getAccountsInfo([account])
+
+      await controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: accountOp,
+        states: accountStates[account.addr]!
+      })
+
+      const updatedAccountOp = structuredClone(accountOp)
+      ;(updatedAccountOp['1']![0]!.nonce as bigint) += 1n
+
+      await controller.discardSimulation(accountOp['1']!)
+
+      const stateAfter = controller.getAccountPortfolioState(account.addr)['1']!
+
+      expect(stateAfter.accountOps).toBeUndefined()
     })
   })
 
@@ -1430,7 +1620,10 @@ describe('Portfolio Controller ', () => {
         fromExternalAPI: {}
       }
       const { controller, storageCtrl } = await prepareTest({
-        initialSetStorage: (storage) => storage.set('previousHints', previousHints)
+        initialSetStorage: async (storage) => {
+          await storage.set('previousHints', previousHints)
+          await storage.remove('learnedAssets') // Make sure learnedAssets is empty to test the migration logic
+        }
       })
 
       const learnedAssets = await storageCtrl.get('learnedAssets', null)
@@ -2102,26 +2295,18 @@ describe('Portfolio Controller ', () => {
     expect(Object.keys(controller.getNetworksWithAssets(account.addr)).length).toEqual(0)
   })
   test('should do a request with a simulation; then a second request without the simulation should come and it should not be allowed to persist', async () => {
-    const { controller } = await prepareTest({
-      hasSimulationChanged: (accAddr: string, chainId: string, accountOps?: AccountOp[]) => {
-        if (accountOps) return false
-        return true
-      }
-    })
+    const { controller, accountsCtrl } = await prepareTest()
+    // We need account state for the simulation to be persisted
+    await accountsCtrl.updateAccountState(account.addr, 'latest', [1n])
     const ethereum = networks.find((n) => n.chainId === 1n)!
     const accountOpsOnEthereum = await getAccountOp()
     const accountStates = await getAccountsInfo([account])
 
     // update and persist the simulation
-    await controller.updateSelectedAccount(
-      account.addr,
-      [ethereum],
-      {
-        accountOps: accountOpsOnEthereum,
-        states: accountStates[account.addr]!
-      },
-      { isManualUpdate: true, isSignAccountOpSimulation: true }
-    )
+    await controller.updateSelectedAccount(account.addr, [ethereum], {
+      accountOps: accountOpsOnEthereum,
+      states: accountStates[account.addr]!
+    })
     // make sure the simulation is there
     const hasItems = (obj: any) => !!Object.keys(obj).length
     const portfolioState = controller.getAccountPortfolioState(account.addr)

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -14,12 +14,7 @@ import { Account, AccountStates } from '../../interfaces/account'
 import { StoredKey } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
 import { RPCProviders } from '../../interfaces/provider'
-import {
-  AccountOp,
-  AccountOpWithId,
-  areAccountOpsEqual,
-  getAccountOpId
-} from '../../libs/accountOp/accountOp'
+import { AccountOp, areAccountOpsEqual } from '../../libs/accountOp/accountOp'
 import { getAccountState } from '../../libs/accountState/accountState'
 import * as defiPricesLib from '../../libs/defiPositions/defiPrices'
 import { getProviderId } from '../../libs/defiPositions/helpers'
@@ -39,6 +34,7 @@ import {
 } from '../../libs/portfolio/interfaces'
 import { Portfolio, PORTFOLIO_LIB_ERROR_NAMES } from '../../libs/portfolio/portfolio'
 import { getRpcProvider } from '../../services/provider'
+import { generateUuid } from '../../utils/uuid'
 import wait from '../../utils/wait'
 import { AccountsController } from '../accounts/accounts'
 import { BannerController } from '../banner/banner'
@@ -408,6 +404,7 @@ describe('Portfolio Controller ', () => {
     const calls = [{ to: collectibleAddress, value: BigInt(0), data }]
 
     const op = {
+      id: generateUuid(),
       accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
       signingKeyAddr: '0x5Be214147EA1AE3653f289E17fE7Dc17A73AD175',
       gasLimit: null,
@@ -419,13 +416,8 @@ describe('Portfolio Controller ', () => {
     } as AccountOp
 
     return {
-      '1': [
-        {
-          id: getAccountOpId(op),
-          ...op
-        }
-      ]
-    } as Record<string, AccountOpWithId[]>
+      '1': [op]
+    } as Record<string, AccountOp[]>
   }
 
   test('Account updates (by account and network, updateSelectedAccount()) are queued and executed sequentially to avoid race conditions', async () => {

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -21,7 +21,12 @@ import { IStorageController } from '../../interfaces/storage'
 import { isBasicAccount } from '../../libs/account/account'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 /* eslint-disable @typescript-eslint/no-shadow */
-import { AccountOp, isAccountOpsIntentEqual } from '../../libs/accountOp/accountOp'
+import {
+  AccountOp,
+  AccountOpWithId,
+  areAccountOpsEqual,
+  getAccountOpId
+} from '../../libs/accountOp/accountOp'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
 import {
@@ -221,8 +226,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     retryCount: 0
   }
 
-  #hasSimulationChanged: Function
-
   constructor(
     storage: IStorageController,
     fetch: Fetch,
@@ -234,7 +237,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     velcroUrl: string,
     banner: IBannerController,
     featureFlags: IFeatureFlagsController,
-    hasSimulationChanged: Function,
     eventEmitterRegistry?: IEventEmitterRegistryController
   ) {
     super(eventEmitterRegistry)
@@ -253,7 +255,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     this.temporaryTokens = {}
     this.#banner = banner
     this.#featureFlags = featureFlags
-    this.#hasSimulationChanged = hasSimulationChanged
     this.batchedPortfolioDiscovery = batcher(
       fetch,
       (queue) => {
@@ -541,7 +542,12 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
   }
 
   /**
-   * Removes simulation results from the portfolio state
+   * Removes simulation results from the portfolio state. This function is used when
+   * all simulated account ops should be discarded for a network-account pair. It does
+   * not update the portfolio but simply removes the simulation results from the state.
+   *
+   * If you instead need to remove a specific accountOp from the simulation results, use `discardSimulation`
+   * (e.g., after an account op is broadcasted and confirmed)
    */
   overrideSimulationResults(accountOp: AccountOp) {
     const { accountAddr, chainId } = accountOp
@@ -569,7 +575,67 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       networkState.result.defiPositions
     )
 
+    delete networkState.accountOps
+
     this.emitUpdate()
+  }
+
+  /**
+   * Removes a specific simulated account op from the portfolio state and updates
+   * the portfolio for the corresponding account and networks.
+   *
+   * The function protects against race conditions by removing specific accountOps
+   *
+   * Example usage: after an account op is broadcasted and confirmed
+   */
+  async discardSimulation(accountOps: AccountOp[]) {
+    let networksToUpdate: Network[] = []
+    let accountAddrToUpdate: string | null = null
+    let accountOpsAfterUpdate: { [key: string]: AccountOpWithId[] } = {}
+
+    accountOps.forEach((accountOp) => {
+      const accountOpId = getAccountOpId(accountOp)
+
+      const { accountAddr, chainId } = accountOp
+
+      if (!this.#state[accountAddr] || !this.#state[accountAddr][chainId.toString()]) return
+
+      const networkState = this.#state[accountAddr][chainId.toString()]!
+
+      if (!networkState.result || !networkState.accountOps) return
+      if (!accountOpsAfterUpdate) {
+        accountOpsAfterUpdate = {}
+      }
+
+      accountOpsAfterUpdate[chainId.toString()] = structuredClone(networkState.accountOps || [])
+
+      const accountOpIndex = accountOpsAfterUpdate[chainId.toString()]!.findIndex(
+        (op) => op.id === accountOpId
+      )
+
+      if (accountOpIndex === -1) return
+
+      accountOpsAfterUpdate[chainId.toString()]!.splice(accountOpIndex, 1)
+      const networkData = this.#networks.networks.find((n) => n.chainId === chainId)
+
+      if (!networkData) {
+        this.emitError({
+          level: 'silent',
+          message: `Network with chainId ${chainId} not found while discarding simulation results.`,
+          error: new Error(`portfolio.discardSimulation: Network with chainId ${chainId} not found`)
+        })
+        return
+      }
+
+      networksToUpdate.push(networkData)
+      accountAddrToUpdate = accountAddr
+    })
+
+    if (!accountAddrToUpdate || networksToUpdate.length === 0) return
+
+    await this.updateSelectedAccount(accountAddrToUpdate, networksToUpdate, {
+      accountOps: accountOpsAfterUpdate
+    })
   }
 
   async updateTokenValidationByStandard(
@@ -1017,10 +1083,9 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       maxDataAgeMs?: number
       defiMaxDataAgeMs?: number
       isManualUpdate?: boolean
-      isSignAccountOpSimulation?: boolean
     }
   ): Promise<[boolean, FormattedPortfolioDiscoveryResponse | null]> {
-    const { maxDataAgeMs, isManualUpdate, isSignAccountOpSimulation } = portfolioProps
+    const { maxDataAgeMs, isManualUpdate } = portfolioProps
     const accountState = this.#state[account.addr]
 
     // Can occur if the account is removed while updateSelectedAccount is in progress
@@ -1032,26 +1097,10 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       accountState[network.chainId.toString()] = { isLoading: false, isReady: false, errors: [] }
     }
 
-    // always persist the simulation if it's isSignAccountOpSimulation
-    // otherwise, check for race conditions as updates happen from wherever
-    // - if the latest account opts from visibleRequests are not those
-    // passed as portfolioProps?.simulation?.accountOps, do not persist
-    // the update as it is outdated!
-    // this often happened when doing approve + action but the dapp sends
-    // the second request action immediately after txn confirmation.
-    // at that time, all kinds of portfolio update request fly in the wallet
-    // and some of them might disturb the correct, final simulation
-    const hasSimalationChanged =
-      !isSignAccountOpSimulation &&
-      this.#hasSimulationChanged(
-        account.addr,
-        network.chainId,
-        portfolioProps?.simulation?.accountOps
-      )
-
-    const canSkipUpdate =
-      hasSimalationChanged ||
-      PortfolioController.#getCanSkipUpdate(accountState[network.chainId.toString()], maxDataAgeMs)
+    const canSkipUpdate = PortfolioController.#getCanSkipUpdate(
+      accountState[network.chainId.toString()],
+      maxDataAgeMs
+    )
 
     if (canSkipUpdate) return [true, null]
 
@@ -1370,9 +1419,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     return hasAssetsOnNetwork ? maxDataAgeMs : maxDataAgeUnused
   }
 
-  // NOTE: we always pass in all `accounts` and `networks` to ensure that the user of this
-  // controller doesn't have to update this controller every time that those are updated
-
   // The recommended behavior of the application that this API encourages is:
   // 1) when the user selects an account, update it's portfolio on all networks by calling updateSelectedAccount
   // 2) every time the user has a change in their pending (to be signed or to be mined) bundle(s) on a
@@ -1381,26 +1427,35 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
   // it will also use a high `priceRecency` to make sure we don't lose time in updating prices (since we care about running the simulations)
 
   // the purpose of this function is to call it when an account is selected or the queue of accountOps changes
+
+  /**
+   * Updates the portfolio of the passed account on the specified networks, or on all networks if none is specified.
+   * If a simulation object is passed, it will be used to perform the update.
+   *
+   * @param accountId - the account for which the portfolio should be updated
+   * @param networks - update only for these networks. If not passed, the portfolio will be updated for all networks in the wallet
+   * @param simulation - simulation data. If not passed the portfolio will use the last passed simulation data
+   * until it's overwritten by a new one or discarded using `discardSimulation(op)`
+   * @param opts
+   */
   async updateSelectedAccount(
     accountId: AccountId,
     networks?: Network[],
     simulation?: {
       accountOps: { [key: string]: AccountOp[] }
-      states: { [chainId: string]: AccountOnchainState }
+      states?: { [chainId: string]: AccountOnchainState }
     },
     opts?: {
       maxDataAgeMs?: number
       defiMaxDataAgeMs?: number
       maxDataAgeMsUnused?: number
       isManualUpdate?: boolean
-      isSignAccountOpSimulation?: boolean
     }
   ) {
     const {
       maxDataAgeMs: paramsMaxDataAgeMs = 0,
       maxDataAgeMsUnused: paramsMaxDataAgeMsUnused,
-      isManualUpdate,
-      isSignAccountOpSimulation
+      isManualUpdate
     } = opts || {}
     await this.#initialLoadPromise
     const selectedAccount = this.#accounts.accounts.find((x) => x.addr === accountId)
@@ -1425,11 +1480,12 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           network
         )
 
-        const currentAccountOps = simulation?.accountOps[network.chainId.toString()]?.filter(
-          (op) => op.accountAddr === accountId
-        )
-        const state = simulation?.states?.[network.chainId.toString()]
-        const simulatedAccountOps = accountState[network.chainId.toString()]?.accountOps
+        const currentAccountOps = simulation?.accountOps[network.chainId.toString()]
+          ?.filter((op) => op.accountAddr === accountId)
+          .map((op) => ({
+            ...op,
+            id: getAccountOpId(op)
+          }))
 
         if (!this.#queue?.[accountId]?.[network.chainId.toString()])
           this.#queue[accountId] = {
@@ -1438,15 +1494,15 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           }
 
         const updatePromise = async (): Promise<void> => {
-          // We are performing the following extended check because both (or one of both) variables may have an undefined value.
-          // If both variables contain AccountOps, we can simply compare for changes in the AccountOps intent.
-          // However, when one of the variables is not set, two cases arise:
-          // 1. A change occurs if one variable is undefined and the other one holds an AccountOps object.
-          // 2. No change occurs if both variables are undefined.
+          const networkAccountState =
+            this.#accounts.accountStates?.[accountId]?.[network.chainId.toString()]
+          const simulatedAccountOps = accountState[network.chainId.toString()]?.accountOps
+          const accountOpsToSimulate = currentAccountOps || simulatedAccountOps
+
+          // Compare the ids of the account ops
           const areAccountOpsChanged =
-            currentAccountOps && simulatedAccountOps
-              ? !isAccountOpsIntentEqual(currentAccountOps, simulatedAccountOps)
-              : currentAccountOps !== simulatedAccountOps
+            !!currentAccountOps && areAccountOpsEqual(currentAccountOps, simulatedAccountOps || [])
+
           // Even if maxDataAgeMs is set to a non-zero value, we want to force an update when the AccountOps change.
           // We pass undefined, because setting the value to 0 would imply a manual update by the user.
           const maxDataAgeMs = this.#getMaxDataAgeMs(
@@ -1456,6 +1512,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
             paramsMaxDataAgeMs,
             paramsMaxDataAgeMsUnused
           )
+          const state = simulation?.states?.[network.chainId.toString()] || networkAccountState
 
           const baseAcc = state ? getBaseAccount(selectedAccount, state, network) : null
 
@@ -1467,17 +1524,17 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
               maxDataAgeMs,
               isManualUpdate,
               blockTag: 'both',
-              ...(currentAccountOps &&
+              ...(accountOpsToSimulate &&
+                accountOpsToSimulate.length &&
                 baseAcc &&
                 state && {
                   simulation: {
                     baseAccount: baseAcc,
-                    accountOps: currentAccountOps,
+                    accountOps: accountOpsToSimulate,
                     state
                   }
                 }),
               disableAutoDiscovery: true,
-              isSignAccountOpSimulation,
               hasKeys: this.#keystore.getAccountKeys(selectedAccount).length > 0
             }
           )
@@ -1966,9 +2023,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         }
       : undefined
 
-    return this.updateSelectedAccount(op.accountAddr, [network], simulation, {
-      isSignAccountOpSimulation: true
-    })
+    return this.updateSelectedAccount(op.accountAddr, [network], simulation)
   }
 
   async updateNetworksWithDefiPositions(

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -21,12 +21,7 @@ import { IStorageController } from '../../interfaces/storage'
 import { isBasicAccount } from '../../libs/account/account'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 /* eslint-disable @typescript-eslint/no-shadow */
-import {
-  AccountOp,
-  AccountOpWithId,
-  areAccountOpsEqual,
-  getAccountOpId
-} from '../../libs/accountOp/accountOp'
+import { AccountOp, areAccountOpsEqual } from '../../libs/accountOp/accountOp'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
 import {
@@ -591,11 +586,9 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
   async discardSimulation(accountOps: AccountOp[]) {
     let networksToUpdate: Network[] = []
     let accountAddrToUpdate: string | null = null
-    let accountOpsAfterUpdate: { [key: string]: AccountOpWithId[] } = {}
+    let accountOpsAfterUpdate: { [key: string]: AccountOp[] } = {}
 
     accountOps.forEach((accountOp) => {
-      const accountOpId = getAccountOpId(accountOp)
-
       const { accountAddr, chainId } = accountOp
 
       if (!this.#state[accountAddr] || !this.#state[accountAddr][chainId.toString()]) return
@@ -610,7 +603,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       accountOpsAfterUpdate[chainId.toString()] = structuredClone(networkState.accountOps || [])
 
       const accountOpIndex = accountOpsAfterUpdate[chainId.toString()]!.findIndex(
-        (op) => op.id === accountOpId
+        (op) => op.id === accountOp.id
       )
 
       if (accountOpIndex === -1) return
@@ -1480,12 +1473,9 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           network
         )
 
-        const currentAccountOps = simulation?.accountOps[network.chainId.toString()]
-          ?.filter((op) => op.accountAddr === accountId)
-          .map((op) => ({
-            ...op,
-            id: getAccountOpId(op)
-          }))
+        const currentAccountOps = simulation?.accountOps[network.chainId.toString()]?.filter(
+          (op) => op.accountAddr === accountId
+        )
 
         if (!this.#queue?.[accountId]?.[network.chainId.toString()])
           this.#queue[accountId] = {

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch'
+import { generateUuid } from 'utils/uuid'
 
 import { describe, expect, test } from '@jest/globals'
 
@@ -183,8 +184,7 @@ const prepareTest = async () => {
     relayerUrl,
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl,
-    () => {}
+    featureFlagsCtrl
   )
   const callRelayer = relayerCall.bind({ url: '', fetch })
   const safe = new SafeController({
@@ -284,6 +284,7 @@ const prepareTest = async () => {
       phishing: phishingCtrl,
       fromRequestId: requestId,
       accountOp: {
+        id: generateUuid(),
         accountAddr: addr,
         signingKeyAddr: null,
         signingKeyType: null,
@@ -430,6 +431,7 @@ describe('RequestsController ', () => {
       type: 'transferRequest',
       params: {
         selectedToken: {
+          marketDataIn: [],
           address: '0x0000000000000000000000000000000000000000',
           amount: 1n,
           symbol: 'ETH',

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -1,5 +1,4 @@
 import fetch from 'node-fetch'
-import { generateUuid } from 'utils/uuid'
 
 import { describe, expect, test } from '@jest/globals'
 
@@ -18,6 +17,7 @@ import {
 } from '../../interfaces/userRequest'
 import { HumanizerMeta } from '../../libs/humanizer/interfaces'
 import { relayerCall } from '../../libs/relayerCall/relayerCall'
+import { generateUuid } from '../../utils/uuid'
 import { AccountsController } from '../accounts/accounts'
 import { ActivityController } from '../activity/activity'
 import { AddressBookController } from '../addressBook/addressBook'

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -55,7 +55,7 @@ import {
   getSafeMessageRequestBanners
 } from '../../libs/banners/banners'
 import { getAmbirePaymasterService, getPaymasterService } from '../../libs/erc7677/erc7677'
-import { getAccountOpsForSimulation } from '../../libs/main/main'
+import { getShouldSimulateInTheBackground } from '../../libs/main/main'
 import { TokenResult } from '../../libs/portfolio'
 import { PortfolioRewardsResult } from '../../libs/portfolio/interfaces'
 import {
@@ -545,6 +545,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       this.currentUserRequest.kind === 'calls' &&
       this.currentUserRequest.signAccountOp
     ) {
+      if (!getShouldSimulateInTheBackground(this.currentUserRequest.signAccountOp.account)) {
+        this.#portfolio.overrideSimulationResults(this.currentUserRequest.signAccountOp.accountOp)
+      }
       this.currentUserRequest.signAccountOp.pause()
     }
 
@@ -814,14 +817,12 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     ids: UserRequest['id'][],
     options?: {
       shouldRemoveSwapAndBridgeRoute?: boolean
-      shouldUpdateAccount?: boolean
       shouldOpenNextRequest?: boolean
       shouldRejectSafeRequests?: boolean
     }
   ) {
     const {
       shouldRemoveSwapAndBridgeRoute = true,
-      shouldUpdateAccount = true,
       shouldOpenNextRequest = true,
       shouldRejectSafeRequests = true
     } = options || {}
@@ -841,16 +842,11 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       // update the pending stuff to be signed
       const { kind, meta } = req
       if (kind === 'calls') {
-        const network = this.#networks.networks.find((net) => net.chainId === meta.chainId)!
         const account = this.#accounts.accounts.find((x) => x.addr === meta.accountAddr)
         if (!account)
           throw new Error(
             `removeUserRequests: tried to run for non-existent account ${meta.accountAddr}`
           )
-
-        if (shouldUpdateAccount) {
-          this.#updateSelectedAccountPortfolio(network ? [network] : undefined)
-        }
 
         if (this.#swapAndBridge.activeRoutes.length && shouldRemoveSwapAndBridgeRoute) {
           req.signAccountOp.accountOp.calls.forEach((c) => {
@@ -958,9 +954,14 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   ) {
     this.userRequests
       .filter((r) => requestIds.includes(r.id))
-      .forEach((r) =>
+      .forEach((r) => {
         r.dappPromises.forEach((p) => p.reject(ethErrors.provider.userRejectedRequest<any>(err)))
-      )
+
+        // Done here because remove handles approved requests too. We want this logic only on reject
+        if (r.kind === 'calls') {
+          this.#portfolio.overrideSimulationResults(r.signAccountOp.accountOp)
+        }
+      })
 
     await this.removeUserRequests(requestIds, options)
   }
@@ -1874,22 +1875,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           },
           shouldSimulate: this.#shouldSimulateAccountOps,
           onUpdateAfterTraceCallSuccess: async () => {
-            const accountOpsForSimulation = getAccountOpsForSimulation(
-              account,
-              this.visibleUserRequests,
-              this.#networks.networks
-            )
-
-            await this.#portfolio.updateSelectedAccount(
-              account.addr,
-              [network],
-              accountOpsForSimulation
-                ? {
-                    accountOps: accountOpsForSimulation,
-                    states: await this.#accounts.getOrFetchAccountStates(account.addr)
-                  }
-                : undefined
-            )
+            await this.#portfolio.updateSelectedAccount(account.addr, [network])
           },
           onBroadcastSuccess: this.#onBroadcastSuccess,
           onBroadcastFailed: this.#onBroadcastFailed

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -458,11 +458,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
         userRequestsToAdd.push(req)
 
-        const network = this.#networks.networks.find((n) => n.chainId === meta.chainId)
         // Even without an initialized SignAccountOpController or Screen, we should still update the portfolio and run the simulation.
         // It's necessary to continue operating with the token `amountPostSimulation` amount.
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.#updateSelectedAccountPortfolio(network ? [network] : undefined)
+        this.#portfolio.simulateAccountOp(req.signAccountOp.accountOp)
       } else if (req.kind === 'typedMessage' || req.kind === 'message' || req.kind === 'siwe') {
         const existingMessageRequest = this.userRequests.find(
           (r) => r.kind === req.kind && r.meta.accountAddr === req.meta.accountAddr

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -545,7 +545,12 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       this.currentUserRequest.kind === 'calls' &&
       this.currentUserRequest.signAccountOp
     ) {
-      if (!getShouldSimulateInTheBackground(this.currentUserRequest.signAccountOp.account)) {
+      if (
+        !getShouldSimulateInTheBackground(
+          this.currentUserRequest,
+          this.visibleUserRequests.filter((r) => r.kind === 'calls')
+        )
+      ) {
         this.#portfolio.overrideSimulationResults(this.currentUserRequest.signAccountOp.accountOp)
       }
       this.currentUserRequest.signAccountOp.pause()

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -73,6 +73,7 @@ import {
   getMintVestingRequestParams,
   getTransferRequestParams
 } from '../../libs/transfer/userRequest'
+import { generateUuid } from '../../utils/uuid'
 import { AutoLoginController } from '../autoLogin/autoLogin'
 import EventEmitter from '../eventEmitter/eventEmitter'
 import {
@@ -1851,6 +1852,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           phishing: this.#phishing,
           fromRequestId: requestId,
           accountOp: {
+            id: generateUuid(),
             accountAddr: meta.accountAddr,
             chainId: meta.chainId,
             signingKeyAddr: null,

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -171,8 +171,7 @@ const prepareTest = async () => {
     relayerUrl,
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl,
-    () => {}
+    featureFlagsCtrl
   )
 
   await accountsCtrl.initialLoadPromise
@@ -393,7 +392,7 @@ describe('SelectedAccount Controller', () => {
           usd: 0
         },
         discoveryTime: 0,
-        priceCache: new Map(),
+        tokenDataCache: new Map(),
         tokenErrors: [],
         collections: [],
         blockNumber: 0,

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -35,6 +35,7 @@ import { BundlerSwitcher } from '../../services/bundlers/bundlerSwitcher'
 import { GasSpeeds } from '../../services/bundlers/types'
 import { paymasterFactory } from '../../services/paymaster'
 import { getRpcProvider } from '../../services/provider'
+import { generateUuid } from '../../utils/uuid'
 import wait from '../../utils/wait'
 import { AccountsController } from '../accounts/accounts'
 import { ActivityController } from '../activity/activity'
@@ -87,6 +88,7 @@ const createEOAAccountOp = (account: Account) => {
       chainId: 1n,
       decimals: 18,
       priceIn: [],
+      marketDataIn: [],
       flags: {
         onGasTank: false,
         rewardsType: null,
@@ -97,6 +99,7 @@ const createEOAAccountOp = (account: Account) => {
   ]
 
   const op = {
+    id: generateUuid(),
     accountAddr: account.addr,
     signingKeyAddr: null,
     signingKeyType: null,
@@ -151,6 +154,7 @@ const createAccountOp = (
       chainId: 1n,
       decimals: 18,
       priceIn: [],
+      marketDataIn: [],
       flags: {
         onGasTank: false,
         rewardsType: null,
@@ -161,6 +165,7 @@ const createAccountOp = (
   ]
 
   const op: AccountOp = {
+    id: generateUuid(),
     accountAddr: account.addr,
     signingKeyAddr: null,
     signingKeyType: null,
@@ -179,6 +184,7 @@ const usdcFeeToken: TokenResult = {
   amount: 54409383n,
   chainId: 137n,
   decimals: Number(6),
+  marketDataIn: [],
   priceIn: [{ baseCurrency: 'usd', price: 1.0 }],
   symbol: 'USDC',
   name: 'USD Coin',
@@ -220,6 +226,7 @@ const nativeFeeTokenPolygon: TokenResult = {
   amount: 1000n,
   chainId: 137n,
   decimals: Number(18),
+  marketDataIn: [],
   priceIn: [{ baseCurrency: 'usd', price: 5000 }],
   flags: {
     onGasTank: false,
@@ -314,6 +321,7 @@ const nativeFeeToken: TokenResult = {
   amount: 1000n,
   chainId: 1n,
   decimals: Number(18),
+  marketDataIn: [],
   priceIn: [{ baseCurrency: 'usd', price: 5000 }],
   flags: {
     onGasTank: false,
@@ -330,6 +338,7 @@ const gasTankToken: TokenResult = {
   amount: 323871237812612123123n,
   chainId: 1n,
   decimals: Number(18),
+  marketDataIn: [],
   priceIn: [{ baseCurrency: 'usd', price: 5000 }],
   flags: {
     onGasTank: true,
@@ -439,8 +448,7 @@ const init = async (
     'https://staging-relayer.ambire.com',
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl,
-    () => {}
+    featureFlagsCtrl
   )
   const phishing = new PhishingController({
     fetch,
@@ -467,6 +475,7 @@ const init = async (
           canTopUpGasTank: true,
           isFeeToken: true
         },
+        marketDataIn: [],
         priceIn: [{ baseCurrency: 'usd', price: 1000.0 }] //  For the sake of simplicity we mocked 1 ETH = 1000 USD
       },
       {
@@ -482,6 +491,7 @@ const init = async (
           canTopUpGasTank: true,
           isFeeToken: true
         },
+        marketDataIn: [],
         priceIn: [{ baseCurrency: 'usd', price: 1.0 }]
       }
     ]
@@ -581,6 +591,7 @@ describe('SignAccountOp Controller ', () => {
           chainId: 137n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -601,6 +612,7 @@ describe('SignAccountOp Controller ', () => {
           name: 'USD Token',
           chainId: 137n,
           decimals: 6,
+          marketDataIn: [],
           priceIn: [
             {
               baseCurrency: 'usd',
@@ -625,6 +637,7 @@ describe('SignAccountOp Controller ', () => {
           amount: 1n,
           symbol: 'usdc',
           name: 'USD Coin',
+          marketDataIn: [],
           chainId: 137n,
           decimals: 6,
           priceIn: [
@@ -789,6 +802,7 @@ describe('SignAccountOp Controller ', () => {
           chainId: 1n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -884,6 +898,7 @@ describe('SignAccountOp Controller ', () => {
           chainId: 1n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -965,6 +980,7 @@ describe('SignAccountOp Controller ', () => {
           chainId: 1n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1045,6 +1061,7 @@ describe('SignAccountOp Controller ', () => {
           chainId: 137n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1071,6 +1088,7 @@ describe('SignAccountOp Controller ', () => {
               price: 1
             }
           ],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1097,6 +1115,7 @@ describe('SignAccountOp Controller ', () => {
               price: 1
             }
           ],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1217,6 +1236,7 @@ describe('Negative cases', () => {
       name: 'USD Coin',
       chainId: 137n,
       decimals: 6,
+      marketDataIn: [],
       // we make the priceIn empty for this test
       priceIn: [],
       flags: {
@@ -1319,6 +1339,7 @@ describe('Negative cases', () => {
           chainId: 1n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: true,
             rewardsType: null,
@@ -1340,6 +1361,7 @@ describe('Negative cases', () => {
           chainId: 1n,
           decimals: 6,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1361,6 +1383,7 @@ describe('Negative cases', () => {
           chainId: 137n,
           decimals: 6,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1472,6 +1495,7 @@ describe('Negative cases', () => {
           chainId: 137n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1493,6 +1517,7 @@ describe('Negative cases', () => {
           chainId: 137n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1514,6 +1539,7 @@ describe('Negative cases', () => {
           chainId: 137n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -1649,6 +1675,7 @@ describe('Negative cases', () => {
           chainId: 137n,
           decimals: 18,
           priceIn: [],
+          marketDataIn: [],
           flags: {
             onGasTank: false,
             rewardsType: null,
@@ -2037,6 +2064,7 @@ test('Signing [V1 with EOA payment]: working case', async () => {
         name: 'Ether',
         chainId: 1n,
         decimals: 18,
+        marketDataIn: [],
         priceIn: [],
         flags: {
           onGasTank: false,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -80,12 +80,7 @@ import {
 import { BaseAccount } from '../../libs/account/BaseAccount'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { Safe } from '../../libs/account/Safe'
-import {
-  AccountOp,
-  AccountOpWithId,
-  GasFeePayment,
-  getSignableCalls
-} from '../../libs/accountOp/accountOp'
+import { AccountOp, GasFeePayment, getSignableCalls } from '../../libs/accountOp/accountOp'
 import { AccountOpIdentifiedBy, SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
 import { getScamDetectedText } from '../../libs/banners/banners'
@@ -254,7 +249,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
    * Otherwise the accountOp will be out of sync with the one stored
    * in requests/actions.
    */
-  #accountOp: AccountOpWithId
+  #accountOp: AccountOp
 
   gasPrices?: GasSpeeds
 
@@ -422,7 +417,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     this.#activity = activity
     this.#phishing = phishing
     this.fromRequestId = fromRequestId
-    this.#accountOp = { ...structuredClone(accountOp), id: generateUuid() }
+    this.#accountOp = structuredClone(accountOp)
 
     if (this.#accountOp.signature && this.#accountOp.txnId) {
       this.#accountOp.signed = getAlreadySignedOwners(
@@ -496,7 +491,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     return !!this.#updateBlacklistedStatusPromise
   }
 
-  get accountOp(): Readonly<AccountOpWithId> {
+  get accountOp(): Readonly<AccountOp> {
     return this.#accountOp
   }
 
@@ -2482,7 +2477,6 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     if (this.baseAccount.shouldIncludeActivatorCall(this.accountOp.gasFeePayment.paidBy)) {
       this.#accountOp.activatorCall = getActivatorCall(this.accountOp.accountAddr)
     }
-    this.#updateAccountOp(this.#accountOp)
 
     const accountState = await this.#accounts.getOrFetchAccountOnChainState(
       this.accountOp.accountAddr,

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -143,8 +143,7 @@ const portfolioCtrl = new PortfolioController(
   relayerUrl,
   velcroUrl,
   new BannerController(storageCtrl),
-  featureFlagsCtrl,
-  () => {}
+  featureFlagsCtrl
 )
 
 const safe = new SafeController({
@@ -183,6 +182,7 @@ const PORTFOLIO_TOKENS = [
     flags: { onGasTank: false, rewardsType: null, isFeeToken: true, canTopUpGasTank: true },
     chainId: 10n,
     priceIn: [{ baseCurrency: 'usd', price: 0.99785 }],
+    marketDataIn: [],
     symbol: 'USDT',
     name: 'Tether'
   },
@@ -193,6 +193,7 @@ const PORTFOLIO_TOKENS = [
     flags: { onGasTank: false, rewardsType: null, isFeeToken: false, canTopUpGasTank: false },
     chainId: 8453n,
     priceIn: [{ baseCurrency: 'usd', price: 64325 }],
+    marketDataIn: [],
     symbol: 'cbBTC',
     name: 'Coinbase wrapped BTC'
   },
@@ -203,6 +204,7 @@ const PORTFOLIO_TOKENS = [
     flags: { onGasTank: false, rewardsType: null, isFeeToken: true, canTopUpGasTank: true },
     chainId: 10n,
     priceIn: [{ baseCurrency: 'usd', price: 3660.27 }],
+    marketDataIn: [],
     symbol: 'ETH',
     name: 'Ether'
   }

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2432,6 +2432,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     }
 
     const accountOp: AccountOp = {
+      id: generateUuid(),
       accountAddr: this.#selectedAccount.account.addr,
       chainId: network.chainId,
       signingKeyAddr: null,

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -228,8 +228,7 @@ const prepareTest = async () => {
     relayerUrl,
     velcroUrl,
     new BannerController(storageCtrl),
-    featureFlagsCtrl,
-    () => {}
+    featureFlagsCtrl
   )
   const safe = new SafeController({
     networks: networksCtrl,
@@ -463,7 +462,8 @@ const ETHEREUM_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 2694.55 }]
+    priceIn: [{ baseCurrency: 'usd', price: 2694.55 }],
+    marketDataIn: []
   },
   {
     amount: 0n,
@@ -480,7 +480,8 @@ const ETHEREUM_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 0.01605456 }]
+    priceIn: [{ baseCurrency: 'usd', price: 0.01605456 }],
+    marketDataIn: []
   },
   {
     amount: 0n,
@@ -497,7 +498,8 @@ const ETHEREUM_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 0.32798689176900603 }]
+    priceIn: [{ baseCurrency: 'usd', price: 0.32798689176900603 }],
+    marketDataIn: []
   },
   {
     amount: 58316260607759458104900n,
@@ -514,7 +516,8 @@ const ETHEREUM_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 0.01565007 }]
+    priceIn: [{ baseCurrency: 'usd', price: 0.01565007 }],
+    marketDataIn: []
   }
 ]
 
@@ -534,6 +537,7 @@ const POLYGON_TOKENS: TokenResult[] = [
       isHidden: false,
       suspectedType: null
     },
-    priceIn: [{ baseCurrency: 'usd', price: 0.177387 }]
+    priceIn: [{ baseCurrency: 'usd', price: 0.177387 }],
+    marketDataIn: []
   }
 ]

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -37,6 +37,7 @@ import {
   convertTokenPriceToBigInt,
   getSafeAmountFromFieldValue
 } from '../../utils/numbers/formatters'
+import { generateUuid } from '../../utils/uuid'
 import EventEmitter from '../eventEmitter/eventEmitter'
 import { OnBroadcastSuccess, SignAccountOpController } from '../signAccountOp/signAccountOp'
 
@@ -818,6 +819,7 @@ export class TransferController extends EventEmitter implements ITransferControl
 
     const baseAcc = getBaseAccount(this.#selectedAccount.account, accountState, network)
     const accountOp = {
+      id: generateUuid(),
       accountAddr: this.#selectedAccount.account.addr,
       chainId: network.chainId,
       signingKeyAddr: null,

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -156,28 +156,6 @@ export function canBroadcast(op: AccountOp, accountIsEOA: boolean): boolean {
   return true
 }
 
-/**
- * Compare two AccountOps intents.
- *
- * By 'intent,' we are referring to the sender of the transaction, the network it is sent on, and the included calls.
- *
- * Since we are comparing the intents, we exclude any other properties of the AccountOps.
- */
-export function isAccountOpsIntentEqual(
-  accountOps1: AccountOp[],
-  accountOps2: AccountOp[]
-): boolean {
-  const createIntent = (accountOps: AccountOp[]) => {
-    return accountOps.map(({ accountAddr, chainId, calls }) => ({
-      accountAddr,
-      chainId,
-      calls
-    }))
-  }
-
-  return stringify(createIntent(accountOps1)) === stringify(createIntent(accountOps2))
-}
-
 export function getSignableCalls(op: AccountOp): [string, string, string][] {
   const callsToSign = op.calls.map(toSingletonCall).map(callToTuple)
   if (op.activatorCall) callsToSign.push(callToTuple(op.activatorCall))
@@ -229,6 +207,31 @@ export function getSignableHash(
  */
 export function accountOpSignableHash(op: AccountOp, chainId: bigint): Uint8Array {
   return getSignableHash(op.accountAddr, chainId, op.nonce ?? 0n, getSignableCalls(op))
+}
+
+export function getAccountOpId(accountOp: AccountOp): string {
+  const { accountAddr, chainId } = accountOp
+  const abiCoder = new AbiCoder()
+
+  return keccak256(
+    abiCoder.encode(
+      ['address', 'uint', 'tuple(address, uint, bytes)[]'],
+      [accountAddr, chainId, getSignableCalls(accountOp)]
+    )
+  )
+}
+
+export const areAccountOpsEqual = (ops1: AccountOpWithId[], ops2: AccountOpWithId[]) => {
+  if (ops1.length !== ops2.length) return false
+
+  const ops2Ids = new Set(ops2.map((op) => op.id))
+
+  for (const op1 of ops1) {
+    if (!ops2Ids.has(op1.id)) return false
+
+    if (op1.nonce !== ops2.find((op2) => op2.id === op1.id)?.nonce) return false
+  }
+  return true
 }
 
 export function haveCallsChanged(callsOne: AccountOp['calls'], callsTwo: AccountOp['calls']) {

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -8,7 +8,6 @@ import { AccountId } from '../../interfaces/account'
 import { Key } from '../../interfaces/keystore'
 import { SwapAndBridgeQuote, SwapAndBridgeSendTxRequest } from '../../interfaces/swapAndBridge'
 import { PaymasterService } from '../erc7677/types'
-import { stringify } from '../richJson/richJson'
 import { UserOperation } from '../userOperation/types'
 import { AccountOpStatus, Call } from './types'
 
@@ -41,6 +40,7 @@ export interface GasFeePayment {
 // a UserOp, or to a direct EOA transaction, or relayed through the Ambire relayer
 // it is more precisely defined than a UserOp though - UserOp just has calldata and this has individual `calls`
 export interface AccountOp {
+  id: string
   accountAddr: string
   chainId: bigint
   // this may not be defined, in case the user has not picked a key yet
@@ -100,8 +100,6 @@ export interface AccountOp {
     hideActivityBanner?: boolean
   }
 }
-
-export type AccountOpWithId = AccountOp & { id: string }
 
 /**
  * If we want to deploy a contract, the to field of Call will actually
@@ -209,19 +207,7 @@ export function accountOpSignableHash(op: AccountOp, chainId: bigint): Uint8Arra
   return getSignableHash(op.accountAddr, chainId, op.nonce ?? 0n, getSignableCalls(op))
 }
 
-export function getAccountOpId(accountOp: AccountOp): string {
-  const { accountAddr, chainId } = accountOp
-  const abiCoder = new AbiCoder()
-
-  return keccak256(
-    abiCoder.encode(
-      ['address', 'uint', 'tuple(address, uint, bytes)[]'],
-      [accountAddr, chainId, getSignableCalls(accountOp)]
-    )
-  )
-}
-
-export const areAccountOpsEqual = (ops1: AccountOpWithId[], ops2: AccountOpWithId[]) => {
+export const areAccountOpsEqual = (ops1: AccountOp[], ops2: AccountOp[]) => {
   if (ops1.length !== ops2.length) return false
 
   const ops2Ids = new Set(ops2.map((op) => op.id))

--- a/src/libs/main/main.ts
+++ b/src/libs/main/main.ts
@@ -1,52 +1,12 @@
 import { Account } from '../../interfaces/account'
-import { Network } from '../../interfaces/network'
-import { UserRequest } from '../../interfaces/userRequest'
-import { isSmartAccount } from '../account/account'
-import { AccountOp } from '../accountOp/accountOp'
-import { getSameNonceRequests } from '../safe/safe'
 
 export const ACCOUNT_SWITCH_USER_REQUEST = 'ACCOUNT_SWITCH_USER_REQUEST'
 
-export const getAccountOpsForSimulation = (
-  account: Account,
-  visibleUserRequests: UserRequest[],
-  networks: Network[]
-): { [key: string]: AccountOp[] } | undefined => {
-  let callRequests = visibleUserRequests.filter((r) => r.kind === 'calls')
-
-  // filter out the safe requests with conflicting nonces (same nonce)
-  // from the simulation as the user will have to choose and broadcast only one
-  if (!!account.safeCreation) {
-    const sameNonceRequestsIds = Object.values(getSameNonceRequests(callRequests))
-      .filter((grouped) => grouped.length > 1) // length of 1 means no conflict
-      .flat()
-      .map((r) => r.id)
-    callRequests = callRequests.filter(
-      (r) => !sameNonceRequestsIds.includes(r.id) || r.signAccountOp.isInRegistry()
-    )
-  }
-
-  const isSmart = isSmartAccount(account)
-  const accountOps = callRequests
-    .map((a) => a.signAccountOp.accountOp)
-    .filter((op) => {
-      if (op.accountAddr !== account.addr) return false
-
-      const networkData = networks.find((n) => n.chainId === op.chainId)
-
-      // We cannot simulate if the account isn't smart and the network's RPC doesn't support
-      // state override
-      return isSmart || (networkData && !networkData.rpcNoStateOverride)
-    })
-
-  if (!accountOps.length) return undefined
-
-  return accountOps.reduce((acc: any, accountOp) => {
-    const { chainId } = accountOp
-
-    if (!acc[chainId.toString()]) acc[chainId.toString()] = []
-
-    acc[chainId.toString()].push(accountOp)
-    return acc
-  }, {})
+/**
+ * Whether to simulate account ops if the request window is closed or the current
+ * request is different.
+ */
+export const getShouldSimulateInTheBackground = (account: Account) => {
+  // Only if it IS NOT a safe account
+  return !account.safeCreation
 }

--- a/src/libs/main/main.ts
+++ b/src/libs/main/main.ts
@@ -1,4 +1,4 @@
-import { Account } from '../../interfaces/account'
+import { CallsUserRequest } from '../../interfaces/userRequest'
 
 export const ACCOUNT_SWITCH_USER_REQUEST = 'ACCOUNT_SWITCH_USER_REQUEST'
 
@@ -6,7 +6,23 @@ export const ACCOUNT_SWITCH_USER_REQUEST = 'ACCOUNT_SWITCH_USER_REQUEST'
  * Whether to simulate account ops if the request window is closed or the current
  * request is different.
  */
-export const getShouldSimulateInTheBackground = (account: Account) => {
-  // Only if it IS NOT a safe account
-  return !account.safeCreation
+export const getShouldSimulateInTheBackground = (
+  currentReq: CallsUserRequest,
+  callUserRequests: CallsUserRequest[]
+) => {
+  // simulations should get persisted for all non-safe accounts
+  if (!currentReq.signAccountOp.account.safeCreation) return true
+
+  // check if there are other requests with a conflicting nonce to this one.
+  // If there are, do not simulate this in the background
+  const currentReqNonce = currentReq.signAccountOp.accountOp.safeTx
+    ? currentReq.signAccountOp.accountOp.safeTx.nonce
+    : currentReq.signAccountOp.accountOp.nonce
+  const conflictingNonceUserRequests = callUserRequests.filter((r) => {
+    r.id !== currentReq.id &&
+      r.signAccountOp.accountOp.chainId === currentReq.signAccountOp.accountOp.chainId &&
+      r.signAccountOp.accountOp.safeTx?.nonce === currentReqNonce
+  })
+
+  return !conflictingNonceUserRequests.length
 }

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -6,7 +6,7 @@ import { getPendingBlockTagIfSupported } from '../../utils/getBlockTag'
 import { yieldToMain } from '../../utils/scheduler'
 import { getNotAmbireStateOverride } from '../../utils/simulationStateOverride'
 import { getAccountDeployParams } from '../account/account'
-import { callToTuple, toSingletonCall } from '../accountOp/accountOp'
+import { AccountOp, callToTuple, toSingletonCall } from '../accountOp/accountOp'
 import { Deployless, DeploylessMode } from '../deployless/deployless'
 import { decodeError } from '../errorDecoder'
 import { DEPLOYLESS_ERRORS } from '../errorHumanizer/errors'
@@ -15,6 +15,7 @@ import { mapToken } from './helpers'
 import {
   CollectionResult,
   GetOptions,
+  GetOptionsSimulation,
   LimitsOptions,
   MetaData,
   TokenError,
@@ -104,7 +105,10 @@ function handleSimulationError(
 export function getDeploylessOpts(
   accountAddr: string,
   supportsStateOverride: boolean,
-  opts: Pick<GetOptions, 'simulation' | 'blockTag'>
+  opts: {
+    simulation?: GetOptionsSimulation<AccountOp[]>
+    blockTag?: GetOptions['blockTag']
+  }
 ) {
   const shouldStateOverride =
     supportsStateOverride &&
@@ -204,7 +208,7 @@ export async function getNFTs(
     before.collections.map((beforeToken: any, i: number) => {
       const simulationToken = simulationTokens
         ? simulationTokens.find(
-            (token: any) => token.addr.toLowerCase() === tokenAddrs[i][0].toLowerCase()
+            (token: any) => token.addr.toLowerCase() === tokenAddrs[i]![0].toLowerCase()
           )
         : null
 

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -1,7 +1,7 @@
 import { AccountId, AccountOnchainState } from '../../interfaces/account'
 import { Price, TokenMarketDataByCurrency } from '../../interfaces/assets'
 import { BaseAccount } from '../account/BaseAccount'
-import { AccountOp } from '../accountOp/accountOp'
+import { AccountOp, AccountOpWithId } from '../accountOp/accountOp'
 import {
   AssetType,
   NetworkState as DefiNetworkState,
@@ -11,8 +11,8 @@ import {
 // @TODO: Move most of these interfaces to src/interfaces and
 // figure out how to restructure portfolio/defiPositions types
 
-export interface GetOptionsSimulation {
-  accountOps: AccountOp[]
+export interface GetOptionsSimulation<T = AccountOpWithId[]> {
+  accountOps: T
   baseAccount: BaseAccount
   state: AccountOnchainState
 }
@@ -420,7 +420,7 @@ export type NetworkState<T = PortfolioKeyResult> = {
   // We store the previously simulated AccountOps only for the pending state.
   // Prior to triggering a pending state update, we compare the newly passed AccountOp[] (updateSelectedAccount) with the cached version.
   // If there are no differences, the update is canceled unless the `forceUpdate` flag is set.
-  accountOps?: AccountOp[]
+  accountOps?: AccountOpWithId[]
 }
 
 export type AccountState = {
@@ -570,7 +570,7 @@ export interface PreviousHintsStorage {
 }
 
 export interface NetworkSimulatedAccountOp {
-  [chainId: string]: AccountOp
+  [chainId: string]: AccountOpWithId
 }
 
 export type PendingAmounts = {

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -1,7 +1,7 @@
 import { AccountId, AccountOnchainState } from '../../interfaces/account'
 import { Price, TokenMarketDataByCurrency } from '../../interfaces/assets'
 import { BaseAccount } from '../account/BaseAccount'
-import { AccountOp, AccountOpWithId } from '../accountOp/accountOp'
+import { AccountOp } from '../accountOp/accountOp'
 import {
   AssetType,
   NetworkState as DefiNetworkState,
@@ -11,7 +11,7 @@ import {
 // @TODO: Move most of these interfaces to src/interfaces and
 // figure out how to restructure portfolio/defiPositions types
 
-export interface GetOptionsSimulation<T = AccountOpWithId[]> {
+export interface GetOptionsSimulation<T = AccountOp[]> {
   accountOps: T
   baseAccount: BaseAccount
   state: AccountOnchainState
@@ -420,7 +420,7 @@ export type NetworkState<T = PortfolioKeyResult> = {
   // We store the previously simulated AccountOps only for the pending state.
   // Prior to triggering a pending state update, we compare the newly passed AccountOp[] (updateSelectedAccount) with the cached version.
   // If there are no differences, the update is canceled unless the `forceUpdate` flag is set.
-  accountOps?: AccountOpWithId[]
+  accountOps?: AccountOp[]
 }
 
 export type AccountState = {
@@ -570,7 +570,7 @@ export interface PreviousHintsStorage {
 }
 
 export interface NetworkSimulatedAccountOp {
-  [chainId: string]: AccountOpWithId
+  [chainId: string]: AccountOp
 }
 
 export type PendingAmounts = {

--- a/src/libs/selectedAccount/portfolioView.ts
+++ b/src/libs/selectedAccount/portfolioView.ts
@@ -2,7 +2,7 @@ import {
   SelectedAccountPortfolio,
   SelectedAccountPortfolioState
 } from '../../interfaces/selectedAccount'
-import { AccountOp } from '../accountOp/accountOp'
+import { AccountOpWithId } from '../accountOp/accountOp'
 import { PositionsByProvider } from '../defiPositions/types'
 import { CollectionResult, TokenResult } from '../portfolio'
 import {
@@ -26,7 +26,7 @@ export default class PortfolioViewBuilder {
 
   private balancePerNetwork: Record<string, number> = {}
 
-  private networkSimulatedAccountOp: Record<string, AccountOp> = {}
+  private networkSimulatedAccountOp: Record<string, AccountOpWithId> = {}
 
   private isAllReady = true
 

--- a/src/libs/selectedAccount/portfolioView.ts
+++ b/src/libs/selectedAccount/portfolioView.ts
@@ -2,7 +2,7 @@ import {
   SelectedAccountPortfolio,
   SelectedAccountPortfolioState
 } from '../../interfaces/selectedAccount'
-import { AccountOpWithId } from '../accountOp/accountOp'
+import { AccountOp } from '../accountOp/accountOp'
 import { PositionsByProvider } from '../defiPositions/types'
 import { CollectionResult, TokenResult } from '../portfolio'
 import {
@@ -26,7 +26,7 @@ export default class PortfolioViewBuilder {
 
   private balancePerNetwork: Record<string, number> = {}
 
-  private networkSimulatedAccountOp: Record<string, AccountOpWithId> = {}
+  private networkSimulatedAccountOp: Record<string, AccountOp> = {}
 
   private isAllReady = true
 


### PR DESCRIPTION
## Changes:
- Adjusts the portfolio so the simulation doesn't have to be passed with every update. 
- Adds a function that discards specific account ops after they have been broadcasted/rejected.
- Adds a bunch of tests