### PR TITLE
Feature/ Defi apps support

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -2606,4 +2606,182 @@ describe('Portfolio Controller ', () => {
       restore()
     })
   })
+
+  describe('batchedPortfolioDiscovery', () => {
+    const createJsonResponse = (body: unknown, status = 200, statusText = 'OK') => ({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body))
+    })
+
+    const getPortfolioResponseByNetworks = (url: string) => {
+      const networkParam = new URL(url).searchParams.get('networks') || ''
+      const networkCount = networkParam.split(',').filter(Boolean).length
+
+      return Array.from({ length: networkCount }, (_, index) => ({
+        hasHints: true,
+        erc20s: [],
+        erc721s: {},
+        prices: {},
+        otherNetworksDefiCounts: {},
+        defi: {
+          positions: [],
+          updatedAt: Date.now()
+        },
+        index
+      }))
+    }
+
+    const createDiscoveryFetchOverride = (
+      handler: (url: string) => Promise<{
+        ok: boolean
+        status: number
+        statusText: string
+        json: () => Promise<unknown>
+      }>
+    ) =>
+      jest.fn((input: Parameters<typeof fetch>[0]) => {
+        const url = typeof input === 'string' ? input : input.toString()
+
+        if (url.includes('/portfolio?')) return handler(url)
+
+        return Promise.resolve(createJsonResponse({}))
+      }) as unknown as typeof fetch
+
+    test('Should add update=true even when batchedPortfolioDiscovery is called for multiple networks, but only one calls with forceUpdateDefi=true', async () => {
+      const discoveryUrls: string[] = []
+      const fetchOverride = createDiscoveryFetchOverride(async (url) => {
+        discoveryUrls.push(url)
+
+        return createJsonResponse(getPortfolioResponseByNetworks(url))
+      })
+
+      const { controller } = await prepareTest({
+        fetchOverride,
+        awaitInitialLoad: false
+      })
+
+      // @ts-ignore
+      const firstCall = controller.batchedPortfolioDiscovery({
+        chainId: 1n,
+        accountAddr: account.addr,
+        baseCurrency: 'usd',
+        forceUpdateDefi: false
+      })
+
+      // @ts-ignore
+      const secondCall = controller.batchedPortfolioDiscovery({
+        chainId: 137n,
+        accountAddr: account.addr,
+        baseCurrency: 'usd',
+        forceUpdateDefi: true
+      })
+
+      await Promise.allSettled([firstCall, secondCall])
+
+      expect(discoveryUrls).toHaveLength(1)
+      expect(new URL(discoveryUrls[0]!).searchParams.get('update')).toBe('true')
+    })
+
+    test('update=true is account-pair specific', async () => {
+      const discoveryUrls: string[] = []
+      const fetchOverride = createDiscoveryFetchOverride(async (url) => {
+        discoveryUrls.push(url)
+
+        return createJsonResponse(getPortfolioResponseByNetworks(url))
+      })
+
+      const { controller } = await prepareTest({
+        fetchOverride,
+        awaitInitialLoad: false
+      })
+
+      const affectedPair = [
+        // @ts-ignore
+        controller.batchedPortfolioDiscovery({
+          chainId: 1n,
+          accountAddr: account.addr,
+          baseCurrency: 'usd',
+          forceUpdateDefi: false
+        }),
+        // @ts-ignore
+        controller.batchedPortfolioDiscovery({
+          chainId: 137n,
+          accountAddr: account.addr,
+          baseCurrency: 'usd',
+          forceUpdateDefi: true
+        })
+      ]
+
+      const unaffectedPair = [
+        // @ts-ignore
+        controller.batchedPortfolioDiscovery({
+          chainId: 1n,
+          accountAddr: account2.addr,
+          baseCurrency: 'usd',
+          forceUpdateDefi: false
+        })
+      ]
+
+      await Promise.allSettled([...affectedPair, ...unaffectedPair])
+
+      const pairWithForceUpdate = discoveryUrls.find((url) =>
+        url.includes(`account=${account.addr}`)
+      )
+      const pairWithoutForceUpdate = discoveryUrls.find((url) =>
+        url.includes(`account=${account2.addr}`)
+      )
+
+      expect(discoveryUrls).toHaveLength(2)
+      expect(pairWithForceUpdate).toBeDefined()
+      expect(pairWithoutForceUpdate).toBeDefined()
+
+      expect(new URL(pairWithForceUpdate!).searchParams.get('update')).toBe('true')
+      expect(new URL(pairWithoutForceUpdate!).searchParams.get('update')).toBeNull()
+    })
+
+    test('Malformed array length mismatch should trigger mismatch rejection', async () => {
+      const fetchOverride = createDiscoveryFetchOverride(async () => createJsonResponse([{}]))
+
+      const { controller } = await prepareTest({
+        fetchOverride,
+        awaitInitialLoad: false
+      })
+
+      // @ts-ignore
+      const firstCall = controller.batchedPortfolioDiscovery({
+        chainId: 1n,
+        accountAddr: account.addr,
+        baseCurrency: 'usd',
+        forceUpdateDefi: false
+      })
+
+      // @ts-ignore
+      const secondCall = controller.batchedPortfolioDiscovery({
+        chainId: 137n,
+        accountAddr: account.addr,
+        baseCurrency: 'usd',
+        forceUpdateDefi: false
+      })
+
+      const [firstResult, secondResult] = await Promise.allSettled([firstCall, secondCall])
+
+      expect(firstResult.status).toBe('rejected')
+      expect(secondResult.status).toBe('rejected')
+
+      if (firstResult.status === 'rejected') {
+        expect(firstResult.reason?.message).toContain(
+          'internal error: queue length and response length mismatch'
+        )
+      }
+
+      if (secondResult.status === 'rejected') {
+        expect(secondResult.reason?.message).toContain(
+          'internal error: queue length and response length mismatch'
+        )
+      }
+    })
+  })
 })

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -1835,7 +1835,7 @@ describe('Portfolio Controller ', () => {
         // @ts-ignore
         .spyOn(controller, 'batchedPortfolioDiscovery')
         // @ts-ignore
-        .mockRejectedValueOnce(new Error('Portfolio discovery failed'))
+        .mockRejectedValue(new Error('Portfolio discovery failed'))
 
       await controller.updateSelectedAccount(DEFI_TEST_ACCOUNT.addr, [ethereum])
       const state = controller.getAccountPortfolioState(DEFI_TEST_ACCOUNT.addr)['1']
@@ -1912,7 +1912,7 @@ describe('Portfolio Controller ', () => {
         // @ts-ignore
         .spyOn(controller, 'batchedPortfolioDiscovery')
         // @ts-ignore
-        .mockRejectedValueOnce(new Error('Portfolio discovery failed'))
+        .mockRejectedValue(new Error('Portfolio discovery failed'))
 
       await controller.updateSelectedAccount(DEFI_TEST_ACCOUNT.addr, [ethereum], undefined, {
         defiMaxDataAgeMs: 0
@@ -1985,7 +1985,7 @@ describe('Portfolio Controller ', () => {
         // @ts-ignore
         .spyOn(controller, 'batchedPortfolioDiscovery')
         // @ts-ignore
-        .mockRejectedValueOnce(new Error('Portfolio discovery failed'))
+        .mockRejectedValue(new Error('Portfolio discovery failed'))
 
       await controller.updateSelectedAccount(DEFI_TEST_ACCOUNT.addr, [ethereum], undefined, {
         defiMaxDataAgeMs: 0,
@@ -2246,7 +2246,7 @@ describe('Portfolio Controller ', () => {
       // @ts-ignore
       .spyOn(controller, 'batchedPortfolioDiscovery')
       // @ts-ignore
-      .mockRejectedValueOnce(new Error('Velcro error'))
+      .mockRejectedValue(new Error('Velcro error'))
 
     // @ts-ignore
     const formatted = await controller.getPortfolioFromApiDiscovery({
@@ -2273,7 +2273,7 @@ describe('Portfolio Controller ', () => {
       // @ts-ignore
       .spyOn(controller, 'batchedPortfolioDiscovery')
       // @ts-ignore
-      .mockRejectedValueOnce(new Error('Velcro error'))
+      .mockRejectedValue(new Error('Velcro error'))
 
     // @ts-ignore
     const formatted = await controller.getPortfolioFromApiDiscovery({
@@ -2299,7 +2299,7 @@ describe('Portfolio Controller ', () => {
       // @ts-ignore
       .spyOn(controller, 'batchedPortfolioDiscovery')
       // @ts-ignore
-      .mockRejectedValueOnce(new Error('Velcro error'))
+      .mockRejectedValue(new Error('Velcro error'))
 
     // @ts-ignore
     const formatted = await controller.getPortfolioFromApiDiscovery({

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -429,9 +429,17 @@ describe('Portfolio Controller ', () => {
           })
       )
 
-    controller.updateSelectedAccount(account.addr, ethereum ? [ethereum] : undefined, undefined)
+    void controller.updateSelectedAccount(
+      account.addr,
+      ethereum ? [ethereum] : undefined,
+      undefined
+    )
 
-    controller.updateSelectedAccount(account.addr, ethereum ? [ethereum] : undefined, undefined)
+    void controller.updateSelectedAccount(
+      account.addr,
+      ethereum ? [ethereum] : undefined,
+      undefined
+    )
 
     // We need to wait for the latest update, or the bellow expect will run too soon,
     // and we won't be able to check the queue properly.
@@ -1735,6 +1743,61 @@ describe('Portfolio Controller ', () => {
 
   describe('Defi positions', () => {
     const ethereum = networks.find((n) => n.chainId === 1n)!
+
+    const getDefiAppsResponse = () => ({
+      networkId: 'customAppChain',
+      chainId: 'customAppChain',
+      accountAddr: account.addr,
+      erc20s: [],
+      erc721s: {},
+      hasHints: true,
+      prices: {},
+      lastUpdate: Date.now(),
+      defi: {
+        positions: [
+          {
+            providerName: 'Polymarket',
+            iconUrl:
+              'https://static.debank.com/image/project/logo_url/app_polymarket/265aca8cef9212e094ef24c71a01c175.png',
+            siteUrl: 'https://polymarket.com/',
+            type: 'Deposit',
+            positions: [
+              {
+                id: '87f34311-e915-48c7-b51f-f5e92dc4ea39',
+                assets: [
+                  {
+                    id: 'be0eecf639f4e6a57e375123e46ed7b4',
+                    name: 'USDC',
+                    symbol: 'USDC',
+                    decimals: 6,
+                    logo_url:
+                      'https://static.debank.com/image/app_token/logo_url/polymarket/fc98c076b66fa798bcd8755cd859032e.png',
+                    app_id: 'polymarket',
+                    price: 0.999500249875063,
+                    amount: 64.230076,
+                    type: 1,
+                    value: 64.1979770114943
+                  }
+                ],
+                additionalData: {
+                  positionInUSD: 64.1979770114943,
+                  collateralInUSD: 64.1979770114943,
+                  positionIndex: 'cash_0xb78006ab9f2acfb90834c16b321eeb5008123393',
+                  name: 'Deposit',
+                  detailTypes: ['common'],
+                  updateAt: 1776933578.75451,
+                  position_index: 'cash_0xb78006ab9f2acfb90834c16b321eeb5008123393'
+                }
+              }
+            ],
+            positionInUSD: 64.1979770114943
+          }
+        ],
+        updatedAt: Date.now()
+      },
+      otherNetworksDefiCounts: {}
+    })
+
     beforeEach(() => {
       jest.restoreAllMocks()
       jest.clearAllMocks()
@@ -2002,6 +2065,169 @@ describe('Portfolio Controller ', () => {
       expect(result2.defiPositions.error).toBe(DeFiPositionsError.CriticalError)
       expect(state2!.errors.length).toBeGreaterThan(0)
       restore()
+    })
+
+    describe('Defi apps', () => {
+      it('should skip update if canSkipUpdate=true', async () => {
+        const { controller } = await prepareTest()
+        // @ts-ignore
+        const discoverySpy: any = jest.spyOn(controller, 'batchedPortfolioDiscovery')
+        discoverySpy.mockResolvedValue(getDefiAppsResponse())
+
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 60 * 1000,
+          hasKeys: true,
+          isManualUpdate: false
+        })
+
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 60 * 1000,
+          hasKeys: true,
+          isManualUpdate: false
+        })
+
+        expect(discoverySpy).toHaveBeenCalledTimes(1)
+      })
+
+      it('should bypass skip and re-fetch on manual update', async () => {
+        const { controller } = await prepareTest()
+        // @ts-ignore
+        const discoverySpy: any = jest.spyOn(controller, 'batchedPortfolioDiscovery')
+        discoverySpy.mockResolvedValue(getDefiAppsResponse())
+
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 60 * 1000,
+          hasKeys: true,
+          isManualUpdate: false
+        })
+
+        const firstUpdateStarted =
+          controller.getAccountPortfolioState(account.addr).defiApps?.result?.updateStarted || 0
+
+        await wait(5)
+
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 60 * 1000,
+          hasKeys: true,
+          isManualUpdate: true
+        })
+
+        const secondUpdateStarted =
+          controller.getAccountPortfolioState(account.addr).defiApps?.result?.updateStarted || 0
+
+        expect(discoverySpy).toHaveBeenCalledTimes(2)
+        expect(secondUpdateStarted).toBeGreaterThan(firstUpdateStarted)
+      })
+
+      it('should persist app positions under defiApps with no chainId and empty tokens', async () => {
+        const { controller } = await prepareTest()
+
+        // @ts-ignore
+        const discoverySpy: any = jest.spyOn(controller, 'batchedPortfolioDiscovery')
+        discoverySpy.mockResolvedValue(getDefiAppsResponse())
+
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 0,
+          hasKeys: true,
+          isManualUpdate: false
+        })
+
+        const state = controller.getAccountPortfolioState(account.addr).defiApps
+        const positionsByProvider = state?.result?.defiPositions.positionsByProvider || []
+        const firstProvider = positionsByProvider[0]
+        const firstAsset = firstProvider?.positions[0]?.assets[0]
+
+        expect(state?.isReady).toBe(true)
+        expect(state?.isLoading).toBe(false)
+        expect(state?.result?.tokens).toEqual([])
+        expect(firstProvider?.chainId).toBeUndefined()
+        expect(firstAsset?.address).toBe(undefined)
+      })
+
+      it('should set criticalError on discovery failure', async () => {
+        const { restore } = suppressConsole()
+        const { controller } = await prepareTest()
+
+        // @ts-ignore
+        const discoverySpy: any = jest.spyOn(controller, 'batchedPortfolioDiscovery')
+        discoverySpy.mockRejectedValue(new Error('Defi apps failure'))
+
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 0,
+          hasKeys: true,
+          isManualUpdate: false
+        })
+
+        const state = controller.getAccountPortfolioState(account.addr).defiApps
+
+        expect(state?.isLoading).toBe(false)
+        expect(state?.criticalError?.message).toContain('Defi apps failure')
+        restore()
+      })
+
+      it('should handle external API errorState responses', async () => {
+        const { restore } = suppressConsole()
+        const { controller } = await prepareTest()
+
+        // @ts-ignore
+        const discoverySpy: any = jest.spyOn(controller, 'batchedPortfolioDiscovery')
+        discoverySpy.mockResolvedValue({
+          defi: {
+            success: false,
+            errorState: [{ message: 'Velcro app error', level: 'fatal' }]
+          }
+        })
+
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 0,
+          hasKeys: true,
+          isManualUpdate: false
+        })
+
+        const state = controller.getAccountPortfolioState(account.addr).defiApps
+
+        expect(state?.isLoading).toBe(false)
+        expect(state?.criticalError?.message).toContain('Velcro app error')
+        restore()
+      })
+
+      it('should not skip update when previous defiApps state has a criticalError', async () => {
+        const { restore } = suppressConsole()
+        const { controller } = await prepareTest()
+        // @ts-ignore
+        const discoverySpy: any = jest.spyOn(controller, 'batchedPortfolioDiscovery')
+        discoverySpy.mockRejectedValueOnce(new Error('first call fails'))
+        discoverySpy.mockResolvedValueOnce(getDefiAppsResponse())
+
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 60 * 1000,
+          hasKeys: true,
+          isManualUpdate: false
+        })
+
+        // Should not be skipped despite maxDataAgeMs, because state.criticalError is set
+        // @ts-ignore
+        await controller.updateDefiAppsState(account, {
+          defiMaxDataAgeMs: 60 * 1000,
+          hasKeys: true,
+          isManualUpdate: false
+        })
+
+        const state = controller.getAccountPortfolioState(account.addr).defiApps
+
+        expect(discoverySpy).toHaveBeenCalledTimes(2)
+        expect(state?.criticalError).toBeUndefined()
+        expect(state?.isReady).toBe(true)
+        restore()
+      })
     })
   })
 
@@ -2782,6 +3008,46 @@ describe('Portfolio Controller ', () => {
           'internal error: queue length and response length mismatch'
         )
       }
+    })
+
+    test('customAppChain discovery is batched with network discovery for the same account/baseCurrency', async () => {
+      const discoveryUrls: string[] = []
+      const fetchOverride = createDiscoveryFetchOverride(async (url) => {
+        discoveryUrls.push(url)
+
+        return createJsonResponse(getPortfolioResponseByNetworks(url))
+      })
+
+      const { controller } = await prepareTest({
+        fetchOverride,
+        awaitInitialLoad: false
+      })
+
+      // @ts-ignore
+      const firstCall = controller.batchedPortfolioDiscovery({
+        chainId: 1n,
+        accountAddr: account.addr,
+        baseCurrency: 'usd',
+        forceUpdateDefi: false
+      })
+
+      // @ts-ignore
+      const secondCall = controller.batchedPortfolioDiscovery({
+        chainId: 'customAppChain',
+        accountAddr: account.addr,
+        baseCurrency: 'usd',
+        forceUpdateDefi: false
+      })
+
+      await Promise.allSettled([firstCall, secondCall])
+
+      expect(discoveryUrls).toHaveLength(1)
+      const networkParams = (new URL(discoveryUrls[0]!).searchParams.get('networks') || '')
+        .split(',')
+        .filter(Boolean)
+
+      expect(networkParams).toContain('1')
+      expect(networkParams).toContain('customAppChain')
     })
   })
 })

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -1408,8 +1408,16 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       isManualUpdate?: boolean
     }
   ) {
-    const updateStarted = Date.now()
     const accountState = this.#state[account.addr] ?? (this.#state[account.addr] = {})
+
+    const canSkipUpdate = PortfolioController.#getCanSkipUpdate(
+      accountState['defiApps'],
+      portfolioProps.defiMaxDataAgeMs
+    )
+
+    if (canSkipUpdate) return
+
+    const updateStarted = Date.now()
 
     this.#setNetworkLoading(account.addr, 'defiApps', true)
     this.emitUpdate()

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -1067,7 +1067,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       lastUpdate: number
       hasHints: boolean
     } | null
-    defiMaxDataAgeMs?: number
+    defiMaxDataAgeMs: number
     isManualUpdate?: boolean
   }): Promise<FormattedPortfolioDiscoveryResponse | null> {
     const discoveryStart = Date.now()
@@ -1078,9 +1078,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       chainId,
       account,
       baseCurrency,
-      // Set to 6 hours by default. That is because we are making a lot of
-      // portfolio updates, most of which shouldn't update the defi positions.
-      defiMaxDataAgeMs = 6 * 60 * 60 * 1000,
+      defiMaxDataAgeMs,
       hasKeys,
       externalApiHintsResponse,
       isManualUpdate
@@ -1088,10 +1086,11 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
     const defiState = this.#state[account.addr]?.[chainId.toString()]?.result?.defiPositions
     const canSkipExternalApiHintsUpdate =
-      !!externalApiHintsResponse &&
-      !isManualUpdate &&
-      Date.now() - externalApiHintsResponse.lastUpdate <
-        EXTERNAL_API_HINTS_TTL[!externalApiHintsResponse.hasHints ? 'static' : 'dynamic']
+      chainId === 'customAppChain' ||
+      (!!externalApiHintsResponse &&
+        !isManualUpdate &&
+        Date.now() - externalApiHintsResponse.lastUpdate <
+          EXTERNAL_API_HINTS_TTL[!externalApiHintsResponse.hasHints ? 'static' : 'dynamic'])
 
     const hasNonceChangedSinceLastUpdate = getHasNonceChangedSinceLastUpdate(
       defiState,
@@ -1171,7 +1170,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       }
 
     // Update the price cache so the lib can use the latest prices from velcro
-    if (response.prices) {
+    if (response.prices && chainId !== 'customAppChain') {
       const networkTokenDataCache: TokenDataCache =
         this.tokenDataCache[chainId.toString()] || new Map<string, [number, TokenDataCacheValue]>()
 
@@ -1215,13 +1214,13 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     network: Network,
     portfolioLib: Portfolio | null,
     portfolioProps: Partial<GetOptions> & {
+      defiMaxDataAgeMs: number
       hasKeys: boolean
       maxDataAgeMs?: number
-      defiMaxDataAgeMs?: number
       isManualUpdate?: boolean
     }
   ): Promise<[boolean, FormattedPortfolioDiscoveryResponse | null]> {
-    const { maxDataAgeMs, isManualUpdate } = portfolioProps
+    const { maxDataAgeMs, isManualUpdate, defiMaxDataAgeMs } = portfolioProps
     const accountState = this.#state[account.addr]
 
     // Can occur if the account is removed while updateSelectedAccount is in progress
@@ -1266,7 +1265,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         baseCurrency: 'usd',
         externalApiHintsResponse: hintsResponse || null,
         isManualUpdate,
-        defiMaxDataAgeMs: portfolioProps?.defiMaxDataAgeMs,
+        defiMaxDataAgeMs,
         hasKeys: portfolioProps.hasKeys
       })
       const allHints = this.getAllHints(
@@ -1402,9 +1401,9 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
   protected async updateDefiAppsState(
     account: Account,
     portfolioProps: Partial<GetOptions> & {
+      defiMaxDataAgeMs: number
       hasKeys: boolean
       maxDataAgeMs?: number
-      defiMaxDataAgeMs?: number
       isManualUpdate?: boolean
     }
   ) {
@@ -1428,7 +1427,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         account,
         baseCurrency: 'usd',
         externalApiHintsResponse: null,
-        defiMaxDataAgeMs: portfolioProps?.defiMaxDataAgeMs,
+        defiMaxDataAgeMs: portfolioProps.defiMaxDataAgeMs,
         hasKeys: portfolioProps.hasKeys
       })
 
@@ -1661,6 +1660,9 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     const {
       maxDataAgeMs: paramsMaxDataAgeMs = 0,
       maxDataAgeMsUnused: paramsMaxDataAgeMsUnused,
+      // Set to 6 hours by default. That is because we are making a lot of
+      // portfolio updates, most of which shouldn't update the defi positions.
+      defiMaxDataAgeMs = 6 * 60 * 60 * 1000,
       isManualUpdate
     } = opts || {}
     await this.initialLoadPromise
@@ -1723,6 +1725,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
               maxDataAgeMs,
               isManualUpdate,
               blockTag: 'both',
+              defiMaxDataAgeMs,
               ...(accountOpsToSimulate &&
                 accountOpsToSimulate.length &&
                 baseAcc &&
@@ -1803,7 +1806,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       }),
       this.updateDefiAppsState(selectedAccount, {
         maxDataAgeMs: paramsMaxDataAgeMs,
-        defiMaxDataAgeMs: paramsMaxDataAgeMs,
+        defiMaxDataAgeMs: defiMaxDataAgeMs,
         isManualUpdate,
         hasKeys: this.#keystore.getAccountKeys(selectedAccount).length > 0
       })

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -131,6 +131,8 @@ const EXTERNAL_API_HINTS_TTL = {
  * before being added as custom.
  * - To be learned tokens - tokens added from sources like swapAndBridge, activity, the humanizer. Some of them
  * may be owned by the user in the near future (e.g. the user swapped a token and will receive it soon).
+ * - App defi positions - defi positions that are not linked to a specific network and have a slightly different structure (no addresses for assets). They are
+ * fetched separately, but batched together with all other calls to the external API. (e.g, Polymarket and Hyperliquid positions)
  *
  * Hints sources:
  * - Velcro, existing defi positions, learned assets, toBeLearnedAssets, custom tokens
@@ -1057,7 +1059,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
    * to Velcro but passes a flag to signal to the server that it can returned cached defi data.
    */
   private async getPortfolioFromApiDiscovery(opts: {
-    chainId: bigint
+    chainId: bigint | 'customAppChain'
     account: Account
     hasKeys: boolean
     baseCurrency: string
@@ -1387,6 +1389,69 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       this.emitUpdate()
 
       return [false, null]
+    }
+  }
+
+  /**
+   * Most defi positions are fetched from the external API per network, but there are some
+   * "app" defi positions that have to be fetched separately, because they are not linked to a specific
+   * network and have a slightly different structure (no addresses for assets).
+   *
+   * @example - Fetches Polymarket and Hyperliquid positions (among other)
+   */
+  protected async updateDefiAppsState(
+    account: Account,
+    portfolioProps: Partial<GetOptions> & {
+      hasKeys: boolean
+      maxDataAgeMs?: number
+      defiMaxDataAgeMs?: number
+      isManualUpdate?: boolean
+    }
+  ) {
+    const updateStarted = Date.now()
+    const accountState = this.#state[account.addr] ?? (this.#state[account.addr] = {})
+
+    this.#setNetworkLoading(account.addr, 'defiApps', true)
+    this.emitUpdate()
+
+    try {
+      const response = await this.getPortfolioFromApiDiscovery({
+        chainId: 'customAppChain',
+        account,
+        baseCurrency: 'usd',
+        externalApiHintsResponse: null,
+        defiMaxDataAgeMs: portfolioProps?.defiMaxDataAgeMs,
+        hasKeys: portfolioProps.hasKeys
+      })
+
+      if (response && response.data?.defi) {
+        accountState.defiApps = {
+          isReady: true,
+          isLoading: false,
+          errors: response.errors,
+          result: {
+            defiPositions: {
+              positionsByProvider: response.data.defi.positions
+            },
+            updateStarted,
+            tokens: [],
+            total: getTotal([], {
+              positionsByProvider: response.data.defi.positions
+            })
+          },
+          lastSuccessfulUpdate: Date.now()
+        }
+      }
+
+      this.#setNetworkLoading(account.addr, 'defiApps', false)
+    } catch (e: any) {
+      this.emitError({
+        level: 'silent',
+        message: `Error while fetching DeFi apps data from Velcro for account ${account.addr}.`,
+        error: e
+      })
+
+      this.#setNetworkLoading(account.addr, 'defiApps', false, e)
     }
   }
 
@@ -1727,6 +1792,12 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
         // Ensure the method waits for the entire queue to resolve
         await this.#queue[accountId][network.chainId.toString()]
+      }),
+      this.updateDefiAppsState(selectedAccount, {
+        maxDataAgeMs: paramsMaxDataAgeMs,
+        defiMaxDataAgeMs: paramsMaxDataAgeMs,
+        isManualUpdate,
+        hasKeys: this.#keystore.getAccountKeys(selectedAccount).length > 0
       })
     ])
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -278,15 +278,22 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       (queue) => {
         const baseCurrencies = [...new Set(queue.map((x) => x.data.baseCurrency))]
         const accountAddrs = [...new Set(queue.map((x) => x.data.accountAddr))]
+
         const pairs = baseCurrencies
           .map((baseCurrency) =>
-            accountAddrs.map((accountAddr, index) => ({
+            accountAddrs.map((accountAddr) => ({
               baseCurrency,
               accountAddr,
-              forceUpdateDefi: queue[index]?.data.forceUpdateDefi
+              forceUpdateDefi: queue.some(
+                (x) =>
+                  x.data.baseCurrency === baseCurrency &&
+                  x.data.accountAddr === accountAddr &&
+                  x.data.forceUpdateDefi
+              )
             }))
           )
           .flat()
+
         return pairs.map(({ baseCurrency, accountAddr, forceUpdateDefi }) => {
           const queueSegment = queue.filter(
             (x) => x.data.baseCurrency === baseCurrency && x.data.accountAddr === accountAddr
@@ -1059,7 +1066,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
    * to Velcro but passes a flag to signal to the server that it can returned cached defi data.
    */
   private async getPortfolioFromApiDiscovery(opts: {
-    chainId: bigint | 'customAppChain'
+    chainId: bigint
     account: Account
     hasKeys: boolean
     baseCurrency: string
@@ -1086,11 +1093,10 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
     const defiState = this.#state[account.addr]?.[chainId.toString()]?.result?.defiPositions
     const canSkipExternalApiHintsUpdate =
-      chainId === 'customAppChain' ||
-      (!!externalApiHintsResponse &&
-        !isManualUpdate &&
-        Date.now() - externalApiHintsResponse.lastUpdate <
-          EXTERNAL_API_HINTS_TTL[!externalApiHintsResponse.hasHints ? 'static' : 'dynamic'])
+      !!externalApiHintsResponse &&
+      !isManualUpdate &&
+      Date.now() - externalApiHintsResponse.lastUpdate <
+        EXTERNAL_API_HINTS_TTL[!externalApiHintsResponse.hasHints ? 'static' : 'dynamic']
 
     const hasNonceChangedSinceLastUpdate = getHasNonceChangedSinceLastUpdate(
       defiState,
@@ -1170,7 +1176,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       }
 
     // Update the price cache so the lib can use the latest prices from velcro
-    if (response.prices && chainId !== 'customAppChain') {
+    if (response.prices) {
       const networkTokenDataCache: TokenDataCache =
         this.tokenDataCache[chainId.toString()] || new Map<string, [number, TokenDataCacheValue]>()
 
@@ -1407,11 +1413,14 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       isManualUpdate?: boolean
     }
   ) {
+    if (!this.#featureFlags.isFeatureEnabled('tokenAndDefiAutoDiscovery')) return
+
+    const defiMaxDataAgeMs = portfolioProps.isManualUpdate ? 0 : portfolioProps.defiMaxDataAgeMs
     const accountState = this.#state[account.addr] ?? (this.#state[account.addr] = {})
 
     const canSkipUpdate = PortfolioController.#getCanSkipUpdate(
       accountState['defiApps'],
-      portfolioProps.defiMaxDataAgeMs
+      defiMaxDataAgeMs
     )
 
     if (canSkipUpdate) return
@@ -1422,32 +1431,40 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     this.emitUpdate()
 
     try {
-      const response = await this.getPortfolioFromApiDiscovery({
+      const response: ExternalPortfolioDiscoveryResponse = await this.batchedPortfolioDiscovery({
         chainId: 'customAppChain',
-        account,
-        baseCurrency: 'usd',
-        externalApiHintsResponse: null,
-        defiMaxDataAgeMs: portfolioProps.defiMaxDataAgeMs,
-        hasKeys: portfolioProps.hasKeys
+        accountAddr: account.addr,
+        baseCurrency: 'usd'
       })
 
-      if (response && response.data?.defi) {
-        accountState.defiApps = {
-          isReady: true,
-          isLoading: false,
-          errors: response.errors,
-          result: {
-            defiPositions: {
-              positionsByProvider: response.data.defi.positions
-            },
-            updateStarted,
-            tokens: [],
-            total: getTotal([], {
-              positionsByProvider: response.data.defi.positions
-            })
+      const defi = response.defi
+      // Throw the error after assigning the response so we can still use the returned hints
+      if ((response && 'errorState' in defi) || !('positions' in defi) || !defi.positions)
+        throw new Error(
+          `Defi discovery failed. Error: ${
+            'errorState' in defi
+              ? defi.errorState[0]?.message || 'Unknown error (2)'
+              : 'Unknown error'
+          }`
+        )
+      const positionsByProvider = getFormattedApiPositions(defi.positions)
+
+      accountState.defiApps = {
+        isReady: true,
+        isLoading: false,
+        errors: [],
+        result: {
+          defiPositions: {
+            positionsByProvider,
+            lastSuccessfulUpdate: Date.now()
           },
-          lastSuccessfulUpdate: Date.now()
-        }
+          updateStarted,
+          tokens: [],
+          total: getTotal([], {
+            positionsByProvider
+          })
+        },
+        lastSuccessfulUpdate: Date.now()
       }
 
       this.#setNetworkLoading(account.addr, 'defiApps', false)

--- a/src/libs/defiPositions/defiPositions.ts
+++ b/src/libs/defiPositions/defiPositions.ts
@@ -1,4 +1,4 @@
-import { getAddress, ZeroAddress } from 'ethers'
+import { formatUnits, getAddress, parseUnits, ZeroAddress } from 'ethers'
 import { isHex } from 'viem'
 
 import { AccountId } from '../../interfaces/account'
@@ -26,6 +26,7 @@ import {
   NetworksWithPositions,
   NetworksWithPositionsByAccounts,
   Position,
+  PositionAsset,
   PositionsByProvider,
   ProviderError
 } from './types'
@@ -258,33 +259,53 @@ const getFormattedApiPositions = (result: Omit<PositionsByProvider, 'source'>[])
   return result.map((p) => ({
     ...p,
     source: 'debank' as const,
-    chainId: BigInt(p.chainId),
+    chainId: !p.chainId ? undefined : BigInt(p.chainId),
     positions: p.positions
       .map((pos) => {
         try {
+          const isCustomAppChain = !p.chainId
           if (pos.additionalData.name === 'Deposit') {
             // eslint-disable-next-line no-param-reassign
             pos.additionalData.name = 'Deposit pool'
-            // eslint-disable-next-line no-param-reassign
-            pos.additionalData.positionIndex = shortenAddress(pos.additionalData.pool.id, 11)
+
+            if (pos.additionalData.pool?.id) {
+              // eslint-disable-next-line no-param-reassign
+              pos.additionalData.positionIndex = shortenAddress(pos.additionalData.pool.id, 11)
+            }
           }
 
           return {
             ...pos,
-            assets: pos.assets.map((asset) => ({
-              ...asset,
-              // Debank returns zero addresses like `0x00` as `ethereum/base` which breaks our logic
-              address: isHex(asset.address) ? getAddress(asset.address) : ZeroAddress,
-              amount: BigInt(asset.amount),
-              protocolAsset: asset.protocolAsset
-                ? {
-                    ...asset.protocolAsset,
-                    address: isHex(asset.protocolAsset.address)
-                      ? getAddress(asset.protocolAsset.address)
-                      : ZeroAddress
-                  }
-                : undefined
-            }))
+            assets: pos.assets.map(
+              (
+                asset: PositionAsset & {
+                  logo_url?: string
+                }
+              ) => {
+                let amount = asset.amount
+
+                if (isCustomAppChain) {
+                  // Amount should be formatted with decimals and turned to bigint after that
+                  amount = parseUnits(String(amount), asset.decimals)
+                }
+
+                return {
+                  ...asset,
+                  iconUrl: asset.iconUrl || asset.logo_url || undefined,
+                  // Debank returns zero addresses like `0x00` as `ethereum/base` which breaks our logic
+                  address: isHex(asset.address) ? getAddress(asset.address) : ZeroAddress,
+                  amount: BigInt(amount),
+                  protocolAsset: asset.protocolAsset
+                    ? {
+                        ...asset.protocolAsset,
+                        address: isHex(asset.protocolAsset.address)
+                          ? getAddress(asset.protocolAsset.address)
+                          : ZeroAddress
+                      }
+                    : undefined
+                }
+              }
+            )
           }
         } catch (error) {
           console.error('DeFi error when mapping positions: ', error, 'position', pos)
@@ -324,6 +345,10 @@ const enhancePortfolioTokensWithDefiPositions = (
     const notYetHandledTokensToAdd: TokenResult[] = []
 
     defiPositionsState.positionsByProvider.forEach((posByProvider) => {
+      // Skip app providers
+      const posChainId = posByProvider.chainId
+      if (!posChainId) return
+
       posByProvider.positions.forEach((pos) => {
         try {
           const controllerAddress = pos.additionalData?.pool?.controller as string | undefined
@@ -412,7 +437,7 @@ const enhancePortfolioTokensWithDefiPositions = (
                 address: protocolAsset.address,
                 symbol: protocolAsset.symbol,
                 name: protocolAsset.name,
-                chainId: BigInt(posByProvider.chainId),
+                chainId: BigInt(posChainId),
                 flags: {
                   canTopUpGasTank: false,
                   isFeeToken: false,

--- a/src/libs/defiPositions/defiPositions.ts
+++ b/src/libs/defiPositions/defiPositions.ts
@@ -287,13 +287,15 @@ const getFormattedApiPositions = (result: Omit<PositionsByProvider, 'source'>[])
                 if (isCustomAppChain) {
                   // Amount should be formatted with decimals and turned to bigint after that
                   amount = parseUnits(String(amount), asset.decimals)
+                  // In else because app assets don't have addresses and we don't want to set them as zero addresses
+                } else {
+                  // Debank returns zero addresses like `0x00` as `ethereum/base` which breaks our logic
+                  asset.address = isHex(asset.address) ? getAddress(asset.address) : ZeroAddress
                 }
 
                 return {
                   ...asset,
                   iconUrl: asset.iconUrl || asset.logo_url || undefined,
-                  // Debank returns zero addresses like `0x00` as `ethereum/base` which breaks our logic
-                  address: isHex(asset.address) ? getAddress(asset.address) : ZeroAddress,
                   amount: BigInt(amount),
                   protocolAsset: asset.protocolAsset
                     ? {

--- a/src/libs/defiPositions/defiPrices.ts
+++ b/src/libs/defiPositions/defiPrices.ts
@@ -28,6 +28,7 @@ export async function updatePositionsByProviderAssetPrices(
   positionsByProvider.forEach((providerPos) => {
     providerPos.positions.forEach((p) => {
       p.assets.forEach((a) => {
+        if (!a.address) return
         addresses.push(a.address)
       })
     })
@@ -52,6 +53,7 @@ export async function updatePositionsByProviderAssetPrices(
       let positionInUSD = position.additionalData.positionInUSD || 0
 
       const updatedAssets = position.assets.map((asset) => {
+        if (!asset.address) return asset
         const priceData = body[asset.address.toLowerCase()]
         if (!priceData) return asset
 

--- a/src/libs/defiPositions/providers/aaveV3.ts
+++ b/src/libs/defiPositions/providers/aaveV3.ts
@@ -46,12 +46,9 @@ export async function getAAVEPositions(
     accountData.healthFactor = null
   }
 
-  const uuid = generateUuid()
-
   const position: Position = {
-    id: uuid,
+    id: generateUuid(),
     additionalData: {
-      positionIndex: uuid,
       healthRate: accountData.healthFactor ? Number(accountData.healthFactor) / 1e18 : null,
       positionInUSD: 0,
       deptInUSD: 0,

--- a/src/libs/defiPositions/providers/aaveV3.ts
+++ b/src/libs/defiPositions/providers/aaveV3.ts
@@ -46,9 +46,12 @@ export async function getAAVEPositions(
     accountData.healthFactor = null
   }
 
-  const position = {
-    id: generateUuid(),
+  const uuid = generateUuid()
+
+  const position: Position = {
+    id: uuid,
     additionalData: {
+      positionIndex: uuid,
       healthRate: accountData.healthFactor ? Number(accountData.healthFactor) / 1e18 : null,
       positionInUSD: 0,
       deptInUSD: 0,
@@ -57,7 +60,7 @@ export async function getAAVEPositions(
       name: 'Lending'
     },
     assets: []
-  } as Position
+  }
 
   position.assets = userAssets
     .map((asset: any) => {
@@ -67,10 +70,12 @@ export async function getAAVEPositions(
       const stableBorrow =
         (Number(asset.stableBorrowAssetBalance) / 10 ** Number(asset.decimals)) * -1
 
-      position.additionalData.positionInUSD += (balance + borrow + stableBorrow) * price
-      position.additionalData.deptInUSD += borrow * price
-      position.additionalData.deptInUSD += stableBorrow * price
-      position.additionalData.collateralInUSD += balance * price
+      position.additionalData.positionInUSD =
+        (position.additionalData.positionInUSD || 0) + (balance + borrow + stableBorrow) * price
+      position.additionalData.debtInUSD =
+        (position.additionalData.debtInUSD || 0) + (borrow + stableBorrow) * price
+      position.additionalData.collateralInUSD =
+        (position.additionalData.collateralInUSD || 0) + balance * price
 
       const assetsResult = []
 

--- a/src/libs/defiPositions/providers/stkWallet.ts
+++ b/src/libs/defiPositions/providers/stkWallet.ts
@@ -18,8 +18,7 @@ export function getStakedWalletPositions(
       id: 'stk-wallet',
       additionalData: {
         name: 'Staked',
-        positionInUSD,
-        positionIndex: '1'
+        positionInUSD
       },
       assets: [
         {

--- a/src/libs/defiPositions/providers/stkWallet.ts
+++ b/src/libs/defiPositions/providers/stkWallet.ts
@@ -18,7 +18,8 @@ export function getStakedWalletPositions(
       id: 'stk-wallet',
       additionalData: {
         name: 'Staked',
-        positionInUSD
+        positionInUSD,
+        positionIndex: '1'
       },
       assets: [
         {

--- a/src/libs/defiPositions/providers/uniV3.ts
+++ b/src/libs/defiPositions/providers/uniV3.ts
@@ -152,10 +152,14 @@ export async function getDebankEnhancedUniV3Positions(
   const positionsMap = new Map<string, Position>()
 
   uniPosition.positions.forEach((customPos) => {
+    if (!customPos.additionalData.positionIndex) return
+
     positionsMap.set(customPos.additionalData.positionIndex, customPos)
   })
 
   uniPositionFromDebank.positions.forEach((debankPos) => {
+    if (!debankPos.additionalData.positionIndex) return
+
     const existingPos = positionsMap.get(debankPos.additionalData.positionIndex)
 
     if (existingPos) {

--- a/src/libs/defiPositions/types.ts
+++ b/src/libs/defiPositions/types.ts
@@ -125,7 +125,7 @@ export interface Position {
   id: string
   assets: PositionAsset[]
   additionalData: {
-    positionIndex: string
+    positionIndex?: string
     name?: string
     APY?: number
     positionInUSD?: number

--- a/src/libs/defiPositions/types.ts
+++ b/src/libs/defiPositions/types.ts
@@ -125,11 +125,13 @@ export interface Position {
   id: string
   assets: PositionAsset[]
   additionalData: {
+    positionIndex: string
     name?: string
     APY?: number
-    positionIndex?: string
     positionInUSD?: number
     collateralInUSD?: number
+    debtInUSD?: number
+    healthRate?: number | null
     description?: string
     [key: string]: any
   }

--- a/src/libs/defiPositions/types.ts
+++ b/src/libs/defiPositions/types.ts
@@ -18,7 +18,10 @@ export enum DeFiPositionsError {
 export type ProviderName = 'AAVE v3' | 'Uniswap V3' | 'Ambire' | string
 
 export interface PositionAsset {
-  address: string
+  /**
+   * Undefined for assets of App positions (polymarket, hyperliquid, etc.) since they don't have an on-chain representation.
+   */
+  address?: string
   symbol: string
   name: string
   decimals: number
@@ -92,7 +95,10 @@ export type NetworksWithPositionsByAccounts = {
 
 export type PositionsByProvider = {
   providerName: ProviderName
-  chainId: bigint
+  /**
+   * Undefined for App positions (polymarket, hyperliquid, etc.) since they don't have an on-chain representation.
+   */
+  chainId?: bigint
   iconUrl: string
   siteUrl: string
   source: 'debank' | 'custom' | 'mixed'
@@ -119,6 +125,12 @@ export interface Position {
   id: string
   assets: PositionAsset[]
   additionalData: {
+    name?: string
+    APY?: number
+    positionIndex?: string
+    positionInUSD?: number
+    collateralInUSD?: number
+    description?: string
     [key: string]: any
   }
 }

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -622,6 +622,11 @@ export const formatExternalHintsAPIResponse = (
 
   const { erc20s, erc721s, lastUpdate, hasHints } = response
 
+  // For customAppChain
+  if (!erc20s || !erc721s) {
+    return null
+  }
+
   const formattedErc721s: Hints['erc721s'] = {}
 
   Object.entries(erc721s).forEach(([collectionAddress, value]) => {

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -202,7 +202,7 @@ export type ExternalHintsAPIResponse = {
  */
 export type ExternalPortfolioDiscoveryResponse = {
   networkId: string
-  chainId: number
+  chainId: number | 'customAppChain'
   accountAddr: string
   erc20s: ExternalHintsAPIResponse['erc20s']
   erc721s: ExternalHintsAPIResponse['erc721s']
@@ -406,11 +406,18 @@ export type ProjectedRewardsStats = {
   | 'reasonToNotDisplayProjectedRewards'
 >
 
+export type PortfolioDefiAppsResult = CommonResultProps & {
+  defiPositions: DefiNetworkState
+}
+
+export type InternalPortfolioChain = 'defiApps' | 'gasTank' | 'rewards' | 'projectedRewards'
+
 export type PortfolioKeyResult =
   | PortfolioRewardsResult
   | PortfolioGasTankResult
   | PortfolioProjectedRewardsResult
   | PortfolioNetworkResult
+  | PortfolioDefiAppsResult
 
 export type NetworkState<T = PortfolioKeyResult> = {
   isReady: boolean
@@ -429,6 +436,11 @@ export type AccountState = {
   rewards?: NetworkState<PortfolioRewardsResult>
   gasTank?: NetworkState<PortfolioGasTankResult>
   projectedRewards?: NetworkState<PortfolioProjectedRewardsResult>
+  /**
+   * Stores "app" defi positions that are not linked to a specific network and have a slightly different structure (no addresses for assets).
+   * Examples: Polymarket and Hyperliquid positions.
+   */
+  defiApps?: NetworkState<PortfolioDefiAppsResult>
 } & {
   [chainId: string]: NetworkState<PortfolioNetworkResult> | undefined
 }

--- a/src/libs/selectedAccount/portfolioView.ts
+++ b/src/libs/selectedAccount/portfolioView.ts
@@ -7,6 +7,7 @@ import { PositionsByProvider } from '../defiPositions/types'
 import { CollectionResult, TokenResult } from '../portfolio'
 import {
   NetworkState,
+  PortfolioDefiAppsResult,
   PortfolioGasTankResult,
   PortfolioNetworkResult,
   PortfolioRewardsResult
@@ -115,6 +116,7 @@ export default class PortfolioViewBuilder {
       | PortfolioGasTankResult
       | PortfolioRewardsResult
       | PortfolioNetworkResult
+      | PortfolioDefiAppsResult
     const loadingFromScratch = PortfolioViewBuilder.isLoadingFromScratch(
       networkData,
       isManualUpdate

--- a/src/libs/selectedAccount/portfolioView.ts
+++ b/src/libs/selectedAccount/portfolioView.ts
@@ -6,6 +6,7 @@ import { AccountOp } from '../accountOp/accountOp'
 import { PositionsByProvider } from '../defiPositions/types'
 import { CollectionResult, TokenResult } from '../portfolio'
 import {
+  InternalPortfolioChain,
   NetworkState,
   PortfolioDefiAppsResult,
   PortfolioGasTankResult,
@@ -96,14 +97,14 @@ export default class PortfolioViewBuilder {
    * Add a network's data to the portfolio view
    */
   addNetworkData(
-    chainId: string,
+    chainId: InternalPortfolioChain | string,
     networkData: NetworkState | undefined,
     isManualUpdate: boolean
   ): void {
     if (chainId === 'projectedRewards') {
       return
     }
-    if (chainId !== 'gasTank' && chainId !== 'rewards') {
+    if (chainId !== 'gasTank' && chainId !== 'rewards' && chainId !== 'defiApps') {
       this.isNonInternalNetworkAdded = true
     }
 

--- a/src/libs/selectedAccount/selectedAccount.ts
+++ b/src/libs/selectedAccount/selectedAccount.ts
@@ -2,11 +2,16 @@ import {
   SelectedAccountPortfolio,
   SelectedAccountPortfolioState
 } from '../../interfaces/selectedAccount'
-import { AccountState, NetworkState } from '../portfolio/interfaces'
+import { AccountState, InternalPortfolioChain, NetworkState } from '../portfolio/interfaces'
 import PortfolioViewBuilder from './portfolioView'
 
-export const isInternalChain = (chainId: string) => {
-  return chainId === 'gasTank' || chainId === 'rewards' || chainId === 'projectedRewards'
+export const isInternalChain = (chainId: InternalPortfolioChain | string) => {
+  return (
+    chainId === 'gasTank' ||
+    chainId === 'rewards' ||
+    chainId === 'projectedRewards' ||
+    chainId === 'defiApps'
+  )
 }
 
 export const stripPortfolioState = (portfolioState: AccountState) => {


### PR DESCRIPTION
Adds defi "Apps" support (e.g., Polymarket and Hyperliquid)

## Changes:
- Adds a new key to the portfolio state - `defiApps`
- Adds `updateDefiAppsState` that fetches the apps from a custom chain using velcro's portfolio discovery route - `customAppChain` 
- Adjusts types and the selectedAccount implementation
- Fixes a bug in the batcher - if only one of the requests has forceUpdateDefi=true and it's not the first request, then the update param is not added to the url
- Adds new tests for this logic and the batcher