### PR TITLE
Config / Migrate ESLint TypeScript parser to projectService API (part 1)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ module.exports = [
     languageOptions: {
       parser: typescriptParser,
       parserOptions: {
-        project: './tsconfig.json',
+        projectService: { defaultProject: './tsconfig.json' },
         ecmaFeatures: {
           jsx: true
         },


### PR DESCRIPTION
Migrates from the legacy project option to the modern projectService API in @typescript-eslint/parser.

**Changes:**
Replaces project: './tsconfig.json' with projectService: { defaultProject: './tsconfig.json' }

**Why:**
The project option is deprecated in @typescript-eslint v8
projectService uses a shared TypeScript language service for better performance and memory efficiency
Improves cross-file type resolution accuracy

**Reference:**
https://typescript-eslint.io/getting-started/typed-linting