### PR TITLE
Fix/ `updateAccountsOpsStatuses` works only for the selected account and add tests

### DIFF
--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from '@jest/globals'
+import { describe, expect, jest, test } from '@jest/globals'
 
 import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { BIP44_STANDARD_DERIVATION_TEMPLATE } from '../../consts/derivation'
+import { AccountOpStatus } from '../../libs/accountOp/types'
 import { KeyIterator } from '../../libs/keyIterator/keyIterator'
 import wait from '../../utils/wait'
 import { MainController } from './main'
@@ -243,5 +244,212 @@ describe('Main Controller ', () => {
 
     const eth3 = controller.networks.networks.find((n) => n.chainId === 1n)!
     expect(eth3.areContractsDeployed).toEqual(true)
+  })
+
+  describe('updateAccountsOpsStatuses', () => {
+    const senderAccount = accounts[0]!.addr
+    const selectedAccountAddr = accounts[1]!.addr
+    const recipientAccount = accounts[2]!.addr
+
+    const flushAsyncUpdates = async () => {
+      await wait(10)
+    }
+
+    const setupController = async () => {
+      const { mainCtrl } = await makeMainController(async (storageCtrl) => {
+        await storageCtrl.set('accounts', accounts)
+      })
+
+      // Avoid noisy side effects from this call while keeping the update flow realistic.
+      jest
+        .spyOn(mainCtrl.portfolio, 'reportMissedPortfolioUpdateAfterUpdatedAccountOp')
+        .mockImplementation(() => {})
+
+      jest
+        .spyOn(mainCtrl.swapAndBridge, 'handleUpdateActiveRouteOnSubmittedAccountOpStatusUpdate')
+        .mockImplementation(() => {})
+
+      return mainCtrl
+    }
+
+    test('should fetch safe txns when shouldEmitUpdate is false and shouldFetchSafeTxns is true', async () => {
+      const mainCtrl = await setupController()
+
+      jest
+        .spyOn(mainCtrl.activity, 'broadcastedButNotConfirmed', 'get')
+        .mockReturnValue({ [senderAccount]: [{ id: 'pending-op', calls: [] } as any] })
+
+      jest.spyOn(mainCtrl.activity, 'updateAccountsOpsStatuses').mockResolvedValue({
+        [senderAccount]: {
+          shouldEmitUpdate: false,
+          chainsToUpdate: [1n],
+          portfoliosToUpdate: { [recipientAccount]: [1n] },
+          shouldFetchSafeTxns: true,
+          newestOpTimestamp: Date.now(),
+          updatedAccountsOps: [
+            {
+              id: '1',
+              accountAddr: senderAccount,
+              chainId: 1n,
+              status: AccountOpStatus.Success,
+              calls: []
+            } as any
+          ]
+        }
+      })
+
+      const fetchSafeTxnsSpy = jest.spyOn(mainCtrl, 'fetchSafeTxns').mockResolvedValue(undefined)
+      const updateAccountStateSpy = jest
+        .spyOn(mainCtrl.accounts, 'updateAccountState')
+        .mockResolvedValue(undefined)
+      const discardSimulationSpy = jest
+        .spyOn(mainCtrl.portfolio, 'discardSimulation')
+        .mockResolvedValue(undefined)
+      const updateSelectedAccountSpy = jest
+        .spyOn(mainCtrl.portfolio, 'updateSelectedAccount')
+        .mockResolvedValue(undefined)
+
+      await mainCtrl.updateAccountsOpsStatuses()
+      await flushAsyncUpdates()
+
+      expect(fetchSafeTxnsSpy).toHaveBeenCalledTimes(1)
+      expect(updateAccountStateSpy).not.toHaveBeenCalled()
+      expect(discardSimulationSpy).not.toHaveBeenCalled()
+      expect(updateSelectedAccountSpy).not.toHaveBeenCalled()
+    })
+
+    test('should update account state for account address and discard finalized simulations', async () => {
+      const mainCtrl = await setupController()
+
+      const finalizedAccountOp = {
+        id: 'finalized-op',
+        accountAddr: senderAccount,
+        chainId: 1n,
+        status: AccountOpStatus.Success,
+        calls: []
+      } as any
+      const pendingAccountOp = {
+        id: 'pending-op',
+        accountAddr: senderAccount,
+        chainId: 1n,
+        status: AccountOpStatus.Pending,
+        calls: []
+      } as any
+
+      jest
+        .spyOn(mainCtrl.activity, 'broadcastedButNotConfirmed', 'get')
+        .mockReturnValue({ [senderAccount]: [pendingAccountOp] })
+
+      jest.spyOn(mainCtrl.activity, 'updateAccountsOpsStatuses').mockResolvedValue({
+        [senderAccount]: {
+          shouldEmitUpdate: true,
+          chainsToUpdate: [1n],
+          portfoliosToUpdate: {},
+          shouldFetchSafeTxns: false,
+          newestOpTimestamp: Date.now(),
+          updatedAccountsOps: [pendingAccountOp, finalizedAccountOp]
+        }
+      })
+
+      const updateAccountStateSpy = jest
+        .spyOn(mainCtrl.accounts, 'updateAccountState')
+        .mockResolvedValue(undefined)
+      const discardSimulationSpy = jest
+        .spyOn(mainCtrl.portfolio, 'discardSimulation')
+        .mockResolvedValue(undefined)
+
+      await mainCtrl.updateAccountsOpsStatuses()
+      await flushAsyncUpdates()
+
+      expect(updateAccountStateSpy).toHaveBeenCalledWith(senderAccount, 'latest', [1n])
+      expect(discardSimulationSpy).toHaveBeenCalledWith([finalizedAccountOp])
+    })
+
+    test('should call updateSelectedAccount for recipient accounts from portfoliosToUpdate', async () => {
+      const mainCtrl = await setupController()
+
+      const finalizedAccountOp = {
+        id: 'finalized-op',
+        accountAddr: senderAccount,
+        chainId: 1n,
+        status: AccountOpStatus.Success,
+        calls: []
+      } as any
+
+      jest
+        .spyOn(mainCtrl.activity, 'broadcastedButNotConfirmed', 'get')
+        .mockReturnValue({ [senderAccount]: [{ id: 'pending-op', calls: [] } as any] })
+
+      jest.spyOn(mainCtrl.activity, 'updateAccountsOpsStatuses').mockResolvedValue({
+        [senderAccount]: {
+          shouldEmitUpdate: true,
+          chainsToUpdate: [1n],
+          portfoliosToUpdate: {
+            [recipientAccount]: [1n]
+          },
+          shouldFetchSafeTxns: false,
+          newestOpTimestamp: Date.now(),
+          updatedAccountsOps: [finalizedAccountOp]
+        }
+      })
+
+      jest.spyOn(mainCtrl.accounts, 'updateAccountState').mockResolvedValue(undefined)
+      jest.spyOn(mainCtrl.portfolio, 'discardSimulation').mockResolvedValue(undefined)
+      const updateSelectedAccountSpy = jest
+        .spyOn(mainCtrl.portfolio, 'updateSelectedAccount')
+        .mockResolvedValue(undefined)
+
+      await mainCtrl.updateAccountsOpsStatuses()
+      await flushAsyncUpdates()
+
+      expect(updateSelectedAccountSpy).toHaveBeenCalledWith(
+        recipientAccount,
+        expect.arrayContaining([expect.objectContaining({ chainId: 1n })])
+      )
+    })
+
+    test('should update account state and discard simulation even when selected account is different', async () => {
+      const mainCtrl = await setupController()
+
+      await mainCtrl.selectedAccount.setAccount(mainCtrl.accounts.accounts[1]!)
+
+      const finalizedAccountOp = {
+        id: 'finalized-op',
+        // Different account than the selected one, but it should still update and discard simulations for it
+        accountAddr: senderAccount,
+        chainId: 1n,
+        status: AccountOpStatus.Success,
+        calls: []
+      } as any
+
+      jest
+        .spyOn(mainCtrl.activity, 'broadcastedButNotConfirmed', 'get')
+        .mockReturnValue({ [senderAccount]: [{ id: 'pending-op', calls: [] } as any] })
+
+      jest.spyOn(mainCtrl.activity, 'updateAccountsOpsStatuses').mockResolvedValue({
+        [senderAccount]: {
+          shouldEmitUpdate: true,
+          chainsToUpdate: [1n],
+          portfoliosToUpdate: {},
+          shouldFetchSafeTxns: false,
+          newestOpTimestamp: Date.now(),
+          updatedAccountsOps: [finalizedAccountOp]
+        }
+      })
+
+      const updateAccountStateSpy = jest
+        .spyOn(mainCtrl.accounts, 'updateAccountState')
+        .mockResolvedValue(undefined)
+      const discardSimulationSpy = jest
+        .spyOn(mainCtrl.portfolio, 'discardSimulation')
+        .mockResolvedValue(undefined)
+
+      await mainCtrl.updateAccountsOpsStatuses()
+      await flushAsyncUpdates()
+
+      expect(mainCtrl.selectedAccount.account?.addr).toBe(selectedAccountAddr)
+      expect(updateAccountStateSpy).toHaveBeenCalledWith(senderAccount, 'latest', [1n])
+      expect(discardSimulationSpy).toHaveBeenCalledWith([finalizedAccountOp])
+    })
   })
 })

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1141,7 +1141,7 @@ export class MainController extends EventEmitter implements IMainController {
     )
   }
 
-  async updateAccountsOpsStatuses(): Promise<{ newestOpTimestamp: number }> {
+  async updateAccountsOpsStatuses() {
     await this.initialLoadPromise
 
     const addressesWithPendingOps = Object.entries(this.activity.broadcastedButNotConfirmed)
@@ -1159,74 +1159,65 @@ export class MainController extends EventEmitter implements IMainController {
       }
     )
 
-    if (!this.selectedAccount.account) return { newestOpTimestamp: 0 }
+    Object.entries(updatedAccountsOpsByAccount).forEach(
+      async ([
+        accountAddr,
+        {
+          shouldEmitUpdate,
+          chainsToUpdate,
+          portfoliosToUpdate,
+          shouldFetchSafeTxns,
+          updatedAccountsOps
+        }
+      ]) => {
+        if (shouldEmitUpdate) {
+          this.emitUpdate()
 
-    const updatedAccountsOpsForSelectedAccount = updatedAccountsOpsByAccount[
-      this.selectedAccount.account.addr
-    ] || {
-      shouldEmitUpdate: false,
-      chainsToUpdate: [],
-      portfoliosToUpdate: {},
-      updatedAccountsOps: [],
-      newestOpTimestamp: 0,
-      shouldFetchSafeTxns: false
-    }
-    const {
-      shouldEmitUpdate,
-      chainsToUpdate,
-      portfoliosToUpdate,
-      newestOpTimestamp,
-      shouldFetchSafeTxns,
-      updatedAccountsOps
-    } = updatedAccountsOpsForSelectedAccount
+          if (chainsToUpdate.length) {
+            const networks = chainsToUpdate
+              ? this.networks.networks.filter((n) => chainsToUpdate.includes(n.chainId))
+              : undefined
 
-    if (shouldEmitUpdate) {
-      this.emitUpdate()
+            if (networks?.length) {
+              // The account state must be updated before the portfolio
+              // as the portfolio has internal checks whether the nonce has changed
+              // to decide if to force refetch certain data
+              await this.accounts.updateAccountState(
+                accountAddr,
+                'latest',
+                networks?.map((net) => net.chainId)
+              )
 
-      if (chainsToUpdate.length) {
-        const networks = chainsToUpdate
-          ? this.networks.networks.filter((n) => chainsToUpdate.includes(n.chainId))
-          : undefined
+              const finalizedAccountOps = updatedAccountsOps.filter(
+                (op) =>
+                  op.status !== AccountOpStatus.Pending &&
+                  op.status !== AccountOpStatus.BroadcastedButNotConfirmed
+              )
 
-        if (networks?.length) {
-          // The account state must be updated before the portfolio
-          // as the portfolio has internal checks whether the nonce has changed
-          // to decide if to force refetch certain data
-          await this.accounts.updateAccountState(
-            this.selectedAccount.account.addr,
-            'latest',
-            networks?.map((net) => net.chainId)
-          )
+              await this.portfolio.discardSimulation(finalizedAccountOps)
 
-          const finalizedAccountOps = updatedAccountsOps.filter(
-            (op) =>
-              op.status !== AccountOpStatus.Pending &&
-              op.status !== AccountOpStatus.BroadcastedButNotConfirmed
-          )
+              // Reports to Sentry if the portfolio was not updated after a confirmed AccountOp
+              this.portfolio.reportMissedPortfolioUpdateAfterUpdatedAccountOp(
+                accountAddr,
+                updatedAccountsOps
+              )
 
-          await this.portfolio.discardSimulation(finalizedAccountOps)
+              Object.entries(portfoliosToUpdate).forEach(([accountAddr, chainIds]) => {
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                this.portfolio.updateSelectedAccount(
+                  accountAddr,
+                  this.networks.networks.filter((n) => chainIds.includes(n.chainId))
+                )
+              })
+            }
+          }
+        }
 
-          // Reports to Sentry if the portfolio was not updated after a confirmed AccountOp
-          this.portfolio.reportMissedPortfolioUpdateAfterUpdatedAccountOp(
-            this.selectedAccount.account.addr,
-            updatedAccountsOpsForSelectedAccount.updatedAccountsOps
-          )
-
-          Object.entries(portfoliosToUpdate).forEach(([accountAddr, chainIds]) => {
-            this.portfolio.updateSelectedAccount(
-              accountAddr,
-              this.networks.networks.filter((n) => chainIds.includes(n.chainId))
-            )
-          })
+        if (shouldFetchSafeTxns) {
+          this.fetchSafeTxns().catch((e) => e) // we catch the error inside
         }
       }
-
-      if (shouldFetchSafeTxns) {
-        this.fetchSafeTxns().catch((e) => e) // we catch the error inside
-      }
-    }
-
-    return { newestOpTimestamp }
+    )
   }
 
   // call this function after a call to the singleton has been made


### PR DESCRIPTION
## How to reproduce:
1. Select Account A
2. Send to Account B
3. Immediately change to Account C

Now, if things are working correctly:
1. There should be no simulation when you change to Account A
2. The portfolio of Account B should be updated automatically when you change to it

Both weren't working as the method was doing side effects ONLY for the selected account.

## Changes:
- Fixes the bug
- Adds unit tests for the logic

Closes https://github.com/AmbireTech/ambire-app/issues/6851