### PR TITLE
Bug / HD derivation for seed + passphrase imports causing "invalid path" errors

### DIFF
--- a/src/libs/keyIterator/keyIterator.ts
+++ b/src/libs/keyIterator/keyIterator.ts
@@ -131,7 +131,7 @@ export class KeyIterator implements KeyIteratorInterface {
             // eslint-disable-next-line no-await-in-loop
             await new Promise((resolve) => setTimeout(resolve, 0))
           }
-          const path = getHdPathFromTemplate(hdPathTemplate, i).replace('m/', '')
+          const path = getHdPathFromTemplate(hdPathTemplate, i)
           const wallet = baseWallet.derivePath(path)
           keys.push(wallet.address)
         }
@@ -166,7 +166,7 @@ export class KeyIterator implements KeyIteratorInterface {
             return []
           }
 
-          const path = getHdPathFromTemplate(hdPathTemplate, index).replace('m/', '')
+          const path = getHdPathFromTemplate(hdPathTemplate, index)
           const privateKey = baseWallet.derivePath(path).privateKey
 
           return [


### PR DESCRIPTION
I missed this in the recent key iterator optimizations in https://github.com/AmbireTech/ambire-common/pull/2216.

This tweak fixes two problems:

- Fixed: invalid path (value="44'/60'/0'/0/0") when importing accounts with seed + passphrase.
- Fixed: unable to import (or even select) smart accounts in the account picker
  <img width="539" height="60" alt="Screenshot 2026-03-16 at 13 28 08" src="https://github.com/user-attachments/assets/2132df1e-377a-417a-9a04-5e9b4b096628" />
