### PR TITLE
Fix Swap & Bridge max handling across fiat/token modes

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -897,10 +897,12 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     }
 
     if (shouldSetMaxAmount) {
-      const maxAmountForCurrentFieldMode =
-        this.fromAmountFieldMode === 'fiat' ? this.maxFromAmountInFiat : this.maxFromAmount
-
-      this.#setFromAmountAmount(maxAmountForCurrentFieldMode, true)
+      // Always derive amounts from exact token balance. Using max fiat here
+      // would run fiat→token rounding and often leave spendable dust.
+      const previousFieldMode = this.fromAmountFieldMode
+      this.fromAmountFieldMode = 'token'
+      this.#setFromAmountAmount(this.maxFromAmount, true)
+      this.fromAmountFieldMode = previousFieldMode
     }
 
     if (fromAmount !== undefined) {

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -173,8 +173,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
   fromAmountFieldMode: 'fiat' | 'token' = 'token'
 
-  isMax: boolean = false
-
   toChainId: number | null = 1
 
   toSelectedToken: SwapAndBridgeToToken | null = null
@@ -899,27 +897,18 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     }
 
     if (shouldSetMaxAmount) {
-      const maxTokenAmount = this.maxFromAmount
-      const maxFiatAmount = this.maxFromAmountInFiat
       const maxAmountForCurrentFieldMode =
-        this.fromAmountFieldMode === 'fiat' ? maxFiatAmount : maxTokenAmount
+        this.fromAmountFieldMode === 'fiat' ? this.maxFromAmountInFiat : this.maxFromAmount
 
       this.#setFromAmountAmount(maxAmountForCurrentFieldMode, true)
-      // Pin both representations to max regardless of active input mode.
-      this.fromAmount = maxTokenAmount
-      this.fromAmountInFiat = maxFiatAmount
-      this.isMax = true
     }
 
-    const shouldKeepMaxState = !!shouldSetMaxAmount
     if (fromAmount !== undefined) {
       this.#setFromAmountAmount(fromAmount)
-      this.isMax = shouldKeepMaxState
     }
 
     if (fromAmountInFiat !== undefined) {
       this.fromAmountInFiat = fromAmountInFiat
-      this.isMax = shouldKeepMaxState
     }
 
     if (shouldIncrementFromAmountUpdateCounter) {
@@ -952,7 +941,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
         this.#setFromAmountAndNotifyUI('')
         this.#setFromAmountInFiatAndNotifyUI('')
         this.fromAmountFieldMode = 'token'
-        this.isMax = false
       }
 
       // Always update to reflect portfolio amount (or other props) changes
@@ -1005,7 +993,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     this.#setFromAmountAndNotifyUI('')
     this.#setFromAmountInFiatAndNotifyUI('')
     this.fromAmountFieldMode = 'token'
-    this.isMax = false
     this.toSelectedToken = null
     this.quote = null
     this.updateQuoteStatus = 'INITIAL'

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -173,6 +173,8 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
   fromAmountFieldMode: 'fiat' | 'token' = 'token'
 
+  isMax: boolean = false
+
   toChainId: number | null = 1
 
   toSelectedToken: SwapAndBridgeToToken | null = null
@@ -897,16 +899,27 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     }
 
     if (shouldSetMaxAmount) {
-      this.fromAmountFieldMode = 'token'
-      this.#setFromAmountAmount(this.maxFromAmount, true)
+      const maxTokenAmount = this.maxFromAmount
+      const maxFiatAmount = this.maxFromAmountInFiat
+      const maxAmountForCurrentFieldMode =
+        this.fromAmountFieldMode === 'fiat' ? maxFiatAmount : maxTokenAmount
+
+      this.#setFromAmountAmount(maxAmountForCurrentFieldMode, true)
+      // Pin both representations to max regardless of active input mode.
+      this.fromAmount = maxTokenAmount
+      this.fromAmountInFiat = maxFiatAmount
+      this.isMax = true
     }
 
+    const shouldKeepMaxState = !!shouldSetMaxAmount
     if (fromAmount !== undefined) {
       this.#setFromAmountAmount(fromAmount)
+      this.isMax = shouldKeepMaxState
     }
 
     if (fromAmountInFiat !== undefined) {
       this.fromAmountInFiat = fromAmountInFiat
+      this.isMax = shouldKeepMaxState
     }
 
     if (shouldIncrementFromAmountUpdateCounter) {
@@ -939,6 +952,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
         this.#setFromAmountAndNotifyUI('')
         this.#setFromAmountInFiatAndNotifyUI('')
         this.fromAmountFieldMode = 'token'
+        this.isMax = false
       }
 
       // Always update to reflect portfolio amount (or other props) changes
@@ -991,6 +1005,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     this.#setFromAmountAndNotifyUI('')
     this.#setFromAmountInFiatAndNotifyUI('')
     this.fromAmountFieldMode = 'token'
+    this.isMax = false
     this.toSelectedToken = null
     this.quote = null
     this.updateQuoteStatus = 'INITIAL'


### PR DESCRIPTION
closes https://github.com/AmbireTech/ambire-app/issues/5678

## Changelog

### Swap & Bridge

- **Fix:** When the user taps **Max** while the from-amount field is in **USD/fiat** mode, the controller now always applies the **exact max token balance** (`maxFromAmount`) and derives fiat from that. Previously, feeding **max USD** through the fiat→token path could round down and leave **spendable dust** after a swap.
- **UX:** The user’s **fiat vs token input mode** is unchanged: we temporarily use the token conversion path only for the max calculation, then restore the previous `fromAmountFieldMode`.

