### PR TITLE
Allow nested safe signatures to be recovered & sorted

### DIFF
--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -436,7 +436,11 @@ export class ContinuousUpdatesController extends EventEmitter {
       // we come here only if transactionHash is undefined
       const signatures = (oneConfirmed.confirmations?.map((c) => c.signature) || []) as Hex[]
       const safeGlobalSigs = callsUserR.signAccountOp.accountOp.txnId
-        ? sortSigs(signatures, callsUserR.signAccountOp.accountOp.txnId)
+        ? sortSigs(
+            signatures,
+            callsUserR.signAccountOp.accountOp.txnId,
+            callsUserR.signAccountOp.accountOp.safeTx?.confirmations
+          )
         : null
       if (
         safeGlobalSigs &&

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -424,7 +424,8 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     if (this.#accountOp.signature && this.#accountOp.txnId) {
       this.#accountOp.signed = getAlreadySignedOwners(
         this.#accountOp.signature,
-        this.#accountOp.txnId
+        this.#accountOp.txnId,
+        this.#accountOp.safeTx
       )
       const notSigned = getImportedSignersThatHaveNotSigned(
         this.#accountOp.signed,
@@ -1254,12 +1255,20 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         const { calls, signature, ...rest } = accountOpData
 
         if (signature && this.accountOp.txnId) {
-          const newlySigned = getAlreadySignedOwners(signature, this.accountOp.txnId)
+          const newlySigned = getAlreadySignedOwners(
+            signature,
+            this.accountOp.txnId,
+            this.accountOp.safeTx
+          )
           const signed = this.accountOp.signed
             ? [...new Set(...this.accountOp.signed, ...newlySigned)]
             : newlySigned
           this.#updateAccountOp({
-            signature: sortSigs(getSigs(signature), this.accountOp.txnId),
+            signature: sortSigs(
+              getSigs(signature),
+              this.accountOp.txnId,
+              this.accountOp.safeTx?.confirmations
+            ),
             signed
           })
         }
@@ -1428,7 +1437,8 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     if (this.#accountOp.signature && this.#accountOp.txnId) {
       this.#accountOp.signed = getAlreadySignedOwners(
         this.#accountOp.signature,
-        this.#accountOp.txnId
+        this.#accountOp.txnId,
+        this.#accountOp.safeTx
       )
       const notSigned = getImportedSignersThatHaveNotSigned(
         this.#accountOp.signed,
@@ -2560,7 +2570,11 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
         this.status = { type: SigningStatus.Queued }
         this.#updateAccountOp({
-          signature: sortSigs(prevSignedSigs.concat(nowSignedSigs), safeTxnHash),
+          signature: sortSigs(
+            prevSignedSigs.concat(nowSignedSigs),
+            safeTxnHash,
+            this.accountOp.safeTx?.confirmations
+          ),
           signed: allSigners,
           txnId: safeTxnHash
         })

--- a/src/libs/safe/safe.ts
+++ b/src/libs/safe/safe.ts
@@ -542,7 +542,8 @@ export function toSigMessageUserRequests(response: SafeResults): {
           messageHash: message.messageHash as Hex,
           signature: sortSigs(
             message.confirmations.map((c) => c.signature) as Hex[],
-            message.messageHash
+            message.messageHash,
+            message.confirmations
           ),
           created: new Date(message.created).getTime()
         },
@@ -554,17 +555,42 @@ export function toSigMessageUserRequests(response: SafeResults): {
   return userRequests
 }
 
+function getOwnerFromSafeTx(
+  sig: string,
+  confirmations?: { owner: string; signature: string }[]
+): string | undefined {
+  return confirmations?.find((c) => c.signature === sig)?.owner
+}
+
+function recoverOwner(
+  sig: string,
+  hash: string,
+  confirmations?: { owner: string; signature: string }[]
+) {
+  // a transaction from safe global may have signatures that are not
+  // ecdsa; therefore, we cannot extract the owner from them by using
+  // a plain recoverAddress. We rely on the safe global information
+  const safeOwner = getOwnerFromSafeTx(sig, confirmations)
+  if (safeOwner) return safeOwner
+
+  // an ambire sig is always ecdsa
+  return recoverAddress(hash, sig)
+}
+
 // the signature is 130 x number_of_sigs + 2 (0x) symbols long
 // so we cut the hex (0x) from the beginning
 // then take each sig (substring(0, 130)) and recover the address
 // finally, we update everything
-export function getAlreadySignedOwners(signature: string, hash: string): string[] {
+export function getAlreadySignedOwners(
+  signature: string,
+  hash: string,
+  safeTx?: SafeMultisigTransactionResponse
+): string[] {
   const signatures = signature.substring(2)
   const signed = []
   for (let i = 0; i < signatures.length; i += 130) {
     const sig = `0x${signatures.substring(i, i + 130)}`
-    const owner = recoverAddress(hash, sig)
-    signed.push(owner)
+    signed.push(recoverOwner(sig, hash, safeTx?.confirmations))
   }
   return signed
 }
@@ -586,13 +612,16 @@ export function getSigs(signature?: string | null): Hex[] {
   return signed
 }
 
-export function sortSigs(signatures: Hex[], hash: string): Hex {
+export function sortSigs(
+  signatures: Hex[],
+  hash: string,
+  confirmations?: { owner: string; signature: string }[]
+): Hex {
   const signed: { sig: string; addr: string }[] = []
 
   for (let i = 0; i < signatures.length; i++) {
     const sig = signatures[i]!
-    const owner = recoverAddress(hash, sig)
-    signed.push({ sig, addr: owner })
+    signed.push({ sig, addr: recoverOwner(sig, hash, confirmations) })
   }
 
   const sorted = sortByAddress(signed)


### PR DESCRIPTION
Problem:
* we were always calling `recoverAddress` on the signature expecting it to be an ecdsa recovereable sig as we're signing only ecdsa in the UI. But a safe global signature could be of another type

Fix:
* take the signed owner directly from the safeTx's confirmations from the API instead of trying to ecdsa recover it