### PR TITLE
Feature/ `eth_createAccessList` and `toBeLearnedAssets` cleanup

### DIFF
--- a/src/consts/safe.ts
+++ b/src/consts/safe.ts
@@ -21,6 +21,15 @@ const vOneFive = {
   singleton: '0xFf51A5898e281Db6DfC7855790607438dF2ca44b'
 }
 
+/**
+ * SimulateTxAccessor addresses by Safe version.
+ */
+export const safeSimulateTxAccessor = {
+  ['v1.3.0']: '0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da',
+  ['v1.4.1']: '0x3d4BA2E0884aa488718476ca2FB8Efc291A46199',
+  ['v1.5.0']: '0x07EfA797c55B5DdE3698d876b277aBb6B893654C'
+}
+
 export const execTransactionAbi = [
   'function execTransaction(address to,uint256 value,bytes calldata data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address payable refundReceiver,bytes memory signatures)'
 ]

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -78,6 +78,7 @@ import {
   LearnedAssets,
   NetworkState,
   PortfolioControllerState,
+  PortfolioLibGetResult,
   PreviousHintsStorage,
   TemporaryTokens,
   ToBeLearnedAssets,
@@ -186,9 +187,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     learnedNfts: {}
   }
 
-  /**
-   * TODO: Figure out a way to clean/reset this structure
-   */
   #toBeLearnedAssets: ToBeLearnedAssets = {
     erc20s: {},
     erc721s: {}
@@ -1690,6 +1688,14 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
               shouldUpdateLearnedInStorage = true
             }
 
+            if (networkResult) {
+              this.cleanupToBeLearnedAssets(
+                network.chainId,
+                networkResult.tokenErrors,
+                networkResult.collectionErrors
+              )
+            }
+
             // Only update this if all networks where updated so we know for sure that the user
             // has disabled the ones in otherNetworksDefiCounts
             if (!networks && discoveryResponse?.data) {
@@ -1825,10 +1831,9 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       this.#toBeLearnedAssets.erc20s[chainIdString] = []
 
     let networkToBeLearnedTokens = this.#toBeLearnedAssets.erc20s[chainIdString]
+    const uniqueTokenAddresses = Array.from(new Set(tokenAddresses))
 
-    const alreadyLearned = networkToBeLearnedTokens.map((addr) => getAddress(addr))
-
-    const tokensToLearn = tokenAddresses.filter((address) => {
+    const tokensToLearn = uniqueTokenAddresses.filter((address) => {
       if (address === ZeroAddress) return false
 
       let normalizedAddress: string | undefined
@@ -1852,7 +1857,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       )
         return false
 
-      return !alreadyLearned.includes(normalizedAddress)
+      return !networkToBeLearnedTokens.includes(normalizedAddress)
     })
 
     if (!tokensToLearn.length) return false
@@ -1954,6 +1959,40 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
       return false
     }
+  }
+
+  /**
+   * toBeLearnedAssets contains arbitrary addresses that include:
+   * - tokens and collectibles
+   * - random smart contracts and addresses
+   * That's why we need to clean it up by removing the addresses that the portfolio lib returned
+   * an error for, as those are not NFTs/Tokens.
+   */
+  private cleanupToBeLearnedAssets(
+    chainId: bigint,
+    tokenErrors: PortfolioLibGetResult['tokenErrors'],
+    collectionErrors: PortfolioLibGetResult['collectionErrors']
+  ) {
+    const chainIdString = chainId.toString()
+    const toBeLearnedTokens = this.#toBeLearnedAssets.erc20s[chainIdString] || []
+    const toBeLearnedNfts = this.#toBeLearnedAssets.erc721s[chainIdString] || {}
+
+    if (!tokenErrors?.length && !collectionErrors?.length) return
+
+    if (!toBeLearnedTokens.length && !Object.keys(toBeLearnedNfts).length) return
+
+    const erroredTokenAddresses = tokenErrors.map((e) => e.address)
+    const erroredCollectionAddresses = collectionErrors?.map((e) => e.address) || []
+
+    this.#toBeLearnedAssets.erc20s[chainIdString] = toBeLearnedTokens.filter(
+      (address) => !erroredTokenAddresses.includes(address)
+    )
+
+    this.#toBeLearnedAssets.erc721s[chainIdString] = Object.fromEntries(
+      Object.entries(toBeLearnedNfts).filter(
+        ([collectionAddress]) => !erroredCollectionAddresses.includes(collectionAddress)
+      )
+    )
   }
 
   /**

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -291,6 +291,7 @@ describe('SelectedAccount Controller', () => {
         discoveryTime: 0,
         tokenDataCache: new Map(),
         tokenErrors: [],
+        collectionErrors: [],
         collections: [],
         blockNumber: 0,
         toBeLearned: {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -125,7 +125,7 @@ import {
   wrapUnprotected
 } from '../../libs/signMessage/signMessage'
 import { getGasUsed } from '../../libs/singleton/singleton'
-import { createAccessListCall } from '../../libs/tracer/accessListCall'
+import { createAccessListCall, getShouldUseAccessListCall } from '../../libs/tracer/accessListCall'
 import { UserOperation } from '../../libs/userOperation/types'
 import {
   getActivatorCall,
@@ -1729,8 +1729,9 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       let erc721s: [string, bigint[]][] = []
 
       const stateOverride = getStateOverride(this.account, this.accountOp, state)
+      const shouldUseAccessList = getShouldUseAccessListCall(this.account, !!stateOverride)
 
-      if (!stateOverride) {
+      if (shouldUseAccessList) {
         const addresses = await createAccessListCall(
           this.baseAccount,
           this.accountOp,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -11,14 +11,13 @@ import {
   Interface,
   isAddress,
   isBytesLike,
-  keccak256,
   toBeHex,
-  toUtf8Bytes,
   ZeroAddress
 } from 'ethers'
 
+import { debugTraceCall, getStateOverride } from '@/libs/tracer/debugTraceCall'
+
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
-import AmbireAccount7702 from '../../../contracts/compiled/AmbireAccount7702.json'
 import ERC20 from '../../../contracts/compiled/IERC20.json'
 import EmittableError from '../../classes/EmittableError'
 import ExternalSignerError from '../../classes/ExternalSignerError'
@@ -103,7 +102,6 @@ import { HumanizerWarning, IrCall } from '../../libs/humanizer/interfaces'
 import { hasRelayerSupport, relayerAdditionalNetworks } from '../../libs/networks/networks'
 import { AbstractPaymaster } from '../../libs/paymaster/abstractPaymaster'
 import { GetOptions, TokenResult } from '../../libs/portfolio'
-import { privSlot } from '../../libs/proxyDeploy/deploy'
 import {
   confirm,
   getAlreadySignedOwners,
@@ -127,7 +125,7 @@ import {
   wrapUnprotected
 } from '../../libs/signMessage/signMessage'
 import { getGasUsed } from '../../libs/singleton/singleton'
-import { debugTraceCall } from '../../libs/tracer/debugTraceCall'
+import { createAccessListCall } from '../../libs/tracer/accessListCall'
 import { UserOperation } from '../../libs/userOperation/types'
 import {
   getActivatorCall,
@@ -1727,46 +1725,36 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         this.#accounts.accountStates[this.account.addr]?.[this.#network.chainId.toString()]
       // TODO: how to handle this case?
       if (!state) return
+      let erc20s: string[] = []
+      let erc721s: [string, bigint[]][] = []
 
-      // if the account is a Safe,
-      // add an additional state override that gives privileges to the assKey;
-      // also, we changed privs storage slot to ambire.smart.contracts.storage
-      // so privs no longer override slot number 0
-      const stateDiff = !!this.account.safeCreation
-        ? {
-            [privSlot(
-              keccak256(toUtf8Bytes('ambire.smart.contracts.storage')),
-              'uint256',
-              this.account.associatedKeys[0],
-              'bytes32'
-            )]: '0x0000000000000000000000000000000000000000000000000000000000000002'
-          }
-        : undefined
+      const stateOverride = getStateOverride(this.account, this.accountOp, state)
 
-      // add stateOverride when using a Safe as well
-      const stateOverride =
-        !!this.account.safeCreation ||
-        (this.accountOp.calls.length > 1 && isBasicAccount(this.account, state))
-          ? {
-              [this.account.addr]: {
-                code: AmbireAccount7702.binRuntime,
-                stateDiff
-              }
-            }
-          : undefined
+      if (!stateOverride) {
+        const addresses = await createAccessListCall(
+          this.baseAccount,
+          this.accountOp,
+          this.#network,
+          state
+        )
+        erc20s = addresses
+        erc721s = addresses.map((address) => [address, []])
+      } else {
+        const { tokens, nfts } = await debugTraceCall(
+          this.baseAccount,
+          this.accountOp,
+          this.#network,
+          state,
+          !this.#network.rpcNoStateOverride,
+          stateOverride
+        )
+        erc20s = tokens
+        erc721s = nfts
+      }
 
-      const { tokens, nfts } = await debugTraceCall(
-        this.baseAccount,
-        this.accountOp,
-        this.#network,
-        state,
-        !this.#network.rpcNoStateOverride,
-        stateOverride
-      )
-
-      const learnedNewTokens = this.#portfolio.addTokensToBeLearned(tokens, this.#network.chainId)
+      const learnedNewTokens = this.#portfolio.addTokensToBeLearned(erc20s, this.#network.chainId)
       const learnedNewNfts = this.#portfolio.addErc721sToBeLearned(
-        nfts,
+        erc721s,
         this.account.addr,
         this.#network.chainId
       )

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1732,6 +1732,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       const shouldUseAccessList = getShouldUseAccessListCall(this.account, !!stateOverride)
 
       if (shouldUseAccessList) {
+        console.log('Debug: using eth_createAccessList for asset discovery')
         const addresses = await createAccessListCall(
           this.baseAccount,
           this.accountOp,
@@ -1741,6 +1742,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         erc20s = addresses
         erc721s = addresses.map((address) => [address, []])
       } else {
+        console.log('Debug: using debug_traceCall for asset discovery')
         const { tokens, nfts } = await debugTraceCall(
           this.baseAccount,
           this.accountOp,

--- a/src/interfaces/selectedAccount.ts
+++ b/src/interfaces/selectedAccount.ts
@@ -25,6 +25,7 @@ export type SelectedAccountPortfolioState = {
           | 'tokens'
           | 'collections'
           | 'tokenErrors'
+          | 'collectionErrors'
           | 'hintsFromExternalAPI'
           | 'priceCache'
           | 'total'

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -139,15 +139,16 @@ export async function getNFTs(
         : opts.blockTag
   })
 
-  const mapNft = (token: any) => {
+  const mapNft = (token: any, address: string) => {
     return {
       name: token.name,
       chainId: network.chainId,
+      address,
       symbol: token.symbol,
       amount: BigInt(token.nfts.length),
       decimals: 1,
       collectibles: [...token.nfts]
-    } as CollectionResult
+    } satisfies Omit<CollectionResult, 'flags' | 'priceIn' | 'marketDataIn'>
   }
 
   if (!opts.simulation) {
@@ -162,7 +163,13 @@ export async function getNFTs(
       deploylessOpts
     )
 
-    return [collections.map((token: any) => [token.error, mapNft(token)]), {}]
+    return [
+      collections.map((token: any, index: number) => [
+        token.error,
+        mapNft(token, tokenAddrs[index]![0])
+      ]),
+      {}
+    ]
   }
 
   const { accountOps, baseAccount, state } = opts.simulation
@@ -199,7 +206,7 @@ export async function getNFTs(
 
   const simulationTokens: (CollectionResult & { addr: any })[] | null = hasSimulation
     ? after.collections.map((simulationToken: any, tokenIndex: number) => ({
-        ...mapNft(simulationToken),
+        ...mapNft(simulationToken, deltaAddressesMapping[tokenIndex]),
         addr: deltaAddressesMapping[tokenIndex]
       }))
     : null
@@ -212,7 +219,7 @@ export async function getNFTs(
           )
         : null
 
-      const token = mapNft(beforeToken)
+      const token = mapNft(beforeToken, tokenAddrs[i]![0])
       const receiving: bigint[] = []
       const sending: bigint[] = []
 

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -286,6 +286,7 @@ export interface PortfolioLibGetResult {
     erc721s: Hints['erc721s']
   }
   tokenErrors: { error: string; address: string }[]
+  collectionErrors: { error: string; address: string }[]
   collections: CollectionResult[]
   errors: ExtendedErrorWithLevel[]
   blockNumber: number
@@ -324,6 +325,7 @@ export type PortfolioNetworkResult = CommonResultProps &
     PortfolioLibGetResult,
     | 'collections'
     | 'tokenErrors'
+    | 'collectionErrors'
     | 'blockNumber'
     | 'tokenDataCache'
     | 'toBeLearned'

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -442,20 +442,7 @@ export class Portfolio {
         return result
       })
 
-    const unfilteredCollections = collectionsWithErrResult.map(([error, x], i) => {
-      const address = collectionsHints[i]![0] as unknown as string
-      return [
-        error,
-        {
-          ...x,
-          address,
-          // We don't store market data for collections, apart from priceIn
-          priceIn: getTokenDataFromCache(address)?.priceIn || []
-        }
-      ] as [string, CollectionResult]
-    })
-
-    const collections = unfilteredCollections.reduce<CollectionResult[]>(
+    const collections = collectionsWithErrResult.reduce<CollectionResult[]>(
       (acc, [error, collection]) => {
         if (!isValidToken(error, collection)) return acc
 
@@ -470,7 +457,10 @@ export class Portfolio {
           toBeLearned.erc721s[collection.address] = collection.collectibles
         }
 
-        acc.push(collection)
+        acc.push({
+          ...collection,
+          priceIn: getTokenDataFromCache(collection.address)?.priceIn || []
+        })
         return acc
       },
       []
@@ -596,8 +586,11 @@ export class Portfolio {
       afterNonce,
       blockNumber,
       tokenErrors: tokensWithErrResult
-        .filter(([error, result]: [string, TokenResult]) => error !== '0x' || result.symbol === '')
+        .filter(([error, result]: [string, TokenResult]) => !isValidToken(error, result))
         .map(([error, result]: [string, TokenResult]) => ({ error, address: result.address })),
+      collectionErrors: collectionsWithErrResult
+        .filter(([error, result]: [string, CollectionResult]) => !isValidToken(error, result))
+        .map(([error, result]: [string, CollectionResult]) => ({ error, address: result.address })),
       collections
     }
   }

--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -29,6 +29,7 @@ export const stripPortfolioState = (portfolioState: AccountState) => {
       tokens,
       collections,
       tokenErrors,
+      collectionErrors,
       toBeLearned,
       lastExternalApiUpdateData,
       tokenDataCache,

--- a/src/libs/tracer/accessListCall.test.ts
+++ b/src/libs/tracer/accessListCall.test.ts
@@ -1,0 +1,366 @@
+import { concat, getAddress, getBytes, Interface, solidityPacked } from 'ethers'
+
+import { networks } from '@/consts/networks'
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+import SafeContract from '../../../contracts/compiled/Safe.json'
+import { ProviderError } from '../../classes/ProviderError'
+import { multiSendAddr, safeSimulateTxAccessor } from '../../consts/safe'
+import { Account, AccountOnchainState } from '../../interfaces/account'
+import { Network } from '../../interfaces/network'
+import { getRpcProvider } from '../../services/provider'
+import { BaseAccount } from '../account/BaseAccount'
+import { AccountOp } from '../accountOp/accountOp'
+import {
+  createAccessListCall,
+  getSafeAccessListCallParams,
+  getShouldUseAccessListCall,
+  getSimulateTxnAccessor,
+  parseAccessList,
+  sendCreateAccessList
+} from './accessListCall'
+
+const safeIface = new Interface(SafeContract)
+const simulateAccessorIface = new Interface([
+  'function simulate(address to, uint256 value, bytes data, uint8 operation)'
+])
+const multiSendIface = new Interface(['function multiSend(bytes transactions)'])
+
+const SAFE_CALL_OPERATION = 0n
+const SAFE_DELEGATE_CALL_OPERATION = 1n
+const ACCOUNT_ADDRESS = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+
+function makeNetwork(overrides: Partial<Network> = {}): Network {
+  const ethereum = networks.find((n) => n.chainId === 1n)!
+  return {
+    ...ethereum,
+    ...overrides
+  }
+}
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    addr: ACCOUNT_ADDRESS,
+    associatedKeys: ['0x2222222222222222222222222222222222222222'],
+    initialPrivileges: [],
+    creation: null,
+    preferences: { label: 'Test', pfp: ACCOUNT_ADDRESS },
+    ...overrides
+  }
+}
+
+function makeSafeAccount(version = '1.4.1', overrides: Partial<Account> = {}): Account {
+  return makeAccount({
+    safeCreation: {
+      factoryAddr: '0x3333333333333333333333333333333333333333',
+      singleton: '0x4444444444444444444444444444444444444444',
+      saltNonce: '0x01',
+      setupData: '0x',
+      version
+    },
+    ...overrides
+  })
+}
+
+function makeAccountState(overrides: Partial<AccountOnchainState> = {}): AccountOnchainState {
+  return {
+    accountAddr: ACCOUNT_ADDRESS,
+    isDeployed: true,
+    eoaNonce: 0n,
+    nonce: 1n,
+    erc4337Nonce: 0n,
+    associatedKeys: ['0x2222222222222222222222222222222222222222'],
+    importedAccountKeys: [],
+    balance: 0n,
+    isEOA: true,
+    isErc4337Enabled: false,
+    isErc4337Nonce: false,
+    isV2: true,
+    currentBlock: 1n,
+    isSmarterEoa: false,
+    delegatedContract: null,
+    delegatedContractName: null,
+    threshold: 1,
+    updatedAt: Date.now(),
+    ...overrides
+  }
+}
+
+function makeAccountOp(overrides: Partial<AccountOp> = {}): AccountOp {
+  return {
+    id: 'op-1',
+    accountAddr: ACCOUNT_ADDRESS,
+    chainId: 1n,
+    signingKeyAddr: '0x2222222222222222222222222222222222222222',
+    signingKeyType: 'internal',
+    nonce: 1n,
+    calls: [
+      {
+        to: '0x5555555555555555555555555555555555555555',
+        value: 1n,
+        data: '0x12'
+      }
+    ],
+    gasLimit: null,
+    signature: null,
+    gasFeePayment: null,
+    ...overrides
+  }
+}
+
+function makeBaseAccount(account: Account): BaseAccount {
+  return {
+    getAccount: () => account
+  } as unknown as BaseAccount
+}
+
+describe('accessListCall helpers', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  describe('getSimulateTxnAccessor', () => {
+    it('returns Safe accessor for supported Safe versions', () => {
+      expect(getSimulateTxnAccessor('1.3.0')).toBe(safeSimulateTxAccessor['v1.3.0'])
+      expect(getSimulateTxnAccessor('1.4.1')).toBe(safeSimulateTxAccessor['v1.4.1'])
+      expect(getSimulateTxnAccessor('1.5.0')).toBe(safeSimulateTxAccessor['v1.5.0'])
+    })
+
+    it('returns null for unsupported and empty versions', () => {
+      expect(getSimulateTxnAccessor()).toBeNull()
+      expect(getSimulateTxnAccessor('')).toBeNull()
+      expect(getSimulateTxnAccessor('1.6.0')).toBeNull()
+      expect(getSimulateTxnAccessor('2.0.0')).toBeNull()
+    })
+  })
+
+  describe('getShouldUseAccessListCall', () => {
+    it('returns true for Safe with supported version', () => {
+      const account = makeSafeAccount('1.4.1')
+      expect(getShouldUseAccessListCall(account, false)).toBe(true)
+    })
+
+    it('returns false for Safe with unsupported version', () => {
+      const account = makeSafeAccount('1.6.0')
+      expect(getShouldUseAccessListCall(account, false)).toBe(false)
+    })
+
+    it('returns true for non-safe without state override need', () => {
+      const account = makeAccount()
+      expect(getShouldUseAccessListCall(account, false)).toBe(true)
+    })
+
+    it('returns false for non-safe with state override need', () => {
+      const account = makeAccount()
+      expect(getShouldUseAccessListCall(account, true)).toBe(false)
+    })
+  })
+
+  describe('parseAccessList', () => {
+    it('returns empty array for undefined or empty access list', () => {
+      expect(parseAccessList(undefined)).toEqual([])
+      expect(parseAccessList([])).toEqual([])
+    })
+
+    it('normalizes and deduplicates addresses', () => {
+      const lower = '0x4E83c8e7982Aa51A3f8dB0be6F373621C9A84E1f'
+      const checksum = getAddress(lower)
+
+      const parsed = parseAccessList([
+        { address: lower, storageKeys: [] },
+        { address: checksum, storageKeys: ['0x01'] }
+      ])
+
+      expect(parsed).toEqual([checksum])
+    })
+
+    it('ignores malformed addresses and keeps valid ones', () => {
+      const valid = '0x4E83c8e7982Aa51A3f8dB0be6F373621C9A84E1f'
+      const parsed = parseAccessList([
+        { address: valid, storageKeys: [] },
+        { address: 'not-an-address', storageKeys: [] }
+      ])
+
+      expect(parsed).toEqual([getAddress(valid)])
+    })
+
+    it('returns empty array when all addresses are malformed', () => {
+      const parsed = parseAccessList([
+        { address: 'invalid-1', storageKeys: [] },
+        { address: 'invalid-2', storageKeys: [] }
+      ])
+
+      expect(parsed).toEqual([])
+    })
+  })
+
+  describe('getSafeAccessListCallParams', () => {
+    it('builds direct simulate payload for single call', () => {
+      const account = makeSafeAccount('1.4.1')
+      const op = makeAccountOp({
+        calls: [{ to: '0x5555555555555555555555555555555555555555', value: 7n, data: '0x1234' }]
+      })
+      const baseAcc = makeBaseAccount(account)
+      const state = makeAccountState({ isDeployed: true })
+
+      const params = getSafeAccessListCallParams(baseAcc, op, state)
+      expect(params).toBeTruthy()
+      expect(params).toMatchObject({ to: account.addr, from: account.addr, value: 0 })
+
+      const decodedOuter = safeIface.decodeFunctionData('simulateAndRevert', params!.data)
+      expect(decodedOuter[0]).toBe(safeSimulateTxAccessor['v1.4.1'])
+
+      const decodedSimulate = simulateAccessorIface.decodeFunctionData('simulate', decodedOuter[1])
+      expect(decodedSimulate[0]).toBe(op.calls[0]!.to)
+      expect(decodedSimulate[1]).toBe(7n)
+      expect(decodedSimulate[2]).toBe('0x1234')
+      expect(decodedSimulate[3]).toBe(SAFE_CALL_OPERATION)
+    })
+
+    it('builds multisend simulate payload for batched calls', () => {
+      const account = makeSafeAccount('1.5.0')
+      const op = makeAccountOp({
+        calls: [
+          { to: '0x5555555555555555555555555555555555555555', value: 1n, data: '0x12' },
+          { to: '0x6666666666666666666666666666666666666666', value: 2n, data: '0x1234' }
+        ]
+      })
+      const baseAcc = makeBaseAccount(account)
+      const state = makeAccountState({ isDeployed: true })
+
+      const params = getSafeAccessListCallParams(baseAcc, op, state)
+      expect(params).toBeTruthy()
+
+      const decodedOuter = safeIface.decodeFunctionData('simulateAndRevert', params!.data)
+      const decodedSimulate = simulateAccessorIface.decodeFunctionData('simulate', decodedOuter[1])
+      expect(decodedSimulate[0]).toBe(multiSendAddr)
+      expect(decodedSimulate[1]).toBe(0n)
+      expect(decodedSimulate[3]).toBe(SAFE_DELEGATE_CALL_OPERATION)
+
+      const decodedMultisend = multiSendIface.decodeFunctionData('multiSend', decodedSimulate[2])
+      const expectedMultisendPayload = concat(
+        op.calls.map((call) =>
+          solidityPacked(
+            ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+            [
+              SAFE_CALL_OPERATION,
+              call.to,
+              call.value,
+              BigInt(getBytes(call.data).length),
+              call.data
+            ]
+          )
+        )
+      )
+
+      expect(decodedMultisend[0]).toBe(expectedMultisendPayload)
+    })
+
+    it('returns null for non-safe or non-deployed Safe', () => {
+      const nonSafeParams = getSafeAccessListCallParams(
+        makeBaseAccount(makeAccount()),
+        makeAccountOp(),
+        makeAccountState({ isDeployed: true })
+      )
+      const undeployedSafeParams = getSafeAccessListCallParams(
+        makeBaseAccount(makeSafeAccount('1.4.1')),
+        makeAccountOp(),
+        makeAccountState({ isDeployed: false })
+      )
+
+      expect(nonSafeParams).toBeNull()
+      expect(undeployedSafeParams).toBeNull()
+    })
+
+    it('Should not throw for unsupported Safe versions and should return null', () => {
+      const account = makeSafeAccount('1.6.0')
+      const baseAcc = makeBaseAccount(account)
+      const state = makeAccountState({ isDeployed: true })
+      const op = makeAccountOp()
+
+      expect(() => getSafeAccessListCallParams(baseAcc, op, state)).not.toThrow()
+      expect(getSafeAccessListCallParams(baseAcc, op, state)).toBeNull()
+    })
+  })
+
+  describe('sendCreateAccessList', () => {
+    const params = {
+      to: '0x5555555555555555555555555555555555555555',
+      value: '15',
+      data: '0x1234',
+      from: ACCOUNT_ADDRESS
+    }
+
+    let network: Network
+    let provider: { send: ReturnType<typeof jest.fn> }
+
+    beforeEach(() => {
+      network = makeNetwork()
+      provider = {
+        send: jest.fn().mockResolvedValue({ accessList: [], gasUsed: '0x1' } as never)
+      }
+      jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    })
+
+    it('sends two-parameter eth_createAccessList request by default', async () => {
+      await sendCreateAccessList(provider as any, params, network)
+
+      expect(provider.send).toHaveBeenCalledTimes(1)
+      expect(provider.send).toHaveBeenCalledWith('eth_createAccessList', [
+        {
+          to: params.to,
+          value: '0xf',
+          data: params.data,
+          from: params.from
+        },
+        'latest'
+      ])
+    })
+
+    it('tries stateOverride and falls back to two-parameter request', async () => {
+      provider.send
+        .mockRejectedValueOnce(new Error('override not supported'))
+        .mockResolvedValueOnce({ accessList: [], gasUsed: '0x1' })
+
+      const stateOverride = {
+        ACCOUNT_ADDRESS: {
+          code: '0x1234'
+        }
+      }
+
+      await sendCreateAccessList(provider as any, params, network, stateOverride)
+
+      expect(provider.send).toHaveBeenCalledTimes(2)
+      const firstCallParams = provider.send.mock.calls[0]![1]
+      expect(firstCallParams).toHaveLength(3)
+      expect(firstCallParams[2][params.from].balance).toBe(
+        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      )
+
+      const secondCallParams = provider.send.mock.calls[1]![1]
+      expect(secondCallParams).toHaveLength(2)
+    })
+
+    it('skips stateOverride usage when rpcNoStateOverride is true', async () => {
+      const noOverrideNetwork = makeNetwork({ rpcNoStateOverride: true })
+
+      await sendCreateAccessList(provider as any, params, noOverrideNetwork, {
+        [params.from]: { code: '0x1234' }
+      })
+
+      expect(provider.send).toHaveBeenCalledTimes(1)
+      const args = provider.send.mock.calls[0]![1]
+      expect(args).toHaveLength(2)
+    })
+
+    it('propagates error when two-parameter request fails', async () => {
+      const error = new Error('rpc down')
+      provider.send.mockRejectedValue(error)
+
+      await expect(sendCreateAccessList(provider as any, params, network)).rejects.toThrow(
+        'rpc down'
+      )
+    })
+  })
+})

--- a/src/libs/tracer/accessListCall.test.ts
+++ b/src/libs/tracer/accessListCall.test.ts
@@ -164,7 +164,7 @@ describe('accessListCall helpers', () => {
     })
 
     it('normalizes and deduplicates addresses', () => {
-      const lower = '0x4E83c8e7982Aa51A3f8dB0be6F373621C9A84E1f'
+      const lower = '0x982f2df63fe38ab8d55f4b1464e8cfdc8ea5dec8'
       const checksum = getAddress(lower)
 
       const parsed = parseAccessList([
@@ -176,7 +176,7 @@ describe('accessListCall helpers', () => {
     })
 
     it('ignores malformed addresses and keeps valid ones', () => {
-      const valid = '0x4E83c8e7982Aa51A3f8dB0be6F373621C9A84E1f'
+      const valid = '0x982f2df63fe38ab8d55f4b1464e8cfdc8ea5dec8'
       const parsed = parseAccessList([
         { address: valid, storageKeys: [] },
         { address: 'not-an-address', storageKeys: [] }

--- a/src/libs/tracer/accessListCall.ts
+++ b/src/libs/tracer/accessListCall.ts
@@ -1,0 +1,131 @@
+import { getAddress, toQuantity } from 'ethers'
+
+import { RPCProvider } from '@/interfaces/provider'
+import { getFunctionParams } from '@/libs/tracer/debugTraceCall'
+
+import { ProviderError } from '../../classes/ProviderError'
+import { AccountOnchainState } from '../../interfaces/account'
+import { Network } from '../../interfaces/network'
+import { getRpcProvider } from '../../services/provider'
+import { BaseAccount } from '../account/BaseAccount'
+import { AccountOp } from '../accountOp/accountOp'
+
+/**
+ * Parses an access list and extracts unique contract addresses
+ */
+function parseAccessList(
+  accessList: Array<{ address: string; storageKeys: string[] }> | undefined
+): string[] {
+  if (!accessList || accessList.length === 0) {
+    return []
+  }
+
+  // Extract and deduplicate addresses
+  const uniqueAddresses = new Set<string>()
+
+  accessList.forEach(({ address }) => {
+    try {
+      // Normalize the address using getAddress (checksum)
+      const normalized = getAddress(address)
+      uniqueAddresses.add(normalized)
+    } catch (e) {
+      // Skip invalid addresses
+    }
+  })
+
+  return Array.from(uniqueAddresses)
+}
+
+/**
+ * eth_createAccessList RPC response structure
+ */
+interface CreateAccessListResponse {
+  accessList: Array<{ address: string; storageKeys: string[] }>
+  gasUsed: string
+}
+
+async function sendCreateAccessList(
+  provider: RPCProvider,
+  params: { to: string; value: number | string; data: string; from: string },
+  network: Network,
+  /**
+   * State override was added in 2025 but is not yet widely supported, so it shouldn't be used
+   * https://github.com/ethereum/go-ethereum/issues/27630
+   */
+  stateOverride?: any
+) {
+  if (stateOverride) {
+    console.error(
+      'Debug: Attempting to use state override with eth_createAccessList, which may not be supported by all RPC providers'
+    )
+  }
+
+  const requestParams: any[] = [
+    {
+      to: params.to,
+      value: toQuantity(params.value.toString()),
+      data: params.data,
+      from: params.from
+    },
+    'latest'
+  ]
+
+  if (!network.rpcNoStateOverride && stateOverride) {
+    try {
+      return await provider.send('eth_createAccessList', [
+        ...requestParams,
+        {
+          ...stateOverride,
+          [params.from]: {
+            balance: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            ...(stateOverride[params.from] || {})
+          }
+        }
+      ])
+    } catch (e) {
+      // Fall back to standard two-param call for RPCs that reject state override on eth_createAccessList.
+    }
+  }
+
+  return provider.send('eth_createAccessList', requestParams)
+}
+
+/**
+ * Uses eth_createAccessList to discover contract addresses accessed during transaction execution.
+ * Traces all calls in the AccountOp and merges the discovered addresses.
+ */
+export async function createAccessListCall(
+  baseAcc: BaseAccount,
+  op: AccountOp,
+  network: Network,
+  accountState: AccountOnchainState
+): Promise<string[]> {
+  const account = baseAcc.getAccount()
+  const params = getFunctionParams(account, op, accountState)
+
+  if (!params) return []
+
+  // Initialize a new provider for eth_createAccessList
+  // Using separate provider to avoid batching issues that can impact performance
+  const provider = getRpcProvider(network.rpcUrls, network.chainId, network.selectedRpcUrl)
+
+  try {
+    const response = await sendCreateAccessList(provider, params, network)
+
+    const returned = parseAccessList((response as CreateAccessListResponse).accessList)
+
+    return returned
+  } catch (e: any) {
+    console.error('Debug: eth_createAccessList error', e)
+    // eslint-disable-next-line no-underscore-dangle
+    throw new ProviderError({ originalError: e, providerUrl: provider._getConnection()?.url })
+  } finally {
+    // Clean up the provider after usage
+    try {
+      provider.destroy()
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e)
+    }
+  }
+}

--- a/src/libs/tracer/accessListCall.ts
+++ b/src/libs/tracer/accessListCall.ts
@@ -1,14 +1,109 @@
-import { getAddress, toQuantity } from 'ethers'
+import { concat, getAddress, getBytes, Interface, solidityPacked, toQuantity } from 'ethers'
 
 import { RPCProvider } from '@/interfaces/provider'
 import { getFunctionParams } from '@/libs/tracer/debugTraceCall'
 
+import SafeContract from '../../../contracts/compiled/Safe.json'
 import { ProviderError } from '../../classes/ProviderError'
-import { AccountOnchainState } from '../../interfaces/account'
+import { multiSendAddr, safeSimulateTxAccessor } from '../../consts/safe'
+import { Account, AccountOnchainState } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
 import { getRpcProvider } from '../../services/provider'
 import { BaseAccount } from '../account/BaseAccount'
-import { AccountOp } from '../accountOp/accountOp'
+import { AccountOp, getSignableCalls } from '../accountOp/accountOp'
+
+const safeSimulateTxAccessorAbi = [
+  'function simulate(address to, uint256 value, bytes data, uint8 operation)'
+]
+const multiSendAbi = ['function multiSend(bytes transactions)']
+const safeIface = new Interface(SafeContract)
+const simulateAccessorIface = new Interface(safeSimulateTxAccessorAbi)
+const multiSendIface = new Interface(multiSendAbi)
+
+const SAFE_CALL_OPERATION = 0
+const SAFE_DELEGATE_CALL_OPERATION = 1
+
+function getSimulateTxnAccessor(version?: string): string | null {
+  if (!version) return null
+
+  if (version.startsWith('1.3')) return safeSimulateTxAccessor['v1.3.0']
+  if (version.startsWith('1.4')) return safeSimulateTxAccessor['v1.4.1']
+  if (version.startsWith('1.5')) return safeSimulateTxAccessor['v1.5.0']
+
+  return null
+}
+
+export function getShouldUseAccessListCall(account: Account, needsStateOverride: boolean): boolean {
+  // Use eth_createAccessList for Safe only if we know the
+  // simulateTxAccessor for the Safe version (see getSafeAccessListCallParams)
+  if (account.safeCreation) {
+    return !!getSimulateTxnAccessor(account.safeCreation.version)
+  }
+
+  return !needsStateOverride
+}
+
+/**
+ * We cannot use execTransaction for the access list call as it would require signatures for the transaction
+ * (which we don't have at the point of simulation). Instead, we can use the simulate function of the SimulateTxAccessor contract,
+ * which executes the transaction but reverts at the end, allowing us to trace it without needing signatures.
+ *
+ * The only downside is that there are multiple deployments of the contract, which is not that bad as we
+ * can easily select the right one based on the Safe version and fall back to debug_traceCall if the version is not supported
+ * All deployments: https://github.com/safe-global/safe-deployments/blob/main/src/deployments.ts
+ */
+function getSafeAccessListCallParams(
+  baseAcc: BaseAccount,
+  op: AccountOp,
+  accountState: AccountOnchainState
+) {
+  const account = baseAcc.getAccount()
+  if (!account.safeCreation || !accountState.isDeployed) return null
+
+  const signableCalls = getSignableCalls(op)
+  if (!signableCalls.length) return null
+
+  let to = signableCalls[0]![0]
+  let value = BigInt(signableCalls[0]![1])
+  let data = signableCalls[0]![2]
+  let operation = SAFE_CALL_OPERATION
+
+  if (signableCalls.length > 1) {
+    const multiSendCalls = signableCalls.map((call) =>
+      solidityPacked(
+        ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+        [SAFE_CALL_OPERATION, call[0], BigInt(call[1]), BigInt(getBytes(call[2]).length), call[2]]
+      )
+    )
+
+    // For batched ops, Safe executes MultiSend via DELEGATECALL.
+    to = multiSendAddr
+    value = 0n
+    data = multiSendIface.encodeFunctionData('multiSend', [concat(multiSendCalls)])
+    operation = SAFE_DELEGATE_CALL_OPERATION
+  }
+
+  const simulateTxAccessor = getSimulateTxnAccessor(account.safeCreation.version)
+
+  const simulatePayload = simulateAccessorIface.encodeFunctionData('simulate', [
+    to,
+    value,
+    data,
+    operation
+  ])
+
+  const outerCalldata = safeIface.encodeFunctionData('simulateAndRevert', [
+    simulateTxAccessor,
+    simulatePayload
+  ])
+
+  return {
+    to: account.addr,
+    value: 0,
+    data: outerCalldata,
+    from: account.addr
+  }
+}
 
 /**
  * Parses an access list and extracts unique contract addresses
@@ -101,7 +196,10 @@ export async function createAccessListCall(
   accountState: AccountOnchainState
 ): Promise<string[]> {
   const account = baseAcc.getAccount()
-  const params = getFunctionParams(account, op, accountState)
+  const params =
+    account.safeCreation && accountState.isDeployed
+      ? getSafeAccessListCallParams(baseAcc, op, accountState)
+      : getFunctionParams(account, op, accountState)
 
   if (!params) return []
 

--- a/src/libs/tracer/accessListCall.ts
+++ b/src/libs/tracer/accessListCall.ts
@@ -23,7 +23,7 @@ const multiSendIface = new Interface(multiSendAbi)
 const SAFE_CALL_OPERATION = 0
 const SAFE_DELEGATE_CALL_OPERATION = 1
 
-function getSimulateTxnAccessor(version?: string): string | null {
+export function getSimulateTxnAccessor(version?: string): string | null {
   if (!version) return null
 
   if (version.startsWith('1.3')) return safeSimulateTxAccessor['v1.3.0']
@@ -52,7 +52,7 @@ export function getShouldUseAccessListCall(account: Account, needsStateOverride:
  * can easily select the right one based on the Safe version and fall back to debug_traceCall if the version is not supported
  * All deployments: https://github.com/safe-global/safe-deployments/blob/main/src/deployments.ts
  */
-function getSafeAccessListCallParams(
+export function getSafeAccessListCallParams(
   baseAcc: BaseAccount,
   op: AccountOp,
   accountState: AccountOnchainState
@@ -85,6 +85,8 @@ function getSafeAccessListCallParams(
 
   const simulateTxAccessor = getSimulateTxnAccessor(account.safeCreation.version)
 
+  if (!simulateTxAccessor) return null
+
   const simulatePayload = simulateAccessorIface.encodeFunctionData('simulate', [
     to,
     value,
@@ -108,7 +110,7 @@ function getSafeAccessListCallParams(
 /**
  * Parses an access list and extracts unique contract addresses
  */
-function parseAccessList(
+export function parseAccessList(
   accessList: Array<{ address: string; storageKeys: string[] }> | undefined
 ): string[] {
   if (!accessList || accessList.length === 0) {
@@ -139,7 +141,7 @@ interface CreateAccessListResponse {
   gasUsed: string
 }
 
-async function sendCreateAccessList(
+export async function sendCreateAccessList(
   provider: RPCProvider,
   params: { to: string; value: number | string; data: string; from: string },
   network: Network,

--- a/src/libs/tracer/debugTraceCall.test.ts
+++ b/src/libs/tracer/debugTraceCall.test.ts
@@ -45,6 +45,7 @@ describe('Debug tracecall detection for transactions', () => {
       newlyAdded: false
     }
     accountOp = {
+      id: 'test-id',
       accountAddr: ACCOUNT_ADDRESS,
       chainId: 10n,
       signingKeyAddr: '"0x02be1F941b6B777D4c30f110E997704fFc26B379"',

--- a/src/libs/tracer/debugTraceCall.ts
+++ b/src/libs/tracer/debugTraceCall.ts
@@ -1,6 +1,9 @@
-import { getAddress, Interface, toQuantity } from 'ethers'
+import { getAddress, Interface, keccak256, toQuantity, toUtf8Bytes } from 'ethers'
+
+import { privSlot } from '@/libs/proxyDeploy/deploy'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
+import AmbireAccount7702 from '../../../contracts/compiled/AmbireAccount7702.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import BalanceGetter from '../../../contracts/compiled/BalanceGetter.json'
 import NFTGetter from '../../../contracts/compiled/NFTGetter.json'
@@ -17,10 +20,49 @@ import { DeploylessMode, fromDescriptor } from '../deployless/deployless'
 import { getDeploylessOpts } from '../portfolio/getOnchainBalances'
 
 const NFT_COLLECTION_LIMIT = 100
+
+export function getStateOverride(
+  account: Account,
+  op: AccountOp,
+  accountState: AccountOnchainState
+) {
+  // if the account is a Safe,
+  // add an additional state override that gives privileges to the assKey;
+  // also, we changed privs storage slot to ambire.smart.contracts.storage
+  // so privs no longer override slot number 0
+  const stateDiff = !!account.safeCreation
+    ? {
+        [privSlot(
+          keccak256(toUtf8Bytes('ambire.smart.contracts.storage')),
+          'uint256',
+          account.associatedKeys[0],
+          'bytes32'
+        )]: '0x0000000000000000000000000000000000000000000000000000000000000002'
+      }
+    : undefined
+
+  // add stateOverride when using a Safe as well
+  const stateOverride =
+    !!account.safeCreation || (op.calls.length > 1 && isBasicAccount(account, accountState))
+      ? {
+          [account.addr]: {
+            code: AmbireAccount7702.binRuntime,
+            stateDiff
+          }
+        }
+      : undefined
+
+  return stateOverride
+}
+
 // if using EOA, use the first and only call of the account op
 // if it's SA, make the data execute or deployAndExecute,
 // set the spoof+addr and pass all the calls
-function getFunctionParams(account: Account, op: AccountOp, accountState: AccountOnchainState) {
+export function getFunctionParams(
+  account: Account,
+  op: AccountOp,
+  accountState: AccountOnchainState
+) {
   if (isBasicAccount(account, accountState) && op.calls.length === 1) {
     const call = op.calls[0]!
     return {


### PR DESCRIPTION
## Changes:
### Adds: `eth_createAccessList` and uses it for asset discovery
The new method is used in all cases that don't require state override (because state override is not yet supported by many RPC providers). If state override is needed we fallback to debug_traceCall.

**Safe accounts**:
It was not a trivial task to get it working with Safe accounts, because `execTransaction` requires signatures (which we obviously don't have during simulation). To get around this, we use Safe's `SimulateTxAccesssor`, which simulates `execTransaction` but reverts at the end. This is perfect for our use case as `eth_createAccessList` succeeds despite reverts.

https://github.com/safe-global/safe-deployments/blob/main/src/deployments.ts

### The portfolio lib returns collectionErrors
### The portfolio controller cleans toBeLearnedAssets