### PR TITLE
Fix/transfer max infinite loop

### DIFF
--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -132,6 +132,8 @@ export class TransferController extends EventEmitter implements ITransferControl
 
   #isMaxAmountSelected: boolean = false
 
+  #maxFeeReservation: { key: string; amount: bigint } | null = null
+
   #accounts: IAccountsController
 
   #keystore: IKeystoreController
@@ -409,6 +411,7 @@ export class TransferController extends EventEmitter implements ITransferControl
     if (!token || Number(getTokenAmount(token)) === 0) {
       this.#selectedToken = null
       this.#isMaxAmountSelected = false
+      this.#resetMaxFeeReservation()
       this.#setAmountAndNotifyUI('')
       this.#setAmountInFiatAndNotifyUI('')
       this.amountFieldMode = 'token'
@@ -424,6 +427,7 @@ export class TransferController extends EventEmitter implements ITransferControl
       prevSelectedToken?.chainId !== token?.chainId
     ) {
       this.#isMaxAmountSelected = false
+      this.#resetMaxFeeReservation()
       if (!token.priceIn.length) this.amountFieldMode = 'token'
       this.#setAmountAndNotifyUI('')
       this.#setAmountInFiatAndNotifyUI('')
@@ -592,11 +596,13 @@ export class TransferController extends EventEmitter implements ITransferControl
     // If we do a regular check the value won't update if it's '' or '0'
     if (typeof amount === 'string') {
       this.#isMaxAmountSelected = false
+      this.#resetMaxFeeReservation()
       this.#setAmount(amount)
     }
 
     if (shouldSetMaxAmount) {
       this.#isMaxAmountSelected = true
+      this.#resetMaxFeeReservation()
       this.amountFieldMode = 'token'
       this.#setTokenAmount(this.#getMaxAmountAfterFeeReservation(), true)
     }
@@ -790,6 +796,47 @@ export class TransferController extends EventEmitter implements ITransferControl
     )
   }
 
+  #resetMaxFeeReservation() {
+    this.#maxFeeReservation = null
+  }
+
+  #getMaxFeeReservationKey() {
+    const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
+    const selectedFeeOption = this.signAccountOpController?.selectedOption
+    const selectedToken = this.selectedToken
+
+    if (!gasFeePayment || !selectedFeeOption || !selectedToken) return null
+
+    return [
+      selectedToken.chainId.toString(),
+      selectedToken.address.toLowerCase(),
+      selectedFeeOption.paidBy.toLowerCase(),
+      selectedFeeOption.token.chainId.toString(),
+      selectedFeeOption.token.address.toLowerCase(),
+      selectedFeeOption.token.flags.onGasTank ? 'gas-tank' : 'account',
+      this.signAccountOpController?.selectedFeeSpeed || '',
+      gasFeePayment.broadcastOption
+    ].join(':')
+  }
+
+  #getMaxReservedFeeAmount(feeAmount: bigint) {
+    const key = this.#getMaxFeeReservationKey()
+    if (!key) return feeAmount
+
+    if (
+      !this.#maxFeeReservation ||
+      this.#maxFeeReservation.key !== key ||
+      this.#maxFeeReservation.amount < feeAmount
+    ) {
+      this.#maxFeeReservation = {
+        key,
+        amount: feeAmount
+      }
+    }
+
+    return this.#maxFeeReservation.amount
+  }
+
   #shouldReserveFeeFromTransferredToken() {
     const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
     const selectedFeeOption = this.signAccountOpController?.selectedOption
@@ -821,6 +868,12 @@ export class TransferController extends EventEmitter implements ITransferControl
     const totalTokenAmount = getTokenAmount(this.selectedToken)
     const shouldReserveFee = this.#shouldReserveFeeFromTransferredToken()
     const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
+    const fee = shouldReserveFee ? gasFeePayment?.amount || 0n : 0n
+    const reservedFee =
+      shouldReserveFee && this.#isMaxAmountSelected ? this.#getMaxReservedFeeAmount(fee) : fee
+
+    if (!shouldReserveFee) this.#resetMaxFeeReservation()
+
     const currentAmount = this.amount
       ? parseUnits(
           getSafeAmountFromFieldValue(this.amount, this.selectedToken.decimals),
@@ -830,7 +883,8 @@ export class TransferController extends EventEmitter implements ITransferControl
     const desiredAmount = getAmountAfterFeeSync({
       currentAmount,
       totalAmount: totalTokenAmount,
-      fee: shouldReserveFee ? gasFeePayment?.amount || 0n : 0n,
+      fee,
+      reservedFee,
       shouldReserveFee,
       isMaxAmountSelected: this.#isMaxAmountSelected
     })

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -800,6 +800,9 @@ export class TransferController extends EventEmitter implements ITransferControl
     this.#maxFeeReservation = null
   }
 
+  /**
+   * Get an unique key to know when to change the calculations
+   */
   #getMaxFeeReservationKey() {
     const gasFeePayment = this.signAccountOpController?.accountOp.gasFeePayment
     const selectedFeeOption = this.signAccountOpController?.selectedOption
@@ -819,6 +822,14 @@ export class TransferController extends EventEmitter implements ITransferControl
     ].join(':')
   }
 
+  /**
+   * The MAX amount you can set was reacting to every small fee estimate change.
+   * When ARB was both the transfer token and fee token, that created a feedback cycle:
+   * fee changes amount, amount re-estimates fee, repeat.
+   * We're changing the MAX same-token fee reservation to keep the highest fee seen for
+   * the current fee token/payer/speed, so the amount can decrease to remain safe
+   * but won’t bounce back upward and retrigger the loop.
+   */
   #getMaxReservedFeeAmount(feeAmount: bigint) {
     const key = this.#getMaxFeeReservationKey()
     if (!key) return feeAmount

--- a/src/libs/transfer/amount.test.ts
+++ b/src/libs/transfer/amount.test.ts
@@ -44,4 +44,17 @@ describe('transfer amount helpers', () => {
       })
     ).toBe(15_000_000n)
   })
+
+  test('should not increase max amount while a larger fee is reserved', () => {
+    expect(
+      getAmountAfterFeeSync({
+        currentAmount: 14_600_000n,
+        totalAmount: 15_000_000n,
+        fee: 350_000n,
+        reservedFee: 400_000n,
+        shouldReserveFee: true,
+        isMaxAmountSelected: true
+      })
+    ).toBe(14_600_000n)
+  })
 })

--- a/src/libs/transfer/amount.ts
+++ b/src/libs/transfer/amount.ts
@@ -6,17 +6,20 @@ const getAmountAfterFeeSync = ({
   currentAmount,
   totalAmount,
   fee,
+  reservedFee,
   shouldReserveFee,
   isMaxAmountSelected
 }: {
   currentAmount: bigint
   totalAmount: bigint
   fee: bigint
+  reservedFee?: bigint
   shouldReserveFee: boolean
   isMaxAmountSelected: boolean
 }): bigint => {
+  const feeToReserve = reservedFee && reservedFee > fee ? reservedFee : fee
   const maxTransferableAmount = shouldReserveFee
-    ? getAmountAfterFeeReserve(totalAmount, fee)
+    ? getAmountAfterFeeReserve(totalAmount, feeToReserve)
     : totalAmount
 
   if (isMaxAmountSelected) return maxTransferableAmount


### PR DESCRIPTION
Networks like Arbitrum each time return a different estimation => causing the transfer amount to change if MAX is chosen & the fee token is the same as the transfer token => causing a re-estimate => repeat:

https://github.com/user-attachments/assets/e88816b2-fbfa-4b9d-9bd7-d06b6d9160aa

This PR fixes that by breaking the loop when a higher gas price is found (to make sure the txn passes)
