### PR TITLE
Fix/ Simulation race conditions and clearing on portfolio error

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -657,7 +657,7 @@ describe('Portfolio Controller ', () => {
       expect(areAccountOpsEqual(stateBefore.accountOps!, accountOp['1']!)).toBe(true)
       expect(collectionBefore?.amountPostSimulation).toBe(0n)
 
-      controller.overrideSimulationResults(accountOp['1']![0]!)
+      await controller.overrideSimulationResults(accountOp['1']![0]!)
 
       const stateAfter = getEthereumPortfolioState(controller)
       const collectionAfter = getSimulatedCollection(controller)
@@ -673,6 +673,30 @@ describe('Portfolio Controller ', () => {
             token.amountPostSimulation !== undefined || token.simulationAmount !== undefined
         )
       ).toBe(false)
+    })
+
+    test('calling overrideSimulationResults during a portfolio update still removes the simulation result and stored accountOps', async () => {
+      const { controller } = await prepareTest()
+      const accountOp = await getAccountOp()
+      const accountStates = await getAccountsInfo([account])
+
+      const updatePromise = controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: accountOp,
+        states: accountStates[account.addr]!
+      })
+
+      // Wait a short period
+      await wait(50)
+
+      // We call overrideSimulationResults in the middle of the updateSelectedAccount flow, to make sure it can handle that case
+      const overridePromise = controller.overrideSimulationResults(accountOp['1']![0]!)
+
+      await updatePromise
+      await overridePromise
+
+      const stateAfter = getEthereumPortfolioState(controller)
+
+      expect(stateAfter.accountOps).toBeUndefined()
     })
 
     test('overrideSimulationResults is a no-op when there is no matching simulated state', async () => {
@@ -795,6 +819,33 @@ describe('Portfolio Controller ', () => {
       const stateAfter = controller.getAccountPortfolioState(account.addr)['1']!
 
       expect(stateAfter.accountOps).toBeUndefined()
+    })
+    test('discardSimulation removes the account ops from state even if the portfolio update fails', async () => {
+      const { restore } = suppressConsole()
+      const { controller } = await prepareTest()
+      const ethereum = networks.find((network) => network.chainId === 1n)!
+      const accountOp = await getAccountOp()
+      const accountStates = await getAccountsInfo([account])
+
+      await controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: accountOp,
+        states: accountStates[account.addr]!
+      })
+
+      expect(controller.getAccountPortfolioState(account.addr)['1']!.accountOps).toBeDefined()
+
+      // Mock getAllHints error which will cause the update to fail
+      // @ts-ignore
+      jest.spyOn(controller, 'getAllHints').mockImplementationOnce(() => {
+        throw new Error('Failed to get hints')
+      })
+
+      await controller.discardSimulation(accountOp['1']!)
+
+      const stateAfter = controller.getAccountPortfolioState(account.addr)['1']!
+
+      expect(stateAfter.accountOps).toBeUndefined()
+      restore()
     })
   })
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -21,7 +21,7 @@ import { IStorageController } from '../../interfaces/storage'
 import { isBasicAccount } from '../../libs/account/account'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 /* eslint-disable @typescript-eslint/no-shadow */
-import { AccountOp, areAccountOpsEqual } from '../../libs/accountOp/accountOp'
+import { AccountOp } from '../../libs/accountOp/accountOp'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
 import {
@@ -544,35 +544,62 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
    * If you instead need to remove a specific accountOp from the simulation results, use `discardSimulation`
    * (e.g., after an account op is broadcasted and confirmed)
    */
-  overrideSimulationResults(accountOp: AccountOp) {
+  async overrideSimulationResults(accountOp: AccountOp) {
     const { accountAddr, chainId } = accountOp
 
-    if (!this.#state[accountAddr] || !this.#state[accountAddr][chainId.toString()]) return
+    const updatePromise = async () => {
+      if (!this.#state[accountAddr] || !this.#state[accountAddr][chainId.toString()]) return
 
-    const networkState = this.#state[accountAddr][chainId.toString()]!
+      const networkState = this.#state[accountAddr][chainId.toString()]!
 
-    if (!networkState.result) return
+      if (!networkState.result) return
 
-    networkState.result.tokens = networkState.result.tokens.map((token) => {
-      const { amountPostSimulation, simulationAmount, ...rest } = token
+      networkState.result.tokens = networkState.result.tokens.map((token) => {
+        const { amountPostSimulation, simulationAmount, ...rest } = token
 
-      return rest
+        return rest
+      })
+
+      networkState.result.collections = (networkState.result.collections || []).map(
+        (collection) => {
+          const { amountPostSimulation, postSimulation, simulationAmount, ...rest } = collection
+
+          return rest
+        }
+      )
+
+      networkState.result.total = getTotal(
+        networkState.result.tokens,
+        networkState.result.defiPositions
+      )
+
+      delete networkState.accountOps
+
+      this.emitUpdate()
+    }
+
+    // overrideSimulationResults is a synchronous function that updates the state by removing the simulation results.
+    // However, there may be a portfolio update in progress that will override the state with the simulation results again. To prevent
+    // this, we use a queue to ensure that if there is an update in progress, the override of the simulation results will be executed after the update is finished.
+    // And that subsequent updates will wait for the override to be finished before updating the state again.
+
+    if (!this.#queue?.[accountAddr]?.[chainId.toString()])
+      this.#queue[accountAddr] = {
+        ...this.#queue[accountAddr],
+        [chainId.toString()]: Promise.resolve()
+      }
+
+    // Chain the new updatePromise to the current queue
+    this.#queue[accountAddr][chainId.toString()] = this.#queue?.[accountAddr]?.[
+      chainId.toString()
+    ]!.then(updatePromise).catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(error)
+      return updatePromise()
     })
 
-    networkState.result.collections = (networkState.result.collections || []).map((collection) => {
-      const { amountPostSimulation, postSimulation, simulationAmount, ...rest } = collection
-
-      return rest
-    })
-
-    networkState.result.total = getTotal(
-      networkState.result.tokens,
-      networkState.result.defiPositions
-    )
-
-    delete networkState.accountOps
-
-    this.emitUpdate()
+    // Ensure the method waits for the entire queue to resolve
+    await this.#queue[accountAddr][chainId.toString()]
   }
 
   /**
@@ -596,9 +623,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       const networkState = this.#state[accountAddr][chainId.toString()]!
 
       if (!networkState.result || !networkState.accountOps) return
-      if (!accountOpsAfterUpdate) {
-        accountOpsAfterUpdate = {}
-      }
 
       accountOpsAfterUpdate[chainId.toString()] = structuredClone(networkState.accountOps || [])
 
@@ -625,7 +649,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     })
 
     if (!accountAddrToUpdate || networksToUpdate.length === 0) return
-
     await this.updateSelectedAccount(accountAddrToUpdate, networksToUpdate, {
       accountOps: accountOpsAfterUpdate
     })
@@ -1195,9 +1218,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       }
 
       accountState[network.chainId.toString()] = {
-        // We cache the previously simulated AccountOps
-        // in order to compare them with the newly passed AccountOps before executing a new updatePortfolioState.
-        // This allows us to identify any differences between the two.
         accountOps: portfolioProps?.simulation?.accountOps,
         isReady: true,
         isLoading: false,
@@ -1228,6 +1248,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         message: `Error while executing the 'get' function in the portfolio library on ${network.name} (${network.chainId})`,
         error: e
       })
+      state.accountOps = portfolioProps?.simulation?.accountOps
       state.isLoading = false
       // Convert the error to an object because the portfolio state is cloned
       // using structuredClone() which doesn't preserve custom error properties
@@ -1389,11 +1410,11 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
   #getMaxDataAgeMs(
     accountId: AccountId,
     chainId: bigint,
-    areAccountOpsChanged: boolean,
+    isSimulating: boolean,
     maxDataAgeMs?: number,
     maxDataAgeUnused?: number
   ): number | undefined {
-    if (areAccountOpsChanged) return undefined
+    if (isSimulating) return undefined
 
     // maxDataAgeMsUnused is optional so we fall back to maxDataAgeMs if not provided
     if (typeof maxDataAgeUnused !== 'number') return maxDataAgeMs
@@ -1489,16 +1510,12 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           const simulatedAccountOps = accountState[network.chainId.toString()]?.accountOps
           const accountOpsToSimulate = currentAccountOps || simulatedAccountOps
 
-          // Compare the ids of the account ops
-          const areAccountOpsChanged =
-            !!currentAccountOps && areAccountOpsEqual(currentAccountOps, simulatedAccountOps || [])
-
           // Even if maxDataAgeMs is set to a non-zero value, we want to force an update when the AccountOps change.
           // We pass undefined, because setting the value to 0 would imply a manual update by the user.
           const maxDataAgeMs = this.#getMaxDataAgeMs(
             accountId,
             network.chainId,
-            areAccountOpsChanged,
+            !!currentAccountOps,
             paramsMaxDataAgeMs,
             paramsMaxDataAgeMsUnused
           )

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -551,7 +551,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           this.visibleUserRequests.filter((r) => r.kind === 'calls')
         )
       ) {
-        this.#portfolio.overrideSimulationResults(this.currentUserRequest.signAccountOp.accountOp)
+        await this.#portfolio.overrideSimulationResults(
+          this.currentUserRequest.signAccountOp.accountOp
+        )
       }
       this.currentUserRequest.signAccountOp.pause()
     }
@@ -959,12 +961,12 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   ) {
     this.userRequests
       .filter((r) => requestIds.includes(r.id))
-      .forEach((r) => {
+      .forEach(async (r) => {
         r.dappPromises.forEach((p) => p.reject(ethErrors.provider.userRejectedRequest<any>(err)))
 
         // Done here because remove handles approved requests too. We want this logic only on reject
         if (r.kind === 'calls') {
-          this.#portfolio.overrideSimulationResults(r.signAccountOp.accountOp)
+          await this.#portfolio.overrideSimulationResults(r.signAccountOp.accountOp)
         }
       })
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1123,7 +1123,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
     // if there's an estimation error, override the pending results
     if (this.estimation.status === EstimationStatus.Error) {
-      this.#portfolio.overrideSimulationResults(this.accountOp)
+      await this.#portfolio.overrideSimulationResults(this.accountOp)
     }
   }
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2502,15 +2502,15 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       }
     }, 'swap-and-bridge')
 
-    this.#signAccountOpController.onError((error) => {
+    this.#signAccountOpController.onError(async (error) => {
       // Need to clean the pending results for THIS signAccountOpController
       // specifically. NOT the one from the getter (this.signAccountOpController)
       // that is ALWAYS up-to-date with the current quote and the current form state.
       // Due to the async nature, it might not exist - an issue caught by our crash reporting.
-      if (this.#signAccountOpController)
-        this.#portfolio.overrideSimulationResults(this.#signAccountOpController.accountOp)
-
       this.emitError(error)
+
+      if (this.#signAccountOpController)
+        await this.#portfolio.overrideSimulationResults(this.#signAccountOpController.accountOp)
     })
     // if the estimation emits an error, handle it
     this.#signAccountOpController.estimation.onUpdate(() => {

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -909,10 +909,11 @@ export class TransferController extends EventEmitter implements ITransferControl
       }
     }, 'transfer')
 
-    this.signAccountOpController.onError((error) => {
-      if (this.signAccountOpController)
-        this.#portfolio.overrideSimulationResults(this.signAccountOpController.accountOp)
+    this.signAccountOpController.onError(async (error) => {
       this.emitError(error)
+
+      if (this.signAccountOpController)
+        await this.#portfolio.overrideSimulationResults(this.signAccountOpController.accountOp)
     })
   }
 


### PR DESCRIPTION
## Fixes:
### `overrideSimulationResult` called during portfolio update
If `overrideSimulationResult` was called while the portfolio is being updated the simulation was removed but then added back by the portfolio update on success. To fix this, we add `overrideSimulationResult` to the update queue.

Video:
https://github.com/user-attachments/assets/d2fe1933-f6cf-4cbb-938b-c75faa9a4ed7

### simulation not stored/removed on error
If an account op is passed for simulation but the portfolio update fails we weren't storing it in the portfolio state. This had two implications:
- Discarding an account op doesn't work if the update fails (possibly https://github.com/AmbireTech/ambire-app/issues/6851)
- Simulated account ops are not persisted on failure (if the first simulation fails, subsequent calls were ok)

To reproduce:
1. Prepare a transaction
2. Prepare a network request block for the RPC of the network
3. Broadcast it
4. The MOMENT that the transaction is confirmed enable network blocking (before the portfolio update)
5. `discardAccountOp` will be called, it will fail and the simulation will not be cleared (this was happening before)

## Tests:
I added two tests to prevent regressions.

Closes https://github.com/AmbireTech/ambire-app/issues/6849