### PR TITLE
Fix / use QR iterator hdPathTemplate and remove unused walletConfig from KeyIterator

### DIFF
--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -882,7 +882,6 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
       }
 
       const masterFingerprint = this.#externalSignerControllers.qr?.masterFingerprint || ''
-      const qrWalletConfig = keyType === 'qr' ? this.keyIterator.walletConfig : undefined
 
       const hdPathTemplate = this.hdPathTemplate as HD_PATH_TEMPLATE_TYPE
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1157,11 +1157,11 @@ export class MainController extends EventEmitter implements IMainController {
 
       const keyIterator = new QrKeyIterator({ controller: qrCtrl })
       // Initialize the QR iterator from payload before AccountPicker init.
-      // This populates QR-specific iterator state (walletConfig, xpub, parsedAccount)
+      // This populates QR-specific iterator state (xpub, parsedAccount, hdPathTemplate)
       // that AccountPicker needs to configure derivation and retrieval.
       await keyIterator.initFromQrPayload(payload)
 
-      const hdPathTemplate = keyIterator.walletConfig?.hdPathTemplate
+      const hdPathTemplate = keyIterator.hdPathTemplate
       if (!hdPathTemplate) {
         const message = 'Invalid QR hardware wallet payload. Please try again.'
         throw new EmittableError({

--- a/src/interfaces/keyIterator.ts
+++ b/src/interfaces/keyIterator.ts
@@ -1,27 +1,11 @@
 import { HD_PATH_TEMPLATE_TYPE } from '../consts/derivation'
 import { SelectedAccountForImport } from './account'
-import {
-  ExternalSignerController,
-  Key,
-  ParsedQrAccount,
-  QrProtocolType,
-  QrWalletType
-} from './keystore'
+import { ExternalSignerController, Key, ParsedQrAccount, QrProtocolType } from './keystore'
 
 export type QrWalletConfig = {
-  walletType: QrWalletType
   protocol: QrProtocolType
   label: string
-  hdPathTemplate: string
-  relativePathTemplate: string
   tutorialUrl?: string
-}
-
-type QrParsedAccountMeta = {
-  hdPath?: string
-  accounts?: Array<{
-    hdPath?: string
-  }>
 }
 
 export interface KeyIterator {
@@ -58,6 +42,5 @@ export interface KeyIterator {
   /** Checks if the seed matches the key iterator's seed (optional, for hot wallets) */
   isSeedMatching?: (seedToCompareWith: string) => boolean
   // QR-specific optional fields
-  walletConfig?: QrWalletConfig
   parsedAccount?: ParsedQrAccount
 }


### PR DESCRIPTION
paired with: https://github.com/AmbireTech/ambire-app/pull/6998

## Summary
This PR fixes QR hardware wallet initialization by reading `hdPathTemplate` directly from `QrKeyIterator` after `initFromQrPayload`, instead of from `walletConfig`.
It also removes unused `walletConfig`-related fields from the `KeyIterator` interface and cleans up dead code in the account picker flow.
## What changed
- Updated QR init flow in `MainController` to use `keyIterator.hdPathTemplate`.
- Adjusted inline docs to reflect the actual QR iterator state being used.
- Removed an unused local `qrWalletConfig` in `AccountPickerController`.
- Simplified `KeyIterator` types by removing unused `walletConfig` and related QR config/meta fields.
## Why
`walletConfig` is no longer needed for this flow, and relying on the iterator’s own `hdPathTemplate` is the correct source of truth after payload initialization. This reduces stale interface surface and helps avoid future QR wallet type/path mismatch issues.
## Test plan
- [ ] Scan/import a QR hardware wallet and confirm account derivation works.
- [ ] Verify invalid QR payload still shows the expected error path.