### PR TITLE
Fix / BenzinUserRequest incomplete meta

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -85,7 +85,11 @@ import { IUiController, UiManager, View } from '@/interfaces/ui'
 import { BenzinUserRequest, CallsUserRequest } from '@/interfaces/userRequest'
 import { getDefaultSelectedAccount } from '@/libs/account/account'
 import { AccountOp } from '@/libs/accountOp/accountOp'
-import { getDappIdentifier, SubmittedAccountOp } from '@/libs/accountOp/submittedAccountOp'
+import {
+  getDappIdentifier,
+  isIdentifiedByUserOpHash,
+  SubmittedAccountOp
+} from '@/libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '@/libs/accountOp/types'
 import { HumanizerMeta } from '@/libs/humanizer/interfaces'
 import { KeyIterator } from '@/libs/keyIterator/keyIterator'
@@ -1651,6 +1655,9 @@ export class MainController extends EventEmitter implements IMainController {
       meta.txnId = submittedAccountOp.txnId
       meta.identifiedBy = submittedAccountOp.identifiedBy
       meta.submittedAccountOp = submittedAccountOp
+      if (isIdentifiedByUserOpHash(submittedAccountOp.identifiedBy)) {
+        meta.userOpHash = submittedAccountOp.identifiedBy.identifier
+      }
     }
 
     if (openBenzin) {


### PR DESCRIPTION
fix: incomplete meta in the benzin req sometimes resulting in crash on the benzin for missing params (repro on mobile)