### PR TITLE
 Bug / Phishing refresh guard that prevents redundant requests to the Scam checker

### DIFF
--- a/src/controllers/phishing/phishing.ts
+++ b/src/controllers/phishing/phishing.ts
@@ -114,7 +114,7 @@ export class PhishingController extends EventEmitter implements IPhishingControl
   async #continuouslyUpdatePhishing() {
     // This prevents redundant requests to the relayer
     // when the extension reloads multiple times within a short period.
-    if (this.#updatedAt && this.#updatedAt < PHISHING_UPDATE_INTERVAL) return
+    if (this.#updatedAt && Date.now() - this.#updatedAt < PHISHING_UPDATE_INTERVAL) return
 
     const res = await fetchWithTimeout(
       this.#fetch,


### PR DESCRIPTION
Fix the phishing refresh guard that prevents redundant requests to the Scam checker when the extension reloads multiple times within a short period.

Logic should compare elapsed time (`Date.now() - updatedAt`) against `PHISHING_UPDATE_INTERVAL` instead of comparing an absolute timestamp to an interval (which would always result `false`).