### PR TITLE
Bug / Account Picker - clear derived accounts cache when account preferences change to prevent bad account names and missing details for a selected account glitches

### DIFF
--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -776,6 +776,11 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
   }
 
   #updateStateWithTheLatestFromAccounts() {
+    // Account preferences (e.g. label/name) can change while this controller is alive.
+    // If we keep using cached derived accounts, the FE can show stale account names.
+    // Clearing forces #deriveAccounts() to rebuild cached entries using the latest accounts.
+    this.#derivedAccountsCache.clear()
+
     this.#alreadyImportedAccounts = [...this.#accounts.accounts]
 
     this.addedAccountsFromCurrentSession = Array.from(


### PR DESCRIPTION
Self-explanatory, see comment in code. Also fixes these troubles, reported on mobile:

<img width="792" height="448" alt="image" src="https://github.com/user-attachments/assets/fa1ea060-85ee-44f2-ab66-c1a4c369c73a" />
