### PR TITLE
Humanizer/ move `And send ETH` to start 

### DIFF
--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -253,14 +253,14 @@ describe('Humanizer main function', () => {
     // const ir: Ir = []
     const expectedVisualizations = [
       [
+        getAction('Send'),
+        getToken(ZeroAddress, 10n ** 18n),
+        getLabel('and'),
         getAction('Grant approval'),
         getLabel('for'),
         getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 10n ** 9n),
         getLabel('to'),
         getAddressVisualization('0x46705dfff24256421a05d056c29e81bdc09723b8'),
-        getLabel('and'),
-        getAction('Send'),
-        getToken(ZeroAddress, 10n ** 18n),
         getToken('0xdac17f958d2ee523a2206206994597c13d831ec7', 0n, true)
       ],
       [

--- a/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
@@ -87,8 +87,8 @@ export const fallbackHumanizer: HumanizerCallModule = (
           fullVisualization[0]?.content || ''
         ))
     ) {
-      if (fullVisualization.length) fullVisualization.push(getLabel('and'))
-      fullVisualization.push(getAction('Send'), getToken(ZeroAddress, call.value))
+      if (fullVisualization.length) fullVisualization.unshift(getLabel('and'))
+      fullVisualization.unshift(getAction('Send'), getToken(ZeroAddress, call.value))
       if (call.data === '0x' && call.to)
         fullVisualization.push(getLabel('to'), getAddressVisualization(call.to))
     }


### PR DESCRIPTION
## Problem
When signing a message that includes long ascii text as hex, the user should scroll to the bottom to be able to see that there is ETH being sent

## Solution
Move the `Send ETH` to start

## To test
go here and click `Send tx`
https://transact.swiss-knife.xyz/send-tx?chainId=1&eth=0.0001&calldata=0x414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141&to=0x88800092ff476844f74dc2fc427974bbee2794ae

<img width="723" height="678" alt="image" src="https://github.com/user-attachments/assets/2970bf44-5e58-441d-b1dd-7749df26f002" />
