### PR TITLE
Feature/better eoa broadcast failure handler

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -560,7 +560,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
               const limit = !provider.batchMaxCount || provider.batchMaxCount > 1 ? 100 : 3
               txIds.push(
                 ...accountOp.calls
-                  .filter((call) => !!call.status)
+                  .filter((call) => !!call.status && call.txnId)
                   .map((call) => call.txnId)
                   .slice(0, limit)
               )

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -51,7 +51,7 @@ import { BenzinUserRequest, CallsUserRequest } from '../../interfaces/userReques
 import { getDefaultSelectedAccount } from '../../libs/account/account'
 import { AccountOp, haveAccountOpsChanged } from '../../libs/accountOp/accountOp'
 import { getDappIdentifier, SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
-import { AccountOpStatus, Call } from '../../libs/accountOp/types'
+import { AccountOpStatus } from '../../libs/accountOp/types'
 import { HumanizerMeta } from '../../libs/humanizer/interfaces'
 import { KeyIterator } from '../../libs/keyIterator/keyIterator'
 import { getAccountOpsForSimulation } from '../../libs/main/main'
@@ -770,18 +770,21 @@ export class MainController extends EventEmitter implements IMainController {
       submittedAccountOp.identifiedBy.type === 'MultipleTxns'
     if (isBasicAccountBroadcastingMultiple) {
       const txnIds = submittedAccountOp.identifiedBy.identifier.split('-')
-      const calls = submittedAccountOp.calls
-        .map((oneCall, i) => {
-          const localCall = { ...oneCall }
+      const calls = submittedAccountOp.calls.map((oneCall, i) => {
+        const localCall = { ...oneCall }
 
-          // we're cutting off calls the user didn't sign / weren't broadcast
-          if (!(i in txnIds)) return null
-
-          localCall.txnId = txnIds[i] as Hex
-          localCall.status = AccountOpStatus.BroadcastedButNotConfirmed
+        // no tx id = failure
+        if (!(i in txnIds)) {
+          localCall.status = AccountOpStatus.Rejected
           return localCall
-        })
-        .filter((aCall) => aCall !== null) as Call[]
+        }
+
+        // maybe we can set it to fialure
+
+        localCall.txnId = txnIds[i] as Hex
+        localCall.status = AccountOpStatus.BroadcastedButNotConfirmed
+        return localCall
+      })
       // eslint-disable-next-line no-param-reassign
       submittedAccountOp.calls = calls
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -769,13 +769,12 @@ export class MainController extends EventEmitter implements IMainController {
       const calls = submittedAccountOp.calls.map((oneCall, i) => {
         const localCall = { ...oneCall }
 
-        // no tx id = failure
+        // if there's no tx id, we set it to Rejected and continue.
+        // it means broadcast has failed
         if (!(i in txnIds)) {
           localCall.status = AccountOpStatus.Rejected
           return localCall
         }
-
-        // maybe we can set it to fialure
 
         localCall.txnId = txnIds[i] as Hex
         localCall.status = AccountOpStatus.BroadcastedButNotConfirmed

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -89,7 +89,11 @@ import {
 import { AccountOpIdentifiedBy, SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
 import { getScamDetectedText } from '../../libs/banners/banners'
-import { BROADCAST_OPTIONS, buildRawTransaction } from '../../libs/broadcast/broadcast'
+import {
+  BROADCAST_OPTIONS,
+  broadcastTransaction,
+  buildRawTransaction
+} from '../../libs/broadcast/broadcast'
 import { PaymasterErrorReponse, PaymasterSuccessReponse, Sponsor } from '../../libs/erc7677/types'
 import { getHumanReadableBroadcastError } from '../../libs/errorHumanizer'
 import { insufficientPaymasterFunds } from '../../libs/errorHumanizer/errors'
@@ -2940,7 +2944,8 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
               hash: await this.provider.send('eth_sendRawTransaction', [signedTxn])
             })
           } else {
-            multipleTxnsBroadcastRes.push(await this.provider.broadcastTransaction(signedTxn))
+            const response = await broadcastTransaction(this.provider, signedTxn, accountOp.chainId)
+            multipleTxnsBroadcastRes.push(response)
           }
           if (txnLength > 1) this.update({ signedTransactionsCount: i + 1 })
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -2938,8 +2938,9 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
               hash: await this.provider.send('eth_sendRawTransaction', [signedTxn])
             })
           } else {
-            const response = await broadcastTransaction(this.provider, signedTxn, accountOp.chainId)
-            multipleTxnsBroadcastRes.push(response)
+            multipleTxnsBroadcastRes.push(
+              await broadcastTransaction(this.provider, signedTxn, accountOp.chainId)
+            )
           }
           if (txnLength > 1) this.update({ signedTransactionsCount: i + 1 })
 

--- a/src/libs/accountOp/submittedAccountOp.ts
+++ b/src/libs/accountOp/submittedAccountOp.ts
@@ -85,15 +85,21 @@ export function getMultipleBroadcastUnconfirmedCallOrLast(op: AccountOp): {
   call: Call
   callIndex: number
 } {
+  let lastWithTxId
+  let callIndex = 0
+
   // get the first BroadcastedButNotConfirmed call if any
   for (let i = 0; i < op.calls.length; i++) {
     const currentCall = op.calls[i]!
     if (currentCall.status === AccountOpStatus.BroadcastedButNotConfirmed)
       return { call: currentCall, callIndex: i }
+
+    lastWithTxId = currentCall
+    callIndex = i
   }
 
   // if no BroadcastedButNotConfirmed, get the last one
-  return { call: op.calls[op.calls.length - 1]!, callIndex: op.calls.length - 1 }
+  return { call: lastWithTxId!, callIndex }
 }
 
 export async function fetchFrontRanTxnId(
@@ -305,7 +311,10 @@ export function updateOpStatus(
       opReference.calls[callIndex]!.gasUsed = toBeHex(receipt.gasUsed)
     }
 
-    if (callIndex === opReference.calls.length - 1) {
+    const left = !!opReference.calls.find(
+      (c) => c.status === AccountOpStatus.BroadcastedButNotConfirmed
+    )
+    if (!left) {
       // eslint-disable-next-line no-param-reassign
       opReference.status = status
       return opReference

--- a/src/libs/broadcast/broadcast.ts
+++ b/src/libs/broadcast/broadcast.ts
@@ -1,4 +1,4 @@
-import { Interface, toQuantity } from 'ethers'
+import { Interface, toQuantity, TransactionResponse } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
@@ -23,6 +23,11 @@ export const BROADCAST_OPTIONS = {
   byRelayer: 'relayer', // execute
   byOtherEOA: 'otherEOA', // execute + standard
   delegation: 'delegation' // txn type 4
+}
+
+async function waitBeforeRetry(chainId: bigint) {
+  // block time at ethereum is bigger, so we wait 3s per failures
+  await wait(chainId === 1n ? 3000 : 1500)
 }
 
 export function getByOtherEOATxnData(
@@ -58,6 +63,7 @@ async function estimateGas(
   from: string,
   call: Call,
   nonce: number,
+  chainId: bigint,
   error?: Error,
   counter: number = 0
 ): Promise<bigint> {
@@ -111,8 +117,8 @@ async function estimateGas(
     if (gasLimit instanceof Error && gasLimit.message.includes('INSUFFICIENT_PRIVILEGE'))
       throw gasLimit
 
-    await wait(1500)
-    return estimateGas(provider, from, call, nonce, gasLimit, counter + 1)
+    await waitBeforeRetry(chainId)
+    return estimateGas(provider, from, call, nonce, chainId, gasLimit, counter + 1)
   }
 
   // add a 10% overhead to prevent OOG
@@ -163,7 +169,7 @@ export async function getTxnData(
     // for each one seperately
     let gasLimit: bigint | undefined = (op.gasFeePayment as GasFeePayment).simulatedGasLimit
     if (op.calls.length > 1) {
-      gasLimit = await estimateGas(provider, account.addr, call, nonce)
+      gasLimit = await estimateGas(provider, account.addr, call, nonce, op.chainId)
     }
 
     const singleCallTxn = {
@@ -182,7 +188,8 @@ export async function getTxnData(
       provider,
       (op.gasFeePayment as GasFeePayment).paidBy,
       otherEOACall,
-      nonce
+      nonce,
+      op.chainId
     )
     return { ...otherEOACall, gasLimit }
   }
@@ -234,4 +241,20 @@ export async function buildRawTransaction(
   }
 
   return rawTxn
+}
+
+export async function broadcastTransaction(
+  provider: RPCProvider,
+  signedTx: string,
+  chainId: bigint,
+  counter: number = 0
+): Promise<TransactionResponse> {
+  if (counter > 2) throw new Error('broadcast failed')
+  try {
+    return provider.broadcastTransaction(signedTx)
+  } catch (e) {
+    console.log('broadcast failed: ', e)
+    await waitBeforeRetry(chainId)
+    return broadcastTransaction(provider, signedTx, chainId, counter + 1)
+  }
 }


### PR DESCRIPTION
When a call from a simulated EOA batch fails:
* we mark that call and every other until the end as rejected
* we display them in benzina as "broadcast failed"