### PR TITLE
Fix/ Request window closes on add to batch

### DIFF
--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1823,7 +1823,11 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         this.sendNewRequestMessage(existingUserRequest, 'queued')
         currentUserRequest = this.currentUserRequest || this.visibleUserRequests[0] || null
       }
-      await this.#setCurrentUserRequest(currentUserRequest)
+
+      // Otherwise we will reset the currentUserRequest when a new request is added to the batch
+      if (executionType !== 'queue') {
+        await this.#setCurrentUserRequest(currentUserRequest)
+      }
     } else {
       const account = this.#accounts.accounts.find((x) => x.addr === meta.accountAddr)!
       const accountStateBefore =


### PR DESCRIPTION
## How to reproduce:
1. Add a transaction to the queue
2. Open the transaction (request window)
3. Add a new transaction to the queue from transfer/swap
4. The request window will close

This is because `currentUserRequest` always starts from `null`:
```
let currentUserRequest = null
...
```
