### PR TITLE
Survey/ add retry mechanisms for relayer fetches

### DIFF
--- a/src/controllers/survey/survey.test.ts
+++ b/src/controllers/survey/survey.test.ts
@@ -67,7 +67,8 @@ const surveys: Record<string, Survey> = {
 }
 
 let sentData
-mockFetch.mockImplementation(async (url: string, ...args) => {
+
+async function successFetch(url: string, ...args: any) {
   if (url.includes('relayer.ambire.com/promotions/survey/') && args[0].method === 'GET') {
     const surveyIdToReturn = url.split('/survey/')[1]!
 
@@ -86,6 +87,9 @@ mockFetch.mockImplementation(async (url: string, ...args) => {
     }
   }
   return fetch(url, ...args)
+}
+mockFetch.mockImplementation(async (url: string, ...args) => {
+  return successFetch(url, ...args)
 })
 
 describe('SurveyController', () => {
@@ -291,5 +295,59 @@ describe('SurveyController', () => {
         surveys['two-flow-survey']?.questions[2]!
       )
     })()
+  })
+  describe('Retry mechanism', () => {
+    test('success on 2 errs', async () => {
+      let i = 0
+      mockFetch.mockImplementation(async (url: string, ...args) => {
+        if (url.includes('promotions/survey')) {
+          i++
+          if (i % 3) throw new Error('Error')
+        }
+        return successFetch(url, ...args)
+      })
+
+      const {
+        mainCtrl: { survey: surveyController }
+      } = await makeMainController(undefined, { overrides: { fetch: mockFetch } })
+
+      await surveyController.fetchSurvey('happy-case', 'bannerId')
+      await surveyController.answerQuestion(0, 0, 0, 'instanceId', 'address')
+      await surveyController.answerQuestion(1, 1, 'ans', 'instanceId', 'address')
+      expect(surveyController.status).toBe('success-submitted')
+    })
+    test('fails on get survey', async () => {
+      mockFetch.mockImplementation(async (url: string, ...args) => {
+        if (url.includes('promotions/survey')) throw new Error('Error')
+        return successFetch(url, ...args)
+      })
+
+      const {
+        mainCtrl: { survey: surveyController }
+      } = await makeMainController(undefined, { overrides: { fetch: mockFetch } })
+
+      await surveyController.fetchSurvey('happy-case', 'bannerId')
+      expect(surveyController.status).toBe('error-fetching')
+    })
+    test('fails on submit answer', async () => {
+      let fetched = false
+      mockFetch.mockImplementation(async (url: string, ...args) => {
+        if (url.includes('promotions/survey')) {
+          if (fetched) {
+            throw new Error('Error')
+          } else fetched = true
+        }
+        return successFetch(url, ...args)
+      })
+
+      const {
+        mainCtrl: { survey: surveyController }
+      } = await makeMainController(undefined, { overrides: { fetch: mockFetch } })
+
+      await surveyController.fetchSurvey('happy-case', 'bannerId')
+      await surveyController.answerQuestion(0, 0, 0, 'instanceId', 'address')
+      await surveyController.answerQuestion(1, 1, 'ans', 'instanceId', 'address')
+      expect(surveyController.status).toBe('error-submitting')
+    })
   })
 })

--- a/src/controllers/survey/survey.ts
+++ b/src/controllers/survey/survey.ts
@@ -2,6 +2,7 @@ import { IStorageController } from '@/interfaces/storage'
 import { IUiController } from '@/interfaces/ui'
 import { BindedRelayerCall, relayerCall } from '@/libs/relayerCall/relayerCall'
 import { getNextQuestionForAnswers } from '@/utils/survey'
+import wait from '@/utils/wait'
 
 import { IEventEmitterRegistryController } from '../../interfaces/eventEmitter'
 import { Fetch } from '../../interfaces/fetch'
@@ -97,6 +98,26 @@ export class SurveyController extends EventEmitter implements ISurveyController 
         undefined,
         5000
       )
+        .catch(async () => {
+          await wait(1000)
+          return this.#callRelayer(
+            `/promotions/survey/${surveyId}`,
+            'GET',
+            undefined,
+            undefined,
+            5000
+          )
+        })
+        .catch(async () => {
+          await wait(1000)
+          return this.#callRelayer(
+            `/promotions/survey/${surveyId}`,
+            'GET',
+            undefined,
+            undefined,
+            5000
+          )
+        })
     } catch (e: any) {
       this.status = 'error-fetching'
       this.emitError({
@@ -185,6 +206,14 @@ export class SurveyController extends EventEmitter implements ISurveyController 
       this.emitUpdate()
 
       await this.#callRelayer(`/promotions/survey`, 'POST', payload, undefined, 5000)
+        .catch(async () => {
+          await wait(1000)
+          await this.#callRelayer(`/promotions/survey`, 'POST', payload, undefined, 5000)
+        })
+        .catch(async () => {
+          await wait(1000)
+          await this.#callRelayer(`/promotions/survey`, 'POST', payload, undefined, 5000)
+        })
       this.status = 'success-submitted'
       this.emitUpdate()
       await this.#storeSurveyIdAsRespondedTo(this.#survey.surveyId)


### PR DESCRIPTION
When the req fails for fetching the survey or submitting the response, simply retry 2 times with 1s wait inbetween