### PR TITLE
Update/ Filter out aave assets with symbol/name=`error`

### DIFF
--- a/src/libs/defiPositions/providers/aaveV3.ts
+++ b/src/libs/defiPositions/providers/aaveV3.ts
@@ -40,7 +40,12 @@ export async function getAAVEPositions(
       aaveAddress: rest.aaveAddr,
       ...rest
     }))
-    .filter((t: any) => t.balance > 0 || t.borrowAssetBalance > 0 || t.stableBorrowAssetBalance > 0)
+    .filter(
+      (t: any) =>
+        t.symbol !== 'error' &&
+        t.name !== 'error' &&
+        (t.balance > 0 || t.borrowAssetBalance > 0 || t.stableBorrowAssetBalance > 0)
+    )
 
   if (accountData.healthFactor === AAVE_NO_HEALTH_FACTOR_MAGIC_NUMBER) {
     accountData.healthFactor = null


### PR DESCRIPTION
The error is coming from deployless and we agreed with Emo to remove them (which works nicely, because when the position doesn't come from deployless we get it from the API)

## Before:
<img width="958" height="1199" alt="image" src="https://github.com/user-attachments/assets/cd785415-2f6c-4522-99d9-fdf7ec51a572" />

## After:
<img width="477" height="603" alt="image" src="https://github.com/user-attachments/assets/09347f44-02c5-48e1-a4e5-40e54de17ad9" />
