### PR TITLE
Fix / RecurrungTimeout race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ambire-common",
-  "version": "2.89.3",
+  "version": "2.91.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ambire-common",
-      "version": "2.89.3",
+      "version": "2.91.2",
       "dependencies": {
         "@ambire/signature-validator": "^1.5.0",
         "@ensdomains/ethers-patch-v6": "^0.0.4",

--- a/src/classes/recurringTimeout/recurringTimeout.test.ts
+++ b/src/classes/recurringTimeout/recurringTimeout.test.ts
@@ -257,4 +257,29 @@ describe('RecurringTimeout', () => {
     await jest.advanceTimersByTimeAsync(250)
     expect(fn).toHaveBeenCalledTimes(2)
   })
+  test('should reject stale microtasks when restart() is called in the same tick', async () => {
+    const fn = jest.fn().mockResolvedValue(undefined)
+    const t = new RecurringTimeout(fn, 12000)
+
+    // Call A: Background start (schedules 12s wait in Microtask A)
+    t.start({ runImmediately: false })
+
+    // Call B: Foreground restart (resets sessionId, queues Microtask B with immediate execution)
+    t.restart({ runImmediately: true })
+
+    // Process all microtasks in the same tick
+    await jest.advanceTimersByTimeAsync(0)
+
+    // Verify Call B won (it was immediate) and fn was called once
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Ensure no additional call was made BEFORE the timeout
+    // We check 11999 to be safe
+    await jest.advanceTimersByTimeAsync(11999)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // The second call (scheduled by B's recurring loop) should happen now
+    await jest.advanceTimersByTimeAsync(1)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/classes/recurringTimeout/recurringTimeout.ts
+++ b/src/classes/recurringTimeout/recurringTimeout.ts
@@ -64,7 +64,11 @@ export class RecurringTimeout implements IRecurringTimeout {
   promise: Promise<void> | undefined
 
   // collapse multiple start/restart calls in the same tick
-  #pendingStart?: RecurringTimeoutStartOptions
+  #pendingStart: RecurringTimeoutStartOptions | undefined
+
+  // we use this id to prevent race conditions where a background-queued 12s wait
+  // would block a foreground-queued immediate execution in the same tick.
+  #internalSessionId = 0
 
   startScheduled = false
 
@@ -89,11 +93,15 @@ export class RecurringTimeout implements IRecurringTimeout {
   }
 
   stop() {
+    this.#internalSessionId += 1
+    this.sessionId = this.#internalSessionId
     this.startScheduled = false
     this.#reset()
   }
 
   restart(opts: RecurringTimeoutStartOptions = {}) {
+    this.#internalSessionId += 1
+    this.sessionId = this.#internalSessionId
     this.#reset()
     this.#scheduleStart(opts)
   }
@@ -132,14 +140,19 @@ export class RecurringTimeout implements IRecurringTimeout {
     if (this.startScheduled) return
     this.startScheduled = true
 
+    const capturedSessionId = this.#internalSessionId
+
     queueMicrotask(() => {
+      // If the session ID changed since we queued this microtask (e.g. stop() or restart() was called),
+      // we self-destruct. This prevents a background-scheduled "wait" from blocking an immediate request.
+      if (this.#internalSessionId !== capturedSessionId) return
+
       this.startScheduled = false
       const { timeout: newTimeout, runImmediately, allowOverlap } = this.#pendingStart || {}
       this.#pendingStart = undefined
 
       this.running = true
       this.startedRunningAt = Date.now()
-      this.sessionId += 1
 
       if (newTimeout) this.updateTimeout({ timeout: newTimeout })
 
@@ -156,8 +169,8 @@ export class RecurringTimeout implements IRecurringTimeout {
 
   #reset() {
     this.running = false
-    this.startedRunningAt = 0
-
+    this.startScheduled = false
+    this.promise = undefined
     if (this.#timeoutId) {
       clearTimeout(this.#timeoutId)
       this.#timeoutId = undefined

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -412,6 +412,14 @@ describe('SwapAndBridge Controller', () => {
     await check()
   })
   it('should continuously update the quote', async () => {
+    // Set #isOnSwapAndBridgeRoute = true so #shouldAutoUpdateQuote can pass.
+    // The controller listens on 'updateView' (not 'addView'), so we add a view
+    // with a different route first, then update it to 'swap-and-bridge'.
+    // Must happen before useFakeTimers so the restart() queued by the listener
+    // resolves immediately and doesn't interfere with the test timers.
+    uiCtrl.addView({ id: 'test-quote', type: 'tab', currentRoute: 'other', isReady: true })
+    uiCtrl.updateView('test-quote', { currentRoute: 'swap-and-bridge', isReady: true })
+
     jest.useFakeTimers()
     const { restore } = suppressConsole()
 
@@ -429,7 +437,6 @@ describe('SwapAndBridge Controller', () => {
     )
 
     expect(swapAndBridgeController.formStatus).not.toBe(SwapAndBridgeFormStatus.ReadyToSubmit)
-    expect(swapAndBridgeController.updateQuoteInterval.running).toBe(false)
 
     swapAndBridgeController.updateQuoteInterval.restart()
     expect(updateQuoteIntervalRestartSpy).toHaveBeenCalledTimes(1)

--- a/test/recurringTimeout.ts
+++ b/test/recurringTimeout.ts
@@ -16,7 +16,10 @@ export const waitForFnToBeCalledAndExecuted = async (
   while (sessionId !== recurringTimeout.sessionId) {
     sessionId = recurringTimeout.sessionId
     await jest.advanceTimersByTimeAsync(
-      recurringTimeout.currentTimeout - (Date.now() - recurringTimeout.startedRunningAt)
+      Math.max(
+        0,
+        recurringTimeout.currentTimeout - (Date.now() - recurringTimeout.startedRunningAt)
+      )
     )
   }
 


### PR DESCRIPTION
**Implements a Session ID locking mechanism in RecurringTimeout to prevent stale background tasks from blocking immediate foreground requests.**

**The Issue:**
When start() and restart() were called in the same event loop tick, 
multiple microtasks were queued. A background-queued "wait" task 
(Microtask A) would execute first, setting the timer to 'running' 
and scheduling a 12s sleep. The subsequent immediate "fetch" 
(Microtask B) would then see the timer was already 'running' 
and return early, effectively being ignored.

**The Fix:**
Added an `internalSessionId` that increments on every stop/restart. 
Microtasks now self-destruct if their captured session ID doesn't 
match the current one, ensuring that immediate foreground requests 
always take priority over background noise.