### PR TITLE
Feature/custom gas prices

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -511,6 +511,9 @@ export class ActivityController extends EventEmitter implements IActivityControl
         const opsToUpdate = recentOps.filter(
           (op) => op.status === AccountOpStatus.BroadcastedButNotConfirmed
         )
+        const confirmedOps = allOps.filter(
+          (op) => op.status === AccountOpStatus.Success || op.status === AccountOpStatus.Failure
+        )
 
         return Promise.all(
           opsToUpdate.map(async (accountOp) => {
@@ -532,6 +535,17 @@ export class ActivityController extends EventEmitter implements IActivityControl
                   }
                 }
               }
+            }
+
+            const hasConfirmedOpWithSameEoaNonce =
+              accountOp.eoaNonce !== null &&
+              typeof accountOp.eoaNonce !== 'undefined' &&
+              confirmedOps.some((op) => op !== accountOp && op.eoaNonce === accountOp.eoaNonce)
+
+            if (hasConfirmedOpWithSameEoaNonce) {
+              const updatedOpIfAny = updateOpStatus(accountOp, AccountOpStatus.UnknownButPastNonce)
+              if (updatedOpIfAny) updatedAccountsOps.push(updatedOpIfAny)
+              return
             }
 
             const txIds = []

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1872,29 +1872,31 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           provider: this.#providers.providers[network.chainId.toString()]!,
           phishing: this.#phishing,
           fromRequestId: requestId,
-          accountOp: providedAccountOp ?? {
-            id: generateUuid(),
-            accountAddr: meta.accountAddr,
-            chainId: meta.chainId,
-            signingKeyAddr: null,
-            signingKeyType: null,
-            gasLimit: null,
-            gasFeePayment: null,
-            nonce: meta.safeTxnProps?.nonce ?? accountState.nonce,
-            signature: meta.safeTxnProps?.signature ?? null,
-            txnId: meta.safeTxnProps?.txnId ?? undefined,
-            calls: [
-              ...calls.map((call) => ({
-                ...call,
-                id: uuidv4(),
-                to: call.to,
-                data: call.data || '0x',
-                value: call.value ? getBigInt(call.value) : 0n
-              }))
-            ],
-            safeTx: meta.safeTx,
-            meta
-          },
+          accountOp: providedAccountOp
+            ? { ...providedAccountOp, nonce: meta.safeTxnProps?.nonce ?? accountState.nonce }
+            : {
+                id: generateUuid(),
+                accountAddr: meta.accountAddr,
+                chainId: meta.chainId,
+                signingKeyAddr: null,
+                signingKeyType: null,
+                gasLimit: null,
+                gasFeePayment: null,
+                nonce: meta.safeTxnProps?.nonce ?? accountState.nonce,
+                signature: meta.safeTxnProps?.signature ?? null,
+                txnId: meta.safeTxnProps?.txnId ?? undefined,
+                calls: [
+                  ...calls.map((call) => ({
+                    ...call,
+                    id: uuidv4(),
+                    to: call.to,
+                    data: call.data || '0x',
+                    value: call.value ? getBigInt(call.value) : 0n
+                  }))
+                ],
+                safeTx: meta.safeTx,
+                meta
+              },
           shouldSimulate: this.shouldSimulateAccountOps,
           onUpdateAfterTraceCallSuccess: async () => {
             await this.#portfolio.updateSelectedAccount(account.addr, [network])

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1729,10 +1729,12 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     {
       calls,
       meta,
+      accountOp: providedAccountOp,
       dappPromises = []
     }: {
       calls: Call[]
       meta: CallsUserRequest['meta']
+      accountOp?: AccountOp
       dappPromises?: CallsUserRequest['dappPromises']
     },
     executionType: RequestExecutionType = 'open-request-window'
@@ -1870,7 +1872,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           provider: this.#providers.providers[network.chainId.toString()]!,
           phishing: this.#phishing,
           fromRequestId: requestId,
-          accountOp: {
+          accountOp: providedAccountOp ?? {
             id: generateUuid(),
             accountAddr: meta.accountAddr,
             chainId: meta.chainId,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -257,7 +257,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
   gasPrices?: GasSpeeds
 
-  #hasCustomGasPrices: boolean = false
+  hasCustomGasPrices: boolean = false
 
   feeSpeeds: {
     [identifier: string]: SpeedCalc[]
@@ -1216,7 +1216,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
       if (this.estimation.status === EstimationStatus.Success) {
         // Start the gas price interval in case it was stopped earlier
-        if (!this.#hasCustomGasPrices) {
+        if (!this.hasCustomGasPrices) {
           this.#gasPriceInterval.start({
             // Refetch immediately if the gas prices are stale
             runImmediately:
@@ -1243,7 +1243,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
           // by transforming and setting the bundler gas prices as this.gasPrices, we accomplish two things:
           // 1. we no longer need to wait for the gasPrice controller to complete in order to refresh the UI
           // 2. we make sure we give priority to the bundler prices as they are generally better
-          if (!this.#hasCustomGasPrices) {
+          if (!this.hasCustomGasPrices) {
             this.gasPrices = this.estimation.estimation.bundlerGasPrices
           }
           // and we're stopping the gas price interval as
@@ -1253,7 +1253,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         } else {
           // if there's an estimate, but no bundlerGasPrices, resume the gas price
           // controller refetch as there's no other way to fetch gas prices
-          if (!this.#hasCustomGasPrices) {
+          if (!this.hasCustomGasPrices) {
             this.#gasPriceInterval.start({
               runImmediately:
                 !this.gasPrice.updatedAt ||
@@ -1331,9 +1331,9 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
       if (customGasPrices) {
         this.gasPrices = customGasPrices
-        this.#hasCustomGasPrices = true
+        this.hasCustomGasPrices = true
         this.#gasPriceInterval.stop()
-      } else if (gasPrices && !this.#hasCustomGasPrices) {
+      } else if (gasPrices && !this.hasCustomGasPrices) {
         this.gasPrices = gasPrices
       }
 
@@ -1504,7 +1504,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     // Other cleanup
     this.#hwCleanup()
     this.gasPrices = undefined
-    this.#hasCustomGasPrices = false
+    this.hasCustomGasPrices = false
     this.selectedFeeSpeed = FeeSpeed.Fast
     this.#paidBy = null
     this.feeTokenResult = null
@@ -1839,7 +1839,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     if (!this.gasPrices) return null
 
     // no increase if the user has set them
-    if (this.#hasCustomGasPrices) return this.gasPrices
+    if (this.hasCustomGasPrices) return this.gasPrices
 
     return {
       slow: {
@@ -3259,11 +3259,11 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
           originalMessage.includes('maxFeePerGas') ||
           originalMessage.includes('maxPriorityFeePerGas')
         ) {
-          if (!this.#hasCustomGasPrices) message = 'Transaction fees changed. Please try again'
+          if (!this.hasCustomGasPrices) message = 'Transaction fees changed. Please try again'
           else message = originalMessage
         }
 
-        if (!this.#hasCustomGasPrices) {
+        if (!this.hasCustomGasPrices) {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.#silentGasPriceUpdate()
           // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1838,6 +1838,9 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
   #getIncreasedPrices(): GasSpeeds | null {
     if (!this.gasPrices) return null
 
+    // no increase if the user has set them
+    if (this.#hasCustomGasPrices) return this.gasPrices
+
     return {
       slow: {
         maxFeePerGas: this.#addExtra(BigInt(this.gasPrices.slow.maxFeePerGas), 5n),
@@ -3256,13 +3259,16 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
           originalMessage.includes('maxFeePerGas') ||
           originalMessage.includes('maxPriorityFeePerGas')
         ) {
-          message = 'Transaction fees changed. Please try again'
+          if (!this.#hasCustomGasPrices) message = 'Transaction fees changed. Please try again'
+          else message = originalMessage
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.#silentGasPriceUpdate()
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.#simulateAndEstimateOrSimulateInterval.restart({ runImmediately: true })
+        if (!this.#hasCustomGasPrices) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          this.#silentGasPriceUpdate()
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          this.#simulateAndEstimateOrSimulateInterval.restart({ runImmediately: true })
+        }
       } else if (originalMessage.includes('Failed to fetch') && isRelayer) {
         message =
           'Currently, the Ambire relayer seems to be down. Please try again a few moments later or broadcast with an EOA account'

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -73,7 +73,6 @@ import { getContractImplementation } from '../../libs/7702/7702'
 import {
   canBecomeSmarter,
   isAmbireV1LinkedAccount,
-  isBasicAccount,
   isSmartAccount
 } from '../../libs/account/account'
 import { BaseAccount } from '../../libs/account/BaseAccount'
@@ -200,6 +199,7 @@ export const noStateUpdateStatuses = [
 
 export type SignAccountOpUpdateProps = {
   gasPrices?: GasSpeeds
+  customGasPrices?: GasSpeeds
   feeToken?: TokenResult
   paidBy?: string
   paidByKeyType?: Key['type']
@@ -256,6 +256,8 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
   #accountOp: AccountOp
 
   gasPrices?: GasSpeeds
+
+  #hasCustomGasPrices: boolean = false
 
   feeSpeeds: {
     [identifier: string]: SpeedCalc[]
@@ -1180,6 +1182,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
   update({
     gasPrices,
+    customGasPrices,
     feeToken,
     paidBy,
     speed,
@@ -1213,12 +1216,16 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
       if (this.estimation.status === EstimationStatus.Success) {
         // Start the gas price interval in case it was stopped earlier
-        this.#gasPriceInterval.start({
-          // Refetch immediately if the gas prices are stale
-          runImmediately:
-            !this.gasPrice.updatedAt ||
-            Date.now() - this.gasPrice.updatedAt > GAS_PRICE_UPDATE_INTERVAL
-        })
+        if (!this.#hasCustomGasPrices) {
+          this.#gasPriceInterval.start({
+            // Refetch immediately if the gas prices are stale
+            runImmediately:
+              !this.gasPrice.updatedAt ||
+              Date.now() - this.gasPrice.updatedAt > GAS_PRICE_UPDATE_INTERVAL
+          })
+        } else {
+          this.#gasPriceInterval.stop()
+        }
 
         const estimation = this.estimation.estimation as FullEstimationSummary
         if (estimation.ambireEstimation) {
@@ -1236,7 +1243,9 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
           // by transforming and setting the bundler gas prices as this.gasPrices, we accomplish two things:
           // 1. we no longer need to wait for the gasPrice controller to complete in order to refresh the UI
           // 2. we make sure we give priority to the bundler prices as they are generally better
-          this.gasPrices = this.estimation.estimation.bundlerGasPrices
+          if (!this.#hasCustomGasPrices) {
+            this.gasPrices = this.estimation.estimation.bundlerGasPrices
+          }
           // and we're stopping the gas price interval as
           // we will use the bundler gas prices
           this.#gasPriceInterval.stop()
@@ -1244,11 +1253,15 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         } else {
           // if there's an estimate, but no bundlerGasPrices, resume the gas price
           // controller refetch as there's no other way to fetch gas prices
-          this.#gasPriceInterval.start({
-            runImmediately:
-              !this.gasPrice.updatedAt ||
-              Date.now() - this.gasPrice.updatedAt > GAS_PRICE_UPDATE_INTERVAL
-          })
+          if (!this.#hasCustomGasPrices) {
+            this.#gasPriceInterval.start({
+              runImmediately:
+                !this.gasPrice.updatedAt ||
+                Date.now() - this.gasPrice.updatedAt > GAS_PRICE_UPDATE_INTERVAL
+            })
+          } else {
+            this.#gasPriceInterval.stop()
+          }
           this.gasPrice.areGasPricesUsedFromBundlerEstimation = false
         }
       }
@@ -1316,7 +1329,13 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         }
       }
 
-      if (gasPrices) this.gasPrices = gasPrices
+      if (customGasPrices) {
+        this.gasPrices = customGasPrices
+        this.#hasCustomGasPrices = true
+        this.#gasPriceInterval.stop()
+      } else if (gasPrices && !this.#hasCustomGasPrices) {
+        this.gasPrices = gasPrices
+      }
 
       if (feeToken && paidBy) {
         this.#paidBy = paidBy
@@ -1385,6 +1404,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         !Object.keys(this.feeSpeeds).length ||
         Array.isArray(accountOpData?.calls) ||
         gasPrices ||
+        customGasPrices ||
         this.#paidBy ||
         this.feeTokenResult ||
         hasNewEstimation
@@ -1484,6 +1504,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     // Other cleanup
     this.#hwCleanup()
     this.gasPrices = undefined
+    this.#hasCustomGasPrices = false
     this.selectedFeeSpeed = FeeSpeed.Fast
     this.#paidBy = null
     this.feeTokenResult = null
@@ -3365,6 +3386,12 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     return this.baseAccount.canBroadcastByItself()
   }
 
+  get canSetCustomGasPrices(): boolean {
+    if (!this.selectedOption) return false
+
+    return this.baseAccount.canSetCustomGasPrices(this.selectedOption)
+  }
+
   get threshold(): number {
     const accountState =
       this.#accounts.accountStates[this.account.addr]![this.#network.chainId.toString()]
@@ -3401,6 +3428,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       isSignAndBroadcastInProgress: this.isSignAndBroadcastInProgress,
       banners: this.banners,
       canAccountBroadcastByItself: this.canAccountBroadcastByItself,
+      canSetCustomGasPrices: this.canSetCustomGasPrices,
       threshold: this.threshold,
       canBroadcast: this.canBroadcast,
       hasSafeApiFailed: this.hasSafeApiFailed

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -3293,10 +3293,13 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
     if (originalMessage) {
       if (originalMessage.includes('replacement fee too low')) {
-        message =
-          'Replacement fee is insufficient. Fees have been automatically adjusted so please try submitting your transaction again.'
-        isReplacementFeeLow = true
-        this.#simulateAndEstimateOrSimulateInterval.restart({ runImmediately: true })
+        // if custom gas prices have been set, show the original error
+        if (!this.hasCustomGasPrices) {
+          message =
+            'Replacement fee is insufficient. Fees have been automatically adjusted so please try submitting your transaction again.'
+          isReplacementFeeLow = true
+          this.#simulateAndEstimateOrSimulateInterval.restart({ runImmediately: true })
+        }
       } else if (originalMessage.includes('INSUFFICIENT_PRIVILEGE')) {
         message = accountState?.isV2
           ? 'Broadcast failed because of a pending transaction. Please try again'

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -424,6 +424,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     this.#phishing = phishing
     this.fromRequestId = fromRequestId
     this.#accountOp = structuredClone(accountOp)
+    this.#setSpeedUpGasPrices()
 
     if (this.#accountOp.signature && this.#accountOp.txnId) {
       this.#accountOp.signed = getAlreadySignedOwners(
@@ -502,6 +503,10 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     return this.#accountOp
   }
 
+  get isSpeedUpTransaction(): boolean {
+    return !!this.#accountOp.meta?.speedUp?.enabled
+  }
+
   #updateAccountOp(accountOp: Partial<AccountOp>) {
     if (!Object.keys(accountOp).length) return
 
@@ -512,6 +517,47 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       ...accountOp,
       id: hasUpdatedCalls ? generateUuid() : this.#accountOp.id
     }
+  }
+
+  #syncSpeedUpFeeSelectionFromEstimation() {
+    if (
+      !this.isSpeedUpTransaction ||
+      this.estimation.status !== EstimationStatus.Success ||
+      !this.accountOp.gasFeePayment
+    ) {
+      return
+    }
+
+    const selectedOption = this.estimation.availableFeeOptions.find(
+      (option) =>
+        option.paidBy === this.accountOp.gasFeePayment?.paidBy &&
+        option.token.address === this.accountOp.gasFeePayment?.inToken &&
+        (!this.accountOp.gasFeePayment?.feeTokenChainId ||
+          option.token.chainId === this.accountOp.gasFeePayment?.feeTokenChainId) &&
+        option.token.flags.onGasTank === this.accountOp.gasFeePayment?.isGasTank
+    )
+
+    if (!selectedOption) return
+
+    this.#paidBy = selectedOption.paidBy
+    this.feeTokenResult = selectedOption.token
+    this.selectedOption = selectedOption
+  }
+
+  #setSpeedUpGasPrices() {
+    const gasFeePayment = this.accountOp.gasFeePayment
+    if (!this.isSpeedUpTransaction || !gasFeePayment) return
+
+    const maxFeePerGas = toBeHex(gasFeePayment.gasPrice) as Hex
+    const maxPriorityFeePerGas = toBeHex(gasFeePayment.maxPriorityFeePerGas || 0n) as Hex
+
+    this.gasPrices = {
+      slow: { maxFeePerGas, maxPriorityFeePerGas },
+      medium: { maxFeePerGas, maxPriorityFeePerGas },
+      fast: { maxFeePerGas, maxPriorityFeePerGas },
+      ape: { maxFeePerGas, maxPriorityFeePerGas }
+    }
+    this.hasCustomGasPrices = true
   }
 
   async #getDefaultSigner() {
@@ -1194,6 +1240,8 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     accountOpData
   }: SignAccountOpUpdateProps) {
     try {
+      const isSpeedUpTransaction = this.isSpeedUpTransaction
+
       // This must be at the top, otherwise it won't be updated because
       // most updates are frozen during the signing process
       if (typeof signedTransactionsCount !== 'undefined') {
@@ -1228,7 +1276,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         }
 
         const estimation = this.estimation.estimation as FullEstimationSummary
-        if (estimation.ambireEstimation) {
+        if (estimation.ambireEstimation && !isSpeedUpTransaction) {
           this.#updateAccountOp({
             nonce: BigInt(estimation.ambireEstimation.ambireAccountNonce)
           })
@@ -1266,7 +1314,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         }
       }
 
-      if (accountOpData) {
+      if (accountOpData && !isSpeedUpTransaction) {
         const { calls, signature, ...rest } = accountOpData
 
         if (signature && this.accountOp.txnId) {
@@ -1337,7 +1385,9 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         this.gasPrices = gasPrices
       }
 
-      if (feeToken && paidBy) {
+      this.#syncSpeedUpFeeSelectionFromEstimation()
+
+      if (feeToken && paidBy && !isSpeedUpTransaction) {
         this.#paidBy = paidBy
         this.feeTokenResult = feeToken
 
@@ -1348,11 +1398,11 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         }
       }
 
-      if (speed && this.isInitialized) {
+      if (speed && this.isInitialized && !isSpeedUpTransaction) {
         this.selectedFeeSpeed = speed
       }
 
-      if (signingKeyAddr && signingKeyType && this.isInitialized) {
+      if (signingKeyAddr && signingKeyType && this.isInitialized && !isSpeedUpTransaction) {
         this.#updateAccountOp({ signingKeyAddr, signingKeyType })
 
         // If the fee is paid by the signer, then we should set the fee payer
@@ -1365,6 +1415,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
       // Set defaults, if some of the optional params are omitted
       this.#setDefaults()
+      if (isSpeedUpTransaction) this.#syncSpeedUpFeeSelectionFromEstimation()
 
       if (
         this.estimation.status === EstimationStatus.Success &&
@@ -2607,23 +2658,24 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         this.#updateAccountOp({ signature: '0x' })
       } else if (broadcastOption === BROADCAST_OPTIONS.byOtherEOA) {
         // SA, EOA pays fee. execute() needs a signature
-
-        // fetch the nonce if needed
-        const nonce = await this.baseAccount.getBroadcastNonce(
-          this.#activity,
-          this.accountOp,
-          this.provider
-        )
-        if (nonce !== this.accountOp.nonce) this.#updateAccountOp({ nonce })
-
-        this.#updateAccountOp({
-          signature: await getExecuteSignature(
-            this.#network,
+        if (!this.isSpeedUpTransaction) {
+          // fetch the nonce if needed
+          const nonce = await this.baseAccount.getBroadcastNonce(
+            this.#activity,
             this.accountOp,
-            accountState,
-            await this.#getDefaultSigner()
+            this.provider
           )
-        })
+          if (nonce !== this.accountOp.nonce) this.#updateAccountOp({ nonce })
+
+          this.#updateAccountOp({
+            signature: await getExecuteSignature(
+              this.#network,
+              this.accountOp,
+              accountState,
+              await this.#getDefaultSigner()
+            )
+          })
+        }
       } else if (broadcastOption === BROADCAST_OPTIONS.delegation) {
         // a delegation request has been made
         if (!this.accountOp.meta) {
@@ -2912,10 +2964,13 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         accountOp.gasFeePayment.broadcastOption === BROADCAST_OPTIONS.byOtherEOA
           ? accountOp.gasFeePayment.paidBy
           : accountOp.accountAddr
-      const nonce = await this.provider.getTransactionCount(senderAddr).catch((e) => e)
+      const senderNonce =
+        accountOp.eoaNonce !== null && typeof accountOp.eoaNonce !== 'undefined'
+          ? Number(accountOp.eoaNonce)
+          : await this.provider.getTransactionCount(senderAddr).catch((e) => e)
 
       // @precaution
-      if (nonce instanceof Error) {
+      if (senderNonce instanceof Error) {
         return this.throwBroadcastAccountOp({
           message: 'RPC error. Please try again',
           accountState
@@ -2941,9 +2996,10 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         const txnLength = this.baseAccount.shouldBroadcastCallsSeparately(accountOp)
           ? accountOp.calls.length
           : 1
+        this.#updateAccountOp({ eoaNonce: BigInt(senderNonce) })
         if (txnLength > 1) this.update({ signedTransactionsCount: 0 })
         for (let i = 0; i < txnLength; i++) {
-          const currentNonce = nonce + i
+          const currentNonce = senderNonce + i
           const rawTxn = await buildRawTransaction(
             account,
             accountOp,
@@ -2988,7 +3044,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
           nonce:
             accountOp.gasFeePayment.broadcastOption === BROADCAST_OPTIONS.byOtherEOA
               ? Number(accountOp.nonce)
-              : nonce,
+              : senderNonce,
           identifiedBy: {
             type: txnLength > 1 ? 'MultipleTxns' : 'Transaction',
             identifier: multipleTxnsBroadcastRes.map((res) => res.hash).join('-')
@@ -3007,7 +3063,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         // allow the user to retry in this case
         if (multipleTxnsBroadcastRes.length && this.#type !== 'one-click-swap-and-bridge') {
           transactionRes = {
-            nonce,
+            nonce: senderNonce,
             identifiedBy: {
               type: 'MultipleTxns',
               identifier: multipleTxnsBroadcastRes.map((res) => res.hash).join('-')
@@ -3116,6 +3172,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
 
     const submittedAccountOp: SubmittedAccountOp = {
       ...accountOp,
+      eoaNonce: this.accountOp.eoaNonce,
       status: AccountOpStatus.BroadcastedButNotConfirmed,
       txnId: transactionRes.txnId,
       nonce: BigInt(transactionRes.nonce),

--- a/src/interfaces/requests.ts
+++ b/src/interfaces/requests.ts
@@ -1,5 +1,6 @@
 import { EIP712TypedData } from '@safe-global/types-kit'
 
+import { AccountOp } from '../libs/accountOp/accountOp'
 import { TokenResult } from '../libs/portfolio'
 import { ControllerInterface } from './controller'
 import { DappProviderRequest } from './dapp'
@@ -30,6 +31,7 @@ export type BuildRequest =
         userRequestParams: {
           calls: CallsUserRequest['signAccountOp']['accountOp']['calls']
           meta: CallsUserRequest['meta']
+          accountOp?: AccountOp
         }
         position?: RequestPosition
         executionType?: RequestExecutionType

--- a/src/libs/account/BaseAccount.ts
+++ b/src/libs/account/BaseAccount.ts
@@ -92,6 +92,8 @@ export abstract class BaseAccount {
 
   abstract canBroadcastByOtherEOA(): boolean
 
+  abstract canSetCustomGasPrices(feeOption: FeePaymentOption): boolean
+
   // this is specific for v2 accounts, hardcoding a false for all else
   shouldIncludeActivatorCall(paidBy?: string) {
     return false

--- a/src/libs/account/EOA.ts
+++ b/src/libs/account/EOA.ts
@@ -131,4 +131,8 @@ export class EOA extends BaseAccount {
   canBroadcastByOtherEOA(): boolean {
     return false
   }
+
+  canSetCustomGasPrices(): boolean {
+    return true
+  }
 }

--- a/src/libs/account/EOA7702.ts
+++ b/src/libs/account/EOA7702.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import { Interface } from 'ethers'
+import { Interface, ZeroAddress } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireAccount7702 from '../../../contracts/compiled/AmbireAccount7702.json'
@@ -215,5 +215,9 @@ export class EOA7702 extends BaseAccount {
 
   canBroadcastByOtherEOA(): boolean {
     return false
+  }
+
+  canSetCustomGasPrices(feeOption: FeePaymentOption): boolean {
+    return feeOption.token.address === ZeroAddress
   }
 }

--- a/src/libs/account/Safe.ts
+++ b/src/libs/account/Safe.ts
@@ -198,4 +198,8 @@ export class Safe extends BaseAccount {
 
     return getSafeTypedData(this.network.chainId, this.account.addr as Hex, safeTx)
   }
+
+  canSetCustomGasPrices(): boolean {
+    return true
+  }
 }

--- a/src/libs/account/V1.ts
+++ b/src/libs/account/V1.ts
@@ -132,4 +132,8 @@ export class V1 extends BaseAccount {
   canBroadcastByOtherEOA(): boolean {
     return true
   }
+
+  canSetCustomGasPrices(): boolean {
+    return true
+  }
 }

--- a/src/libs/account/V2.ts
+++ b/src/libs/account/V2.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Interface } from 'ethers'
+import { Interface, ZeroAddress } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
@@ -194,5 +194,12 @@ export class V2 extends BaseAccount {
 
   canBroadcastByOtherEOA(): boolean {
     return true
+  }
+
+  canSetCustomGasPrices(feeOption: FeePaymentOption): boolean {
+    return (
+      feeOption.token.address === ZeroAddress &&
+      feeOption.paidBy.toLowerCase() !== this.account.addr.toLowerCase()
+    )
   }
 }

--- a/src/libs/account/customGasPrices.test.ts
+++ b/src/libs/account/customGasPrices.test.ts
@@ -1,0 +1,90 @@
+import { ZeroAddress } from 'ethers'
+
+import { describe, expect, test } from '@jest/globals'
+
+import { Account, AccountOnchainState } from '../../interfaces/account'
+import { Network } from '../../interfaces/network'
+import { FeePaymentOption } from '../estimate/interfaces'
+import { EOA } from './EOA'
+import { EOA7702 } from './EOA7702'
+import { Safe } from './Safe'
+import { V1 } from './V1'
+import { V2 } from './V2'
+
+const account = {
+  addr: '0x1111111111111111111111111111111111111111',
+  associatedKeys: [],
+  initialPrivileges: [],
+  creation: null,
+  preferences: {
+    label: 'Account',
+    pfp: '0x1111111111111111111111111111111111111111'
+  }
+} as Account
+
+const network = {
+  chainId: 1n,
+  nativeAssetSymbol: 'ETH'
+} as Network
+
+const accountState = {
+  isDeployed: true,
+  isSmarterEoa: false,
+  isErc4337Enabled: true,
+  nonce: 0n,
+  eoaNonce: 0n,
+  erc4337Nonce: 0n,
+  threshold: 1
+} as AccountOnchainState
+
+const nativeFeeOption = {
+  availableAmount: 1n,
+  paidBy: account.addr,
+  gasUsed: 21000n,
+  addedNative: 0n,
+  token: {
+    address: ZeroAddress,
+    symbol: 'ETH',
+    decimals: 18,
+    flags: {
+      onGasTank: false
+    }
+  }
+} as FeePaymentOption
+
+const eoaNativeFeeOption = {
+  ...nativeFeeOption,
+  paidBy: '0x2222222222222222222222222222222222222222'
+} as FeePaymentOption
+
+const tokenFeeOption = {
+  ...nativeFeeOption,
+  token: {
+    ...nativeFeeOption.token,
+    address: '0x3333333333333333333333333333333333333333',
+    symbol: 'USDC'
+  }
+} as FeePaymentOption
+
+describe('custom gas price support', () => {
+  test('EOA, V1 and Safe always allow custom gas prices', () => {
+    expect(new EOA(account, network, accountState).canSetCustomGasPrices()).toBe(true)
+    expect(new V1(account, network, accountState).canSetCustomGasPrices()).toBe(true)
+    expect(new Safe(account, network, accountState).canSetCustomGasPrices()).toBe(true)
+  })
+
+  test('EOA7702 allows custom gas prices only for native fee options', () => {
+    const eoa7702 = new EOA7702(account, network, accountState)
+
+    expect(eoa7702.canSetCustomGasPrices(nativeFeeOption)).toBe(true)
+    expect(eoa7702.canSetCustomGasPrices(tokenFeeOption)).toBe(false)
+  })
+
+  test('V2 allows custom gas prices only for native EOA-paid fee options', () => {
+    const v2 = new V2(account, network, accountState)
+
+    expect(v2.canSetCustomGasPrices(nativeFeeOption)).toBe(false)
+    expect(v2.canSetCustomGasPrices(eoaNativeFeeOption)).toBe(true)
+    expect(v2.canSetCustomGasPrices(tokenFeeOption)).toBe(false)
+  })
+})

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -51,6 +51,8 @@ export interface AccountOp {
   // this may not be set in case we haven't set it yet
   // this is a number and not a bigint because of ethers (it uses number for nonces)
   nonce: bigint | null
+  // the EOA nonce used for raw transaction broadcast, if applicable
+  eoaNonce?: bigint | null
   // @TODO: nonce namespace? it is dependent on gasFeePayment
   calls: Call[]
   // the feeCall is an extra call we add manually when there's a
@@ -94,6 +96,9 @@ export interface AccountOp {
       nativePrice: number
       fromTokenPriceInUsd: number
       fromTokenDecimals: number
+    }
+    speedUp?: {
+      enabled: boolean
     }
   }
   flags?: {


### PR DESCRIPTION
Change log:
* add the ability for the user to set custom gas prices
* add a hasCustomGasPrices flag in signAccountOp with a goal to stop all gas prices updates once the user has chosen gas prices on his own
* display the RPC error message in full to the user if hasCustomGasPrices has been selected as he will probably have problems when selecting too low a few and the full error message with more useful to him than a generic "transaction underpriced". Nothing changes for users that don't touch the custom gas price options
* custom gas prices are available for chain native broadcast only (they will be disabled for gas tank, tokens, etc