### PR TITLE
Config / Disable Account Picker derived accounts cache

### DIFF
--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -167,8 +167,6 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     accounts?: SelectedAccountForImport[]
   } | null = null
 
-  #derivedAccountsCache: Map<string, DerivedAccountWithoutNetworkMeta> = new Map()
-
   constructor({
     eventEmitterRegistry,
     accounts,
@@ -481,7 +479,6 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     }
     if (resetInitParams) this.initParams = null
     this.keyIterator = null
-    this.#derivedAccountsCache.clear()
     this.selectedAccountsFromCurrentSession = []
     this.page = DEFAULT_PAGE
     this.pageSize = DEFAULT_PAGE_SIZE
@@ -776,11 +773,6 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
   }
 
   #updateStateWithTheLatestFromAccounts() {
-    // Account preferences (e.g. label/name) can change while this controller is alive.
-    // If we keep using cached derived accounts, the FE can show stale account names.
-    // Clearing forces #deriveAccounts() to rebuild cached entries using the latest accounts.
-    this.#derivedAccountsCache.clear()
-
     this.#alreadyImportedAccounts = [...this.#accounts.accounts]
 
     this.addedAccountsFromCurrentSession = Array.from(
@@ -1090,13 +1082,6 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
       combinedBasicAndSmartAccKeys.length
     )
 
-    // Use Cache if possible
-    const cacheKey = combinedBasicAndSmartAccKeys.join(',')
-    if (this.#derivedAccountsCache.has(cacheKey)) {
-      // Though technically we should cache per-account, caching the whole page is easier
-      // and sufficient for the pagination use case.
-    }
-
     const smartAccountsPromises: Promise<DerivedAccountWithoutNetworkMeta | null>[] = []
     // Replace the parallel getKeys with foreach to prevent issues with Ledger,
     // which can only handle one request at a time.
@@ -1104,36 +1089,31 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     for (const [index, smartAccKey] of smartAccKeys.entries()) {
       const slot = startIdx + (index + 1)
       const indexWithOffset = slot - 1 + SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
-      const accountCacheKey = `smart-${smartAccKey}`
 
-      if (this.#derivedAccountsCache.has(accountCacheKey)) {
-        const cached = this.#derivedAccountsCache.get(accountCacheKey)! // would always exist inside if
-        accounts.push({ ...cached, slot, index: indexWithOffset })
-      } else {
-        // The derived EOA (basic) account which is the key for the smart account
-        const account = getBasicAccount(smartAccKey, this.#alreadyImportedAccounts)
-        accounts.push({ account, isLinked: false, slot, index: indexWithOffset })
+      // The derived EOA (basic) account which is the key for the smart account
+      const account = getBasicAccount(smartAccKey, this.#alreadyImportedAccounts)
+      accounts.push({ account, isLinked: false, slot, index: indexWithOffset })
 
-        // Derive the Ambire (smart) account
-        smartAccountsPromises.push(
-          getSmartAccount(
-            [{ addr: smartAccKey, hash: dedicatedToOneSAPriv }],
-            this.#alreadyImportedAccounts
-          )
-            .then((smartAccount) => {
-              const result = { account: smartAccount, isLinked: false, slot, index: slot - 1 }
-              this.#derivedAccountsCache.set(accountCacheKey, result)
-              return result
-            })
-            // If the error isn't caught here and the promise is rejected, Promise.all
-            // will be rejected entirely.
-            .catch(() => {
-              // No need for emitting an error here, because a relevant error is already
-              // emitted in the method #getAccountsUsedOnNetworks
-              return null
-            })
+      // Derive the Ambire (smart) account
+      smartAccountsPromises.push(
+        getSmartAccount(
+          [{ addr: smartAccKey, hash: dedicatedToOneSAPriv }],
+          this.#alreadyImportedAccounts
         )
-      }
+          .then((smartAccount) => ({
+            account: smartAccount,
+            isLinked: false,
+            slot,
+            index: slot - 1
+          }))
+          // If the error isn't caught here and the promise is rejected, Promise.all
+          // will be rejected entirely.
+          .catch(() => {
+            // No need for emitting an error here, because a relevant error is already
+            // emitted in the method #getAccountsUsedOnNetworks
+            return null
+          })
+      )
 
       // Yield to event loop to keep UI responsive
       // eslint-disable-next-line no-await-in-loop
@@ -1150,18 +1130,10 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     // eslint-disable-next-line no-restricted-syntax
     for (const [index, basicAccKey] of basicAccKeys.entries()) {
       const slot = startIdx + (index + 1)
-      const accountCacheKey = `basic-${basicAccKey}`
-
-      if (this.#derivedAccountsCache.has(accountCacheKey)) {
-        const cached = this.#derivedAccountsCache.get(accountCacheKey)! // would always exist inside if
-        accounts.push({ ...cached, slot, index: slot - 1 })
-      } else {
-        // The EOA (basic) account on this slot
-        const account = getBasicAccount(basicAccKey, this.#alreadyImportedAccounts)
-        const result = { account, isLinked: false, slot, index: slot - 1 }
-        this.#derivedAccountsCache.set(accountCacheKey, result)
-        accounts.push(result)
-      }
+      // The EOA (basic) account on this slot
+      const account = getBasicAccount(basicAccKey, this.#alreadyImportedAccounts)
+      const result = { account, isLinked: false, slot, index: slot - 1 }
+      accounts.push(result)
     }
 
     return accounts


### PR DESCRIPTION
For simplicity reasons, disable the cashing parts in the Account Picker of the derived accounts only, because this brings way too many corner cases that must be handled on one side, and on the other - is causing no big performance gain.