### PR TITLE
Fix: pass the signer to the ui, sign message

### DIFF
--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -297,6 +297,7 @@ export class SignMessageController extends EventEmitter implements ISignMessageC
     if (this.signer.init) {
       this.signer.init(this.#externalSignerControllers[signerKey.type])
     }
+    this.emitUpdate() // pass the signer to the UI
 
     try {
       if (!this.#isSigningOperationValidAfterAsyncOperation()) return


### PR DESCRIPTION
In the case of hardware wallets, the "sign with your hardware device" screen was not visible