### PR TITLE
Humanizer: display send ETH amount on contract interactions

### DIFF
--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { ethers } from 'ethers'
+import { ethers, ZeroAddress } from 'ethers'
 
 import { describe, test } from '@jest/globals'
 
@@ -73,6 +73,12 @@ const transactions = {
   ],
   // currently with USDT
   erc20: [
+    // approve erc-20 token USDT with hidden eth send
+    {
+      to: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      value: 10n ** 18n,
+      data: '0x095ea7b300000000000000000000000046705dfff24256421a05d056c29e81bdc09723b8000000000000000000000000000000000000000000000000000000003b9aca00'
+    },
     // approve erc-20 token USDT
     {
       to: '0xdac17f958d2ee523a2206206994597c13d831ec7',
@@ -241,6 +247,44 @@ describe('Humanizer main function', () => {
 
     accountOp.calls = [...transactions.generic]
     const irCalls = humanizeAccountOp(accountOp)
+    compareHumanizerVisualizations(irCalls, expectedVisualizations)
+  })
+
+  test('erc20 humanize end to end', async () => {
+    // const ir: Ir = []
+    const expectedVisualizations = [
+      [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 10n ** 9n),
+        getLabel('to'),
+        getAddressVisualization('0x46705dfff24256421a05d056c29e81bdc09723b8'),
+        getLabel('and'),
+        getAction('Send'),
+        getToken(ZeroAddress, 10n ** 18n),
+        getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 0n, true)
+      ],
+      [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 1000000000n),
+        getLabel('to'),
+        getAddressVisualization('0x46705dfff24256421a05d056c29e81bdc09723b8'),
+        getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 0n, true)
+      ],
+      [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 1000000000n),
+        getLabel('to'),
+        getAddressVisualization('0x46705dfff24256421a05d056c29e81bdc09723b8'),
+        getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 0n, true)
+      ]
+    ]
+
+    accountOp.calls = [...transactions.erc20.slice(0, 3)]
+    const irCalls = humanizeAccountOp(accountOp)
+    console.log(irCalls[0]?.fullVisualization)
     compareHumanizerVisualizations(irCalls, expectedVisualizations)
   })
 })

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { ethers, ZeroAddress } from 'ethers'
 
 import { describe, test } from '@jest/globals'
@@ -34,7 +33,7 @@ const accountOp: AccountOp = {
   // or any other data that needs to otherwise be retrieved in an async manner and/or needs to be
   // "remembered" at the time of signing in order to visualize history properly
   // humanizerMeta: {}
-}
+} as any
 
 const accounts: Account[] = [
   {
@@ -284,7 +283,6 @@ describe('Humanizer main function', () => {
 
     accountOp.calls = [...transactions.erc20.slice(0, 3)]
     const irCalls = humanizeAccountOp(accountOp)
-    console.log(irCalls[0]?.fullVisualization)
     compareHumanizerVisualizations(irCalls, expectedVisualizations)
   })
 })

--- a/src/libs/humanizer/modules/AsciiModule/asciiModule.test.ts
+++ b/src/libs/humanizer/modules/AsciiModule/asciiModule.test.ts
@@ -19,7 +19,7 @@ const accountOp: AccountOp = {
   gasLimit: null,
   signature: null,
   gasFeePayment: null
-}
+} as any
 const transactions = [
   { to: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', value: 0n, data: '0x68656c6c6f' },
   { to: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', value: 1n, data: '0x68656c6c6f' },
@@ -41,14 +41,8 @@ describe('asciiHumanizer', () => {
     const irCalls = asciiModule(accountOp, accountOp.calls, humanizerInfo as HumanizerMeta)
 
     compareVisualizations(irCalls[0]!.fullVisualization!, [...humanizationPrefix, getText('hello')])
-    compareVisualizations(irCalls[1]!.fullVisualization!, [
-      ...humanizationPrefix,
-      getText('hello'),
-      getLabel('and'),
-      getAction('Send'),
-      getToken(ZeroAddress, 1n)
-    ])
-    compareVisualizations(irCalls[2].fullVisualization!, [
+    compareVisualizations(irCalls[1]!.fullVisualization!, [...humanizationPrefix, getText('hello')])
+    compareVisualizations(irCalls[2]!.fullVisualization!, [
       ...humanizationPrefix,
       getText('Some example onchain text message')
     ])

--- a/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
+++ b/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
@@ -40,9 +40,6 @@ export const asciiModule: HumanizerCallModule = (
     let messageAsText = tryGetMEssageAsText(call.data)
     if (!messageAsText) return call
 
-    const sendNativeHumanization = call.value
-      ? [getLabel('and'), getAction('Send'), getToken(ZeroAddress, call.value)]
-      : []
     return {
       ...call,
       fullVisualization: call.to
@@ -50,10 +47,9 @@ export const asciiModule: HumanizerCallModule = (
             getAction('Send this message'),
             getLabel('to'),
             getAddressVisualization(call.to),
-            getText(messageAsText),
-            ...sendNativeHumanization
+            getText(messageAsText)
           ]
-        : [getAction('Send this message'), getText(messageAsText), ...sendNativeHumanization]
+        : [getAction('Send this message'), getText(messageAsText)]
     }
   })
   return newCalls

--- a/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
+++ b/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
@@ -3,14 +3,7 @@ import { getBytes, toUtf8String, ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerCallModule, IrCall } from '../../interfaces'
-import {
-  checkIfUnknownAction,
-  getAction,
-  getAddressVisualization,
-  getLabel,
-  getText,
-  getToken
-} from '../../utils'
+import { getAction, getAddressVisualization, getLabel, getText, getToken } from '../../utils'
 
 function tryGetMEssageAsText(msg: string) {
   const bytes = getBytes(msg)
@@ -32,7 +25,7 @@ export const asciiModule: HumanizerCallModule = (
 ) => {
   const newCalls = currentIrCalls.map((call) => {
     if (!call.data || call.data === '0x') return call
-    if (call.fullVisualization && !checkIfUnknownAction(call?.fullVisualization)) return call
+    if (call.fullVisualization) return call
     // assuming that if there are only 4 bytes it is probably just contract method call
     // and further logic is irrelevant
     if (call.data.length === '0x12345678'.length) return call

--- a/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
@@ -86,7 +86,13 @@ export const fallbackHumanizer: HumanizerCallModule = (
       }
     }
 
-    if (call.value) {
+    if (
+      call.value &&
+      (!fullVisualization.length ||
+        !['Swap', 'Bridge', 'Swap/Bridge', 'Supply', 'Deposit', 'Supply to vault', 'Wrap'].includes(
+          fullVisualization[0]?.content || ''
+        ))
+    ) {
       if (fullVisualization.length) fullVisualization.push(getLabel('and'))
       fullVisualization.push(getAction('Send'), getToken(ZeroAddress, call.value))
       if (call.data === '0x' && call.to)

--- a/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import { Interface, isAddress, ZeroAddress } from 'ethers'
 
+import humanizerMeta from '../../../../consts/humanizer/humanizerInfo.json'
 import { AccountOp } from '../../../accountOp/accountOp'
 import {
   HumanizerCallModule,
@@ -34,73 +35,71 @@ function extractAddresses(data: string, _selector: string): string[] {
   return deepSearchForAddress(args)
 }
 
+const knownSigHashes: HumanizerMeta['abis']['NO_ABI'] = Object.values(
+  (humanizerMeta as HumanizerMeta).abis as HumanizerMeta['abis']
+).reduce((a, b) => ({ ...a, ...b }), {})
+
 export const fallbackHumanizer: HumanizerCallModule = (
   accountOp: AccountOp,
-  currentIrCalls: IrCall[],
-  humanizerMeta: HumanizerMeta
+  currentIrCalls: IrCall[]
 ) => {
   const newCalls = currentIrCalls.map((call) => {
-    if (!call.to)
-      return {
-        ...call,
-        fullVisualization: [getAction('Deploy contract')]
-      }
-    if (call.fullVisualization && !checkIfUnknownAction(call?.fullVisualization)) return call
-
-    const knownSigHashes: HumanizerMeta['abis']['NO_ABI'] = Object.values(
-      humanizerMeta.abis as HumanizerMeta['abis']
-    ).reduce((a, b) => ({ ...a, ...b }), {})
-
-    const visualization: Array<HumanizerVisualization> = []
-    if (call.data !== '0x') {
-      let extractedAddresses: string[] = []
-      if (knownSigHashes[call.data.slice(0, 10)]?.signature) {
-        try {
-          extractedAddresses = extractAddresses(
-            call.data,
-            knownSigHashes[call.data.slice(0, 10)].signature
+    let fullVisualization = []
+    if (!call.to) fullVisualization = [getAction('Deploy contract')]
+    else if (call.fullVisualization?.length) fullVisualization = call.fullVisualization
+    else {
+      if (call.data !== '0x') {
+        let extractedAddresses: string[] = []
+        const foundSignature = knownSigHashes[call.data.slice(0, 10)]?.signature
+        if (foundSignature && typeof foundSignature === 'string') {
+          try {
+            extractedAddresses = extractAddresses(call.data, foundSignature)
+          } catch (e) {
+            console.error('Humanizer: fallback: Could not decode addresses from calldata')
+          }
+          fullVisualization.push(
+            getAction(
+              `Call ${
+                //  from function asd(address asd) returns ... => asd(address asd)
+                foundSignature
+                  .split('function ')
+                  .filter((x) => x !== '')[0]
+                  ?.split('(')
+                  .filter((x) => x !== '')[0]
+                  ?.split(' returns')
+                  .filter((x) => x !== '')[0]
+              }`
+            ),
+            getLabel('from'),
+            getAddressVisualization(call.to),
+            ...extractedAddresses.map(
+              (a): HumanizerVisualization => ({ ...getToken(a, 0n), isHidden: true })
+            )
           )
-        } catch (e) {
-          console.error('Humanizer: fallback: Could not decode addresses from calldata')
+        } else {
+          fullVisualization.push(
+            getAction('Interacting'),
+            getLabel('with'),
+            getAddressVisualization(call.to)
+          )
         }
-        visualization.push(
-          getAction(
-            `Call ${
-              //  from function asd(address asd) returns ... => asd(address asd)
-              knownSigHashes[call.data.slice(0, 10)].signature
-                .split('function ')
-                .filter((x) => x !== '')[0]
-                .split('(')
-                .filter((x) => x !== '')[0]
-                .split(' returns')
-                .filter((x) => x !== '')[0]
-            }`
-          ),
-          getLabel('from'),
-          getAddressVisualization(call.to),
-          ...extractedAddresses.map(
-            (a): HumanizerVisualization => ({ ...getToken(a, 0n), isHidden: true })
-          )
-        )
-      } else {
-        visualization.push(
-          getAction('Interacting'),
-          getLabel('with'),
-          getAddressVisualization(call.to)
-        )
       }
     }
+
     if (call.value) {
-      if (call.data !== '0x') visualization.push(getLabel('and'))
-      visualization.push(getAction('Send'), getToken(ZeroAddress, call.value))
-      if (call.data === '0x') visualization.push(getLabel('to'), getAddressVisualization(call.to))
+      if (fullVisualization.length) fullVisualization.push(getLabel('and'))
+      fullVisualization.push(getAction('Send'), getToken(ZeroAddress, call.value))
+      if (call.data === '0x' && call.to)
+        fullVisualization.push(getLabel('to'), getAddressVisualization(call.to))
     }
 
     return {
       ...call,
-      fullVisualization: visualization.length
-        ? visualization
-        : [getAction('Empty call to'), getAddressVisualization(call.to)]
+      fullVisualization: fullVisualization.length
+        ? fullVisualization
+        : call.to
+          ? [getAction('Empty call to'), getAddressVisualization(call.to)]
+          : [getAction('Empty call')]
     }
   })
 

--- a/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
@@ -9,13 +9,7 @@ import {
   HumanizerVisualization,
   IrCall
 } from '../../interfaces'
-import {
-  checkIfUnknownAction,
-  getAction,
-  getAddressVisualization,
-  getLabel,
-  getToken
-} from '../../utils'
+import { getAction, getAddressVisualization, getLabel, getToken } from '../../utils'
 
 function extractAddresses(data: string, _selector: string): string[] {
   const selector = _selector.startsWith('function') ? _selector : `function ${_selector}`

--- a/src/libs/humanizer/modules/Uniswap/uniV3.ts
+++ b/src/libs/humanizer/modules/Uniswap/uniV3.ts
@@ -29,7 +29,7 @@ const uniV32Mapping = (): HumanizerUniMatcher => {
         (data: string): HumanizerVisualization[] => {
           const sigHash = data.slice(0, 10)
           const humanizer = mappingResult[sigHash]
-          return humanizer ? humanizer(accountOp, { ...call, data }) : [getAction('Unknown action')]
+          return humanizer ? humanizer(accountOp, { ...call, data }) : [getAction('Uniswap action')]
         }
       )
       const res = uniReduce(parsed)
@@ -48,7 +48,7 @@ const uniV32Mapping = (): HumanizerUniMatcher => {
         const sigHash = data.slice(0, 10)
 
         const humanizer = mappingResult[sigHash]
-        return humanizer ? humanizer(accountOp, { ...call, data }) : [getAction('Unknown action')]
+        return humanizer ? humanizer(accountOp, { ...call, data }) : [getAction('Uniswap action')]
       })
       return uniReduce(parsed)
     },
@@ -65,7 +65,7 @@ const uniV32Mapping = (): HumanizerUniMatcher => {
         (data: string): HumanizerVisualization[] => {
           const sigHash = data.slice(0, 10)
           const humanizer = mappingResult[sigHash]
-          return humanizer ? humanizer(accountOp, { ...call, data }) : [getAction('Unknown action')]
+          return humanizer ? humanizer(accountOp, { ...call, data }) : [getAction('Uniswap action')]
         }
       )
       return parsed.length
@@ -324,7 +324,7 @@ const uniV3Mapping = (): HumanizerUniMatcher => {
       const parsed = calls.map((data: string): HumanizerVisualization[] => {
         const sigHash = data.slice(0, 10)
         const humanizer = mappingResult[sigHash]
-        return humanizer ? humanizer(accountOp, { ...call, data }) : [getAction('Unknown action')]
+        return humanizer ? humanizer(accountOp, { ...call, data }) : [getAction('Uniswap action')]
       })
 
       return parsed.length

--- a/src/libs/humanizer/modules/WALLET/index.ts
+++ b/src/libs/humanizer/modules/WALLET/index.ts
@@ -4,7 +4,7 @@ import { STK_WALLET, WALLET_STAKING_ADDR, WALLET_TOKEN } from '../../../../const
 import { AccountOp } from '../../../accountOp/accountOp'
 import { StkWallet } from '../../const/abis/stkWallet'
 import { HumanizerCallModule, IrCall } from '../../interfaces'
-import { checkIfUnknownAction, getAction, getLabel, getToken } from '../../utils'
+import { getAction, getLabel, getToken } from '../../utils'
 import { StakingPools } from './stakingPools'
 // update return ir to be {...ir,calls:newCalls} instead of {calls:newCalls} everywhere
 import { WALLETSupplyControllerMapping } from './WALLETSupplyController'
@@ -66,32 +66,29 @@ export const WALLETModule: HumanizerCallModule = (_: AccountOp, irCalls: IrCall[
     }
   }
   const newCalls = irCalls.map((call: IrCall) => {
-    if (
-      call.to &&
-      stakingAddresses.includes(call.to.toLowerCase()) &&
-      (!call.fullVisualization || checkIfUnknownAction(call.fullVisualization))
-    ) {
-      if (matcher.stakingPool[call.data.slice(0, 10)]) {
+    const selector = call.data.slice(0, 10)
+    if (call.to && stakingAddresses.includes(call.to.toLowerCase()) && !call.fullVisualization) {
+      if (matcher.stakingPool[selector]) {
         return {
           ...call,
-          fullVisualization: matcher.stakingPool[call.data.slice(0, 10)](call)
+          fullVisualization: matcher.stakingPool[selector](call)
         }
       }
     }
-    if (matcher.supplyController[call.data.slice(0, 10)]) {
+    if (matcher.supplyController[selector]) {
       return {
         ...call,
-        fullVisualization: matcher.supplyController[call.data.slice(0, 10)](call)
+        fullVisualization: matcher.supplyController[selector](call)
       }
     }
     if (
       call.to &&
       call.to.toLowerCase() === STK_WALLET.toLowerCase() &&
-      matcher.stkWallet[call.data.slice(0, 10)]
+      matcher.stkWallet[selector]
     ) {
       return {
         ...call,
-        fullVisualization: matcher.stkWallet[call.data.slice(0, 10)](call)
+        fullVisualization: matcher.stkWallet[selector](call)
       }
     }
     return call

--- a/src/libs/humanizer/utils.ts
+++ b/src/libs/humanizer/utils.ts
@@ -104,10 +104,6 @@ export function getLink(url: string, content: string): HumanizerVisualization {
   return { type: 'link', url, content, id: randomId() }
 }
 
-export function checkIfUnknownAction(v: HumanizerVisualization[] | undefined): boolean {
-  return !!(v && v[0]?.type === 'action' && v?.[0]?.content?.startsWith('Unknown action'))
-}
-
 export function getWrapping(address: string, amount: bigint): HumanizerVisualization[] {
   return [getAction('Wrap'), getToken(address, amount)]
 }


### PR DESCRIPTION
We want to display when the user is sending ETH while doing something else. Not displaying it is vuln as funds will be moved and the humanizer should say so.

implemented for all transactions, except the ones that are humanized with one of the following actions
`['Swap', 'Bridge', 'Swap/Bridge', 'Supply', 'Deposit', 'Supply to vault', 'Wrap']`

<img width="709" height="283" alt="image" src="https://github.com/user-attachments/assets/95b8f9e9-639d-4bb5-b727-71cc1c4a54d0" />
<img width="719" height="362" alt="image" src="https://github.com/user-attachments/assets/524d57f4-74ee-47ff-b885-cd345eb78d0e" />
