### PR TITLE
Fix/ Requests test simulation errors

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from '@jest/globals'
 
-import { relayerUrl } from '../../../test/config'
 import { makeMainController } from '../../../test/helpers/mainController'
-import { mockUiManager } from '../../../test/helpers/ui'
 import { Session } from '../../classes/session'
 import {
   BenzinUserRequest,
@@ -11,9 +9,7 @@ import {
   UserRequest
 } from '../../interfaces/userRequest'
 import { generateUuid } from '../../utils/uuid'
-import { EventEmitterRegistryController } from '../eventEmitterRegistry/eventEmitterRegistry'
 import { SignAccountOpController } from '../signAccountOp/signAccountOp'
-import { RequestsController } from './requests'
 
 const MOCK_SESSION = new Session({ tabId: 1, url: 'https://test-dApp.com' })
 
@@ -66,12 +62,12 @@ const accounts = [
 ]
 
 const prepareTest = async () => {
-  const { uiManager, getWindowId, eventEmitter: event } = mockUiManager()
-
-  const { mainCtrl } = await makeMainController(async (storageCtrl) => {
-    await storageCtrl.set('accounts', accounts)
-    await storageCtrl.set('selectedAccount', '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
-  })
+  const { mainCtrl, eventEmitterRegistry, getWindowId, eventEmitter } = await makeMainController(
+    async (storageCtrl) => {
+      await storageCtrl.set('accounts', accounts)
+      await storageCtrl.set('selectedAccount', '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
+    }
+  )
 
   // Mock account states for all accounts
   for (const account of mainCtrl.accounts.accounts) {
@@ -99,8 +95,6 @@ const prepareTest = async () => {
       } as any
     }
   }
-
-  const eventEmitterRegistry = new EventEmitterRegistryController(() => null)
 
   const getSignAccountOp = async ({
     addr,
@@ -185,40 +179,14 @@ const prepareTest = async () => {
     } as CallsUserRequest
   }
 
-  const requestsController = new RequestsController({
-    relayerUrl,
-    callRelayer: mainCtrl.callRelayer,
-    portfolio: mainCtrl.portfolio,
-    externalSignerControllers: {},
-    activity: mainCtrl.activity,
-    phishing: mainCtrl.phishing,
-    accounts: mainCtrl.accounts,
-    networks: mainCtrl.networks,
-    providers: mainCtrl.providers,
-    selectedAccount: mainCtrl.selectedAccount,
-    keystore: mainCtrl.keystore,
-    transfer: mainCtrl.transfer,
-    swapAndBridge: mainCtrl.swapAndBridge,
-    ui: uiManager as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    safe: mainCtrl.safe,
-    autoLogin: mainCtrl.autoLogin,
-    getDapp: async () => undefined,
-    updateSelectedAccountPortfolio: () => Promise.resolve(),
-    addTokensToBeLearned: () => {},
-    onSetCurrentUserRequest: () => {},
-    onBroadcastSuccess: async () => {},
-    onBroadcastFailed: () => {},
-    eventEmitterRegistry,
-    shouldSimulateAccountOps: false
-  })
-
   return {
     selectedAccountCtrl: mainCtrl.selectedAccount,
-    controller: requestsController,
+    controller: mainCtrl.requests,
     getSignAccountOp,
     getCallsRequest,
-    event,
-    getWindowId
+    event: eventEmitter,
+    getWindowId,
+    uiCtrl: mainCtrl.ui
   }
 }
 
@@ -240,11 +208,6 @@ const DAPP_CONNECT_REQUEST: DappConnectRequest = {
 describe('RequestsController ', () => {
   beforeEach(() => {
     jest.restoreAllMocks()
-  })
-  test('Init controller', async () => {
-    const { controller } = await prepareTest()
-    expect(controller.initialLoadPromise).toBeInstanceOf(Promise)
-    await expect(controller.initialLoadPromise).resolves.toBeUndefined()
   })
 
   test('Add and then remove a user request', async () => {

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -181,7 +181,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
   #currentUserRequest: UserRequest | null = null
 
-  #shouldSimulateAccountOps = true
+  private shouldSimulateAccountOps = true
 
   get currentUserRequest() {
     return this.#currentUserRequest
@@ -281,7 +281,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     this.#onSetCurrentUserRequest = onSetCurrentUserRequest
     this.#onBroadcastSuccess = onBroadcastSuccess
     this.#onBroadcastFailed = onBroadcastFailed
-    this.#shouldSimulateAccountOps = shouldSimulateAccountOps
+    this.shouldSimulateAccountOps = shouldSimulateAccountOps
 
     this.#ui.window.event.on('windowRemoved', async (winId: number) => {
       // When windowManager.focus is called, it may close and reopen the request window as part of its fallback logic.
@@ -461,8 +461,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
         // Even without an initialized SignAccountOpController or Screen, we should still update the portfolio and run the simulation.
         // It's necessary to continue operating with the token `amountPostSimulation` amount.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.#portfolio.simulateAccountOp(req.signAccountOp.accountOp)
+        if (this.shouldSimulateAccountOps)
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          this.#portfolio.simulateAccountOp(req.signAccountOp.accountOp)
       } else if (req.kind === 'typedMessage' || req.kind === 'message' || req.kind === 'siwe') {
         const existingMessageRequest = this.userRequests.find(
           (r) => r.kind === req.kind && r.meta.accountAddr === req.meta.accountAddr
@@ -1888,7 +1889,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
             safeTx: meta.safeTx,
             meta
           },
-          shouldSimulate: this.#shouldSimulateAccountOps,
+          shouldSimulate: this.shouldSimulateAccountOps,
           onUpdateAfterTraceCallSuccess: async () => {
             await this.#portfolio.updateSelectedAccount(account.addr, [network])
           },

--- a/test/helpers/mainController.ts
+++ b/test/helpers/mainController.ts
@@ -1,5 +1,7 @@
 import fetch from 'node-fetch'
 
+import { EventEmitterRegistryController } from '@/controllers/eventEmitterRegistry/eventEmitterRegistry'
+
 import { AccountsController } from '../../src/controllers/accounts/accounts'
 import { DappsController } from '../../src/controllers/dapps/dapps'
 import { MainController } from '../../src/controllers/main/main'
@@ -59,6 +61,9 @@ export interface MakeMainControllerResult {
   storage: Storage
   /** The `StorageController` passed to `initialSetStorage`. Note: `mainCtrl.storage` is a separate instance wrapping the same underlying map. */
   storageCtrl: StorageController
+  eventEmitterRegistry: EventEmitterRegistryController
+  eventEmitter: ReturnType<typeof mockUiManager>['eventEmitter']
+  getWindowId: ReturnType<typeof mockUiManager>['getWindowId']
 }
 
 export const makeMainController = async (
@@ -75,6 +80,7 @@ export const makeMainController = async (
     skipPortfolioFetchBlacklistOnLoad = true,
     overrides = {}
   } = opts
+  const eventEmitterRegistry = new EventEmitterRegistryController(() => null)
 
   const storage: Storage = produceMemoryStore()
 
@@ -140,7 +146,7 @@ export const makeMainController = async (
     ...overrides.featureFlags
   }
 
-  const { uiManager } = mockUiManager()
+  const { uiManager, eventEmitter, getWindowId } = mockUiManager()
   const mainCtrl = new MainController({
     appVersion: overrides.appVersion ?? '1.0.0',
     platform: overrides.platform ?? 'browser-webkit',
@@ -153,8 +159,13 @@ export const makeMainController = async (
     featureFlags,
     keystoreSigners: overrides.keystoreSigners ?? { internal: KeystoreSigner },
     externalSignerControllers: overrides.externalSignerControllers ?? {},
-    uiManager
+    uiManager,
+    eventEmitterRegistry
   })
+
+  // Disable simulation in requests' signAccountOps
+  // @ts-ignore
+  mainCtrl.requests.shouldSimulateAccountOps = false
 
   // Applied synchronously before any async callbacks run, so the initial load
   // will use the mocked versions.
@@ -170,12 +181,14 @@ export const makeMainController = async (
   }
 
   await mainCtrl.accounts.accountStateInitialLoadPromise
-
   accountStateSpy?.mockRestore()
 
   return {
     mainCtrl,
     storage,
-    storageCtrl
+    storageCtrl,
+    eventEmitterRegistry,
+    eventEmitter,
+    getWindowId
   }
 }


### PR DESCRIPTION
## Changes:
- Use requests controller from main controller in requests test
- Set `shouldSimulateAccountOps` to false in the tests and simulate only if `shouldSimulateAccountOps=true`