### PR TITLE
CI/ no unit tests for draft PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: tests
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
+
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ on:
       - v2
       - main
       - 'release/*'
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: tests
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
-
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     environment: tests
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
+
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
Do not run unit tests for draft PRs
But run them when the pr is converted from draft to ready for review