### PR TITLE
Fix/ Additional portfolio banner timestamps are of type string

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -941,13 +941,20 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     if (res.data.banner) {
       const banner = res.data.banner
 
+      const endTimeNumber =
+        typeof banner.endTime === 'number' ? banner.endTime : new Date(banner.endTime).getTime()
+      const startTimeNumber =
+        typeof banner.startTime === 'number'
+          ? banner.startTime
+          : new Date(banner.startTime).getTime()
+
       const formattedBanner: Banner = {
         // eslint-disable-next-line no-underscore-dangle
         id: banner.id || banner._id,
         type: banner.type || 'updates',
         meta: {
-          startTime: banner.startTime,
-          endTime: banner.endTime
+          startTime: startTimeNumber,
+          endTime: endTimeNumber
         },
         ...(banner.text && { text: banner.text }),
         ...(banner.title && { title: banner.title }),


### PR DESCRIPTION
## How to reproduce:
1. Add this mock banner above line 941 in the portfolio controller:
```
res.data.banner = {
      _id: '68022d0ae576cdb9f3cf4d2d',
      startTime: '2026-04-15T00:00:00.301+00:00',
      endTime: '2026-04-19T14:00:00.301+00:00',
      url: 'https://snapshot.box/#/s:ambire.eth/proposal/0x5646c64b284e49ddb25f5df4e2f93db85020b5f2ca472e7af9f2d5a4c2cbf74a',
      type: 'rewards',
      title: 'Governance Vote Open!',
      text: 'Decide how to end Ambire Rewards Season 2'
    }
```
2. Reload the extension
3. The banner is expired so it shouldn't be visible

## Before:
<img width="1711" height="323" alt="image" src="https://github.com/user-attachments/assets/585105af-34c1-4714-9c7a-9bb1fd34c1e0" />

## After:
<img width="1352" height="291" alt="image" src="https://github.com/user-attachments/assets/62e2fa73-ab72-4b98-ac4b-ceb8de9b41ee" />
