### PR TITLE
Refactor/ simplify `BalanceGetter` and `getOnchainBalances`

### DIFF
--- a/contracts/compiled/BalanceGetter.json
+++ b/contracts/compiled/BalanceGetter.json
@@ -1,634 +1,562 @@
 {
-  "abi": [
-    {
-      "inputs": [
+    "abi": [
         {
-          "internalType": "contract IAmbireAccount",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "address[]",
-          "name": "tokenAddrs",
-          "type": "address[]"
-        }
-      ],
-      "name": "getBalances",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "symbol",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint8",
-              "name": "decimals",
-              "type": "uint8"
-            },
-            {
-              "internalType": "bytes",
-              "name": "error",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct BalanceGetter.TokenInfo[]",
-          "name": "",
-          "type": "tuple[]"
-        },
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "contract IAmbireAccount",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "address[]",
-          "name": "tokenAddrs",
-          "type": "address[]"
-        }
-      ],
-      "name": "getBalancesOf",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "bytes",
-              "name": "error",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct BalanceGetter.BalanceInfo[]",
-          "name": "",
-          "type": "tuple[]"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "contract IAmbireAccount",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "address[]",
-          "name": "tokenAddrs",
-          "type": "address[]"
-        }
-      ],
-      "name": "getBalancesWithInfo",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "symbol",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint8",
-              "name": "decimals",
-              "type": "uint8"
-            },
-            {
-              "internalType": "bytes",
-              "name": "error",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct BalanceGetter.TokenInfo[]",
-          "name": "",
-          "type": "tuple[]"
-        },
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "symbol",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint8",
-              "name": "decimals",
-              "type": "uint8"
-            },
-            {
-              "internalType": "bytes",
-              "name": "error",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct BalanceGetter.TokenInfo[]",
-          "name": "balancesA",
-          "type": "tuple[]"
-        },
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "symbol",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint8",
-              "name": "decimals",
-              "type": "uint8"
-            },
-            {
-              "internalType": "bytes",
-              "name": "error",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct BalanceGetter.TokenInfo[]",
-          "name": "balancesB",
-          "type": "tuple[]"
-        },
-        {
-          "internalType": "address[]",
-          "name": "tokenAddrs",
-          "type": "address[]"
-        }
-      ],
-      "name": "getDelta",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "symbol",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint8",
-              "name": "decimals",
-              "type": "uint8"
-            },
-            {
-              "internalType": "bytes",
-              "name": "error",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct BalanceGetter.TokenInfo[]",
-          "name": "",
-          "type": "tuple[]"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "contract IAmbireAccount",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "contract IERC20",
-          "name": "token",
-          "type": "address"
-        }
-      ],
-      "name": "getERC20TokenBalance",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "bytes",
-              "name": "error",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct BalanceGetter.BalanceInfo",
-          "name": "info",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "contract IAmbireAccount",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "contract IERC20",
-          "name": "token",
-          "type": "address"
-        }
-      ],
-      "name": "getERC20TokenInfo",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "symbol",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint8",
-              "name": "decimals",
-              "type": "uint8"
-            },
-            {
-              "internalType": "bytes",
-              "name": "error",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct BalanceGetter.TokenInfo",
-          "name": "info",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "contract IAmbireAccount",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "address[]",
-          "name": "associatedKeys",
-          "type": "address[]"
-        }
-      ],
-      "name": "getSpoof",
-      "outputs": [
-        {
-          "internalType": "bytes",
-          "name": "spoofSig",
-          "type": "bytes"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "contract IAmbireAccount",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "address[]",
-          "name": "associatedKeys",
-          "type": "address[]"
-        },
-        {
-          "internalType": "address",
-          "name": "factory",
-          "type": "address"
-        },
-        {
-          "internalType": "bytes",
-          "name": "factoryCalldata",
-          "type": "bytes"
-        },
-        {
-          "components": [
-            {
-              "internalType": "uint256",
-              "name": "nonce",
-              "type": "uint256"
-            },
-            {
-              "components": [
+            "inputs": [
                 {
-                  "internalType": "address",
-                  "name": "to",
-                  "type": "address"
+                    "internalType": "contract IAmbireAccount",
+                    "name": "account",
+                    "type": "address"
                 },
                 {
-                  "internalType": "uint256",
-                  "name": "value",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "bytes",
-                  "name": "data",
-                  "type": "bytes"
+                    "internalType": "address[]",
+                    "name": "tokenAddrs",
+                    "type": "address[]"
                 }
-              ],
-              "internalType": "struct Transaction[]",
-              "name": "txns",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct Simulation.ToSimulate[]",
-          "name": "toSimulate",
-          "type": "tuple[]"
-        }
-      ],
-      "name": "simulate",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "startingNonce",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        },
-        {
-          "internalType": "bytes",
-          "name": "",
-          "type": "bytes"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "contract IAmbireAccount",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "address[]",
-          "name": "associatedKeys",
-          "type": "address[]"
-        },
-        {
-          "internalType": "address[]",
-          "name": "tokenAddrs",
-          "type": "address[]"
-        },
-        {
-          "internalType": "address",
-          "name": "factory",
-          "type": "address"
-        },
-        {
-          "internalType": "bytes",
-          "name": "factoryCalldata",
-          "type": "bytes"
-        },
-        {
-          "components": [
-            {
-              "internalType": "uint256",
-              "name": "nonce",
-              "type": "uint256"
-            },
-            {
-              "components": [
+            ],
+            "name": "getBalances",
+            "outputs": [
                 {
-                  "internalType": "address",
-                  "name": "to",
-                  "type": "address"
+                    "components": [
+                        {
+                            "internalType": "string",
+                            "name": "symbol",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "error",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BalanceGetter.TokenInfo[]",
+                    "name": "",
+                    "type": "tuple[]"
                 },
                 {
-                  "internalType": "uint256",
-                  "name": "value",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "bytes",
-                  "name": "data",
-                  "type": "bytes"
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
                 }
-              ],
-              "internalType": "struct Transaction[]",
-              "name": "txns",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct Simulation.ToSimulate[]",
-          "name": "toSimulate",
-          "type": "tuple[]"
-        }
-      ],
-      "name": "simulateAndGetBalances",
-      "outputs": [
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
         {
-          "components": [
-            {
-              "components": [
+            "inputs": [
                 {
-                  "internalType": "string",
-                  "name": "symbol",
-                  "type": "string"
+                    "internalType": "contract IAmbireAccount",
+                    "name": "account",
+                    "type": "address"
                 },
                 {
-                  "internalType": "string",
-                  "name": "name",
-                  "type": "string"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "amount",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint8",
-                  "name": "decimals",
-                  "type": "uint8"
-                },
-                {
-                  "internalType": "bytes",
-                  "name": "error",
-                  "type": "bytes"
+                    "internalType": "address[]",
+                    "name": "tokenAddrs",
+                    "type": "address[]"
                 }
-              ],
-              "internalType": "struct BalanceGetter.TokenInfo[]",
-              "name": "balances",
-              "type": "tuple[]"
-            },
-            {
-              "internalType": "uint256",
-              "name": "nonce",
-              "type": "uint256"
-            }
-          ],
-          "internalType": "struct BalanceGetter.BalancesAtNonce",
-          "name": "before",
-          "type": "tuple"
-        },
-        {
-          "components": [
-            {
-              "components": [
+            ],
+            "name": "getBalancesWithInfo",
+            "outputs": [
                 {
-                  "internalType": "string",
-                  "name": "symbol",
-                  "type": "string"
+                    "components": [
+                        {
+                            "internalType": "string",
+                            "name": "symbol",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "error",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BalanceGetter.TokenInfo[]",
+                    "name": "",
+                    "type": "tuple[]"
                 },
                 {
-                  "internalType": "string",
-                  "name": "name",
-                  "type": "string"
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
                 },
                 {
-                  "internalType": "uint256",
-                  "name": "amount",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint8",
-                  "name": "decimals",
-                  "type": "uint8"
-                },
-                {
-                  "internalType": "bytes",
-                  "name": "error",
-                  "type": "bytes"
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
                 }
-              ],
-              "internalType": "struct BalanceGetter.TokenInfo[]",
-              "name": "balances",
-              "type": "tuple[]"
-            },
-            {
-              "internalType": "uint256",
-              "name": "nonce",
-              "type": "uint256"
-            }
-          ],
-          "internalType": "struct BalanceGetter.BalancesAtNonce",
-          "name": "afterSimulation",
-          "type": "tuple"
+            ],
+            "stateMutability": "view",
+            "type": "function"
         },
         {
-          "internalType": "bytes",
-          "name": "",
-          "type": "bytes"
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "string",
+                            "name": "symbol",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "error",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BalanceGetter.TokenInfo[]",
+                    "name": "balancesA",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "string",
+                            "name": "symbol",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "error",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BalanceGetter.TokenInfo[]",
+                    "name": "balancesB",
+                    "type": "tuple[]"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "tokenAddrs",
+                    "type": "address[]"
+                }
+            ],
+            "name": "getDelta",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "string",
+                            "name": "symbol",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "error",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BalanceGetter.TokenInfo[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
         },
         {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
+            "inputs": [
+                {
+                    "internalType": "contract IAmbireAccount",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "contract IERC20",
+                    "name": "token",
+                    "type": "address"
+                }
+            ],
+            "name": "getERC20TokenInfo",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "string",
+                            "name": "symbol",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "amount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "decimals",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "error",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct BalanceGetter.TokenInfo",
+                    "name": "info",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
         },
         {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
+            "inputs": [
+                {
+                    "internalType": "contract IAmbireAccount",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "associatedKeys",
+                    "type": "address[]"
+                }
+            ],
+            "name": "getSpoof",
+            "outputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "spoofSig",
+                    "type": "bytes"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
         },
         {
-          "internalType": "address[]",
-          "name": "",
-          "type": "address[]"
+            "inputs": [
+                {
+                    "internalType": "contract IAmbireAccount",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "associatedKeys",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "address",
+                    "name": "factory",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "factoryCalldata",
+                    "type": "bytes"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "nonce",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "to",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "value",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes",
+                                    "name": "data",
+                                    "type": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Transaction[]",
+                            "name": "txns",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "internalType": "struct Simulation.ToSimulate[]",
+                    "name": "toSimulate",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "simulate",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "startingNonce",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "",
+                    "type": "bytes"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "contract IAmbireAccount",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "associatedKeys",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "tokenAddrs",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "address",
+                    "name": "factory",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "factoryCalldata",
+                    "type": "bytes"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "nonce",
+                            "type": "uint256"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "address",
+                                    "name": "to",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "value",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bytes",
+                                    "name": "data",
+                                    "type": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Transaction[]",
+                            "name": "txns",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "internalType": "struct Simulation.ToSimulate[]",
+                    "name": "toSimulate",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "simulateAndGetBalances",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "string",
+                                    "name": "symbol",
+                                    "type": "string"
+                                },
+                                {
+                                    "internalType": "string",
+                                    "name": "name",
+                                    "type": "string"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "decimals",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "bytes",
+                                    "name": "error",
+                                    "type": "bytes"
+                                }
+                            ],
+                            "internalType": "struct BalanceGetter.TokenInfo[]",
+                            "name": "balances",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "nonce",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct BalanceGetter.BalancesAtNonce",
+                    "name": "before",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "string",
+                                    "name": "symbol",
+                                    "type": "string"
+                                },
+                                {
+                                    "internalType": "string",
+                                    "name": "name",
+                                    "type": "string"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "amount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "decimals",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "bytes",
+                                    "name": "error",
+                                    "type": "bytes"
+                                }
+                            ],
+                            "internalType": "struct BalanceGetter.TokenInfo[]",
+                            "name": "balances",
+                            "type": "tuple[]"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "nonce",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct BalanceGetter.BalancesAtNonce",
+                    "name": "afterSimulation",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "",
+                    "type": "bytes"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "",
+                    "type": "address[]"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
         }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    }
-  ],
-  "bin": "0x6080806040523461001657611b8e908161001c8239f35b600080fdfe6040608081526004908136101561001557600080fd5b6000803560e01c8063036896ab146107fb578063299ab72a1461079f57806358197024146107635780636a385ae91461072c578063745a93d814610540578063c80aca311461048b578063f7deade814610227578063f9a7fe721461019c5763fd201de81461008357600080fd5b346101895760c03660031901126101895761009c610898565b9067ffffffffffffffff602435818111610198576100bd9036908701610a04565b94604435828111610194576100d59036908301610a6a565b91606435936001600160a01b03851685036101905760843581811161018c576101019036908401610bad565b9560a43591821161018957509461016d94610137946101529a9461012f6101859a956101609a369101610a6a565b96909561148d565b959389939297919599519a8b9a60c08c5260c08c0190610cfc565b908a820360208c0152610cfc565b918883039089015261091b565b926060860152608085015283820360a0850152610d1c565b0390f35b80fd5b8680fd5b8580fd5b8380fd5b8280fd5b5091346101985760603660031901126101985767ffffffffffffffff908035828111610223576101cf9036908301610bf4565b91602435818111610190576101e79036908401610bf4565b94604435918211610189575091610208610185959261021094369101610a6a565b9290916111b2565b9051918291602083526020830190610b35565b8480fd5b5082346104875761023736610a9b565b91610241836109ec565b9361024e875195866109ca565b838552601f1961025d856109ec565b01865b818110610470575050855b8481106102cf57875160208082528751818301819052899291600582901b83018c0191818b0191848e015b8287106102a35785850386f35b9091929382806102bf600193603f198a82030186528851610940565b9601920196019592919092610296565b6001600160a01b039087826102ed6102e8848a8a610e8a565b610eb0565b1661033b5750610336918416318951610305816109ae565b8981528a519161031483610960565b825260208201526103258289610ec4565b526103308188610ec4565b50610e65565b61026b565b61039a9261034d6102e8848a8a610e8a565b168a51809481927f036896ab000000000000000000000000000000000000000000000000000000008352888884019060209093929360408301946001600160a01b03809216845216910152565b0381305afa8089916103ed575b61033693506103e357506103b9610ed8565b8051156103d5575b60206103cd838a610ec4565b510152610e65565b506103de610f08565b6103c1565b6103258289610ec4565b919290503d808a833e61040081836109ca565b8101602090818382031261046c57825167ffffffffffffffff938482116104645701928c84830312610468578c519361043885610960565b8051855283810151918211610464579161045a91610336979695949301610d85565b90820152906103a7565b8c80fd5b8b80fd5b8a80fd5b60209061047b610dfb565b82828a01015201610260565b5080fd5b508290346101895760a0366003190112610189576104a7610898565b9067ffffffffffffffff602435818111610198576104c89036908601610a04565b93604435916001600160a01b038316830361019457606435818111610223576104f49036908401610bad565b9360843591821161018957509260609592610519610185969361052196369101610a6a565b9490936115c5565b919390948051958695865215156020860152840152606083019061091b565b5091903461019857610551366108c7565b93909261055c610d59565b946001600160a01b03809116908451956370a0823160e01b875216828601526020948581602481855afa9081156106db5784916106ff575b508487015283517f95d89b4100000000000000000000000000000000000000000000000000000000815283818481855afa9081156106db5784916106e5575b50865283517f06fdde0300000000000000000000000000000000000000000000000000000000815283818481855afa9081156106db579086929185916106b9575b50828801528451928380927f313ce5670000000000000000000000000000000000000000000000000000000082525afa9182156106ae578092610670575b50509060ff6101859216606085015251928284938452830190610adf565b9091508382813d83116106a7575b61068881836109ca565b8101031261018957509060ff6106a061018593610ded565b9192610652565b503d61067e565b8351903d90823e3d90fd5b6106d591503d8087833e6106cd81836109ca565b810190610dc7565b38610614565b85513d86823e3d90fd5b6106f991503d8086833e6106cd81836109ca565b386105d3565b90508581813d8311610725575b61071681836109ca565b81010312610194575138610594565b503d61070c565b5034610189575061074561073f36610a9b565b91610f41565b825183815292839261075991840190610b35565b9060208301520390f35b509034610487576107929061077a61073f36610a9b565b9190915a918051948594606086526060860190610b35565b9260208501528301520390f35b5091346101985781600319360112610198576107b9610898565b926024359067ffffffffffffffff82116101895750926107e26107e89261018595369101610a04565b9061199f565b905191829160208352602083019061091b565b509190346101985761080c366108c7565b939092610817610dfb565b948351916370a0823160e01b83526001600160a01b0380961690830152816024816020978894165afa9182156106ae578092610866575b50509061018591845251928284938452830190610940565b9091508382813d8311610891575b61087e81836109ca565b810103126101895750516101853861084e565b503d610874565b600435906001600160a01b03821682036108ae57565b600080fd5b35906001600160a01b03821682036108ae57565b60409060031901126108ae576001600160a01b039060043582811681036108ae579160243590811681036108ae5790565b60005b83811061090b5750506000910152565b81810151838201526020016108fb565b90602091610934815180928185528580860191016108f8565b601f01601f1916010190565b906040602061095d9380518452015191816020820152019061091b565b90565b6040810190811067ffffffffffffffff82111761097c57604052565b634e487b7160e01b600052604160045260246000fd5b60a0810190811067ffffffffffffffff82111761097c57604052565b6020810190811067ffffffffffffffff82111761097c57604052565b90601f8019910116810190811067ffffffffffffffff82111761097c57604052565b67ffffffffffffffff811161097c5760051b60200190565b81601f820112156108ae57803591610a1b836109ec565b92610a2960405194856109ca565b808452602092838086019260051b8201019283116108ae578301905b828210610a53575050505090565b838091610a5f846108b3565b815201910190610a45565b9181601f840112156108ae5782359167ffffffffffffffff83116108ae576020808501948460051b0101116108ae57565b9060406003198301126108ae576004356001600160a01b03811681036108ae57916024359067ffffffffffffffff82116108ae57610adb91600401610a6a565b9091565b61095d916080610b0d610afb845160a0855260a085019061091b565b6020850151848203602086015261091b565b926040810151604084015260ff6060820151166060840152015190608081840391015261091b565b908082519081815260208091019281808460051b8301019501936000915b848310610b635750505050505090565b9091929394958480610b81600193601f198682030187528a51610adf565b9801930193019194939290610b53565b67ffffffffffffffff811161097c57601f01601f191660200190565b81601f820112156108ae57803590610bc482610b91565b92610bd260405194856109ca565b828452602083830101116108ae57816000926020809301838601378301015290565b9080601f830112156108ae578135610c0b816109ec565b92604091610c1b835195866109ca565b808552602093848087019260051b840101938185116108ae57858401925b858410610c4a575050505050505090565b67ffffffffffffffff84358181116108ae5786019160a080601f1985880301126108ae57845190610c7a82610992565b8a8501358481116108ae57878c610c9392880101610bad565b8252858501358481116108ae57878c610cae92880101610bad565b8b8301526060908186013587840152608091828701359060ff821682036108ae578401528501359384116108ae57610ced878c80979681970101610bad565b90820152815201930192610c39565b90602080610d138451604085526040850190610b35565b93015191015290565b90815180825260208080930193019160005b828110610d3c575050505090565b83516001600160a01b031685529381019392810192600101610d2e565b60405190610d6682610992565b6060608083828152826020820152600060408201526000838201520152565b81601f820112156108ae578051610d9b81610b91565b92610da960405194856109ca565b818452602082840101116108ae5761095d91602080850191016108f8565b906020828203126108ae57815167ffffffffffffffff81116108ae5761095d9201610d85565b519060ff821682036108ae57565b60405190610e0882610960565b6060602083600081520152565b90610e1f826109ec565b610e2c60405191826109ca565b8281528092610e3d601f19916109ec565b019060005b828110610e4e57505050565b602090610e59610d59565b82828501015201610e42565b6000198114610e745760010190565b634e487b7160e01b600052601160045260246000fd5b9190811015610e9a5760051b0190565b634e487b7160e01b600052603260045260246000fd5b356001600160a01b03811681036108ae5790565b8051821015610e9a5760209160051b010190565b3d15610f03573d90610ee982610b91565b91610ef760405193846109ca565b82523d6000602084013e565b606090565b60405190610f1582610960565b600482527f756e6b6e000000000000000000000000000000000000000000000000000000006020830152565b9091610f4c81610e15565b9260005b828110610f605750505050904390565b6001600160a01b039081610f786102e8838787610e8a565b1661103b576040805161103693871631610f91826109ae565b60008252825192610fa184610992565b8051610fac81610960565b600381526020907f4554480000000000000000000000000000000000000000000000000000000000828201528552815190610fe682610960565b600582527f45746865720000000000000000000000000000000000000000000000000000008183015285015283015260126060830152608082015261102b8288610ec4565b526103308187610ec4565b610f50565b6110a09161104d6102e8838787610e8a565b1660006040918251809581927f745a93d80000000000000000000000000000000000000000000000000000000083528a600484019060209093929360408301946001600160a01b03809216845216910152565b0381305afa600091816110ed575b5061103693506110e357506110c1610ed8565b8051156110d5575b60806103cd8389610ec4565b506110de610f08565b6110c9565b61102b8288610ec4565b919092933d8083833e61110081836109ca565b810190602093848284031261019457815167ffffffffffffffff9283821161019057019060a0828503126102235780519561113a87610992565b825184811161018c578561114f918501610d85565b87528083015184811161018c5785611168918501610d85565b9087015280820151908601526060611181818301610ded565b90860152608093848201519283116101895750916111a791611036979695949301610d85565b9082015290386110ae565b93929192600092835b865181101561120b576040806111d1838a610ec4565b510151906111df8387610ec4565b510151036111f6575b6111f190610e65565b6111bb565b936112036111f191610e65565b9490506111e8565b509290939161121982610e15565b91611223816109ec565b61123d604092611235845193846109ca565b8083526109ec565b6020808301929091601f1901368437519167ffffffffffffffff831161097c5768010000000000000000831161097c57600054836000558084106113bb575b50906000805260005b8381106113805750505050600096875b815181101561137557826112a98284610ec4565b510151836112b78387610ec4565b510151036112ce575b6112c990610e65565b611295565b976112d98985610ec4565b516112e48287610ec4565b526112ef8186610ec4565b506112fe6102e88a8989610e8a565b600054821015610e9a576112c99161136d91600080526001600160a01b03827f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5630191167fffffffffffffffffffffffff0000000000000000000000000000000000000000825416179055610e65565b9890506112c0565b509296505050505050565b82516001600160a01b03167f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56382015591810191600101611285565b837f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56391820191015b8181106113f0575061127c565b600081556001016113e3565b6040519061140982610960565b6000602083606081520152565b604051906000548083528260209182820190600080527f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563936000905b82821061146a57505050611468925003836109ca565b565b85546001600160a01b031684526001958601958895509381019390910190611452565b94956114c092939496989791986114a26113fc565b976114ab6113fc565b9a6114b788888b610f41565b508a52886115c5565b90602092838801521561158d57506040519063057ff68760e51b825280826004816001600160a01b0389165afa91821561158157600092611552575b5081818901528501510361152f575b5050506040519161151b836109ae565b600083525a9193929190439061095d611416565b61153d828261154895610f41565b5080875284516111b2565b835238808061150b565b90918282813d831161157a575b61156981836109ca565b8101031261018957505190386114fc565b503d61155f565b6040513d6000823e3d90fd5b9593505050505a9193929190439061095d611416565b9190811015610e9a5760051b81013590603e19813603018212156108ae570190565b9194929093946001600160a01b0383163b1561196d575b50506040519163057ff68760e51b928381526020816004816001600160a01b0387165afa9081156115815760009161193b575b509460005b828110611639575050505050506040519061162e826109ae565b600082529160019190565b6040518581526020816004816001600160a01b0389165afa90811561158157600091611909575b5061166c8285856115a3565b3514611681575b61167c90610e65565b611614565b6040517f299ab72a0000000000000000000000000000000000000000000000000000000081526001600160a01b038516600482015260406024820152600081806116ce604482018b610d1c565b0381305afa600091816118c6575b506116f857505050505050506116f0610ed8565b909160009190565b6117038285856115a3565b602081013591601e19823603018312156108ae5767ffffffffffffffff83830135116108ae57602083830101918381013560051b9384360384136108ae576001600160a01b0389163b156108ae579192906040519485937f6171d1c9000000000000000000000000000000000000000000000000000000008552604485016040600487015281840135905260648086019286010193926000905b82810135821061180b5750505050506117c5829160009460031984830301602485015261091b565b0381836001600160a01b038a165af190816117f3575b506117ee575050505050506116f0610ed8565b611673565b67ffffffffffffffff811161097c57604052386117db565b919396955091936063198882030185528635607e198584013603018112156108ae57848301016001600160a01b03611845602083016108b3565b1682526040810135602083015260609081810135603e19823603018112156108ae57019060406020830135920167ffffffffffffffff83116108ae5782360381136108ae5783836020948486956040600199015283015280608093848401376000838284010152601f8019910116010198019501920187959694939161179d565b90913d8082843e6118d781846109ca565b8201916020818403126104875780519167ffffffffffffffff83116101895750611902929101610d85565b90386116dc565b906020823d602011611933575b81611923602093836109ca565b8101031261018957505138611660565b3d9150611916565b906020823d602011611965575b81611955602093836109ca565b810103126101895750513861160f565b3d9150611948565b81600092918360208194519301915af1611985610ed8565b901561199157806115dc565b935050505060009160009190565b90606091815115611b145760005b82518114611ad0576001600160a01b03806119c88386610ec4565b5116906040805180937fc066a5b1000000000000000000000000000000000000000000000000000000008252816004948286830152602096879160249586918c165afa908115611ac557600091611a98575b50611a32575050505050611a2d90610e65565b6119ad565b8251948501527f03000000000000000000000000000000000000000000000000000000000000008483015260218452929687019550935090915067ffffffffffffffff841185851017611a855750505290565b604190634e487b7160e01b600052526000fd5b908682813d8311611abe575b611aae81836109ca565b8101031261018957505138611a1a565b503d611aa4565b84513d6000823e3d90fd5b606460405162461bcd60e51b815260206004820152601860248201527f53706f6f66206661696c65643a2077726f6e67206b65797300000000000000006044820152fd5b606460405162461bcd60e51b815260206004820152601560248201527f53706f6f66206661696c65643a206e6f206b65797300000000000000000000006044820152fdfea2646970667358221220ef6fac3748ab4d96647c3080a445474804ff46e291451ab02ce8d86cf51cd9d064736f6c63430008130033",
-  "binRuntime": "0x6040608081526004908136101561001557600080fd5b6000803560e01c8063036896ab146107fb578063299ab72a1461079f57806358197024146107635780636a385ae91461072c578063745a93d814610540578063c80aca311461048b578063f7deade814610227578063f9a7fe721461019c5763fd201de81461008357600080fd5b346101895760c03660031901126101895761009c610898565b9067ffffffffffffffff602435818111610198576100bd9036908701610a04565b94604435828111610194576100d59036908301610a6a565b91606435936001600160a01b03851685036101905760843581811161018c576101019036908401610bad565b9560a43591821161018957509461016d94610137946101529a9461012f6101859a956101609a369101610a6a565b96909561148d565b959389939297919599519a8b9a60c08c5260c08c0190610cfc565b908a820360208c0152610cfc565b918883039089015261091b565b926060860152608085015283820360a0850152610d1c565b0390f35b80fd5b8680fd5b8580fd5b8380fd5b8280fd5b5091346101985760603660031901126101985767ffffffffffffffff908035828111610223576101cf9036908301610bf4565b91602435818111610190576101e79036908401610bf4565b94604435918211610189575091610208610185959261021094369101610a6a565b9290916111b2565b9051918291602083526020830190610b35565b8480fd5b5082346104875761023736610a9b565b91610241836109ec565b9361024e875195866109ca565b838552601f1961025d856109ec565b01865b818110610470575050855b8481106102cf57875160208082528751818301819052899291600582901b83018c0191818b0191848e015b8287106102a35785850386f35b9091929382806102bf600193603f198a82030186528851610940565b9601920196019592919092610296565b6001600160a01b039087826102ed6102e8848a8a610e8a565b610eb0565b1661033b5750610336918416318951610305816109ae565b8981528a519161031483610960565b825260208201526103258289610ec4565b526103308188610ec4565b50610e65565b61026b565b61039a9261034d6102e8848a8a610e8a565b168a51809481927f036896ab000000000000000000000000000000000000000000000000000000008352888884019060209093929360408301946001600160a01b03809216845216910152565b0381305afa8089916103ed575b61033693506103e357506103b9610ed8565b8051156103d5575b60206103cd838a610ec4565b510152610e65565b506103de610f08565b6103c1565b6103258289610ec4565b919290503d808a833e61040081836109ca565b8101602090818382031261046c57825167ffffffffffffffff938482116104645701928c84830312610468578c519361043885610960565b8051855283810151918211610464579161045a91610336979695949301610d85565b90820152906103a7565b8c80fd5b8b80fd5b8a80fd5b60209061047b610dfb565b82828a01015201610260565b5080fd5b508290346101895760a0366003190112610189576104a7610898565b9067ffffffffffffffff602435818111610198576104c89036908601610a04565b93604435916001600160a01b038316830361019457606435818111610223576104f49036908401610bad565b9360843591821161018957509260609592610519610185969361052196369101610a6a565b9490936115c5565b919390948051958695865215156020860152840152606083019061091b565b5091903461019857610551366108c7565b93909261055c610d59565b946001600160a01b03809116908451956370a0823160e01b875216828601526020948581602481855afa9081156106db5784916106ff575b508487015283517f95d89b4100000000000000000000000000000000000000000000000000000000815283818481855afa9081156106db5784916106e5575b50865283517f06fdde0300000000000000000000000000000000000000000000000000000000815283818481855afa9081156106db579086929185916106b9575b50828801528451928380927f313ce5670000000000000000000000000000000000000000000000000000000082525afa9182156106ae578092610670575b50509060ff6101859216606085015251928284938452830190610adf565b9091508382813d83116106a7575b61068881836109ca565b8101031261018957509060ff6106a061018593610ded565b9192610652565b503d61067e565b8351903d90823e3d90fd5b6106d591503d8087833e6106cd81836109ca565b810190610dc7565b38610614565b85513d86823e3d90fd5b6106f991503d8086833e6106cd81836109ca565b386105d3565b90508581813d8311610725575b61071681836109ca565b81010312610194575138610594565b503d61070c565b5034610189575061074561073f36610a9b565b91610f41565b825183815292839261075991840190610b35565b9060208301520390f35b509034610487576107929061077a61073f36610a9b565b9190915a918051948594606086526060860190610b35565b9260208501528301520390f35b5091346101985781600319360112610198576107b9610898565b926024359067ffffffffffffffff82116101895750926107e26107e89261018595369101610a04565b9061199f565b905191829160208352602083019061091b565b509190346101985761080c366108c7565b939092610817610dfb565b948351916370a0823160e01b83526001600160a01b0380961690830152816024816020978894165afa9182156106ae578092610866575b50509061018591845251928284938452830190610940565b9091508382813d8311610891575b61087e81836109ca565b810103126101895750516101853861084e565b503d610874565b600435906001600160a01b03821682036108ae57565b600080fd5b35906001600160a01b03821682036108ae57565b60409060031901126108ae576001600160a01b039060043582811681036108ae579160243590811681036108ae5790565b60005b83811061090b5750506000910152565b81810151838201526020016108fb565b90602091610934815180928185528580860191016108f8565b601f01601f1916010190565b906040602061095d9380518452015191816020820152019061091b565b90565b6040810190811067ffffffffffffffff82111761097c57604052565b634e487b7160e01b600052604160045260246000fd5b60a0810190811067ffffffffffffffff82111761097c57604052565b6020810190811067ffffffffffffffff82111761097c57604052565b90601f8019910116810190811067ffffffffffffffff82111761097c57604052565b67ffffffffffffffff811161097c5760051b60200190565b81601f820112156108ae57803591610a1b836109ec565b92610a2960405194856109ca565b808452602092838086019260051b8201019283116108ae578301905b828210610a53575050505090565b838091610a5f846108b3565b815201910190610a45565b9181601f840112156108ae5782359167ffffffffffffffff83116108ae576020808501948460051b0101116108ae57565b9060406003198301126108ae576004356001600160a01b03811681036108ae57916024359067ffffffffffffffff82116108ae57610adb91600401610a6a565b9091565b61095d916080610b0d610afb845160a0855260a085019061091b565b6020850151848203602086015261091b565b926040810151604084015260ff6060820151166060840152015190608081840391015261091b565b908082519081815260208091019281808460051b8301019501936000915b848310610b635750505050505090565b9091929394958480610b81600193601f198682030187528a51610adf565b9801930193019194939290610b53565b67ffffffffffffffff811161097c57601f01601f191660200190565b81601f820112156108ae57803590610bc482610b91565b92610bd260405194856109ca565b828452602083830101116108ae57816000926020809301838601378301015290565b9080601f830112156108ae578135610c0b816109ec565b92604091610c1b835195866109ca565b808552602093848087019260051b840101938185116108ae57858401925b858410610c4a575050505050505090565b67ffffffffffffffff84358181116108ae5786019160a080601f1985880301126108ae57845190610c7a82610992565b8a8501358481116108ae57878c610c9392880101610bad565b8252858501358481116108ae57878c610cae92880101610bad565b8b8301526060908186013587840152608091828701359060ff821682036108ae578401528501359384116108ae57610ced878c80979681970101610bad565b90820152815201930192610c39565b90602080610d138451604085526040850190610b35565b93015191015290565b90815180825260208080930193019160005b828110610d3c575050505090565b83516001600160a01b031685529381019392810192600101610d2e565b60405190610d6682610992565b6060608083828152826020820152600060408201526000838201520152565b81601f820112156108ae578051610d9b81610b91565b92610da960405194856109ca565b818452602082840101116108ae5761095d91602080850191016108f8565b906020828203126108ae57815167ffffffffffffffff81116108ae5761095d9201610d85565b519060ff821682036108ae57565b60405190610e0882610960565b6060602083600081520152565b90610e1f826109ec565b610e2c60405191826109ca565b8281528092610e3d601f19916109ec565b019060005b828110610e4e57505050565b602090610e59610d59565b82828501015201610e42565b6000198114610e745760010190565b634e487b7160e01b600052601160045260246000fd5b9190811015610e9a5760051b0190565b634e487b7160e01b600052603260045260246000fd5b356001600160a01b03811681036108ae5790565b8051821015610e9a5760209160051b010190565b3d15610f03573d90610ee982610b91565b91610ef760405193846109ca565b82523d6000602084013e565b606090565b60405190610f1582610960565b600482527f756e6b6e000000000000000000000000000000000000000000000000000000006020830152565b9091610f4c81610e15565b9260005b828110610f605750505050904390565b6001600160a01b039081610f786102e8838787610e8a565b1661103b576040805161103693871631610f91826109ae565b60008252825192610fa184610992565b8051610fac81610960565b600381526020907f4554480000000000000000000000000000000000000000000000000000000000828201528552815190610fe682610960565b600582527f45746865720000000000000000000000000000000000000000000000000000008183015285015283015260126060830152608082015261102b8288610ec4565b526103308187610ec4565b610f50565b6110a09161104d6102e8838787610e8a565b1660006040918251809581927f745a93d80000000000000000000000000000000000000000000000000000000083528a600484019060209093929360408301946001600160a01b03809216845216910152565b0381305afa600091816110ed575b5061103693506110e357506110c1610ed8565b8051156110d5575b60806103cd8389610ec4565b506110de610f08565b6110c9565b61102b8288610ec4565b919092933d8083833e61110081836109ca565b810190602093848284031261019457815167ffffffffffffffff9283821161019057019060a0828503126102235780519561113a87610992565b825184811161018c578561114f918501610d85565b87528083015184811161018c5785611168918501610d85565b9087015280820151908601526060611181818301610ded565b90860152608093848201519283116101895750916111a791611036979695949301610d85565b9082015290386110ae565b93929192600092835b865181101561120b576040806111d1838a610ec4565b510151906111df8387610ec4565b510151036111f6575b6111f190610e65565b6111bb565b936112036111f191610e65565b9490506111e8565b509290939161121982610e15565b91611223816109ec565b61123d604092611235845193846109ca565b8083526109ec565b6020808301929091601f1901368437519167ffffffffffffffff831161097c5768010000000000000000831161097c57600054836000558084106113bb575b50906000805260005b8381106113805750505050600096875b815181101561137557826112a98284610ec4565b510151836112b78387610ec4565b510151036112ce575b6112c990610e65565b611295565b976112d98985610ec4565b516112e48287610ec4565b526112ef8186610ec4565b506112fe6102e88a8989610e8a565b600054821015610e9a576112c99161136d91600080526001600160a01b03827f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5630191167fffffffffffffffffffffffff0000000000000000000000000000000000000000825416179055610e65565b9890506112c0565b509296505050505050565b82516001600160a01b03167f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56382015591810191600101611285565b837f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56391820191015b8181106113f0575061127c565b600081556001016113e3565b6040519061140982610960565b6000602083606081520152565b604051906000548083528260209182820190600080527f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563936000905b82821061146a57505050611468925003836109ca565b565b85546001600160a01b031684526001958601958895509381019390910190611452565b94956114c092939496989791986114a26113fc565b976114ab6113fc565b9a6114b788888b610f41565b508a52886115c5565b90602092838801521561158d57506040519063057ff68760e51b825280826004816001600160a01b0389165afa91821561158157600092611552575b5081818901528501510361152f575b5050506040519161151b836109ae565b600083525a9193929190439061095d611416565b61153d828261154895610f41565b5080875284516111b2565b835238808061150b565b90918282813d831161157a575b61156981836109ca565b8101031261018957505190386114fc565b503d61155f565b6040513d6000823e3d90fd5b9593505050505a9193929190439061095d611416565b9190811015610e9a5760051b81013590603e19813603018212156108ae570190565b9194929093946001600160a01b0383163b1561196d575b50506040519163057ff68760e51b928381526020816004816001600160a01b0387165afa9081156115815760009161193b575b509460005b828110611639575050505050506040519061162e826109ae565b600082529160019190565b6040518581526020816004816001600160a01b0389165afa90811561158157600091611909575b5061166c8285856115a3565b3514611681575b61167c90610e65565b611614565b6040517f299ab72a0000000000000000000000000000000000000000000000000000000081526001600160a01b038516600482015260406024820152600081806116ce604482018b610d1c565b0381305afa600091816118c6575b506116f857505050505050506116f0610ed8565b909160009190565b6117038285856115a3565b602081013591601e19823603018312156108ae5767ffffffffffffffff83830135116108ae57602083830101918381013560051b9384360384136108ae576001600160a01b0389163b156108ae579192906040519485937f6171d1c9000000000000000000000000000000000000000000000000000000008552604485016040600487015281840135905260648086019286010193926000905b82810135821061180b5750505050506117c5829160009460031984830301602485015261091b565b0381836001600160a01b038a165af190816117f3575b506117ee575050505050506116f0610ed8565b611673565b67ffffffffffffffff811161097c57604052386117db565b919396955091936063198882030185528635607e198584013603018112156108ae57848301016001600160a01b03611845602083016108b3565b1682526040810135602083015260609081810135603e19823603018112156108ae57019060406020830135920167ffffffffffffffff83116108ae5782360381136108ae5783836020948486956040600199015283015280608093848401376000838284010152601f8019910116010198019501920187959694939161179d565b90913d8082843e6118d781846109ca565b8201916020818403126104875780519167ffffffffffffffff83116101895750611902929101610d85565b90386116dc565b906020823d602011611933575b81611923602093836109ca565b8101031261018957505138611660565b3d9150611916565b906020823d602011611965575b81611955602093836109ca565b810103126101895750513861160f565b3d9150611948565b81600092918360208194519301915af1611985610ed8565b901561199157806115dc565b935050505060009160009190565b90606091815115611b145760005b82518114611ad0576001600160a01b03806119c88386610ec4565b5116906040805180937fc066a5b1000000000000000000000000000000000000000000000000000000008252816004948286830152602096879160249586918c165afa908115611ac557600091611a98575b50611a32575050505050611a2d90610e65565b6119ad565b8251948501527f03000000000000000000000000000000000000000000000000000000000000008483015260218452929687019550935090915067ffffffffffffffff841185851017611a855750505290565b604190634e487b7160e01b600052526000fd5b908682813d8311611abe575b611aae81836109ca565b8101031261018957505138611a1a565b503d611aa4565b84513d6000823e3d90fd5b606460405162461bcd60e51b815260206004820152601860248201527f53706f6f66206661696c65643a2077726f6e67206b65797300000000000000006044820152fd5b606460405162461bcd60e51b815260206004820152601560248201527f53706f6f66206661696c65643a206e6f206b65797300000000000000000000006044820152fdfea2646970667358221220ef6fac3748ab4d96647c3080a445474804ff46e291451ab02ce8d86cf51cd9d064736f6c63430008130033"
+    ],
+    "bin": "0x60808060405234610016576118a5908161001c8239f35b600080fdfe6040608081526004908136101561001557600080fd5b6000803560e01c8063299ab72a1461055457806358197024146105185780636a385ae9146104e1578063745a93d8146102c6578063c80aca3114610211578063f9a7fe72146101865763fd201de81461006d57600080fd5b346101735760c0366003190112610173576100866105b0565b9067ffffffffffffffff602435818111610182576100a79036908701610683565b9460443582811161017e576100bf9036908301610731565b91606435936001600160a01b038516850361017a57608435818111610176576100eb9036908401610877565b9560a435918211610173575094610157946101219461013c9a9461011961016f9a9561014a9a369101610731565b9690956111a4565b959389939297919599519a8b9a60c08c5260c08c01906109c6565b908a820360208c01526109c6565b918883039089015261070c565b926060860152608085015283820360a0850152610a2e565b0390f35b80fd5b8680fd5b8580fd5b8380fd5b8280fd5b5091346101825760603660031901126101825767ffffffffffffffff90803582811161020d576101b990369083016108be565b9160243581811161017a576101d190369084016108be565b946044359182116101735750916101f261016f95926101fa94369101610731565b929091610eb8565b90519182916020835260208301906107ff565b8480fd5b508290346101735760a03660031901126101735761022d6105b0565b9067ffffffffffffffff6024358181116101825761024e9036908601610683565b93604435916001600160a01b038316830361017e5760643581811161020d5761027a9036908401610877565b936084359182116101735750926060959261029f61016f96936102a796369101610731565b9490936112dc565b919390948051958695865215156020860152840152606083019061070c565b5090346104dd57806003193601126104dd576102e06105b0565b91602435936001600160a01b039485811680910361018257610300610a6b565b958451957f70a0823100000000000000000000000000000000000000000000000000000000875216828601526020948581602481855afa90811561048c5784916104b0575b508487015283517f95d89b4100000000000000000000000000000000000000000000000000000000815283818481855afa90811561048c578491610496575b50865283517f06fdde0300000000000000000000000000000000000000000000000000000000815283818481855afa90811561048c5790869291859161046a575b50828801528451928380927f313ce5670000000000000000000000000000000000000000000000000000000082525afa91821561045f578092610421575b50509060ff61016f92166060850152519282849384528301906107a6565b9091508382813d8311610458575b6104398183610649565b8101031261017357509060ff61045161016f93610aff565b9192610403565b503d61042f565b8351903d90823e3d90fd5b61048691503d8087833e61047e8183610649565b810190610ad9565b386103c5565b85513d86823e3d90fd5b6104aa91503d8086833e61047e8183610649565b38610384565b90508581813d83116104d6575b6104c78183610649565b8101031261017e575138610345565b503d6104bd565b5080fd5b503461017357506104fa6104f436610762565b91610c00565b825183815292839261050e918401906107ff565b9060208301520390f35b5090346104dd576105479061052f6104f436610762565b9190915a9180519485946060865260608601906107ff565b9260208501528301520390f35b50913461018257816003193601126101825761056e6105b0565b926024359067ffffffffffffffff821161017357509261059761059d9261016f95369101610683565b906116b6565b905191829160208352602083019061070c565b600435906001600160a01b03821682036105c657565b600080fd5b35906001600160a01b03821682036105c657565b60a0810190811067ffffffffffffffff8211176105fb57604052565b634e487b7160e01b600052604160045260246000fd5b6040810190811067ffffffffffffffff8211176105fb57604052565b6020810190811067ffffffffffffffff8211176105fb57604052565b90601f8019910116810190811067ffffffffffffffff8211176105fb57604052565b67ffffffffffffffff81116105fb5760051b60200190565b81601f820112156105c65780359161069a8361066b565b926106a86040519485610649565b808452602092838086019260051b8201019283116105c6578301905b8282106106d2575050505090565b8380916106de846105cb565b8152019101906106c4565b60005b8381106106fc5750506000910152565b81810151838201526020016106ec565b90602091610725815180928185528580860191016106e9565b601f01601f1916010190565b9181601f840112156105c65782359167ffffffffffffffff83116105c6576020808501948460051b0101116105c657565b9060406003198301126105c6576004356001600160a01b03811681036105c657916024359067ffffffffffffffff82116105c6576107a291600401610731565b9091565b6107fc9160806107d46107c2845160a0855260a085019061070c565b6020850151848203602086015261070c565b926040810151604084015260ff6060820151166060840152015190608081840391015261070c565b90565b908082519081815260208091019281808460051b8301019501936000915b84831061082d5750505050505090565b909192939495848061084b600193601f198682030187528a516107a6565b980193019301919493929061081d565b67ffffffffffffffff81116105fb57601f01601f191660200190565b81601f820112156105c65780359061088e8261085b565b9261089c6040519485610649565b828452602083830101116105c657816000926020809301838601378301015290565b9080601f830112156105c65781356108d58161066b565b926040916108e583519586610649565b808552602093848087019260051b840101938185116105c657858401925b858410610914575050505050505090565b67ffffffffffffffff84358181116105c65786019160a080601f1985880301126105c657845190610944826105df565b8a8501358481116105c657878c61095d92880101610877565b8252858501358481116105c657878c61097892880101610877565b8b8301526060908186013587840152608091828701359060ff821682036105c6578401528501359384116105c6576109b7878c80979681970101610877565b90820152815201930192610903565b9060408101918051906040835281518094526060830160608560051b850101946020809401916000905b828210610a04575050505081015191015290565b909192968580610a20600193605f198b82030186528b516107a6565b9901920192019092916109f0565b90815180825260208080930193019160005b828110610a4e575050505090565b83516001600160a01b031685529381019392810192600101610a40565b60405190610a78826105df565b6060608083828152826020820152600060408201526000838201520152565b81601f820112156105c6578051610aad8161085b565b92610abb6040519485610649565b818452602082840101116105c6576107fc91602080850191016106e9565b906020828203126105c657815167ffffffffffffffff81116105c6576107fc9201610a97565b519060ff821682036105c657565b90610b178261066b565b610b246040519182610649565b8281528092610b35601f199161066b565b019060005b828110610b4657505050565b602090610b51610a6b565b82828501015201610b3a565b6000198114610b6c5760010190565b634e487b7160e01b600052601160045260246000fd5b9190811015610b925760051b0190565b634e487b7160e01b600052603260045260246000fd5b356001600160a01b03811681036105c65790565b8051821015610b925760209160051b010190565b3d15610bfb573d90610be18261085b565b91610bef6040519384610649565b82523d6000602084013e565b606090565b929190610c0c82610b0d565b916000945b818610610c2357505050909150904390565b6001600160a01b039586610c40610c3b838688610b82565b610ba8565b16610d1557819293949596610d0b921631604090815190610c608261062d565b60008252825192610c70846105df565b8051610c7b81610611565b600381526020907f4554480000000000000000000000000000000000000000000000000000000000828201528552815190610cb582610611565b600582527f457468657200000000000000000000000000000000000000000000000000000081830152850152830152601260608301526080820152610cfa8288610bbc565b52610d058187610bbc565b50610b5d565b9493929190610c11565b86610d24610c3b838688610b82565b16966040908151987f745a93d8000000000000000000000000000000000000000000000000000000008a526004918516828b015260248a0152600089604481305afa60009981610df2575b5098610d0b94959697989915600014610de55750610d8b610bd0565b805190929015610dac5750505b6080610da48389610bbc565b510152610b5d565b519150610db882610611565b81527f756e6b6e000000000000000000000000000000000000000000000000000000006020820152610d98565b915050610cfa8288610bbc565b3d808c833e610e018183610649565b81019a818c602093849103126104dd57805167ffffffffffffffff9182821161017e570160a0818f031261018257865193610e3b856105df565b815183811161020d578f610e50918401610a97565b85528082015183811161020d578f610e69918401610a97565b9085015286810151878501526060610e82818301610aff565b908501526080928382015192831161017357509c610ea991610d0b999a9b9c9d9e01610a97565b90820152999897969594610d6f565b93929192600092835b8651811015610f1157604080610ed7838a610bbc565b51015190610ee58387610bbc565b51015103610efc575b610ef790610b5d565b610ec1565b93610f09610ef791610b5d565b949050610eee565b5092909391610f1f82610b0d565b91610f298161066b565b610f43604092610f3b84519384610649565b80835261066b565b6020808301929091601f1901368437519167ffffffffffffffff83116105fb576801000000000000000083116105fb57600054836000558084106110c1575b50906000805260005b8381106110865750505050600096875b815181101561107b5782610faf8284610bbc565b51015183610fbd8387610bbc565b51015103610fd4575b610fcf90610b5d565b610f9b565b97610fdf8985610bbc565b51610fea8287610bbc565b52610ff58186610bbc565b50611004610c3b8a8989610b82565b600054821015610b9257610fcf9161107391600080526001600160a01b03827f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5630191167fffffffffffffffffffffffff0000000000000000000000000000000000000000825416179055610b5d565b989050610fc6565b509296505050505050565b82516001600160a01b03167f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56382015591810191600101610f8b565b837f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56391820191015b8181106110f65750610f82565b600081556001016110e9565b604051906040820182811067ffffffffffffffff8211176105fb576040526000602083606081520152565b604051906000548083528260209182820190600080527f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563936000905b8282106111815750505061117f92500383610649565b565b85546001600160a01b031684526001958601958895509381019390910190611169565b94956111d792939496989791986111b9611102565b976111c2611102565b9a6111ce88888b610c00565b508a52886112dc565b9060209283880152156112a457506040519063057ff68760e51b825280826004816001600160a01b0389165afa91821561129857600092611269575b50818189015285015103611246575b505050604051916112328361062d565b600083525a919392919043906107fc61112d565b611254828261125f95610c00565b508087528451610eb8565b8352388080611222565b90918282813d8311611291575b6112808183610649565b810103126101735750519038611213565b503d611276565b6040513d6000823e3d90fd5b9593505050505a919392919043906107fc61112d565b9190811015610b925760051b81013590603e19813603018212156105c6570190565b9194929093946001600160a01b0383163b15611684575b50506040519163057ff68760e51b928381526020816004816001600160a01b0387165afa90811561129857600091611652575b509460005b82811061135057505050505050604051906113458261062d565b600082529160019190565b6040518581526020816004816001600160a01b0389165afa90811561129857600091611620575b506113838285856112ba565b3514611398575b61139390610b5d565b61132b565b6040517f299ab72a0000000000000000000000000000000000000000000000000000000081526001600160a01b038516600482015260406024820152600081806113e5604482018b610a2e565b0381305afa600091816115dd575b5061140f5750505050505050611407610bd0565b909160009190565b61141a8285856112ba565b602081013591601e19823603018312156105c65767ffffffffffffffff83830135116105c657602083830101918381013560051b9384360384136105c6576001600160a01b0389163b156105c6579192906040519485937f6171d1c9000000000000000000000000000000000000000000000000000000008552604485016040600487015281840135905260648086019286010193926000905b8281013582106115225750505050506114dc829160009460031984830301602485015261070c565b0381836001600160a01b038a165af1908161150a575b5061150557505050505050611407610bd0565b61138a565b67ffffffffffffffff81116105fb57604052386114f2565b919396955091936063198882030185528635607e198584013603018112156105c657848301016001600160a01b0361155c602083016105cb565b1682526040810135602083015260609081810135603e19823603018112156105c657019060406020830135920167ffffffffffffffff83116105c65782360381136105c65783836020948486956040600199015283015280608093848401376000838284010152601f801991011601019801950192018795969493916114b4565b90913d8082843e6115ee8184610649565b8201916020818403126104dd5780519167ffffffffffffffff83116101735750611619929101610a97565b90386113f3565b906020823d60201161164a575b8161163a60209383610649565b8101031261017357505138611377565b3d915061162d565b906020823d60201161167c575b8161166c60209383610649565b8101031261017357505138611326565b3d915061165f565b81600092918360208194519301915af161169c610bd0565b90156116a857806112f3565b935050505060009160009190565b9060609181511561182b5760005b825181146117e7576001600160a01b03806116df8386610bbc565b5116906040805180937fc066a5b1000000000000000000000000000000000000000000000000000000008252816004948286830152602096879160249586918c165afa9081156117dc576000916117af575b5061174957505050505061174490610b5d565b6116c4565b8251948501527f03000000000000000000000000000000000000000000000000000000000000008483015260218452929687019550935090915067ffffffffffffffff84118585101761179c5750505290565b604190634e487b7160e01b600052526000fd5b908682813d83116117d5575b6117c58183610649565b8101031261017357505138611731565b503d6117bb565b84513d6000823e3d90fd5b606460405162461bcd60e51b815260206004820152601860248201527f53706f6f66206661696c65643a2077726f6e67206b65797300000000000000006044820152fd5b606460405162461bcd60e51b815260206004820152601560248201527f53706f6f66206661696c65643a206e6f206b65797300000000000000000000006044820152fdfea26469706673582212203bc009559cf9e0befb0674a93a5c80e8ab981a2dafc10dcb4c644667d0220d5d64736f6c63430008130033",
+    "binRuntime": "0x6040608081526004908136101561001557600080fd5b6000803560e01c8063299ab72a1461055457806358197024146105185780636a385ae9146104e1578063745a93d8146102c6578063c80aca3114610211578063f9a7fe72146101865763fd201de81461006d57600080fd5b346101735760c0366003190112610173576100866105b0565b9067ffffffffffffffff602435818111610182576100a79036908701610683565b9460443582811161017e576100bf9036908301610731565b91606435936001600160a01b038516850361017a57608435818111610176576100eb9036908401610877565b9560a435918211610173575094610157946101219461013c9a9461011961016f9a9561014a9a369101610731565b9690956111a4565b959389939297919599519a8b9a60c08c5260c08c01906109c6565b908a820360208c01526109c6565b918883039089015261070c565b926060860152608085015283820360a0850152610a2e565b0390f35b80fd5b8680fd5b8580fd5b8380fd5b8280fd5b5091346101825760603660031901126101825767ffffffffffffffff90803582811161020d576101b990369083016108be565b9160243581811161017a576101d190369084016108be565b946044359182116101735750916101f261016f95926101fa94369101610731565b929091610eb8565b90519182916020835260208301906107ff565b8480fd5b508290346101735760a03660031901126101735761022d6105b0565b9067ffffffffffffffff6024358181116101825761024e9036908601610683565b93604435916001600160a01b038316830361017e5760643581811161020d5761027a9036908401610877565b936084359182116101735750926060959261029f61016f96936102a796369101610731565b9490936112dc565b919390948051958695865215156020860152840152606083019061070c565b5090346104dd57806003193601126104dd576102e06105b0565b91602435936001600160a01b039485811680910361018257610300610a6b565b958451957f70a0823100000000000000000000000000000000000000000000000000000000875216828601526020948581602481855afa90811561048c5784916104b0575b508487015283517f95d89b4100000000000000000000000000000000000000000000000000000000815283818481855afa90811561048c578491610496575b50865283517f06fdde0300000000000000000000000000000000000000000000000000000000815283818481855afa90811561048c5790869291859161046a575b50828801528451928380927f313ce5670000000000000000000000000000000000000000000000000000000082525afa91821561045f578092610421575b50509060ff61016f92166060850152519282849384528301906107a6565b9091508382813d8311610458575b6104398183610649565b8101031261017357509060ff61045161016f93610aff565b9192610403565b503d61042f565b8351903d90823e3d90fd5b61048691503d8087833e61047e8183610649565b810190610ad9565b386103c5565b85513d86823e3d90fd5b6104aa91503d8086833e61047e8183610649565b38610384565b90508581813d83116104d6575b6104c78183610649565b8101031261017e575138610345565b503d6104bd565b5080fd5b503461017357506104fa6104f436610762565b91610c00565b825183815292839261050e918401906107ff565b9060208301520390f35b5090346104dd576105479061052f6104f436610762565b9190915a9180519485946060865260608601906107ff565b9260208501528301520390f35b50913461018257816003193601126101825761056e6105b0565b926024359067ffffffffffffffff821161017357509261059761059d9261016f95369101610683565b906116b6565b905191829160208352602083019061070c565b600435906001600160a01b03821682036105c657565b600080fd5b35906001600160a01b03821682036105c657565b60a0810190811067ffffffffffffffff8211176105fb57604052565b634e487b7160e01b600052604160045260246000fd5b6040810190811067ffffffffffffffff8211176105fb57604052565b6020810190811067ffffffffffffffff8211176105fb57604052565b90601f8019910116810190811067ffffffffffffffff8211176105fb57604052565b67ffffffffffffffff81116105fb5760051b60200190565b81601f820112156105c65780359161069a8361066b565b926106a86040519485610649565b808452602092838086019260051b8201019283116105c6578301905b8282106106d2575050505090565b8380916106de846105cb565b8152019101906106c4565b60005b8381106106fc5750506000910152565b81810151838201526020016106ec565b90602091610725815180928185528580860191016106e9565b601f01601f1916010190565b9181601f840112156105c65782359167ffffffffffffffff83116105c6576020808501948460051b0101116105c657565b9060406003198301126105c6576004356001600160a01b03811681036105c657916024359067ffffffffffffffff82116105c6576107a291600401610731565b9091565b6107fc9160806107d46107c2845160a0855260a085019061070c565b6020850151848203602086015261070c565b926040810151604084015260ff6060820151166060840152015190608081840391015261070c565b90565b908082519081815260208091019281808460051b8301019501936000915b84831061082d5750505050505090565b909192939495848061084b600193601f198682030187528a516107a6565b980193019301919493929061081d565b67ffffffffffffffff81116105fb57601f01601f191660200190565b81601f820112156105c65780359061088e8261085b565b9261089c6040519485610649565b828452602083830101116105c657816000926020809301838601378301015290565b9080601f830112156105c65781356108d58161066b565b926040916108e583519586610649565b808552602093848087019260051b840101938185116105c657858401925b858410610914575050505050505090565b67ffffffffffffffff84358181116105c65786019160a080601f1985880301126105c657845190610944826105df565b8a8501358481116105c657878c61095d92880101610877565b8252858501358481116105c657878c61097892880101610877565b8b8301526060908186013587840152608091828701359060ff821682036105c6578401528501359384116105c6576109b7878c80979681970101610877565b90820152815201930192610903565b9060408101918051906040835281518094526060830160608560051b850101946020809401916000905b828210610a04575050505081015191015290565b909192968580610a20600193605f198b82030186528b516107a6565b9901920192019092916109f0565b90815180825260208080930193019160005b828110610a4e575050505090565b83516001600160a01b031685529381019392810192600101610a40565b60405190610a78826105df565b6060608083828152826020820152600060408201526000838201520152565b81601f820112156105c6578051610aad8161085b565b92610abb6040519485610649565b818452602082840101116105c6576107fc91602080850191016106e9565b906020828203126105c657815167ffffffffffffffff81116105c6576107fc9201610a97565b519060ff821682036105c657565b90610b178261066b565b610b246040519182610649565b8281528092610b35601f199161066b565b019060005b828110610b4657505050565b602090610b51610a6b565b82828501015201610b3a565b6000198114610b6c5760010190565b634e487b7160e01b600052601160045260246000fd5b9190811015610b925760051b0190565b634e487b7160e01b600052603260045260246000fd5b356001600160a01b03811681036105c65790565b8051821015610b925760209160051b010190565b3d15610bfb573d90610be18261085b565b91610bef6040519384610649565b82523d6000602084013e565b606090565b929190610c0c82610b0d565b916000945b818610610c2357505050909150904390565b6001600160a01b039586610c40610c3b838688610b82565b610ba8565b16610d1557819293949596610d0b921631604090815190610c608261062d565b60008252825192610c70846105df565b8051610c7b81610611565b600381526020907f4554480000000000000000000000000000000000000000000000000000000000828201528552815190610cb582610611565b600582527f457468657200000000000000000000000000000000000000000000000000000081830152850152830152601260608301526080820152610cfa8288610bbc565b52610d058187610bbc565b50610b5d565b9493929190610c11565b86610d24610c3b838688610b82565b16966040908151987f745a93d8000000000000000000000000000000000000000000000000000000008a526004918516828b015260248a0152600089604481305afa60009981610df2575b5098610d0b94959697989915600014610de55750610d8b610bd0565b805190929015610dac5750505b6080610da48389610bbc565b510152610b5d565b519150610db882610611565b81527f756e6b6e000000000000000000000000000000000000000000000000000000006020820152610d98565b915050610cfa8288610bbc565b3d808c833e610e018183610649565b81019a818c602093849103126104dd57805167ffffffffffffffff9182821161017e570160a0818f031261018257865193610e3b856105df565b815183811161020d578f610e50918401610a97565b85528082015183811161020d578f610e69918401610a97565b9085015286810151878501526060610e82818301610aff565b908501526080928382015192831161017357509c610ea991610d0b999a9b9c9d9e01610a97565b90820152999897969594610d6f565b93929192600092835b8651811015610f1157604080610ed7838a610bbc565b51015190610ee58387610bbc565b51015103610efc575b610ef790610b5d565b610ec1565b93610f09610ef791610b5d565b949050610eee565b5092909391610f1f82610b0d565b91610f298161066b565b610f43604092610f3b84519384610649565b80835261066b565b6020808301929091601f1901368437519167ffffffffffffffff83116105fb576801000000000000000083116105fb57600054836000558084106110c1575b50906000805260005b8381106110865750505050600096875b815181101561107b5782610faf8284610bbc565b51015183610fbd8387610bbc565b51015103610fd4575b610fcf90610b5d565b610f9b565b97610fdf8985610bbc565b51610fea8287610bbc565b52610ff58186610bbc565b50611004610c3b8a8989610b82565b600054821015610b9257610fcf9161107391600080526001600160a01b03827f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5630191167fffffffffffffffffffffffff0000000000000000000000000000000000000000825416179055610b5d565b989050610fc6565b509296505050505050565b82516001600160a01b03167f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56382015591810191600101610f8b565b837f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56391820191015b8181106110f65750610f82565b600081556001016110e9565b604051906040820182811067ffffffffffffffff8211176105fb576040526000602083606081520152565b604051906000548083528260209182820190600080527f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563936000905b8282106111815750505061117f92500383610649565b565b85546001600160a01b031684526001958601958895509381019390910190611169565b94956111d792939496989791986111b9611102565b976111c2611102565b9a6111ce88888b610c00565b508a52886112dc565b9060209283880152156112a457506040519063057ff68760e51b825280826004816001600160a01b0389165afa91821561129857600092611269575b50818189015285015103611246575b505050604051916112328361062d565b600083525a919392919043906107fc61112d565b611254828261125f95610c00565b508087528451610eb8565b8352388080611222565b90918282813d8311611291575b6112808183610649565b810103126101735750519038611213565b503d611276565b6040513d6000823e3d90fd5b9593505050505a919392919043906107fc61112d565b9190811015610b925760051b81013590603e19813603018212156105c6570190565b9194929093946001600160a01b0383163b15611684575b50506040519163057ff68760e51b928381526020816004816001600160a01b0387165afa90811561129857600091611652575b509460005b82811061135057505050505050604051906113458261062d565b600082529160019190565b6040518581526020816004816001600160a01b0389165afa90811561129857600091611620575b506113838285856112ba565b3514611398575b61139390610b5d565b61132b565b6040517f299ab72a0000000000000000000000000000000000000000000000000000000081526001600160a01b038516600482015260406024820152600081806113e5604482018b610a2e565b0381305afa600091816115dd575b5061140f5750505050505050611407610bd0565b909160009190565b61141a8285856112ba565b602081013591601e19823603018312156105c65767ffffffffffffffff83830135116105c657602083830101918381013560051b9384360384136105c6576001600160a01b0389163b156105c6579192906040519485937f6171d1c9000000000000000000000000000000000000000000000000000000008552604485016040600487015281840135905260648086019286010193926000905b8281013582106115225750505050506114dc829160009460031984830301602485015261070c565b0381836001600160a01b038a165af1908161150a575b5061150557505050505050611407610bd0565b61138a565b67ffffffffffffffff81116105fb57604052386114f2565b919396955091936063198882030185528635607e198584013603018112156105c657848301016001600160a01b0361155c602083016105cb565b1682526040810135602083015260609081810135603e19823603018112156105c657019060406020830135920167ffffffffffffffff83116105c65782360381136105c65783836020948486956040600199015283015280608093848401376000838284010152601f801991011601019801950192018795969493916114b4565b90913d8082843e6115ee8184610649565b8201916020818403126104dd5780519167ffffffffffffffff83116101735750611619929101610a97565b90386113f3565b906020823d60201161164a575b8161163a60209383610649565b8101031261017357505138611377565b3d915061162d565b906020823d60201161167c575b8161166c60209383610649565b8101031261017357505138611326565b3d915061165f565b81600092918360208194519301915af161169c610bd0565b90156116a857806112f3565b935050505060009160009190565b9060609181511561182b5760005b825181146117e7576001600160a01b03806116df8386610bbc565b5116906040805180937fc066a5b1000000000000000000000000000000000000000000000000000000008252816004948286830152602096879160249586918c165afa9081156117dc576000916117af575b5061174957505050505061174490610b5d565b6116c4565b8251948501527f03000000000000000000000000000000000000000000000000000000000000008483015260218452929687019550935090915067ffffffffffffffff84118585101761179c5750505290565b604190634e487b7160e01b600052526000fd5b908682813d83116117d5575b6117c58183610649565b8101031261017357505138611731565b503d6117bb565b84513d6000823e3d90fd5b606460405162461bcd60e51b815260206004820152601860248201527f53706f6f66206661696c65643a2077726f6e67206b65797300000000000000006044820152fd5b606460405162461bcd60e51b815260206004820152601560248201527f53706f6f66206661696c65643a206e6f206b65797300000000000000000000006044820152fdfea26469706673582212203bc009559cf9e0befb0674a93a5c80e8ab981a2dafc10dcb4c644667d0220d5d64736f6c63430008130033"
 }

--- a/contracts/deployless/BalanceGetter.sol
+++ b/contracts/deployless/BalanceGetter.sol
@@ -21,10 +21,6 @@ contract BalanceGetter is Simulation {
     uint8 decimals;
     bytes error;
   }
-  struct BalanceInfo {
-    uint256 amount;
-    bytes error;
-  }
   struct BalancesAtNonce {
     TokenInfo[] balances;
     uint nonce;
@@ -38,13 +34,6 @@ contract BalanceGetter is Simulation {
     info.symbol = token.symbol();
     info.name = token.name();
     info.decimals = token.decimals();
-  }
-
-  function getERC20TokenBalance(
-    IAmbireAccount account,
-    IERC20 token
-  ) external view returns (BalanceInfo memory info) {
-    info.amount = token.balanceOf(address(account));
   }
 
   function getBalances(
@@ -73,27 +62,6 @@ contract BalanceGetter is Simulation {
   ) public view returns (TokenInfo[] memory, uint, uint) {
     (TokenInfo[] memory results, uint blockNumber) = getBalances(account, tokenAddrs);
     return (results, gasleft(), blockNumber);
-  }
-
-  function getBalancesOf(
-    IAmbireAccount account,
-    address[] calldata tokenAddrs
-  ) public view returns (BalanceInfo[] memory) {
-    uint len = tokenAddrs.length;
-    BalanceInfo[] memory results = new BalanceInfo[](len);
-    
-    for (uint256 i = 0; i < len; i++) {
-      if (tokenAddrs[i] == address(0)) {
-        results[i] = BalanceInfo(address(account).balance, bytes(''));
-      } else {
-        try this.getERC20TokenBalance(account, IERC20(tokenAddrs[i])) returns (BalanceInfo memory balanceInfo) {
-          results[i] = balanceInfo;
-        } catch (bytes memory e) {
-          results[i].error = e.length > 0 ? e : bytes('unkn');
-        }
-      }
-    }
-    return results;
   }
 
   // Compare the tokens balances before (balancesA) and after simulation (balancesB)

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -274,23 +274,13 @@ export async function getTokens(
         : opts.blockTag
   })
 
-  // If we are fetching both the pending and latest block, we don't need to fetch the entire token
-  // info twice, just the info from the pending block and the balances from the latest block
-  const getLatestBalances = async () => {
-    if (!isFetchingBothBlocks) return null
-
-    return deployless.call('getBalancesOf', [accountAddr, tokenAddrs], {
-      ...deploylessOpts,
-      blockTag: 'latest'
-    })
-  }
-
   const getMainResults = async () => {
-    if (!opts.simulation) {
-      return deployless.call('getBalances', [accountAddr, tokenAddrs], deploylessOpts)
+    const { accountOps, baseAccount } = opts.simulation || {}
+
+    if (!baseAccount) {
+      throw new Error('Base account is required for simulation')
     }
 
-    const { accountOps, baseAccount, state } = opts.simulation || {}
     const account = baseAccount.getAccount()
     const shouldStateOverride =
       !network.rpcNoStateOverride && baseAccount.shouldStateOverrideDuringSimulations()
@@ -318,22 +308,17 @@ export async function getTokens(
     }
   }
 
-  const [mainResults, latestBalances] = await Promise.all([getMainResults(), getLatestBalances()])
-
   if (!opts.simulation) {
-    const [results, blockNumber] = mainResults
+    const [results, blockNumber] = await deployless.call(
+      'getBalances',
+      [accountAddr, tokenAddrs],
+      deploylessOpts
+    )
 
     return [
       results.map((token: any, i: number) => [
-        token.error || (latestBalances && latestBalances[i].error ? latestBalances[i].error : null),
-        mapToken(
-          token,
-          network,
-          tokenAddrs[i]!,
-          opts,
-          undefined,
-          Array.isArray(latestBalances) ? latestBalances[i].amount : undefined
-        )
+        token.error,
+        mapToken(token, network, tokenAddrs[i]!, opts, undefined, token.amount)
       ]),
       {
         blockNumber
@@ -341,11 +326,12 @@ export async function getTokens(
     ]
   }
 
+  const mainResults = await getMainResults()
   const [before, after, simulationErr, , blockNumber, deltaAddressesMapping] = mainResults.result
 
   const beforeNonce = before.nonce
   const afterNonce = after.nonce
-  handleSimulationError(simulationErr, beforeNonce, afterNonce, mainResults.simulationOps)
+  handleSimulationError(simulationErr, beforeNonce, afterNonce, mainResults.simulationOps || [])
 
   // simulation was performed if the nonce is changed
   const hasSimulation = afterNonce !== beforeNonce
@@ -378,16 +364,9 @@ export async function getTokens(
       // Final balance displayed on the Dashboard (we will call it `amountPostSimulation`):
       //   - after.balances, 8 USDC.
       return [
-        token.error || (latestBalances && latestBalances[i].error ? latestBalances[i].error : null),
+        token.error,
         {
-          ...mapToken(
-            token,
-            network,
-            tokenAddrs[i]!,
-            opts,
-            !!simulationAmount,
-            Array.isArray(latestBalances) ? latestBalances[i].amount : undefined
-          ),
+          ...mapToken(token, network, tokenAddrs[i]!, opts, !!simulationAmount, token.amount),
           simulationAmount,
           amountPostSimulation
         }


### PR DESCRIPTION
For some reason I thought that latest balances have to be fetched separately while refactoring https://github.com/AmbireTech/ambire-common/pull/1925/changes. Turns out it's not needed because all balances are already contained in `before` of `simulateAndGetBalances` and `getBalances` 