### PR TITLE
Hotfix / Swap & Bridge - stop Quote update interval when the pop-up is closed or tab is inactive

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -433,7 +433,8 @@ export class MainController extends EventEmitter implements IMainController {
       getUserRequests: () => this.requests.userRequests || [],
       getVisibleUserRequests: () => this.requests.visibleUserRequests || [],
       onBroadcastSuccess: this.commonHandlerForBroadcastSuccess.bind(this),
-      onBroadcastFailed: this.#handleBroadcastFailed.bind(this)
+      onBroadcastFailed: this.#handleBroadcastFailed.bind(this),
+      ui: this.ui
     })
     this.transfer = new TransferController(
       this.callRelayer,

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -229,7 +229,8 @@ const swapAndBridgeController = new SwapAndBridgeController({
   getUserRequests: () => [],
   getVisibleUserRequests: () => (requestsCtrl ? requestsCtrl.visibleUserRequests : []),
   onBroadcastSuccess: () => Promise.resolve(),
-  onBroadcastFailed: () => {}
+  onBroadcastFailed: () => {},
+  ui: uiCtrl
 })
 
 const transferCtrl = new TransferController(

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -19,6 +19,7 @@ import { ISelectedAccountController } from '../../interfaces/selectedAccount'
 /* eslint-disable no-await-in-loop */
 import { ISignAccountOpController, SignAccountOpError } from '../../interfaces/signAccountOp'
 import { IStorageController } from '../../interfaces/storage'
+import { IUiController, View } from '../../interfaces/ui'
 import {
   CachedSupportedChains,
   CachedTokenListKey,
@@ -84,6 +85,8 @@ type SwapAndBridgeErrorType = {
 }
 
 const HARD_CODED_CURRENCY = 'usd'
+
+const isSwapAndBridge = (route: string | undefined) => route === 'swap-and-bridge'
 
 const CONVERSION_PRECISION = 16
 const CONVERSION_PRECISION_POW = BigInt(10 ** CONVERSION_PRECISION)
@@ -270,6 +273,10 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
   #onBroadcastFailed: OnBroadcastFailed
 
+  #ui: IUiController
+
+  #isOnSwapAndBridgeRoute: boolean = false
+
   constructor({
     eventEmitterRegistry,
     callRelayer,
@@ -290,7 +297,8 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     getVisibleUserRequests,
     swapProvider,
     onBroadcastSuccess,
-    onBroadcastFailed
+    onBroadcastFailed,
+    ui
   }: {
     eventEmitterRegistry?: IEventEmitterRegistryController
     callRelayer: Function
@@ -312,6 +320,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     swapProvider: SwapProvider
     onBroadcastSuccess: OnBroadcastSuccess
     onBroadcastFailed: OnBroadcastFailed
+    ui: IUiController
   }) {
     super(eventEmitterRegistry)
 
@@ -335,6 +344,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     this.#getVisibleUserRequests = getVisibleUserRequests
     this.#onBroadcastSuccess = onBroadcastSuccess
     this.#onBroadcastFailed = onBroadcastFailed
+    this.#ui = ui
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.#initialLoadPromise = this.#load().finally(() => {
@@ -352,6 +362,29 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       BRIDGE_STATUS_INTERVAL,
       this.emitError.bind(this)
     )
+
+    this.#ui.uiEvent.on('updateView', (view: View) => {
+      if (isSwapAndBridge(view.currentRoute)) {
+        this.#isOnSwapAndBridgeRoute = true
+        // Fetch a fresh quote immediately if the form is ready and the last
+        // quote is older than 20 seconds (e.g. user was away on another screen).
+        // If the user just briefly switched screens, skip the immediate fetch
+        // and let the normal interval handle the next update.
+        const isQuoteStale = Date.now() - this.updateQuoteInterval.startedRunningAt > 20_000
+        this.updateQuoteInterval.restart({
+          runImmediately: !!this.#shouldAutoUpdateQuote && isQuoteStale
+        })
+      } else if (isSwapAndBridge(view.previousRoute)) {
+        this.#isOnSwapAndBridgeRoute = false
+        this.updateQuoteInterval.stop()
+      }
+    })
+
+    this.#ui.uiEvent.on('removeView', (view: View) => {
+      if (!isSwapAndBridge(view.currentRoute)) return
+      this.#isOnSwapAndBridgeRoute = false
+      this.updateQuoteInterval.stop()
+    })
   }
 
   #emitUpdateIfNeeded(forceUpdate: boolean = false) {
@@ -2606,6 +2639,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
   get #shouldAutoUpdateQuote() {
     return (
+      this.#isOnSwapAndBridgeRoute &&
       this.formStatus === SwapAndBridgeFormStatus.ReadyToSubmit &&
       !this.hasProceeded &&
       this.quote &&


### PR DESCRIPTION
Fix: Pause `updateQuoteInterval` when the pop-up is closed or the tab is inactive. Resume it when the form becomes visible again, and trigger an immediate quote update if the last one was more than 20 seconds ago.