### PR TITLE
Asset info/fix blacklisted tokens

### DIFF
--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -520,7 +520,7 @@ export interface GetOptions {
    */
   blacklist?: TokenBlacklist
   /**
-   * Used to prevent blacklisting of Monerium Euro sp the assetInfo service can get symbol
+   * Used to prevent blacklisting of Monerium Euro so the assetInfo service can get symbol
    * and decimals from the portfolio
    */
   preventTokenBlacklisting?: true

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -519,6 +519,11 @@ export interface GetOptions {
    * blacklist defined in the portfolio library.
    */
   blacklist?: TokenBlacklist
+  /**
+   * Used to prevent blacklisting of Monerium Euro sp the assetInfo service can get symbol
+   * and decimals from the portfolio
+   */
+  preventTokenBlacklisting?: true
 }
 
 /**

--- a/src/libs/portfolio/pagination.ts
+++ b/src/libs/portfolio/pagination.ts
@@ -10,9 +10,9 @@ export function paginate(input: string[] | [string, bigint[]][], limit: number):
   return pages
 }
 
-export function flattenResults(
-  everything: Promise<[[string, TokenResult | CollectionResult][], MetaData][]>[]
-): Promise<[[TokenError, TokenResult | CollectionResult][], MetaData | {}]> {
+export function flattenResults<T>(
+  everything: Promise<[[string, T][], MetaData][]>[]
+): Promise<[[TokenError, T][], MetaData | {}]> {
   return Promise.all(everything).then((results) => {
     if (!results || !results.length) {
       return [[], {}]

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -247,7 +247,8 @@ export class Portfolio {
       tokenDataRecencyOnFailure,
       tokenDataCache: paramsTokenDataCache,
       tokenDataRecency,
-      blacklist
+      blacklist,
+      preventTokenBlacklisting
     } = { ...defaultOptions, ...opts }
     const toBeLearned: PortfolioLibGetResult['toBeLearned'] = {
       erc20s: [],
@@ -300,10 +301,9 @@ export class Portfolio {
     const staticBlacklistedAddrs = STATIC_BLACKLIST.blacklistAddrs[chainIdStr] || []
     const dynamicBlacklistedAddrs = blacklist?.blacklistAddrs[chainIdStr] || []
     const allBlacklistedAddrs = new Set([...staticBlacklistedAddrs, ...dynamicBlacklistedAddrs])
-    const filteredChecksummedHints =
-      allBlacklistedAddrs.size > 0
-        ? checksummedErc20Hints.filter((addr) => !allBlacklistedAddrs.has(addr))
-        : checksummedErc20Hints
+    const filteredChecksummedHints = preventTokenBlacklisting
+      ? checksummedErc20Hints
+      : checksummedErc20Hints.filter((addr) => !allBlacklistedAddrs.has(addr))
 
     // Remove duplicates and always add ZeroAddress
     hints.erc20s = [...new Set(filteredChecksummedHints.concat(ZeroAddress))]

--- a/src/services/assetInfo/assetInfo.test.ts
+++ b/src/services/assetInfo/assetInfo.test.ts
@@ -11,24 +11,26 @@ const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
 const LOBSTER_ADDRESS = '0x026224A2940bFE258D0dbE947919B62fE321F042'
 const UNISWAP_ROUTER = '0xE592427A0AEce92De3Edee1F18E0157C05861564'
-
+const MONERIUM_ADDRESS = '0x3231Cb76718CDeF2155FC47b5286d82e6eDA273f'
 global.fetch = fetch as any
-interface CallbackArgs {
-  nftInfo?: { name: string }
-  tokenInfo?: { decimals: number; symbol: string }
-}
+
 describe('Asset info service', () => {
   test('Fetches all tokens and NFTS correctly', async () => {
     jest.spyOn(assetInfo, 'executeBatchedFetch')
 
-    const wethCallback = jest.fn(({ tokenInfo }: CallbackArgs) =>
+    const wethCallback = jest.fn(({ tokenInfo }: any) =>
       expect(tokenInfo).toMatchObject({ symbol: 'WETH', decimals: 18 })
     )
 
-    const usdcCallback = jest.fn(({ tokenInfo }: CallbackArgs) => {
+    const moneriumCallback = jest.fn(({ tokenInfo, nftInfo }: any) => {
+      expect(tokenInfo).toMatchObject({ symbol: 'EURe', decimals: 18 })
+      expect(nftInfo).toBeFalsy()
+    })
+
+    const usdcCallback = jest.fn(({ tokenInfo }: any) => {
       expect(tokenInfo).toMatchObject({ symbol: 'USDC', decimals: 6 })
     })
-    const lobsterCallback = jest.fn(({ nftInfo }: CallbackArgs) => {
+    const lobsterCallback = jest.fn(({ nftInfo }: any) => {
       expect(nftInfo).toMatchObject({ name: 'lobsterdao' })
     })
     const uniswapCallback = jest.fn((res: any) => {
@@ -36,21 +38,25 @@ describe('Asset info service', () => {
       expect(res?.tokenInfo).toBeFalsy()
     })
 
+    if (!networks[0]) throw Error('Networks array should have at least 1 element') // using err so ts knows networks[0] exists
     await Promise.all([
       assetInfo.resolveAssetInfo(WETH_ADDRESS, networks[0], wethCallback),
       assetInfo.resolveAssetInfo(USDC_ADDRESS, networks[0], usdcCallback),
       assetInfo.resolveAssetInfo(UNISWAP_ROUTER, networks[0], uniswapCallback),
-      assetInfo.resolveAssetInfo(LOBSTER_ADDRESS, networks[0], lobsterCallback)
+      assetInfo.resolveAssetInfo(LOBSTER_ADDRESS, networks[0], lobsterCallback),
+      assetInfo.resolveAssetInfo(MONERIUM_ADDRESS, networks[0], moneriumCallback)
     ])
     expect(wethCallback).toHaveBeenCalledTimes(1)
     expect(usdcCallback).toHaveBeenCalledTimes(1)
     expect(lobsterCallback).toHaveBeenCalledTimes(1)
     expect(uniswapCallback).toHaveBeenCalledTimes(1)
+    expect(moneriumCallback).toHaveBeenCalledTimes(1)
   })
 
   test('Batches', async () => {
     const interceptedRequests = monitor()
 
+    if (!networks[0]) throw Error('Networks array should have at least 1 element') // using err so ts knows networks[0] exists
     await Promise.all([
       assetInfo.resolveAssetInfo(WETH_ADDRESS, networks[0], () => {}),
       assetInfo.resolveAssetInfo(USDC_ADDRESS, networks[0], () => {}),

--- a/src/services/assetInfo/assetInfo.ts
+++ b/src/services/assetInfo/assetInfo.ts
@@ -22,7 +22,8 @@ export async function executeBatchedFetch(network: Network): Promise<void> {
   const options: Partial<GetOptions> = {
     disableAutoDiscovery: true,
     additionalErc20Hints: allAddresses,
-    additionalErc721Hints: Object.fromEntries(allAddresses.map((i) => [i, [1n]]))
+    additionalErc721Hints: Object.fromEntries(allAddresses.map((i) => [i, [1n]])),
+    preventTokenBlacklisting: true
   }
   const portfolioResponse = await portfolio.get(RANDOM_ADDRESS, options)
 


### PR DESCRIPTION
## Problem
The asset info uses the portfolio to get token decimals and symbol, but for blacklisted tokens, the portfolio does not return them

## This adds a 

after
<img width="863" height="494" alt="image" src="https://github.com/user-attachments/assets/986ac8cb-5116-471b-bb85-fe421e869598" />

before
<img width="868" height="793" alt="image" src="https://github.com/user-attachments/assets/951a66fb-9e4f-4252-b12f-cfecc6eb68b1" />
