### PR TITLE
Fix/ HumanizerMetaAddress missing 'logo' property

### DIFF
--- a/src/libs/humanizer/interfaces.ts
+++ b/src/libs/humanizer/interfaces.ts
@@ -73,6 +73,7 @@ export interface AbiFragment {
 }
 
 export interface HumanizerMetaAddress {
+  logo?: string
   name?: string
   // undefined means it is not a token
   token?: { symbol: string; decimals?: number }


### PR DESCRIPTION
It's present in `humanizerInfo`, but missing in the type.