### PR TITLE
Smooth max transfer

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -150,6 +150,7 @@ import {
   getUnknownTokenWarning,
   SignAccountOpType
 } from './helper'
+import { isTransferredTokenFeeOption } from '../../libs/account/feeOptions'
 
 export enum SigningStatus {
   EstimationError = 'estimation-error',
@@ -857,7 +858,10 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       this.canBroadcast
     ) {
       const identifier = getFeeSpeedIdentifier(this.selectedOption, this.accountOp.accountAddr)
-      if (this.hasSpeeds(identifier))
+      if (
+        this.hasSpeeds(identifier) &&
+        !this.#shouldSuppressTransferFeeSelectionError(this.selectedOption)
+      )
         errors.push({
           title: 'Please select a token and an account for paying the gas fee.'
         })
@@ -868,6 +872,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       this.selectedOption &&
       this.accountOp.gasFeePayment &&
       this.selectedOption.availableAmount < this.accountOp.gasFeePayment.amount &&
+      !this.#shouldSuppressTransferFeeSelectionError(this.selectedOption) &&
       this.canBroadcast
     ) {
       const speedCoverage = []
@@ -1608,13 +1613,14 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
   #getIsFeeOptionDisabled(feeOption: FeePaymentOption): boolean {
     const id = getFeeSpeedIdentifier(feeOption, this.accountOp.accountAddr)
     const speeds = this.feeSpeeds[id] ?? []
+    const isTransferredTokenOption = isTransferredTokenFeeOption(feeOption, this.accountOp)
 
     const coversSlow = speeds.some(
       (speed: SpeedCalc) =>
         speed.type === FeeSpeed.Slow && feeOption.availableAmount >= speed.amount
     )
 
-    if (!coversSlow) return true
+    if (!coversSlow && !isTransferredTokenOption) return true
 
     const isExternal = this.accountKeyStoreKeys.some(
       (keyStoreKey) => keyStoreKey.addr === feeOption.paidBy && keyStoreKey.isExternallyStored
@@ -1625,6 +1631,14 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     if (isExternal && canNotBecomeSmarter && feeOption.token.address !== ZERO_ADDRESS) return true
 
     return false
+  }
+
+  #shouldSuppressTransferFeeSelectionError(feeOption?: FeePaymentOption): boolean {
+    return (
+      this.#type === 'one-click-transfer' &&
+      !!feeOption &&
+      isTransferredTokenFeeOption(feeOption, this.accountOp)
+    )
   }
 
   /**

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -150,7 +150,7 @@ import {
   getUnknownTokenWarning,
   SignAccountOpType
 } from './helper'
-import { isTransferredTokenFeeOption } from '../../libs/account/feeOptions'
+import { canFeeOptionCoverAmount, isTransferredTokenFeeOption } from '../../libs/account/feeOptions'
 
 export enum SigningStatus {
   EstimationError = 'estimation-error',
@@ -1582,12 +1582,12 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     const aId = getFeeSpeedIdentifier(a, this.accountOp.accountAddr)
     const aSlow = this.feeSpeeds[aId]?.find((speed) => speed.type === 'slow')
     if (!aSlow) return 1
-    const aCanCoverFee = a.availableAmount >= aSlow.amount
+    const aCanCoverFee = canFeeOptionCoverAmount(a, this.accountOp, aSlow.amount)
 
     const bId = getFeeSpeedIdentifier(b, this.accountOp.accountAddr)
     const bSlow = this.feeSpeeds[bId]?.find((speed) => speed.type === 'slow')
     if (!bSlow) return -1
-    const bCanCoverFee = b.availableAmount >= bSlow.amount
+    const bCanCoverFee = canFeeOptionCoverAmount(b, this.accountOp, bSlow.amount)
 
     if (aCanCoverFee && !bCanCoverFee) return -1
     if (!aCanCoverFee && bCanCoverFee) return 1

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
-import { ZeroAddress } from 'ethers'
+import { ZeroAddress, formatUnits } from 'ethers'
 
 import { expect } from '@jest/globals'
 
@@ -116,6 +116,43 @@ describe('Transfer Controller', () => {
       amount: '1'
     })
     expect(transferController.amount).toBe('1')
+  })
+  test('should set max amount minus fee when the selected fee token matches the transfer token', async () => {
+    const { transferController, tokens } = await prepareTest()
+
+    const nativeToken = tokens.find((t) => t.address === ZeroAddress && t.chainId === 1n)!
+    const feeAmount = 1_000_000_000_000_000n
+
+    await transferController.update({
+      selectedToken: nativeToken
+    })
+    ;(transferController as any).signAccountOpController = {
+      accountOp: {
+        gasFeePayment: {
+          amount: feeAmount,
+          inToken: nativeToken.address,
+          feeTokenChainId: nativeToken.chainId
+        }
+      },
+      selectedOption: {
+        paidBy: account.addr,
+        token: {
+          ...nativeToken,
+          flags: {
+            ...nativeToken.flags,
+            onGasTank: false
+          }
+        }
+      }
+    }
+
+    await transferController.update({
+      shouldSetMaxAmount: true
+    })
+
+    expect(transferController.amount).toBe(
+      formatUnits(nativeToken.amount - feeAmount, nativeToken.decimals)
+    )
   })
   test('should set validation form messages', async () => {
     const { transferController, tokens } = await prepareTest()

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -829,6 +829,37 @@ export class TransferController extends EventEmitter implements ITransferControl
     return true
   }
 
+  /**
+   * When doing a MAX transfer or a close to MAX transfer out,
+   * if the selected fee token is the same as the transfer token,
+   * we automatically adjust the transfer amount so the user
+   * can successfully broadcast. For that, we put an additional
+   * warning telling him why this is happening
+   */
+  get amountAdjustmentWarning(): Validation | null {
+    if (!this.amount || !this.selectedToken || !this.#shouldReserveFeeFromTransferredToken()) {
+      return null
+    }
+
+    const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
+    if (!gasFeePayment) return null
+
+    const currentAmount = parseUnits(
+      getSafeAmountFromFieldValue(this.amount, this.selectedToken.decimals),
+      this.selectedToken.decimals
+    )
+    const totalTokenAmount = getTokenAmount(this.selectedToken)
+
+    if (currentAmount > 0n && currentAmount + gasFeePayment.amount >= totalTokenAmount) {
+      return {
+        severity: 'warning',
+        message: 'Amount adjusted to cover blockchain fees'
+      }
+    }
+
+    return null
+  }
+
   get hasPersistedState() {
     return !!(this.amount || this.amountInFiat || this.addressState.fieldValue)
   }
@@ -1089,7 +1120,8 @@ export class TransferController extends EventEmitter implements ITransferControl
       maxAmountInFiat: this.maxAmountInFiat,
       shouldSkipTransactionQueuedModal: this.shouldSkipTransactionQueuedModal,
       hasPersistedState: this.hasPersistedState,
-      isRecipientAddressViewOnly: this.isRecipientAddressViewOnly
+      isRecipientAddressViewOnly: this.isRecipientAddressViewOnly,
+      amountAdjustmentWarning: this.amountAdjustmentWarning
     }
   }
 }

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -1038,11 +1038,9 @@ export class TransferController extends EventEmitter implements ITransferControl
     })
 
     this.signAccountOpController.onUpdate((forceEmit) => {
-      const hasAdjustedAmount = this.#syncAmountWithFeeReservation(forceEmit)
+      this.#syncAmountWithFeeReservation(forceEmit)
 
-      if (!hasAdjustedAmount) {
-        this.propagateUpdate(forceEmit)
-      }
+      this.propagateUpdate(forceEmit)
 
       if (this.signAccountOpController?.broadcastStatus === 'SUCCESS') {
         // Reset the form on the next tick so the FE receives the final

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -24,7 +24,7 @@ import { HumanizerMeta } from '../../libs/humanizer/interfaces'
 import { randomId } from '../../libs/humanizer/utils'
 import { TokenResult } from '../../libs/portfolio'
 import { getTokenAmount, getTokenBalanceInUSD } from '../../libs/portfolio/helpers'
-import { getSanitizedAmount } from '../../libs/transfer/amount'
+import { getAmountAfterFeeReserve, getSanitizedAmount } from '../../libs/transfer/amount'
 import { getTransferRequestParams } from '../../libs/transfer/userRequest'
 import {
   validateSendTransferAddress,
@@ -125,6 +125,8 @@ export class TransferController extends EventEmitter implements ITransferControl
   isTopUp: boolean = false
 
   #shouldSkipTransactionQueuedModal: boolean = false
+
+  #isMaxAmountSelected: boolean = false
 
   #accounts: IAccountsController
 
@@ -402,6 +404,7 @@ export class TransferController extends EventEmitter implements ITransferControl
 
     if (!token || Number(getTokenAmount(token)) === 0) {
       this.#selectedToken = null
+      this.#isMaxAmountSelected = false
       this.#setAmountAndNotifyUI('')
       this.#setAmountInFiatAndNotifyUI('')
       this.amountFieldMode = 'token'
@@ -416,6 +419,7 @@ export class TransferController extends EventEmitter implements ITransferControl
       prevSelectedToken?.address !== token?.address ||
       prevSelectedToken?.chainId !== token?.chainId
     ) {
+      this.#isMaxAmountSelected = false
       if (!token.priceIn.length) this.amountFieldMode = 'token'
       this.#setAmountAndNotifyUI('')
       this.#setAmountInFiatAndNotifyUI('')
@@ -461,6 +465,7 @@ export class TransferController extends EventEmitter implements ITransferControl
   }
 
   resetForm(shouldDestroyAccountOp = true) {
+    this.#isMaxAmountSelected = false
     this.amount = ''
     this.amountInFiat = ''
     this.amountFieldMode = 'token'
@@ -587,12 +592,14 @@ export class TransferController extends EventEmitter implements ITransferControl
     }
     // If we do a regular check the value won't update if it's '' or '0'
     if (typeof amount === 'string') {
+      this.#isMaxAmountSelected = false
       this.#setAmount(amount)
     }
 
     if (shouldSetMaxAmount) {
+      this.#isMaxAmountSelected = true
       this.amountFieldMode = 'token'
-      this.#setAmount(this.maxAmount, true)
+      this.#setTokenAmount(this.maxAmount, true)
     }
 
     if (addressState) {
@@ -760,6 +767,63 @@ export class TransferController extends EventEmitter implements ITransferControl
     }
   }
 
+  #setTokenAmount(amount: string, isProgrammaticUpdate = false) {
+    const amountFieldMode = this.amountFieldMode
+
+    this.amountFieldMode = 'token'
+    this.#setAmount(amount, isProgrammaticUpdate)
+    this.amountFieldMode = amountFieldMode
+  }
+
+  #syncMaxAmountWithFeeReservation(forceEmit?: boolean) {
+    if (
+      !this.#isMaxAmountSelected ||
+      !this.selectedToken ||
+      typeof this.selectedToken.decimals !== 'number'
+    )
+      return false
+
+    const totalTokenAmount = getTokenAmount(this.selectedToken)
+    const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
+    const selectedFeeOption = this.signAccountOpController?.selectedOption
+    const accountAddr = this.#selectedAccount.account?.addr.toLowerCase()
+
+    const shouldReserveFeeFromTransferredToken =
+      !!accountAddr &&
+      !!gasFeePayment &&
+      !!selectedFeeOption &&
+      !selectedFeeOption.token.flags.onGasTank &&
+      selectedFeeOption.paidBy.toLowerCase() === accountAddr &&
+      selectedFeeOption.token.chainId === this.selectedToken.chainId &&
+      selectedFeeOption.token.address.toLowerCase() === this.selectedToken.address.toLowerCase() &&
+      gasFeePayment.inToken.toLowerCase() === this.selectedToken.address.toLowerCase() &&
+      (!gasFeePayment.feeTokenChainId ||
+        gasFeePayment.feeTokenChainId === this.selectedToken.chainId)
+
+    const desiredAmount = shouldReserveFeeFromTransferredToken
+      ? getAmountAfterFeeReserve(totalTokenAmount, gasFeePayment.amount)
+      : totalTokenAmount
+
+    const currentAmount = this.amount
+      ? parseUnits(
+          getSafeAmountFromFieldValue(this.amount, this.selectedToken.decimals),
+          this.selectedToken.decimals
+        )
+      : 0n
+
+    if (currentAmount === desiredAmount) return false
+
+    this.#setTokenAmount(
+      desiredAmount === 0n ? '0' : formatUnits(desiredAmount, this.selectedToken.decimals),
+      true
+    )
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.syncSignAccountOp()
+    this.propagateUpdate(forceEmit)
+
+    return true
+  }
+
   get hasPersistedState() {
     return !!(this.amount || this.amountInFiat || this.addressState.fieldValue)
   }
@@ -860,7 +924,8 @@ export class TransferController extends EventEmitter implements ITransferControl
       calls,
       meta: {
         paymasterService: getAmbirePaymasterService(baseAcc, this.#relayerUrl),
-        topUpAmount
+        topUpAmount,
+        allowTransferFeeTokenSelfReserve: true
       }
     }
 
@@ -899,7 +964,7 @@ export class TransferController extends EventEmitter implements ITransferControl
       shouldSimulate: false,
       onBroadcastSuccess: async (props) => {
         const { submittedAccountOp } = props
-        this.#portfolio.simulateAccountOp(props.accountOp).then(() => {
+        void this.#portfolio.simulateAccountOp(props.accountOp).then(() => {
           this.#portfolio.markSimulationAsBroadcasted(accountOp.accountAddr, accountOp.chainId)
         })
 
@@ -918,7 +983,11 @@ export class TransferController extends EventEmitter implements ITransferControl
     })
 
     this.signAccountOpController.onUpdate((forceEmit) => {
-      this.propagateUpdate(forceEmit)
+      const hasAdjustedMaxAmount = this.#syncMaxAmountWithFeeReservation(forceEmit)
+
+      if (!hasAdjustedMaxAmount) {
+        this.propagateUpdate(forceEmit)
+      }
 
       if (this.signAccountOpController?.broadcastStatus === 'SUCCESS') {
         // Reset the form on the next tick so the FE receives the final

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -435,12 +435,7 @@ export class TransferController extends EventEmitter implements ITransferControl
   }
 
   get maxAmount(): string {
-    if (
-      !this.selectedToken ||
-      getTokenAmount(this.selectedToken) === 0n ||
-      typeof this.selectedToken.decimals !== 'number'
-    )
-      return '0'
+    if (!this.selectedToken || getTokenAmount(this.selectedToken) === 0n) return '0'
 
     return formatUnits(getTokenAmount(this.selectedToken), this.selectedToken.decimals)
   }
@@ -775,6 +770,31 @@ export class TransferController extends EventEmitter implements ITransferControl
     this.amountFieldMode = amountFieldMode
   }
 
+  #shouldReserveFeeFromTransferredToken() {
+    const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
+    const selectedFeeOption = this.signAccountOpController?.selectedOption
+    const selectedToken = this.selectedToken
+    const accountAddr = this.#selectedAccount.account?.addr.toLowerCase()
+
+    if (!accountAddr || !gasFeePayment || !selectedFeeOption || !selectedToken) return false
+    if (selectedFeeOption.token.flags.onGasTank) return false
+    if (selectedFeeOption.paidBy.toLowerCase() !== accountAddr) return false
+
+    const selectedTokenAddress = selectedToken.address.toLowerCase()
+
+    return (
+      !!accountAddr &&
+      !!gasFeePayment &&
+      !!selectedFeeOption &&
+      !selectedFeeOption.token.flags.onGasTank &&
+      selectedFeeOption.paidBy.toLowerCase() === accountAddr &&
+      selectedFeeOption.token.chainId === selectedToken.chainId &&
+      selectedFeeOption.token.address.toLowerCase() === selectedTokenAddress &&
+      gasFeePayment.inToken.toLowerCase() === selectedTokenAddress &&
+      (!gasFeePayment.feeTokenChainId || gasFeePayment.feeTokenChainId === selectedToken.chainId)
+    )
+  }
+
   #syncMaxAmountWithFeeReservation(forceEmit?: boolean) {
     if (
       !this.#isMaxAmountSelected ||
@@ -783,24 +803,16 @@ export class TransferController extends EventEmitter implements ITransferControl
     )
       return false
 
+    if (!this.#shouldReserveFeeFromTransferredToken()) return
+
     const totalTokenAmount = getTokenAmount(this.selectedToken)
     const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
-    const selectedFeeOption = this.signAccountOpController?.selectedOption
-    const accountAddr = this.#selectedAccount.account?.addr.toLowerCase()
 
-    const shouldReserveFeeFromTransferredToken =
-      !!accountAddr &&
-      !!gasFeePayment &&
-      !!selectedFeeOption &&
-      !selectedFeeOption.token.flags.onGasTank &&
-      selectedFeeOption.paidBy.toLowerCase() === accountAddr &&
-      selectedFeeOption.token.chainId === this.selectedToken.chainId &&
-      selectedFeeOption.token.address.toLowerCase() === this.selectedToken.address.toLowerCase() &&
-      gasFeePayment.inToken.toLowerCase() === this.selectedToken.address.toLowerCase() &&
-      (!gasFeePayment.feeTokenChainId ||
-        gasFeePayment.feeTokenChainId === this.selectedToken.chainId)
-
-    const desiredAmount = shouldReserveFeeFromTransferredToken
+    // this.#shouldReserveFeeFromTransferredToken() makes sure gasFeePayment
+    // is set. However, typescript doesn't know that. Also, this is a precaution
+    // if this.#shouldReserveFeeFromTransferredToken()'s implementation changes
+    // and doesn't look at the gasFeePayment anymore
+    const desiredAmount = gasFeePayment
       ? getAmountAfterFeeReserve(totalTokenAmount, gasFeePayment.amount)
       : totalTokenAmount
 

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -786,7 +786,6 @@ export class TransferController extends EventEmitter implements ITransferControl
       !!accountAddr &&
       !!gasFeePayment &&
       !!selectedFeeOption &&
-      !selectedFeeOption.token.flags.onGasTank &&
       selectedFeeOption.paidBy.toLowerCase() === accountAddr &&
       selectedFeeOption.token.chainId === selectedToken.chainId &&
       selectedFeeOption.token.address.toLowerCase() === selectedTokenAddress &&

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -24,7 +24,11 @@ import { HumanizerMeta } from '../../libs/humanizer/interfaces'
 import { randomId } from '../../libs/humanizer/utils'
 import { TokenResult } from '../../libs/portfolio'
 import { getTokenAmount, getTokenBalanceInUSD } from '../../libs/portfolio/helpers'
-import { getAmountAfterFeeSync, getSanitizedAmount } from '../../libs/transfer/amount'
+import {
+  getAmountAfterFeeReserve,
+  getAmountAfterFeeSync,
+  getSanitizedAmount
+} from '../../libs/transfer/amount'
 import { getTransferRequestParams } from '../../libs/transfer/userRequest'
 import {
   validateSendTransferAddress,
@@ -594,7 +598,7 @@ export class TransferController extends EventEmitter implements ITransferControl
     if (shouldSetMaxAmount) {
       this.#isMaxAmountSelected = true
       this.amountFieldMode = 'token'
-      this.#setTokenAmount(this.maxAmount, true)
+      this.#setTokenAmount(this.#getMaxAmountAfterFeeReservation(), true)
     }
 
     if (addressState) {
@@ -768,6 +772,22 @@ export class TransferController extends EventEmitter implements ITransferControl
     this.amountFieldMode = 'token'
     this.#setAmount(amount, isProgrammaticUpdate)
     this.amountFieldMode = amountFieldMode
+  }
+
+  #getMaxAmountAfterFeeReservation() {
+    if (!this.selectedToken) return this.maxAmount
+
+    const totalTokenAmount = getTokenAmount(this.selectedToken)
+    const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
+
+    if (!this.#shouldReserveFeeFromTransferredToken() || !gasFeePayment) {
+      return formatUnits(totalTokenAmount, this.selectedToken.decimals)
+    }
+
+    return formatUnits(
+      getAmountAfterFeeReserve(totalTokenAmount, gasFeePayment.amount),
+      this.selectedToken.decimals
+    )
   }
 
   #shouldReserveFeeFromTransferredToken() {

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -24,7 +24,7 @@ import { HumanizerMeta } from '../../libs/humanizer/interfaces'
 import { randomId } from '../../libs/humanizer/utils'
 import { TokenResult } from '../../libs/portfolio'
 import { getTokenAmount, getTokenBalanceInUSD } from '../../libs/portfolio/helpers'
-import { getAmountAfterFeeReserve, getSanitizedAmount } from '../../libs/transfer/amount'
+import { getAmountAfterFeeSync, getSanitizedAmount } from '../../libs/transfer/amount'
 import { getTransferRequestParams } from '../../libs/transfer/userRequest'
 import {
   validateSendTransferAddress,
@@ -795,33 +795,26 @@ export class TransferController extends EventEmitter implements ITransferControl
     )
   }
 
-  #syncMaxAmountWithFeeReservation(forceEmit?: boolean) {
-    if (
-      !this.#isMaxAmountSelected ||
-      !this.selectedToken ||
-      typeof this.selectedToken.decimals !== 'number'
-    )
+  #syncAmountWithFeeReservation(forceEmit?: boolean) {
+    if (!this.amount || !this.selectedToken || typeof this.selectedToken.decimals !== 'number')
       return false
 
-    if (!this.#shouldReserveFeeFromTransferredToken()) return
-
     const totalTokenAmount = getTokenAmount(this.selectedToken)
+    const shouldReserveFee = this.#shouldReserveFeeFromTransferredToken()
     const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
-
-    // this.#shouldReserveFeeFromTransferredToken() makes sure gasFeePayment
-    // is set. However, typescript doesn't know that. Also, this is a precaution
-    // if this.#shouldReserveFeeFromTransferredToken()'s implementation changes
-    // and doesn't look at the gasFeePayment anymore
-    const desiredAmount = gasFeePayment
-      ? getAmountAfterFeeReserve(totalTokenAmount, gasFeePayment.amount)
-      : totalTokenAmount
-
     const currentAmount = this.amount
       ? parseUnits(
           getSafeAmountFromFieldValue(this.amount, this.selectedToken.decimals),
           this.selectedToken.decimals
         )
       : 0n
+    const desiredAmount = getAmountAfterFeeSync({
+      currentAmount,
+      totalAmount: totalTokenAmount,
+      fee: shouldReserveFee ? gasFeePayment?.amount || 0n : 0n,
+      shouldReserveFee,
+      isMaxAmountSelected: this.#isMaxAmountSelected
+    })
 
     if (currentAmount === desiredAmount) return false
 
@@ -995,9 +988,9 @@ export class TransferController extends EventEmitter implements ITransferControl
     })
 
     this.signAccountOpController.onUpdate((forceEmit) => {
-      const hasAdjustedMaxAmount = this.#syncMaxAmountWithFeeReservation(forceEmit)
+      const hasAdjustedAmount = this.#syncAmountWithFeeReservation(forceEmit)
 
-      if (!hasAdjustedMaxAmount) {
+      if (!hasAdjustedAmount) {
         this.propagateUpdate(forceEmit)
       }
 

--- a/src/libs/account/EOA7702.ts
+++ b/src/libs/account/EOA7702.ts
@@ -17,6 +17,7 @@ import { TokenResult } from '../portfolio'
 import { isNative } from '../portfolio/helpers'
 import { UserOperation } from '../userOperation/types'
 import { BaseAccount } from './BaseAccount'
+import { isTransferredTokenFeeOption } from './feeOptions'
 
 // this class describes an EOA that CAN transition to 7702
 // even if it is YET to transition to 7702
@@ -78,7 +79,7 @@ export class EOA7702 extends BaseAccount {
         opt.paidBy === this.account.addr &&
         (isNative(opt.token) ||
           (!isDelegating &&
-            opt.availableAmount > 0n &&
+            (opt.availableAmount > 0n || isTransferredTokenFeeOption(opt, op)) &&
             estimation.bundlerEstimation &&
             estimation.bundlerEstimation.paymaster.isUsable()))
     )

--- a/src/libs/account/V2.ts
+++ b/src/libs/account/V2.ts
@@ -23,6 +23,7 @@ import { privSlot } from '../proxyDeploy/deploy'
 import { UserOperation } from '../userOperation/types'
 import { getSpoof } from './account'
 import { BaseAccount } from './BaseAccount'
+import { isTransferredTokenFeeOption } from './feeOptions'
 
 // this class describes a plain EOA that cannot transition
 // to 7702 either because the network or the hardware wallet doesnt' support it
@@ -50,7 +51,8 @@ export class V2 extends BaseAccount {
 
   getAvailableFeeOptions(
     estimation: FullEstimationSummary,
-    feePaymentOptions: FeePaymentOption[]
+    feePaymentOptions: FeePaymentOption[],
+    op: AccountOp
   ): FeePaymentOption[] {
     const hasPaymaster =
       estimation.bundlerEstimation && estimation.bundlerEstimation.paymaster.isUsable()
@@ -61,7 +63,8 @@ export class V2 extends BaseAccount {
         (isNative(opt.token) && opt.paidBy === this.account.addr) ||
         // show EOA native only if it has amount to pay the fee
         (isNative(opt.token) && opt.availableAmount > 0n) ||
-        (opt.availableAmount > 0n && (this.network.hasRelayer || hasPaymaster))
+        ((opt.availableAmount > 0n || isTransferredTokenFeeOption(opt, op)) &&
+          (this.network.hasRelayer || hasPaymaster))
     )
   }
 

--- a/src/libs/account/feeOptions.test.ts
+++ b/src/libs/account/feeOptions.test.ts
@@ -1,0 +1,174 @@
+import { Interface, ZeroAddress } from 'ethers'
+
+import IERC20 from '../../../contracts/compiled/IERC20.json'
+import { AccountOp } from '../accountOp/accountOp'
+import { FeePaymentOption } from '../estimate/interfaces'
+import { isTransferredTokenFeeOption } from './feeOptions'
+
+const ERC20Interface = new Interface(IERC20.abi)
+
+describe('account fee options', () => {
+  test('should keep the same token when the op transfers it out', () => {
+    const op = {
+      accountAddr: '0x1111111111111111111111111111111111111111',
+      meta: {
+        allowTransferFeeTokenSelfReserve: true
+      },
+      calls: [
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          value: 0n,
+          data: ERC20Interface.encodeFunctionData('transfer', [
+            '0x3333333333333333333333333333333333333333',
+            15_000_000n
+          ])
+        }
+      ]
+    } as AccountOp
+
+    const feeOption = {
+      paidBy: op.accountAddr,
+      availableAmount: 0n,
+      gasUsed: 0n,
+      addedNative: 0n,
+      token: {
+        address: '0x2222222222222222222222222222222222222222',
+        flags: {
+          onGasTank: false
+        }
+      }
+    } as FeePaymentOption
+
+    expect(isTransferredTokenFeeOption(feeOption, op)).toBe(true)
+  })
+
+  test('should not keep unrelated zero-balance fee tokens', () => {
+    const op = {
+      accountAddr: '0x1111111111111111111111111111111111111111',
+      meta: {
+        allowTransferFeeTokenSelfReserve: true
+      },
+      calls: [
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          value: 0n,
+          data: ERC20Interface.encodeFunctionData('transfer', [
+            '0x3333333333333333333333333333333333333333',
+            15_000_000n
+          ])
+        }
+      ]
+    } as AccountOp
+
+    const feeOption = {
+      paidBy: op.accountAddr,
+      availableAmount: 0n,
+      gasUsed: 0n,
+      addedNative: 0n,
+      token: {
+        address: '0x4444444444444444444444444444444444444444',
+        flags: {
+          onGasTank: false
+        }
+      }
+    } as FeePaymentOption
+
+    expect(isTransferredTokenFeeOption(feeOption, op)).toBe(false)
+  })
+
+  test('should keep the native token when the op transfers native value', () => {
+    const op = {
+      accountAddr: '0x1111111111111111111111111111111111111111',
+      meta: {
+        allowTransferFeeTokenSelfReserve: true
+      },
+      calls: [
+        {
+          to: '0x3333333333333333333333333333333333333333',
+          value: 15_000_000_000_000_000n,
+          data: '0x'
+        }
+      ]
+    } as AccountOp
+
+    const feeOption = {
+      paidBy: op.accountAddr,
+      availableAmount: 0n,
+      gasUsed: 0n,
+      addedNative: 0n,
+      token: {
+        address: ZeroAddress,
+        flags: {
+          onGasTank: false
+        }
+      }
+    } as FeePaymentOption
+
+    expect(isTransferredTokenFeeOption(feeOption, op)).toBe(true)
+  })
+
+  test('should not keep the native token when no native value is transferred', () => {
+    const op = {
+      accountAddr: '0x1111111111111111111111111111111111111111',
+      meta: {
+        allowTransferFeeTokenSelfReserve: true
+      },
+      calls: [
+        {
+          to: '0x3333333333333333333333333333333333333333',
+          value: 0n,
+          data: ERC20Interface.encodeFunctionData('transfer', [
+            '0x4444444444444444444444444444444444444444',
+            15_000_000n
+          ])
+        }
+      ]
+    } as AccountOp
+
+    const feeOption = {
+      paidBy: op.accountAddr,
+      availableAmount: 0n,
+      gasUsed: 0n,
+      addedNative: 0n,
+      token: {
+        address: ZeroAddress,
+        flags: {
+          onGasTank: false
+        }
+      }
+    } as FeePaymentOption
+
+    expect(isTransferredTokenFeeOption(feeOption, op)).toBe(false)
+  })
+
+  test('should not keep the transferred token outside the direct transfer controller flow', () => {
+    const op = {
+      accountAddr: '0x1111111111111111111111111111111111111111',
+      calls: [
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          value: 0n,
+          data: ERC20Interface.encodeFunctionData('transfer', [
+            '0x3333333333333333333333333333333333333333',
+            15_000_000n
+          ])
+        }
+      ]
+    } as AccountOp
+
+    const feeOption = {
+      paidBy: op.accountAddr,
+      availableAmount: 0n,
+      gasUsed: 0n,
+      addedNative: 0n,
+      token: {
+        address: '0x2222222222222222222222222222222222222222',
+        flags: {
+          onGasTank: false
+        }
+      }
+    } as FeePaymentOption
+
+    expect(isTransferredTokenFeeOption(feeOption, op)).toBe(false)
+  })
+})

--- a/src/libs/account/feeOptions.test.ts
+++ b/src/libs/account/feeOptions.test.ts
@@ -3,7 +3,7 @@ import { Interface, ZeroAddress } from 'ethers'
 import IERC20 from '../../../contracts/compiled/IERC20.json'
 import { AccountOp } from '../accountOp/accountOp'
 import { FeePaymentOption } from '../estimate/interfaces'
-import { isTransferredTokenFeeOption } from './feeOptions'
+import { canFeeOptionCoverAmount, isTransferredTokenFeeOption } from './feeOptions'
 
 const ERC20Interface = new Interface(IERC20.abi)
 
@@ -170,5 +170,67 @@ describe('account fee options', () => {
     } as FeePaymentOption
 
     expect(isTransferredTokenFeeOption(feeOption, op)).toBe(false)
+  })
+
+  test('should allow the transferred token to cover the fee even when availableAmount is zero', () => {
+    const op = {
+      accountAddr: '0x1111111111111111111111111111111111111111',
+      meta: {
+        allowTransferFeeTokenSelfReserve: true
+      },
+      calls: [
+        {
+          to: '0x3333333333333333333333333333333333333333',
+          value: 15_000_000_000_000_000n,
+          data: '0x'
+        }
+      ]
+    } as AccountOp
+
+    const feeOption = {
+      paidBy: op.accountAddr,
+      availableAmount: 0n,
+      gasUsed: 0n,
+      addedNative: 0n,
+      token: {
+        address: ZeroAddress,
+        flags: {
+          onGasTank: false
+        }
+      }
+    } as FeePaymentOption
+
+    expect(canFeeOptionCoverAmount(feeOption, op, 1n)).toBe(true)
+  })
+
+  test('should not allow unrelated zero-balance fee options to cover the fee', () => {
+    const op = {
+      accountAddr: '0x1111111111111111111111111111111111111111',
+      meta: {
+        allowTransferFeeTokenSelfReserve: true
+      },
+      calls: [
+        {
+          to: '0x3333333333333333333333333333333333333333',
+          value: 15_000_000_000_000_000n,
+          data: '0x'
+        }
+      ]
+    } as AccountOp
+
+    const feeOption = {
+      paidBy: op.accountAddr,
+      availableAmount: 0n,
+      gasUsed: 0n,
+      addedNative: 0n,
+      token: {
+        address: '0x4444444444444444444444444444444444444444',
+        flags: {
+          onGasTank: false
+        }
+      }
+    } as FeePaymentOption
+
+    expect(canFeeOptionCoverAmount(feeOption, op, 1n)).toBe(false)
   })
 })

--- a/src/libs/account/feeOptions.ts
+++ b/src/libs/account/feeOptions.ts
@@ -31,4 +31,12 @@ const isTransferredTokenFeeOption = (feeOption: FeePaymentOption, op: AccountOp)
   })
 }
 
-export { isTransferredTokenFeeOption }
+const canFeeOptionCoverAmount = (
+  feeOption: FeePaymentOption,
+  op: AccountOp,
+  amount: bigint
+): boolean => {
+  return feeOption.availableAmount >= amount || isTransferredTokenFeeOption(feeOption, op)
+}
+
+export { canFeeOptionCoverAmount, isTransferredTokenFeeOption }

--- a/src/libs/account/feeOptions.ts
+++ b/src/libs/account/feeOptions.ts
@@ -1,0 +1,34 @@
+import { Interface, ZeroAddress } from 'ethers'
+
+import IERC20 from '../../../contracts/compiled/IERC20.json'
+import { AccountOp } from '../accountOp/accountOp'
+import { FeePaymentOption } from '../estimate/interfaces'
+
+const ERC20Interface = new Interface(IERC20.abi)
+
+const isTransferredTokenFeeOption = (feeOption: FeePaymentOption, op: AccountOp): boolean => {
+  if (!op.meta?.allowTransferFeeTokenSelfReserve) return false
+
+  if (
+    feeOption.token.flags.onGasTank ||
+    feeOption.paidBy.toLowerCase() !== op.accountAddr.toLowerCase()
+  )
+    return false
+
+  if (feeOption.token.address === ZeroAddress) {
+    return op.calls.some((call) => call.value > 0n && call.data === '0x')
+  }
+
+  return op.calls.some((call) => {
+    if (!call.to || call.to.toLowerCase() !== feeOption.token.address.toLowerCase()) return false
+
+    try {
+      ERC20Interface.decodeFunctionData('transfer', call.data)
+      return true
+    } catch {
+      return false
+    }
+  })
+}
+
+export { isTransferredTokenFeeOption }

--- a/src/libs/accountOp/accountOp.ts
+++ b/src/libs/accountOp/accountOp.ts
@@ -88,6 +88,8 @@ export interface AccountOp {
     fromQuoteId?: string
     /** Used to enable the gas tank if the user is topping up */
     topUpAmount?: bigint
+    /** Allows transfer.ts-owned MAX flows to reserve the fee from the transferred token. */
+    allowTransferFeeTokenSelfReserve?: boolean
     /** Used to enable swap&bridge sponsorship */
     swapSponsorship?: {
       swapFeeInUsd: number

--- a/src/libs/transfer/amount.test.ts
+++ b/src/libs/transfer/amount.test.ts
@@ -1,4 +1,4 @@
-import { getAmountAfterFeeReserve } from './amount'
+import { getAmountAfterFeeReserve, getAmountAfterFeeSync } from './amount'
 
 describe('transfer amount helpers', () => {
   test('should subtract the reserved fee from the transferable amount', () => {
@@ -7,5 +7,41 @@ describe('transfer amount helpers', () => {
 
   test('should never return a negative transferable amount', () => {
     expect(getAmountAfterFeeReserve(15_000_000n, 15_000_001n)).toBe(0n)
+  })
+
+  test('should clamp manually entered amounts that exceed the reserved max', () => {
+    expect(
+      getAmountAfterFeeSync({
+        currentAmount: 14_900_000n,
+        totalAmount: 15_000_000n,
+        fee: 350_000n,
+        shouldReserveFee: true,
+        isMaxAmountSelected: false
+      })
+    ).toBe(14_650_000n)
+  })
+
+  test('should preserve smaller manual amounts when fee reservation is needed', () => {
+    expect(
+      getAmountAfterFeeSync({
+        currentAmount: 14_000_000n,
+        totalAmount: 15_000_000n,
+        fee: 350_000n,
+        shouldReserveFee: true,
+        isMaxAmountSelected: false
+      })
+    ).toBe(14_000_000n)
+  })
+
+  test('should keep max selection synced with the current fee option', () => {
+    expect(
+      getAmountAfterFeeSync({
+        currentAmount: 14_650_000n,
+        totalAmount: 15_000_000n,
+        fee: 350_000n,
+        shouldReserveFee: false,
+        isMaxAmountSelected: true
+      })
+    ).toBe(15_000_000n)
   })
 })

--- a/src/libs/transfer/amount.test.ts
+++ b/src/libs/transfer/amount.test.ts
@@ -1,0 +1,11 @@
+import { getAmountAfterFeeReserve } from './amount'
+
+describe('transfer amount helpers', () => {
+  test('should subtract the reserved fee from the transferable amount', () => {
+    expect(getAmountAfterFeeReserve(15_000_000n, 350_000n)).toBe(14_650_000n)
+  })
+
+  test('should never return a negative transferable amount', () => {
+    expect(getAmountAfterFeeReserve(15_000_000n, 15_000_001n)).toBe(0n)
+  })
+})

--- a/src/libs/transfer/amount.ts
+++ b/src/libs/transfer/amount.ts
@@ -2,6 +2,29 @@ const getAmountAfterFeeReserve = (amount: bigint, fee: bigint): bigint => {
   return amount > fee ? amount - fee : 0n
 }
 
+const getAmountAfterFeeSync = ({
+  currentAmount,
+  totalAmount,
+  fee,
+  shouldReserveFee,
+  isMaxAmountSelected
+}: {
+  currentAmount: bigint
+  totalAmount: bigint
+  fee: bigint
+  shouldReserveFee: boolean
+  isMaxAmountSelected: boolean
+}): bigint => {
+  const maxTransferableAmount = shouldReserveFee
+    ? getAmountAfterFeeReserve(totalAmount, fee)
+    : totalAmount
+
+  if (isMaxAmountSelected) return maxTransferableAmount
+  if (!shouldReserveFee) return currentAmount
+
+  return currentAmount > maxTransferableAmount ? maxTransferableAmount : currentAmount
+}
+
 /**
  * Removes any extra decimals from the amount.
  * @example getSanitizedAmount('1.123456', 2) => '1.12'
@@ -14,4 +37,4 @@ const getSanitizedAmount = (amount: string, decimals: number): string => {
   return sanitizedAmount.join('.')
 }
 
-export { getAmountAfterFeeReserve, getSanitizedAmount }
+export { getAmountAfterFeeReserve, getAmountAfterFeeSync, getSanitizedAmount }

--- a/src/libs/transfer/amount.ts
+++ b/src/libs/transfer/amount.ts
@@ -1,3 +1,7 @@
+const getAmountAfterFeeReserve = (amount: bigint, fee: bigint): bigint => {
+  return amount > fee ? amount - fee : 0n
+}
+
 /**
  * Removes any extra decimals from the amount.
  * @example getSanitizedAmount('1.123456', 2) => '1.12'
@@ -10,4 +14,4 @@ const getSanitizedAmount = (amount: string, decimals: number): string => {
   return sanitizedAmount.join('.')
 }
 
-export { getSanitizedAmount }
+export { getAmountAfterFeeReserve, getSanitizedAmount }


### PR DESCRIPTION
Change log:
* a sync mechanism between transfer & sign-account-op for MAX transfers
* enable the MAX transfered out token as a fee (if it's a legit fee token)
* suppress "not enough to pay the fee" errors during synching period in one click transfer mode