### PR TITLE
fix / infinite loop in the transfer ctrl

### DIFF
--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -493,6 +493,23 @@ export class TransferController extends EventEmitter implements ITransferControl
     this.emitUpdate()
   }
 
+  #fetchRecipientAccountStateIfNeeded() {
+    if (!this.isInitialized) return
+
+    const recipientAcc = this.#accounts.accounts.find((a) => a.addr === this.recipientAddress)
+    if (recipientAcc && this.selectedToken?.chainId) {
+      const state =
+        this.#accounts.accountStates[recipientAcc.addr]?.[this.selectedToken.chainId.toString()]
+      if (!state) {
+        this.#accounts
+          .getOrFetchAccountOnChainState(recipientAcc.addr, this.selectedToken.chainId)
+          .catch((e) => {
+            console.log('Failed to get the account on chain state:', e)
+          })
+      }
+    }
+  }
+
   get validationFormMsgs() {
     if (!this.isInitialized) return DEFAULT_VALIDATION_FORM_MSGS
 
@@ -504,17 +521,6 @@ export class TransferController extends EventEmitter implements ITransferControl
       // so that we could validate the account properly
       // example: Safe accounts may not be deployed on certain networks
       const recipientAcc = this.#accounts.accounts.find((a) => a.addr === this.recipientAddress)
-      if (recipientAcc && this.selectedToken?.chainId) {
-        const state =
-          this.#accounts.accountStates[recipientAcc.addr]?.[this.selectedToken.chainId.toString()]
-        if (!state) {
-          this.#accounts
-            .getOrFetchAccountOnChainState(recipientAcc.addr, this.selectedToken.chainId)
-            .catch((e) => {
-              console.log('Failed to get the account on chain state:', e)
-            })
-        }
-      }
 
       validationFormMsgsNew.recipientAddress = validateSendTransferAddress(
         this.recipientAddress,
@@ -595,6 +601,7 @@ export class TransferController extends EventEmitter implements ITransferControl
       }
 
       this.selectedToken = selectedToken
+      this.#fetchRecipientAccountStateIfNeeded()
     }
     // If we do a regular check the value won't update if it's '' or '0'
     if (typeof amount === 'string') {
@@ -696,6 +703,7 @@ export class TransferController extends EventEmitter implements ITransferControl
 
     this.checkIsRecipientAddressViewOnly()
     this.checkIsRecipientAddressUnknown()
+    this.#fetchRecipientAccountStateIfNeeded()
   }
 
   #setAmountAndNotifyUI(amount: string) {


### PR DESCRIPTION
**Fix infinite render loop and freeze on transfer form**

**Description**
Selecting a known extension account as the recipient on the transfer screen caused the application to freeze due to an infinite state-sync loop within the controllers.

**Root Cause**
The validationFormMsgs getter in TransferController was executing a side effect during object serialization. If the selected recipient was a known account but its on-chain state wasn't loaded, evaluating the getter invoked AccountsController.getOrFetchAccountOnChainState(). This fetch immediately fired a synchronous this.emitUpdate() from the AccountsController to indicate a loading state.

This update triggered a chain reaction where SelectedAccountController and then TransferController emitted their own updates. Emitting the TransferController update calls .toJSON(), which re-evaluated the getter, firing the fetch and emitting another update before the first one even finished. This locked the backend thread in an infinite serialization loop that eventually spammed the bridge and froze the UI.

**Fix**
Refactored the on-chain state fetch out of the validationFormMsgs getter (which acts as a computed property and must remain pure during serialization). The fetch is now handled by a dedicated #fetchRecipientAccountStateIfNeeded() helper method that is safely invoked only when the recipientAddress or selectedToken actually changes.

---

Issue explained  - Side-Effect in Getter
The TransferController included a side-effect within the validationFormMsgs getter. When evaluated, this getter would trigger AccountsController.getOrFetchAccountOnChainState().

During state synchronization (serialization), the following circular dependency was created:

TransferController.toJSON() is called to sync state to the UI.
This invokes the validationFormMsgs getter, which triggers AccountsController.getOrFetchAccountOnChainState().
AccountsController emits a synchronous update (emitUpdate) to signal it is loading.
Through the controller subscription chain (Accounts -> SelectedAccount -> Transfer), this forces TransferController to emit its own update.
TransferController then triggers another toJSON() serialization via the bridge debouncer, restarting the cycle.
Why Mobile Freezes (Bridge Deadlock)
On Mobile, the loop becomes a Deadlock. Every fetch request is proxied over the bridge to React Native.

The infinite loop of ctrl.update messages floods the React Native bridge and JS thread.
The React Native thread becomes so choked that it cannot process the network.fetch request or its response.
Because the fetch never resolves, the account state never populates, the "already loaded" exit condition is never met, and the loop runs forever, hard-freezing the UI.
Why the Extension was Resilient
On the Extension, fetch is native and runs in a separate browser process.

Even if the loop spins for a few milliseconds, the network request finishes successfully in the background.
Once the state is populated, the if (!state) guard in the controller passes, and the loop terminates naturally.
Because the Extension process architecture is multi-processed, the background loop doesn't block the UI thread from remaining responsive.
Reproduction via Artificial Delay
By adding a 30-second delay to the fetch on Web and removing the state guards, we successfully reproduced the mobile behavior. This proved that if the network response is delayed (or blocked), the controller enters an infinite asynchronous loop that exhausts the JS thread, exactly as observed on mobile.