### PR TITLE
Feature/ Namoshi names resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "ambire-common",
-  "version": "2.89.3",
+  "version": "2.91.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ambire-common",
-      "version": "2.89.3",
+      "version": "2.91.2",
       "dependencies": {
         "@ambire/signature-validator": "^1.5.0",
-        "@ensdomains/ethers-patch-v6": "^0.0.4",
         "@lifi/types": "^17.7.1",
         "@metamask/eth-sig-util": "^8.2.0",
         "@safe-global/api-kit": "^4.0.1",
@@ -25,7 +24,7 @@
         "siwe": "3.0.0",
         "tldts": "7.0.17",
         "uuid": "9.0.0",
-        "viem": "^2.33.3"
+        "viem": "2.45.2"
       },
       "devDependencies": {
         "@borislav.itskov/schnorrkel.js": "2.0.85",
@@ -74,7 +73,6 @@
         "typescript": "5.9.3"
       },
       "peerDependencies": {
-        "@ensdomains/eth-ens-namehash": "^2.0.15",
         "@noble/hashes": "^1.8.0",
         "bip44-constants": "^128.0.0",
         "react": "^19.1.0",
@@ -827,21 +825,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/@ensdomains/eth-ens-namehash": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz",
-      "integrity": "sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw==",
-      "peer": true
-    },
-    "node_modules/@ensdomains/ethers-patch-v6": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@ensdomains/ethers-patch-v6/-/ethers-patch-v6-0.0.4.tgz",
-      "integrity": "sha512-jELdSlwtLl10HA18PfHyaPSCqtgTOazNLc95+5+wMb0XTx+XozHYWLPHVPOUhmSt2Ag0cz9ufZviLRzwQIgxGw==",
-      "peerDependencies": {
-        "ethers": "6",
-        "typescript": "^5"
-      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -5652,16 +5635,16 @@
       ]
     },
     "node_modules/abitype": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
+        "zod": "^3.22.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -15437,9 +15420,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.8.6.tgz",
-      "integrity": "sha512-eiKcgiVVEGDtEpEdFi1EGoVVI48j6icXHce9nFwCNM7CKG3uoCXKdr4TPhS00Iy1TR2aWSF1ltPD0x/YgqIL9w==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.11.3.tgz",
+      "integrity": "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==",
       "funding": [
         {
           "type": "github",
@@ -15450,11 +15433,11 @@
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.1",
+        "@noble/curves": "1.9.1",
         "@noble/hashes": "^1.8.0",
         "@scure/bip32": "^1.7.0",
         "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.8",
+        "abitype": "^1.2.3",
         "eventemitter3": "5.0.1"
       },
       "peerDependencies": {
@@ -15467,15 +15450,15 @@
       }
     },
     "node_modules/ox/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
     "node_modules/ox/node_modules/@noble/curves": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-      "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -17992,6 +17975,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -18191,9 +18175,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.33.3",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.33.3.tgz",
-      "integrity": "sha512-aWDr6i6r3OfNCs0h9IieHFhn7xQJJ8YsuA49+9T5JRyGGAkWhLgcbLq2YMecgwM7HdUZpx1vPugZjsShqNi7Gw==",
+      "version": "2.45.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.45.2.tgz",
+      "integrity": "sha512-GXPMmj0ukqFNL87sgpsZBy4CjGvsFQk42/EUdsn8dv3ZWtL4ukDXNCM0nME2hU0IcuS29CuUbrwbZN6iWxAipw==",
       "funding": [
         {
           "type": "github",
@@ -18203,14 +18187,14 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@noble/curves": "1.9.2",
+        "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
         "@scure/bip32": "1.7.0",
         "@scure/bip39": "1.6.0",
-        "abitype": "1.0.8",
+        "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.8.6",
-        "ws": "8.18.2"
+        "ox": "0.11.3",
+        "ws": "8.18.3"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -18222,9 +18206,9 @@
       }
     },
     "node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
-      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -18273,9 +18257,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@ambire/signature-validator": "^1.5.0",
-    "@ensdomains/ethers-patch-v6": "^0.0.4",
     "@lifi/types": "^17.7.1",
     "@metamask/eth-sig-util": "^8.2.0",
     "@safe-global/api-kit": "^4.0.1",
@@ -31,10 +30,9 @@
     "siwe": "3.0.0",
     "tldts": "7.0.17",
     "uuid": "9.0.0",
-    "viem": "^2.33.3"
+    "viem": "2.45.2"
   },
   "peerDependencies": {
-    "@ensdomains/eth-ens-namehash": "^2.0.15",
     "@noble/hashes": "^1.8.0",
     "bip44-constants": "^128.0.0",
     "react": "^19.1.0",

--- a/src/controllers/domains/domains.test.ts
+++ b/src/controllers/domains/domains.test.ts
@@ -235,7 +235,6 @@ describe('Domains', () => {
 
     await domainsController.resolveDomain({ domain: TEST.name })
 
-    // namoshi resolution shouldn't be saved to ensToAddress mapping
     expect(domainsController.domainToAddresses[TEST.name]?.address).toBe(TEST.address)
     expect(domainsController.domainToAddresses[TEST.name]?.type).toBe('namoshi')
     expect(domainsController.domains[TEST.address]!.namoshi).toBe(TEST.name)

--- a/src/controllers/domains/domains.test.ts
+++ b/src/controllers/domains/domains.test.ts
@@ -227,7 +227,7 @@ describe('Domains', () => {
       CCIP_READ_TEST.address
     )
   })
-  it('should resolve btc domain on citrea network', async () => {
+  it('should resolve .citrea domain on citrea network', async () => {
     const TEST = {
       address: getAddress('0x4f0b5579136f88135572010276c2a4a884729e7b'),
       name: 'nemo.citrea'

--- a/src/controllers/domains/domains.test.ts
+++ b/src/controllers/domains/domains.test.ts
@@ -1,3 +1,5 @@
+import { getAddress } from 'ethers'
+
 import { expect, jest } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
@@ -10,9 +12,45 @@ import {
   PERSIST_DOMAIN_FOR_IN_MS
 } from './domains'
 
-const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
-)
+const citrea = {
+  predefinedConfigVersion: 5,
+  chainId: 4114n,
+  platformId: 'citrea',
+  name: 'Citrea Mainnet',
+  nativeAssetSymbol: 'wBTC',
+  nativeAssetName: 'Wrapped Citrea Bitcoin',
+  iconUrls: ['https://cena.ambire.com/public/networks/citrea-logo.png'],
+  explorerUrl: 'https://explorer.mainnet.citrea.xyz',
+  rpcUrls: ['https://rpc.mainnet.citrea.xyz'],
+  selectedRpcUrl: 'https://rpc.mainnet.citrea.xyz',
+  rpcNoStateOverride: false,
+  isOptimistic: false,
+  disableEstimateGas: true,
+  feeOptions: {
+    is1559: true
+  },
+  isSAEnabled: true,
+  areContractsDeployed: true,
+  hasRelayer: false,
+  erc4337: {
+    enabled: true,
+    hasPaymaster: true,
+    hasBundlerSupport: true,
+    bundlers: ['pimlico'],
+    defaultBundler: 'pimlico'
+  },
+  nativeAssetId: 'bitcoin',
+  hasSingleton: true,
+  features: [],
+  predefined: true,
+  wrappedAddr: '0x0000000000000000000000000000000000000000',
+  has7702: true
+}
+
+const providers = {
+  ['1']: getRpcProvider(networks.find((n) => n.chainId === 1n)!.rpcUrls, 1n),
+  ['4114']: getRpcProvider(citrea.rpcUrls, citrea.chainId)
+}
 
 // 0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41
 const ENS_OLDEST_RESOLVER = {
@@ -61,7 +99,8 @@ describe('Domains', () => {
 
     await domainsController.resolveDomain({ domain: name })
 
-    expect(domainsController.ensToAddress[name]).toBe(address)
+    expect(domainsController.domainToAddresses[name]?.address).toBe(address)
+    expect(domainsController.domainToAddresses[name]?.type).toBe('ens')
   })
   it(`reverse lookup should expire after ${
     PERSIST_DOMAIN_FOR_IN_MS / 1000 / 60
@@ -171,9 +210,10 @@ describe('Domains', () => {
 
     await domainsController.resolveDomain({ domain: UNIVERSAL_RESOLVER_TEST.name })
 
-    expect(domainsController.ensToAddress[UNIVERSAL_RESOLVER_TEST.name]).toBe(
+    expect(domainsController.domainToAddresses[UNIVERSAL_RESOLVER_TEST.name]?.address).toBe(
       UNIVERSAL_RESOLVER_TEST.address
     )
+    expect(domainsController.domainToAddresses[UNIVERSAL_RESOLVER_TEST.name]?.type).toBe('ens')
   })
   it('should support CCIP Read', async () => {
     const CCIP_READ_TEST = {
@@ -183,6 +223,37 @@ describe('Domains', () => {
 
     await domainsController.resolveDomain({ domain: CCIP_READ_TEST.name })
 
-    expect(domainsController.ensToAddress[CCIP_READ_TEST.name]).toBe(CCIP_READ_TEST.address)
+    expect(domainsController.domainToAddresses[CCIP_READ_TEST.name]?.address).toBe(
+      CCIP_READ_TEST.address
+    )
+  })
+  it('should resolve btc domain on citrea network', async () => {
+    const TEST = {
+      address: getAddress('0x4f0b5579136f88135572010276c2a4a884729e7b'),
+      name: 'nemo.citrea'
+    }
+
+    await domainsController.resolveDomain({ domain: TEST.name })
+
+    // namoshi resolution shouldn't be saved to ensToAddress mapping
+    expect(domainsController.domainToAddresses[TEST.name]?.address).toBe(TEST.address)
+    expect(domainsController.domainToAddresses[TEST.name]?.type).toBe('namoshi')
+    expect(domainsController.domains[TEST.address]!.namoshi).toBe(TEST.name)
+  })
+  it('controller works without a citrea provider', async () => {
+    const controllerWithoutCitrea = new DomainsController({
+      providers: {
+        ['1']: getRpcProvider(networks.find((n) => n.chainId === 1n)!.rpcUrls, 1n)
+      }
+    })
+
+    const TEST = {
+      address: getAddress('0x4f0b5579136f88135572010276c2a4a884729e7b'),
+      name: 'nemo.citrea'
+    }
+
+    await controllerWithoutCitrea.resolveDomain({ domain: TEST.name })
+
+    expect(controllerWithoutCitrea.domains[TEST.address]).toBeUndefined()
   })
 })

--- a/src/controllers/domains/domains.ts
+++ b/src/controllers/domains/domains.ts
@@ -270,10 +270,10 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
           timeoutMs: 15000
         })
         this.domainToAddresses[ens] = { address: checksummedAddress, type: 'ens' }
-      } else if (namoshi) {
+      } else if (namoshi && citreaProvider) {
         ensAvatar = await withTimeout(
           () =>
-            getEnsAvatar(namoshi, ethereumProvider, {
+            getEnsAvatar(namoshi, citreaProvider, {
               universalResolverAddress: NAMOSHI_UNIVERSAL_RESOLVER
             }),
           {
@@ -297,7 +297,7 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
       // Fail silently with a console error, no biggie, since that would get retried
       // Ignore, the user simply doesn't have a namoshi domain
       if (typeof shortMessage !== 'string' || !shortMessage.includes('data="0x77209fe8')) {
-        console.warn('reverse ENS lookup failed', e)
+        console.warn('reverse ENS/Namoshi lookup failed for address', checksummedAddress, e)
       }
 
       const hasBeenResolvedOnce = !!this.domains[checksummedAddress]?.createdAt

--- a/src/controllers/domains/domains.ts
+++ b/src/controllers/domains/domains.ts
@@ -3,13 +3,23 @@ import { getAddress, isAddress } from 'ethers'
 import { IDomainsController } from '../../interfaces/domains'
 import { IEventEmitterRegistryController } from '../../interfaces/eventEmitter'
 import { RPCProviders } from '../../interfaces/provider'
-import { getEnsAvatar, resolveENSDomain, reverseLookupEns } from '../../services/ensDomains'
+import {
+  getEnsAvatar,
+  getIsNamoshiDomain,
+  NAMOSHI_UNIVERSAL_RESOLVER,
+  resolveENSDomain,
+  reverseLookupEns
+} from '../../services/ensDomains'
 import { withTimeout } from '../../utils/with-timeout'
 import EventEmitter from '../eventEmitter/eventEmitter'
 
 interface Domains {
   [address: string]: {
     ens: string | null
+    namoshi: string | null
+    /**
+     * ENS or Namoshi avatar URL
+     */
     ensAvatar?: string | null
     createdAt?: number
     updatedAt?: number
@@ -35,8 +45,15 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
 
   /** Maps domain names to account addresses; necessary because the 'domains' state
    * only indexes by address, making getting an address for an existing domain name inefficient.
+   * And is also problematic if a domain name that has been resolved doesn't have a corresponding address
+   * (because no one owns it). We don't want to keep trying to resolve it every time.
    */
-  ensToAddress: { [ensName: string]: string } = {}
+  domainToAddresses: {
+    [domain: string]: {
+      address: string | undefined
+      type: 'ens' | 'namoshi'
+    }
+  } = {}
 
   loadingAddresses: string[] = []
 
@@ -69,11 +86,19 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
   /**
    * Resolves an ENS domain and persists it to state only if resolution succeeds.
    */
-  async resolveDomain({ domain, bip44Item }: { domain: string; bip44Item?: number[][] }) {
-    const ethereumProvider =
-      this.#providers[this.#defaultNetworksMode === 'mainnet' ? '1' : '11155111']
+  async resolveDomain({ domain }: { domain: string }) {
+    const isNamoshiDomain = getIsNamoshiDomain(domain)
+    const providerChainId = isNamoshiDomain
+      ? '4114'
+      : this.#defaultNetworksMode === 'mainnet'
+        ? '1'
+        : '11155111'
+    const provider = this.#providers[providerChainId]
 
-    if (!ethereumProvider) {
+    if (!provider) {
+      // Don't emit an error if the citrea provider is missing
+      if (isNamoshiDomain) return
+
       this.emitError({
         error: new Error('domains.resolveDomain: Ethereum provider is not available'),
         message: 'The RPC provider for Ethereum is not available.',
@@ -92,7 +117,7 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
     this.resolveDomainsStatus[domain] = 'LOADING'
     await this.forceEmitUpdate()
 
-    if (this.ensToAddress[domain]) {
+    if (this.domainToAddresses[domain]) {
       this.resolveDomainsStatus[domain] = 'RESOLVED'
       await this.forceEmitUpdate()
       this.resolveDomainsStatus[domain] = undefined
@@ -100,13 +125,25 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
     }
 
     await resolveENSDomain({
-      provider: ethereumProvider,
+      provider: provider,
       domain,
-      bip44Item
+      options: isNamoshiDomain
+        ? { universalResolverAddress: NAMOSHI_UNIVERSAL_RESOLVER }
+        : undefined
     })
       .then(async ({ address, avatar }) => {
+        this.domainToAddresses[domain] = {
+          address: address ? getAddress(address) : undefined,
+          type: isNamoshiDomain ? 'namoshi' : 'ens'
+        }
+
         if (address) {
-          this.#saveResolvedDomain({ address, ensAvatar: avatar, domain, type: 'ens' })
+          this.#saveResolvedDomain({
+            address,
+            ensAvatar: avatar,
+            domain,
+            type: isNamoshiDomain ? 'namoshi' : 'ens'
+          })
         }
         this.resolveDomainsStatus[domain] = 'RESOLVED'
         await this.forceEmitUpdate()
@@ -132,7 +169,7 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
     address: string
     domain: string
     ensAvatar: string | null
-    type: 'ens'
+    type: 'ens' | 'namoshi'
   }) {
     const checksummedAddress = getAddress(address)
     const { ens: prevEns } = this.domains[checksummedAddress] || { ens: null }
@@ -140,10 +177,10 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
     const existing = this.domains[checksummedAddress]
     const now = Date.now()
 
-    this.ensToAddress[domain] = checksummedAddress
     this.domains[checksummedAddress] = {
       ensAvatar: type === 'ens' ? ensAvatar : (existing?.ensAvatar ?? null),
       ens: type === 'ens' ? domain : prevEns,
+      namoshi: type === 'namoshi' ? domain : (existing?.namoshi ?? null),
       createdAt: existing?.createdAt ?? now,
       updatedAt: now
     }
@@ -169,6 +206,7 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
   async #reverseLookup(address: string, emitUpdate = true) {
     const ethereumProvider =
       this.#providers[this.#defaultNetworksMode === 'mainnet' ? '1' : '11155111']
+    const citreaProvider = this.#providers['4114']
 
     if (!ethereumProvider) {
       this.emitError({
@@ -195,22 +233,57 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
     try {
       let ensAvatar: string | undefined | null
 
-      const ens = await withTimeout(() => reverseLookupEns(checksummedAddress, ethereumProvider), {
-        timeoutMs: 15000
-      })
+      const [ens, namoshi] = await Promise.all([
+        withTimeout(() => reverseLookupEns(checksummedAddress, ethereumProvider), {
+          timeoutMs: 15000
+        }),
+        withTimeout(
+          () => {
+            if (!citreaProvider) return Promise.resolve(null)
+
+            return reverseLookupEns(checksummedAddress, citreaProvider, {
+              universalResolverAddress: NAMOSHI_UNIVERSAL_RESOLVER
+            }).catch((e) => {
+              const shortMessage = e?.cause?.shortMessage ?? e?.cause?.message ?? ''
+
+              // Ignore, the user simply doesn't have a namoshi domain
+              if (typeof shortMessage === 'string' && shortMessage.includes('data="0x77209fe8'))
+                return null
+
+              console.warn('reverse Namoshi lookup failed', e)
+              return null
+            })
+          },
+          {
+            timeoutMs: 15000
+          }
+        )
+      ])
 
       if (ens) {
         // We need the ens name to resolve the avatar
         ensAvatar = await withTimeout(() => getEnsAvatar(ens, ethereumProvider), {
           timeoutMs: 15000
         })
-        this.ensToAddress[ens] = checksummedAddress
+        this.domainToAddresses[ens] = { address: checksummedAddress, type: 'ens' }
+      } else if (namoshi) {
+        ensAvatar = await withTimeout(
+          () =>
+            getEnsAvatar(namoshi, ethereumProvider, {
+              universalResolverAddress: NAMOSHI_UNIVERSAL_RESOLVER
+            }),
+          {
+            timeoutMs: 15000
+          }
+        )
+        this.domainToAddresses[namoshi] = { address: checksummedAddress, type: 'namoshi' }
       }
 
       const now = Date.now()
       const existing = this.domains[checksummedAddress]
       this.domains[checksummedAddress] = {
         ens,
+        namoshi,
         ensAvatar,
         createdAt: existing?.createdAt ?? now,
         updatedAt: now
@@ -223,7 +296,7 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
       if (hasBeenResolvedOnce) {
         this.domains[checksummedAddress]!.updateFailedAt = Date.now()
       } else {
-        this.domains[checksummedAddress] = { ens: null, updateFailedAt: Date.now() }
+        this.domains[checksummedAddress] = { ens: null, namoshi: null, updateFailedAt: Date.now() }
       }
     }
 

--- a/src/controllers/domains/domains.ts
+++ b/src/controllers/domains/domains.ts
@@ -16,6 +16,10 @@ import EventEmitter from '../eventEmitter/eventEmitter'
 interface Domains {
   [address: string]: {
     ens: string | null
+    /**
+     * Namoshi domains are fully compatible with the ENS implementation, they just use a different universal resolver contract
+     * and have different TLDs (.btc and .citrea).
+     */
     namoshi: string | null
     /**
      * ENS or Namoshi avatar URL
@@ -289,8 +293,12 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
         updatedAt: now
       }
     } catch (e: any) {
+      const shortMessage = e?.cause?.shortMessage ?? e?.cause?.message ?? ''
       // Fail silently with a console error, no biggie, since that would get retried
-      console.warn('reverse ENS lookup failed', e)
+      // Ignore, the user simply doesn't have a namoshi domain
+      if (typeof shortMessage !== 'string' || !shortMessage.includes('data="0x77209fe8')) {
+        console.warn('reverse ENS lookup failed', e)
+      }
 
       const hasBeenResolvedOnce = !!this.domains[checksummedAddress]?.createdAt
       if (hasBeenResolvedOnce) {

--- a/src/controllers/transaction/controllers/intent.ts
+++ b/src/controllers/transaction/controllers/intent.ts
@@ -41,6 +41,7 @@ export class IntentController extends EventEmitter {
         inputAmount: currentState.fromAmount,
         recipient:
           currentState.addressState.ensAddress ||
+          currentState.addressState.namoshiAddress ||
           currentState.addressState.interopAddress ||
           currentState.addressState.fieldValue,
         sender: this.dependencies.selectedAccount.account?.addr

--- a/src/controllers/transaction/controllers/intent.ts
+++ b/src/controllers/transaction/controllers/intent.ts
@@ -40,8 +40,7 @@ export class IntentController extends EventEmitter {
         outputChainId: currentState.toChainId,
         inputAmount: currentState.fromAmount,
         recipient:
-          currentState.addressState.ensAddress ||
-          currentState.addressState.namoshiAddress ||
+          currentState.addressState.resolvedAddress ||
           currentState.addressState.interopAddress ||
           currentState.addressState.fieldValue,
         sender: this.dependencies.selectedAccount.account?.addr

--- a/src/controllers/transaction/transactionFormState.ts
+++ b/src/controllers/transaction/transactionFormState.ts
@@ -47,8 +47,8 @@ const DEFAULT_VALIDATION_FORM_MSGS = {
 
 const DEFAULT_ADDRESS_STATE = {
   fieldValue: '',
-  ensAddress: '',
-  namoshiAddress: '',
+  resolvedAddress: '',
+  resolvedAddressType: null,
   interopAddress: '',
   isDomainResolving: false
 }
@@ -849,7 +849,7 @@ export class TransactionFormState extends EventEmitter {
         this.isRecipientAddressUnknownAgreed,
         this.isRecipientAddressUnknown,
         this.isRecipientHumanizerKnownTokenOrSmartContract,
-        !!this.addressState.ensAddress || !!this.addressState.namoshiAddress,
+        !!this.addressState.resolvedAddress,
         this.addressState.isDomainResolving,
         this.dependencies.networks.networks,
         this.dependencies.accounts.accountStates,
@@ -862,8 +862,7 @@ export class TransactionFormState extends EventEmitter {
 
   get recipientAddress() {
     return (
-      this.addressState.ensAddress ||
-      this.addressState.namoshiAddress ||
+      this.addressState.resolvedAddress ||
       this.addressState.interopAddress ||
       this.addressState.fieldValue
     )

--- a/src/controllers/transaction/transactionFormState.ts
+++ b/src/controllers/transaction/transactionFormState.ts
@@ -48,6 +48,7 @@ const DEFAULT_VALIDATION_FORM_MSGS = {
 const DEFAULT_ADDRESS_STATE = {
   fieldValue: '',
   ensAddress: '',
+  namoshiAddress: '',
   interopAddress: '',
   isDomainResolving: false
 }
@@ -842,15 +843,13 @@ export class TransactionFormState extends EventEmitter {
     const validationFormMsgsNew = DEFAULT_VALIDATION_FORM_MSGS
 
     if (this.#humanizerInfo && this.#selectedAccountData) {
-      const isEnsAddress = !!this.addressState.ensAddress
-
       validationFormMsgsNew.recipientAddress = validateSendTransferAddress(
         this.recipientAddress,
         this.#selectedAccountData.addr,
         this.isRecipientAddressUnknownAgreed,
         this.isRecipientAddressUnknown,
         this.isRecipientHumanizerKnownTokenOrSmartContract,
-        isEnsAddress,
+        !!this.addressState.ensAddress || !!this.addressState.namoshiAddress,
         this.addressState.isDomainResolving,
         this.dependencies.networks.networks,
         this.dependencies.accounts.accountStates,

--- a/src/controllers/transaction/transactionFormState.ts
+++ b/src/controllers/transaction/transactionFormState.ts
@@ -863,6 +863,7 @@ export class TransactionFormState extends EventEmitter {
   get recipientAddress() {
     return (
       this.addressState.ensAddress ||
+      this.addressState.namoshiAddress ||
       this.addressState.interopAddress ||
       this.addressState.fieldValue
     )

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -64,7 +64,8 @@ describe('Transfer Controller', () => {
     await transferController.update({
       addressState: {
         fieldValue: PLACEHOLDER_RECIPIENT,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })
@@ -75,7 +76,8 @@ describe('Transfer Controller', () => {
     await transferController.update({
       addressState: {
         fieldValue: PLACEHOLDER_RECIPIENT,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })
@@ -88,7 +90,8 @@ describe('Transfer Controller', () => {
     await transferController.update({
       addressState: {
         fieldValue: XWALLET_ADDRESS,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })
@@ -126,7 +129,8 @@ describe('Transfer Controller', () => {
       selectedToken: xwalletOnEthereum,
       addressState: {
         fieldValue: PLACEHOLDER_RECIPIENT,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })
@@ -187,7 +191,8 @@ describe('Transfer Controller', () => {
     await transferController.update({
       addressState: {
         fieldValue: FEE_COLLECTOR,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })
@@ -206,8 +211,8 @@ describe('Transfer Controller', () => {
     expect(transferController.isRecipientAddressUnknown).toBe(false)
     expect(transferController.addressState).toEqual({
       fieldValue: '',
-      ensAddress: '',
-      namoshiAddress: '',
+      resolvedAddress: '',
+      resolvedAddressType: null,
       isDomainResolving: false
     })
     expect(transferController.isRecipientAddressUnknownAgreed).toBe(false)
@@ -284,7 +289,8 @@ describe('Transfer Controller defaults logic', () => {
       amount: '1',
       addressState: {
         fieldValue: PLACEHOLDER_RECIPIENT,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })
@@ -369,7 +375,8 @@ describe('Transfer Controller defaults logic', () => {
       amount: '1',
       addressState: {
         fieldValue: PLACEHOLDER_RECIPIENT,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })
@@ -411,7 +418,8 @@ describe('Transfer Controller defaults logic', () => {
       amount: '1',
       addressState: {
         fieldValue: PLACEHOLDER_RECIPIENT,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })
@@ -487,7 +495,8 @@ describe('Transfer Controller defaults logic', () => {
       amount: '1',
       addressState: {
         fieldValue: PLACEHOLDER_RECIPIENT,
-        ensAddress: '',
+        resolvedAddress: '',
+        resolvedAddressType: null,
         isDomainResolving: false
       }
     })

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -207,6 +207,7 @@ describe('Transfer Controller', () => {
     expect(transferController.addressState).toEqual({
       fieldValue: '',
       ensAddress: '',
+      namoshiAddress: '',
       isDomainResolving: false
     })
     expect(transferController.isRecipientAddressUnknownAgreed).toBe(false)

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -47,6 +47,7 @@ const CONVERSION_PRECISION_POW = BigInt(10 ** CONVERSION_PRECISION)
 const DEFAULT_ADDRESS_STATE = {
   fieldValue: '',
   ensAddress: '',
+  namoshiAddress: '',
   isDomainResolving: false
 }
 
@@ -487,8 +488,6 @@ export class TransferController extends EventEmitter implements ITransferControl
     const validationFormMsgsNew = DEFAULT_VALIDATION_FORM_MSGS
 
     if (this.#humanizerInfo && this.#selectedAccount.account?.addr) {
-      const isEnsAddress = !!this.addressState.ensAddress
-
       // if the recipientAcc is an account in the extension
       // & the account state is not fetched for it, fetch it
       // so that we could validate the account properly
@@ -512,7 +511,7 @@ export class TransferController extends EventEmitter implements ITransferControl
         this.isRecipientAddressUnknownAgreed,
         this.isRecipientAddressUnknown,
         this.isRecipientHumanizerKnownTokenOrSmartContract,
-        isEnsAddress,
+        !!this.addressState.ensAddress || !!this.addressState.namoshiAddress,
         this.addressState.isDomainResolving,
         this.#networks.networks,
         this.#accounts.accountStates,
@@ -556,7 +555,7 @@ export class TransferController extends EventEmitter implements ITransferControl
   }
 
   get recipientAddress() {
-    return this.addressState.ensAddress || this.addressState.fieldValue
+    return getAddressFromAddressState(this.addressState)
   }
 
   async update({

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -44,10 +44,10 @@ import { OnBroadcastSuccess, SignAccountOpController } from '../signAccountOp/si
 const CONVERSION_PRECISION = 16
 const CONVERSION_PRECISION_POW = BigInt(10 ** CONVERSION_PRECISION)
 
-const DEFAULT_ADDRESS_STATE = {
+const DEFAULT_ADDRESS_STATE: AddressState = {
   fieldValue: '',
-  ensAddress: '',
-  namoshiAddress: '',
+  resolvedAddress: '',
+  resolvedAddressType: null,
   isDomainResolving: false
 }
 
@@ -511,7 +511,7 @@ export class TransferController extends EventEmitter implements ITransferControl
         this.isRecipientAddressUnknownAgreed,
         this.isRecipientAddressUnknown,
         this.isRecipientHumanizerKnownTokenOrSmartContract,
-        !!this.addressState.ensAddress || !!this.addressState.namoshiAddress,
+        !!this.addressState.resolvedAddress,
         this.addressState.isDomainResolving,
         this.#networks.networks,
         this.#accounts.accountStates,

--- a/src/interfaces/domains.ts
+++ b/src/interfaces/domains.ts
@@ -7,12 +7,14 @@ export type IDomainsController = ControllerInterface<
 type AddressState = {
   fieldValue: string
   ensAddress: string
+  namoshiAddress: string
   isDomainResolving: boolean
 }
 
 type AddressStateOptional = {
   fieldValue?: AddressState['fieldValue']
   ensAddress?: AddressState['ensAddress']
+  namoshiAddress?: AddressState['namoshiAddress']
   isDomainResolving?: AddressState['isDomainResolving']
 }
 

--- a/src/interfaces/domains.ts
+++ b/src/interfaces/domains.ts
@@ -6,15 +6,15 @@ export type IDomainsController = ControllerInterface<
 
 type AddressState = {
   fieldValue: string
-  ensAddress: string
-  namoshiAddress: string
+  resolvedAddress: string
+  resolvedAddressType: 'ens' | 'namoshi' | null
   isDomainResolving: boolean
 }
 
 type AddressStateOptional = {
   fieldValue?: AddressState['fieldValue']
-  ensAddress?: AddressState['ensAddress']
-  namoshiAddress?: AddressState['namoshiAddress']
+  resolvedAddress?: AddressState['resolvedAddress']
+  resolvedAddressType?: AddressState['resolvedAddressType']
   isDomainResolving?: AddressState['isDomainResolving']
 }
 

--- a/src/services/ensDomains/ensDomains.ts
+++ b/src/services/ensDomains/ensDomains.ts
@@ -16,6 +16,11 @@ export function isCorrectAddress(address: string) {
   return !(ADDRESS_ZERO === address) && isAddress(address)
 }
 
+/**
+ * Resolves an ENS/Namoshi domain to an address and avatar.
+ *
+ * Can work with a custom universal resolver if the domain is a Namoshi domain, otherwise it defaults to the ENS universal resolver.
+ */
 async function resolveENSDomain({
   provider,
   domain,

--- a/src/services/ensDomains/ensDomains.ts
+++ b/src/services/ensDomains/ensDomains.ts
@@ -1,39 +1,15 @@
-import '@ensdomains/ethers-patch-v6'
+import { isAddress } from 'viem'
+import { normalize } from 'viem/ens'
 
-// @ts-ignore
-import constants from 'bip44-constants'
-import { EnsResolver, isAddress } from 'ethers'
+import { RPCProvider } from '@/interfaces/provider'
+import { getViemClientForProvider } from '@/services/provider'
 
-// @ts-ignore
-import { normalize } from '@ensdomains/eth-ens-namehash'
-
-import { RPCProvider } from '../../interfaces/provider'
-
-const BIP44_BASE_VALUE = 2147483648
 const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
+const ENS_UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe'
+export const NAMOSHI_UNIVERSAL_RESOLVER = '0xc5Ed1fA34AD1F23F0cD2E36DB288290488B1B493'
 
-const normalizeDomain = (domain: string) => {
-  try {
-    return normalize(domain)
-  } catch (e) {
-    return null
-  }
-}
-
-function getNormalisedCoinType(bip44Item: number[][]) {
-  const firstItem = bip44Item[0]
-
-  if (!firstItem) return null
-  return firstItem.length && firstItem[0] ? firstItem[0] - BIP44_BASE_VALUE : null
-}
-
-async function resolveForCoin(resolver: any, bip44Item?: number[][]) {
-  if (bip44Item && bip44Item.length === 1) {
-    const coinType = getNormalisedCoinType(bip44Item)
-    if (!coinType) return null
-    return resolver.getAddress(coinType)
-  }
-  return resolver.getAddress()
+export function getIsNamoshiDomain(domain: string) {
+  return domain.endsWith('.btc') || domain.endsWith('.citrea')
 }
 
 export function isCorrectAddress(address: string) {
@@ -43,62 +19,70 @@ export function isCorrectAddress(address: string) {
 async function resolveENSDomain({
   provider,
   domain,
-  bip44Item
+  options
 }: {
   provider: RPCProvider
   domain: string
-  bip44Item?: number[][]
+  options?: {
+    universalResolverAddress?: string
+  }
 }): Promise<{
   address: string
   avatar: string | null
 }> {
-  const normalizedDomainName = normalizeDomain(domain)
+  const normalizedDomainName = normalize(domain)
   if (!normalizedDomainName) return { address: '', avatar: null }
-  const resolver = await EnsResolver.fromName(provider, normalizedDomainName).catch(() => null)
 
-  if (!resolver)
-    return {
-      address: '',
-      avatar: null
-    }
+  const client = getViemClientForProvider(provider)
 
-  try {
-    const [ethAddress, avatar] = await Promise.all([
-      resolver.getAddress().catch(() => null),
-      resolver.getAvatar().catch(() => null)
-    ])
-    const addressForCoin = await resolveForCoin(resolver, bip44Item).catch(() => null)
+  const [address, avatar] = await Promise.all([
+    client.getEnsAddress({
+      name: normalizedDomainName,
+      universalResolverAddress: options?.universalResolverAddress || ENS_UNIVERSAL_RESOLVER
+    }),
+    client.getEnsAvatar({
+      name: normalizedDomainName,
+      universalResolverAddress: options?.universalResolverAddress || ENS_UNIVERSAL_RESOLVER
+    })
+  ])
 
-    return {
-      address: isCorrectAddress(addressForCoin) ? addressForCoin : ethAddress || '',
-      avatar
-    }
-  } catch (e: any) {
-    // If the error comes from an internal server error don't
-    // show it to the user, because it happens when a domain
-    // doesn't exist and we already show a message for that.
-    // https://dnssec-oracle.ens.domains/ 500 (ISE)
-    if (e.message?.includes('500_SERVER_ERROR'))
-      return {
-        address: '',
-        avatar: null
-      }
-
-    throw e
+  return {
+    address: address || '',
+    avatar
   }
 }
 
-function getBip44Items(coinTicker: string) {
-  if (!coinTicker) return null
-  return constants.filter((item: string[]) => item[1] === coinTicker)
+async function reverseLookupEns(
+  address: string,
+  provider: RPCProvider,
+  options?: {
+    universalResolverAddress?: string
+  }
+) {
+  const client = getViemClientForProvider(provider)
+
+  return client.getEnsName({
+    address: address as `0x${string}`,
+    universalResolverAddress: options?.universalResolverAddress || ENS_UNIVERSAL_RESOLVER
+  })
 }
 
-async function reverseLookupEns(address: string, provider: RPCProvider) {
-  return provider.lookupAddress(address)
+async function getEnsAvatar(
+  name: string,
+  provider: RPCProvider,
+  options?: {
+    universalResolverAddress?: string
+  }
+) {
+  const normalizedName = normalize(name)
+  if (!normalizedName) return null
+
+  const client = getViemClientForProvider(provider)
+
+  return client.getEnsAvatar({
+    name: normalizedName,
+    universalResolverAddress: options?.universalResolverAddress || ENS_UNIVERSAL_RESOLVER
+  })
 }
 
-async function getEnsAvatar(name: string, provider: RPCProvider) {
-  return provider.getAvatar(name)
-}
-
-export { resolveENSDomain, getBip44Items, getEnsAvatar, reverseLookupEns }
+export { resolveENSDomain, getEnsAvatar, reverseLookupEns }

--- a/src/services/provider/getRpcProvider.ts
+++ b/src/services/provider/getRpcProvider.ts
@@ -1,4 +1,5 @@
 import { JsonRpcApiProviderOptions, JsonRpcProvider, Network } from 'ethers'
+import { createPublicClient, custom, PublicClient } from 'viem'
 
 import { Network as NetworkInterface } from '../../interfaces/network'
 import getRootDomain from '../../utils/getRootDomain'
@@ -10,6 +11,8 @@ const RPC_BATCH_CONFIG: Record<string, number> = {
   // Keep tatum.io config disabled - if restricted to 1 it hits their limit of 5 requests per minute anyways
   // 'tatum.io': 1 // batch calls are available for paid plans only (response 402)
 }
+
+const viemClientByProvider = new WeakMap<JsonRpcProvider, PublicClient>()
 
 /** Some RPCs limit batching which causes immediate failures on our end, so configure the known ones */
 const getBatchCountFromUrl = (rpcUrl: string): number | undefined => {
@@ -56,4 +59,18 @@ const getRpcProvider = (
   return new JsonRpcProvider(rpcUrl, undefined, providerOptions)
 }
 
-export { getRpcProvider }
+const getViemClientForProvider = (provider: JsonRpcProvider): PublicClient => {
+  const cached = viemClientByProvider.get(provider)
+  if (cached) return cached
+
+  const client = createPublicClient({
+    transport: custom({
+      request: ({ method, params }) => provider.send(method, params || [])
+    })
+  })
+
+  viemClientByProvider.set(provider, client)
+  return client
+}
+
+export { getRpcProvider, getViemClientForProvider }

--- a/src/services/validations/validate.ts
+++ b/src/services/validations/validate.ts
@@ -96,7 +96,7 @@ const validateSendTransferAddress = (
   addressConfirmed: any,
   isRecipientAddressUnknown: boolean,
   isRecipientHumanizerKnownTokenOrSmartContract: boolean,
-  isEnsAddress: boolean,
+  isDomain: boolean,
   isRecipientDomainResolving: boolean,
   networks: Network[],
   accountStates: AccountStates,
@@ -156,7 +156,7 @@ const validateSendTransferAddress = (
     isRecipientAddressUnknown &&
     isRecipientAddressFirstTimeSend &&
     !addressConfirmed &&
-    !isEnsAddress &&
+    !isDomain &&
     !isRecipientDomainResolving
   ) {
     return {
@@ -169,7 +169,7 @@ const validateSendTransferAddress = (
     isRecipientAddressUnknown &&
     isRecipientAddressFirstTimeSend &&
     !addressConfirmed &&
-    isEnsAddress &&
+    isDomain &&
     !isRecipientDomainResolving
   ) {
     return {

--- a/src/utils/domains.ts
+++ b/src/utils/domains.ts
@@ -1,12 +1,9 @@
 import { AddressState } from '../interfaces/domains'
 
-const getAddressFromAddressState = (addressState: Omit<AddressState, 'isDomainResolving'>) => {
-  return (
-    addressState.ensAddress ||
-    addressState.namoshiAddress ||
-    addressState.fieldValue ||
-    ''
-  ).trim()
+const getAddressFromAddressState = (
+  addressState: Pick<AddressState, 'resolvedAddress' | 'fieldValue'>
+) => {
+  return (addressState.resolvedAddress || addressState.fieldValue || '').trim()
 }
 
 export { getAddressFromAddressState }

--- a/src/utils/domains.ts
+++ b/src/utils/domains.ts
@@ -1,7 +1,12 @@
 import { AddressState } from '../interfaces/domains'
 
-const getAddressFromAddressState = (addressState: AddressState) => {
-  return (addressState.ensAddress || addressState.fieldValue || '').trim()
+const getAddressFromAddressState = (addressState: Omit<AddressState, 'isDomainResolving'>) => {
+  return (
+    addressState.ensAddress ||
+    addressState.namoshiAddress ||
+    addressState.fieldValue ||
+    ''
+  ).trim()
 }
 
 export { getAddressFromAddressState }


### PR DESCRIPTION
## Changes:
- Adds `getViemClientForProvider` which allows us to use existing ethers RPC providers with viem
- Adds https://www.namoshi.xyz/ support
- Refactors the ens implementation, removes `@ensdomains/eth-ens-namehash` and `@ensdomains/ethers-patch-v6` and updates `viem`