### PR TITLE
Portfolio: stricter limits on simulations

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -2192,6 +2192,31 @@ describe('Portfolio Controller ', () => {
 
     // @ts-ignore
     expect(controller.tokenDataCache['137']).toBe(undefined)
+
+    jest
+      // @ts-ignore
+      .spyOn(controller, 'batchedPortfolioDiscovery')
+      // @ts-ignore
+      .mockResolvedValueOnce({
+        networkId: 'polygon',
+        chainId: 137,
+        accountAddr: account.addr,
+        erc20s: [ZeroAddress],
+        erc721s: {},
+        prices: {
+          [ZeroAddress]: {
+            baseCurrency: 'usd',
+            price: 1
+          }
+        },
+        hasHints: true,
+        defi: {
+          updatedAt: Date.now(),
+          positions: []
+        },
+        otherNetworksDefiCounts: {}
+      })
+
     // @ts-ignore
     await controller.getPortfolioFromApiDiscovery({
       chainId: 137n,

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -440,6 +440,11 @@ export type PortfolioControllerState = {
 
 export interface LimitsOptions {
   erc20: number
+  // describe the limit during simulation only;
+  // simulation is computational heavy and it costs a lot of gas;
+  // putting a stricter limit allows more txns to succeed albeit having
+  // to send more requests
+  erc20Simulation: number
   erc721: number
   erc721TokensInput: number
   erc721Tokens: number

--- a/src/libs/portfolio/portfolio.test.ts
+++ b/src/libs/portfolio/portfolio.test.ts
@@ -216,7 +216,8 @@ describe('Portfolio', () => {
         await providerArbitrum.getTransactionCount('0xf2d83373bE7dE6dEB14745F6512Df1306b6175EA')
       ),
       signature: spoofSig,
-      calls: [{ to: '0xA245fe89Af4573Bc53f4BeA5Ae4c38db431d9123', value: BigInt(0), data }]
+      calls: [{ to: '0xA245fe89Af4573Bc53f4BeA5Ae4c38db431d9123', value: BigInt(0), data }],
+      id: 'test-id'
     }
     const account = {
       addr: '0xf2d83373bE7dE6dEB14745F6512Df1306b6175EA',

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -76,10 +76,17 @@ export const STATIC_BLACKLIST: Omit<TokenBlacklist, 'updatedAt'> = {
 export const LIMITS: Limits = {
   // we have to be conservative with erc721Tokens because if we pass 30x20 (worst case) tokenIds, that's 30x20 extra words which is 19kb
   // proxy mode input is limited to 24kb
-  deploylessProxyMode: { erc20: 66, erc721: 30, erc721TokensInput: 20, erc721Tokens: 50 },
+  deploylessProxyMode: {
+    erc20: 66,
+    erc20Simulation: 50,
+    erc721: 30,
+    erc721TokensInput: 20,
+    erc721Tokens: 50
+  },
   // theoretical capacity is 1666/450
   deploylessStateOverrideMode: {
     erc20: 230,
+    erc20Simulation: 50,
     erc721: 70,
     erc721TokensInput: 70,
     erc721Tokens: 70
@@ -327,15 +334,16 @@ export class Portfolio {
     const collectionsHints = Object.entries(hints.erc721s)
     const [tokensWithErr, collectionsWithErr] = await Promise.all([
       flattenResults(
-        paginate(hints.erc20s, limits.erc20).map((page, index) =>
-          getTokens(
-            this.network,
-            this.deploylessTokens,
-            { simulation, blockTag, specialErc20Hints },
-            accountAddr,
-            page,
-            index
-          )
+        paginate(hints.erc20s, opts.simulation ? limits.erc20Simulation : limits.erc20).map(
+          (page, index) =>
+            getTokens(
+              this.network,
+              this.deploylessTokens,
+              { simulation, blockTag, specialErc20Hints },
+              accountAddr,
+              page,
+              index
+            )
         )
       ),
       flattenResults(


### PR DESCRIPTION
Put stricter limits when simulating transactions as they revert with out of gas if the simulated transaction is computational heavy.

One example for this is staking / unstaking on https://app.infinifi.xyz/ . The simulation reverted on our end with out of gas:

<img width="720" height="719" alt="Screenshot 2026-04-27 at 15 52 09" src="https://github.com/user-attachments/assets/ccbc7575-113a-4943-a96d-d6f205d68eba" />
<img width="585" height="147" alt="Screenshot 2026-04-27 at 15 52 23" src="https://github.com/user-attachments/assets/ecd364a6-7cc1-471c-8ef3-535b2837217e" />

This is really because we're hitting the RPC gas limit. To avoid that, we put stricter limits when simulating transactions. By doing so, the simulation passes:

<img width="750" height="745" alt="Screenshot 2026-04-27 at 15 53 07" src="https://github.com/user-attachments/assets/69aecad9-fbeb-4124-bdeb-d381aa8e896d" />



