### PR TITLE
Fix / dApp not-present-in-catalog verification + integration/unit tests

### DIFF
--- a/src/controllers/dapps/dapps.test.ts
+++ b/src/controllers/dapps/dapps.test.ts
@@ -2,12 +2,15 @@ import fetch from 'node-fetch'
 
 import { expect } from '@jest/globals'
 
+import { PhishingController } from '../phishing/phishing'
 import { suppressConsole } from '../../../test/helpers/console'
+import { makeDapp } from '../../../test/helpers/dapps'
 import { makeMainController } from '../../../test/helpers/mainController'
 import { Session } from '../../classes/session'
 import { predefinedDapps } from '../../consts/dapps/dapps'
 import mockChains from '../../consts/dapps/mockChains'
 import mockDapps from '../../consts/dapps/mockDapps'
+import { DAPP_VERIFICATION_BANNER_IDS, type Dapp } from '../../interfaces/dapp'
 import { IStorageController } from '../../interfaces/storage'
 import { DappConnectRequest } from '../../interfaces/userRequest'
 
@@ -259,5 +262,133 @@ describe('DappsController', () => {
 
     expect(controller.getDapp('test-dapp.com')?.blacklisted).toBe('BLACKLISTED')
     expect(resetShouldSyncSpy).toHaveBeenCalledTimes(1)
+  })
+
+  describe('getDappVerificationBanner', () => {
+    const mockDappVerificationStatuses = (statuses: Record<string, Dapp['blacklisted']>) =>
+      jest
+        .spyOn(PhishingController.prototype, 'updateDomainsBlacklistedStatus')
+        .mockImplementation(async (_urls, callback) => {
+          callback(statuses)
+        })
+
+    test('should return loading banner for dapps with pending verification', async () => {
+      const updateDomainsSpy = mockDappVerificationStatuses({ 'aave.com': 'LOADING' })
+
+      try {
+        const { controller } = await prepareTest(async (storageCtrl) => {
+          await storageCtrl.set('dappsV2', predefinedDapps)
+          await storageCtrl.set('lastDappsUpdateVersion', 'test-version')
+        })
+        await controller.fetchAndUpdatePromise
+
+        const aave = controller.getDapp('aave.com')!
+        expect(updateDomainsSpy).toHaveBeenCalled()
+        expect(controller.getDappVerificationBanner([aave.url])).toEqual({
+          id: DAPP_VERIFICATION_BANNER_IDS.LOADING,
+          type: 'warning',
+          text: "We're still verifying the app. Please wait, or make sure you trust it before signing requests: AAVE"
+        })
+      } finally {
+        updateDomainsSpy.mockRestore()
+      }
+    })
+
+    test('should return failed banner for dapps with failed verification', async () => {
+      const updateDomainsSpy = mockDappVerificationStatuses({ 'aave.com': 'FAILED_TO_GET' })
+
+      try {
+        const { controller } = await prepareTest(async (storageCtrl) => {
+          await storageCtrl.set('dappsV2', predefinedDapps)
+          await storageCtrl.set('lastDappsUpdateVersion', 'test-version')
+        })
+        await controller.fetchAndUpdatePromise
+
+        const aave = controller.getDapp('aave.com')!
+        expect(updateDomainsSpy).toHaveBeenCalled()
+        expect(controller.getDappVerificationBanner([aave.url])).toEqual({
+          id: DAPP_VERIFICATION_BANNER_IDS.FAILED_TO_GET_OR_UNKNOWN,
+          type: 'warning',
+          text: "We couldn't verify the app. Make sure you trust it before signing requests: AAVE"
+        })
+      } finally {
+        updateDomainsSpy.mockRestore()
+      }
+    })
+
+    test('should return blacklisted banner for blacklisted dapps', async () => {
+      const updateDomainsSpy = mockDappVerificationStatuses({ 'aave.com': 'BLACKLISTED' })
+
+      try {
+        const { controller } = await prepareTest(async (storageCtrl) => {
+          await storageCtrl.set('dappsV2', predefinedDapps)
+          await storageCtrl.set('lastDappsUpdateVersion', 'test-version')
+        })
+        await controller.fetchAndUpdatePromise
+
+        const aave = controller.getDapp('aave.com')!
+        expect(updateDomainsSpy).toHaveBeenCalled()
+        expect(controller.getDappVerificationBanner([aave.url])).toEqual({
+          id: DAPP_VERIFICATION_BANNER_IDS.BLACKLISTED,
+          type: 'error',
+          text: "This app didn't pass our safety check. Proceed at your own risk: AAVE"
+        })
+      } finally {
+        updateDomainsSpy.mockRestore()
+      }
+    })
+
+    test('should return not-in-catalog banner for verified custom dapps', async () => {
+      const customDapp = makeDapp({
+        id: 'custom-dapp.com',
+        name: 'Custom Dapp',
+        url: 'https://custom-dapp.com',
+        blacklisted: 'LOADING',
+        isCustom: true
+      })
+      const updateDomainsSpy = mockDappVerificationStatuses({ 'custom-dapp.com': 'VERIFIED' })
+
+      try {
+        const { controller } = await prepareTest(async (storageCtrl) => {
+          await storageCtrl.set('dappsV2', [...predefinedDapps, customDapp])
+          await storageCtrl.set('lastDappsUpdateVersion', 'test-version')
+        })
+        await controller.fetchAndUpdatePromise
+
+        const verifiedCustomDapp = controller.getDapp(customDapp.id)!
+        expect(updateDomainsSpy).toHaveBeenCalled()
+        expect(controller.getDappVerificationBanner([verifiedCustomDapp.url])).toEqual({
+          id: DAPP_VERIFICATION_BANNER_IDS.NOT_IN_CATALOG,
+          type: 'warning',
+          text: 'App is not on the default Ambire App Catalog. Make sure you trust it before signing requests: Custom Dapp'
+        })
+      } finally {
+        updateDomainsSpy.mockRestore()
+      }
+    })
+
+    test('should not return banner for verified dapps in the default catalog', async () => {
+      const updateDomainsSpy = jest.spyOn(
+        PhishingController.prototype,
+        'updateDomainsBlacklistedStatus'
+      )
+
+      try {
+        const { controller } = await prepareTest(async (storageCtrl) => {
+          await storageCtrl.set('dappsV2', predefinedDapps)
+          await storageCtrl.set('lastDappsUpdateVersion', 'test-version')
+        })
+
+        await controller.fetchAndUpdatePromise
+
+        const aave = controller.dapps.find((dapp) => dapp.name === 'AAVE')!
+        expect(updateDomainsSpy).toHaveBeenCalled()
+        expect(updateDomainsSpy.mock.calls.some(([urls]) => urls.includes(aave.url))).toBe(true)
+        expect(aave.blacklisted).toBe('VERIFIED')
+        expect(controller.getDappVerificationBanner([aave.url])).toBe(null)
+      } finally {
+        updateDomainsSpy.mockRestore()
+      }
+    })
   })
 })

--- a/src/controllers/dapps/dapps.ts
+++ b/src/controllers/dapps/dapps.ts
@@ -810,7 +810,7 @@ export class DappsController extends EventEmitter implements IDappsController {
    * 1) dApp verification in progress (`LOADING`)
    * 2) dApp verification failed / unknown (`FAILED_TO_GET` or missing status)
    * 3) dApp is blacklisted (`BLACKLISTED`)
-   * 4) dApp is not in the default catalog (not `VERIFIED`)
+   * 4) dApp is verified but not in the default catalog
    *
    * Pass `includeDappNamesInText: false` in single-dApp flows (e.g. SignMessage),
    * where appending the dApp names in the banner text is redundant.
@@ -825,8 +825,11 @@ export class DappsController extends EventEmitter implements IDappsController {
     if (!validDappUrls.length) return null
 
     const dappVerificationData = validDappUrls.map((url) => {
-      const dapp = this.#dapps.get(getDappIdFromUrl(url))
+      const id = getDappIdFromUrl(url)
+      const dapp = this.#dapps.get(id)
+
       return {
+        id,
         status: dapp?.blacklisted,
         name: dapp?.name || new URL(url).hostname
       }
@@ -850,6 +853,13 @@ export class DappsController extends EventEmitter implements IDappsController {
         : `${baseText}:`
 
       return `${withColon} ${dappNames}`
+    }
+
+    const isDappInDefaultCatalog = (dappId: string) => {
+      const storedDapp = this.#dapps.get(dappId)
+
+      // Custom dApps are user-added/connected entries, not default catalog entries.
+      return !!storedDapp && !storedDapp.isCustom
     }
 
     // 1) dApp verification in progress
@@ -894,14 +904,16 @@ export class DappsController extends EventEmitter implements IDappsController {
     }
 
     // 4) dApp is not in the default catalog
-    const notVerifiedDappNames = getDappNamesByPredicate((dapp) => dapp.status !== 'VERIFIED')
-    if (notVerifiedDappNames.length) {
+    const notInCatalogDappNames = getDappNamesByPredicate(
+      (dapp) => dapp.status === 'VERIFIED' && !isDappInDefaultCatalog(dapp.id)
+    )
+    if (notInCatalogDappNames.length) {
       return {
         id: DAPP_VERIFICATION_BANNER_IDS.NOT_IN_CATALOG,
         type: 'warning',
         text: withOptionalDappNames(
           'App is not on the default Ambire App Catalog. Make sure you trust it before signing requests.',
-          notVerifiedDappNames
+          notInCatalogDappNames
         )
       }
     }

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -3,18 +3,27 @@
 import { AbiCoder, getAddress, hexlify, parseEther, toBeHex, verifyMessage } from 'ethers'
 import fetch from 'node-fetch'
 
-import { describe, expect, test } from '@jest/globals'
+import { describe, expect, jest, test } from '@jest/globals'
 import { recoverTypedSignature, SignTypedDataVersion } from '@metamask/eth-sig-util'
 
 import { relayerUrl, trezorSlot7v24337Deployed, velcroUrl } from '../../../test/config'
 import { produceMemoryStore, waitForAccountsCtrlFirstLoad } from '../../../test/helpers'
 import { suppressConsole, suppressConsoleBeforeEach } from '../../../test/helpers/console'
+import {
+  blacklistedDapp,
+  customDapp,
+  failedDapp,
+  getDappVerificationTestDapps,
+  getDappRequestData,
+  loadingDapp
+} from '../../../test/helpers/dapps'
 import { mockUiManager } from '../../../test/helpers/ui'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { FEE_COLLECTOR } from '../../consts/addresses'
 import { EOA_SIMULATION_NONCE } from '../../consts/deployless'
 import { networks } from '../../consts/networks'
 import { Account } from '../../interfaces/account'
+import { DAPP_VERIFICATION_BANNER_IDS, Dapp, IDappsController } from '../../interfaces/dapp'
 import { Hex } from '../../interfaces/hex'
 import { IProvidersController } from '../../interfaces/provider'
 import { Storage } from '../../interfaces/storage'
@@ -27,6 +36,7 @@ import { FullEstimationSummary } from '../../libs/estimate/interfaces'
 import { KeystoreSigner } from '../../libs/keystoreSigner/keystoreSigner'
 import { TokenResult } from '../../libs/portfolio'
 import { relayerCall, RelayerError } from '../../libs/relayerCall/relayerCall'
+import { PERMIT2_ADDRESS_LOWERCASED } from '../../libs/simulation/detectPermit2Interaction'
 import {
   adaptTypedMessageForMetaMaskSigUtil,
   getTypedData
@@ -42,6 +52,7 @@ import { ActivityController } from '../activity/activity'
 import { AddressBookController } from '../addressBook/addressBook'
 import { AutoLoginController } from '../autoLogin/autoLogin'
 import { BannerController } from '../banner/banner'
+import { DappsController } from '../dapps/dapps'
 import { EstimationController } from '../estimation/estimation'
 import { EstimationStatus } from '../estimation/types'
 import { FeatureFlagsController } from '../featureFlags/featureFlags'
@@ -361,12 +372,19 @@ const init = async (
   signer: any,
   estimationOrMock: FullEstimationSummary,
   gasPricesOrMock: GasSpeeds,
-  updateWholePortfolio?: boolean
+  updateWholePortfolio?: boolean,
+  options?: {
+    dapps?: Dapp[]
+  }
 ) => {
   const storage: Storage = produceMemoryStore()
   const storageCtrl = new StorageController(storage)
   await storageCtrl.set('accounts', [account])
   await storageCtrl.set('selectedAccount', account.addr)
+  if (options?.dapps) {
+    await storageCtrl.set('dappsV2', options.dapps)
+    await storageCtrl.set('lastDappsUpdateVersion', '1.0.0')
+  }
   const keystore = new KeystoreController(
     'default',
     storageCtrl,
@@ -465,12 +483,25 @@ const init = async (
     bannerCtrl,
     featureFlagsCtrl
   )
+  const continuouslyUpdatePhishingSpy = options?.dapps
+    ? jest
+        .spyOn(PhishingController.prototype, 'continuouslyUpdatePhishing')
+        .mockImplementation(async () => {
+          await wait(1)
+        })
+    : undefined
   const phishing = new PhishingController({
     fetch,
     storage: storageCtrl,
     addressBook: addressBookCtrl,
     ui: uiCtrl
   })
+  if (options?.dapps) {
+    await phishing.initialLoadPromise
+    await phishing.updatePhishingInterval.promise
+    phishing.updatePhishingInterval.stop()
+    continuouslyUpdatePhishingSpy?.mockRestore()
+  }
   const { op } = accountOp
   const network = networksCtrl.networks.find((x) => x.chainId === op.chainId)!
   await portfolio.updateSelectedAccount(account.addr, updateWholePortfolio ? undefined : [network])
@@ -566,6 +597,25 @@ const init = async (
     onUpdate: () => () => {},
     getDappVerificationBanner: () => null
   }
+  let dapps: IDappsController = dappsControllerMock as any
+  if (options?.dapps) {
+    const fetchAndUpdateSpy = jest
+      .spyOn(DappsController.prototype, 'fetchAndUpdateDapps')
+      .mockImplementation(async () => {
+        await wait(1)
+      })
+    const realDappsController = new DappsController({
+      appVersion: '1.0.0',
+      fetch,
+      storage: storageCtrl,
+      networks: networksCtrl,
+      phishing,
+      ui: uiCtrl
+    })
+    await realDappsController.initialLoadPromise
+    fetchAndUpdateSpy.mockRestore()
+    dapps = realDappsController
+  }
   const controller = new SignAccountOpTesterController({
     accounts: accountsCtrl,
     networks: networksCtrl,
@@ -575,7 +625,7 @@ const init = async (
     account,
     network,
     activity,
-    dapps: dappsControllerMock as any,
+    dapps,
     provider,
     phishing,
     fromRequestId: 1,
@@ -592,6 +642,85 @@ const init = async (
   })
 
   return { controller }
+}
+
+const bannerTestFeePaymentOptions = [
+  {
+    paidBy: eoaAccount.addr,
+    availableAmount: 1000000000000000000n,
+    gasUsed: 0n,
+    addedNative: 5000n,
+    token: {
+      address: '0x0000000000000000000000000000000000000000',
+      amount: parseEther('1'),
+      symbol: 'ETH',
+      name: 'Ether',
+      chainId: 1n,
+      decimals: 18,
+      priceIn: [],
+      marketDataIn: [],
+      flags: {
+        onGasTank: false,
+        rewardsType: null,
+        canTopUpGasTank: true,
+        isFeeToken: true
+      }
+    }
+  }
+]
+
+const bannerTestEstimation: FullEstimationSummary = {
+  providerEstimation: {
+    gasUsed: 10000n,
+    feePaymentOptions: bannerTestFeePaymentOptions
+  },
+  ambireEstimation: {
+    deploymentGas: 0n,
+    gasUsed: 10000n,
+    feePaymentOptions: bannerTestFeePaymentOptions,
+    ambireAccountNonce: Number(EOA_SIMULATION_NONCE),
+    flags: {}
+  },
+  flags: {},
+  updatedAt: Date.now()
+}
+
+const bannerTestGasPrices: GasSpeeds = {
+  slow: {
+    maxFeePerGas: toBeHex(200n) as Hex,
+    maxPriorityFeePerGas: toBeHex(100n) as Hex
+  },
+  medium: {
+    maxFeePerGas: toBeHex(400n) as Hex,
+    maxPriorityFeePerGas: toBeHex(200n) as Hex
+  },
+  fast: {
+    maxFeePerGas: toBeHex(600n) as Hex,
+    maxPriorityFeePerGas: toBeHex(300n) as Hex
+  },
+  ape: {
+    maxFeePerGas: toBeHex(800n) as Hex,
+    maxPriorityFeePerGas: toBeHex(400n) as Hex
+  }
+}
+
+const initDappVerificationBannerTest = async (
+  dapp: Dapp,
+  { isPermit2 = false }: { isPermit2?: boolean } = {}
+) => {
+  const accountOp = createEOAAccountOp(eoaAccount)
+  ;(accountOp.op.calls as any) = [
+    {
+      to: isPermit2 ? PERMIT2_ADDRESS_LOWERCASED : '0x0000000000000000000000000000000000000000',
+      value: BigInt(1),
+      data: '0x',
+      dapp: getDappRequestData(dapp)
+    }
+  ]
+
+  return init(eoaAccount, accountOp, eoaSigner, bannerTestEstimation, bannerTestGasPrices, false, {
+    dapps: getDappVerificationTestDapps()
+  })
 }
 
 describe('SignAccountOp Controller ', () => {
@@ -2163,4 +2292,60 @@ test('Signing [V1 with EOA payment]: working case', async () => {
 
   // If signing is successful, we expect controller's status to be done
   expect(controller.status).toEqual({ type: 'done' })
+})
+
+describe('dapp verification banners', () => {
+  test('should return loading banners', async () => {
+    const { controller } = await initDappVerificationBannerTest(loadingDapp)
+
+    expect(controller.banners).toEqual([
+      {
+        id: DAPP_VERIFICATION_BANNER_IDS.LOADING,
+        type: 'warning',
+        text: "We're still verifying the app. Please wait, or make sure you trust it before signing requests: Loading Dapp"
+      }
+    ])
+  })
+
+  test('should return failed verification banners', async () => {
+    const { controller } = await initDappVerificationBannerTest(failedDapp)
+
+    expect(controller.banners).toEqual([
+      {
+        id: DAPP_VERIFICATION_BANNER_IDS.FAILED_TO_GET_OR_UNKNOWN,
+        type: 'warning',
+        text: "We couldn't verify the app. Make sure you trust it before signing requests: Failed Dapp"
+      }
+    ])
+  })
+
+  test('should return blacklisted banners', async () => {
+    const { controller } = await initDappVerificationBannerTest(blacklistedDapp)
+
+    expect(controller.banners).toEqual([
+      {
+        id: DAPP_VERIFICATION_BANNER_IDS.BLACKLISTED,
+        type: 'error',
+        text: "This app didn't pass our safety check. Proceed at your own risk: Blacklisted Dapp"
+      }
+    ])
+  })
+
+  test('should hide not-in-catalog banners for non-Permit2 interactions', async () => {
+    const { controller } = await initDappVerificationBannerTest(customDapp)
+
+    expect(controller.banners).toEqual([])
+  })
+
+  test('should show not-in-catalog banners for Permit2 interactions', async () => {
+    const { controller } = await initDappVerificationBannerTest(customDapp, { isPermit2: true })
+
+    expect(controller.banners).toEqual([
+      {
+        id: DAPP_VERIFICATION_BANNER_IDS.NOT_IN_CATALOG,
+        type: 'warning',
+        text: 'App is not on the default Ambire App Catalog. Make sure you trust it before signing requests: Custom Dapp'
+      }
+    ])
+  })
 })

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -644,66 +644,6 @@ const init = async (
   return { controller }
 }
 
-const bannerTestFeePaymentOptions = [
-  {
-    paidBy: eoaAccount.addr,
-    availableAmount: 1000000000000000000n,
-    gasUsed: 0n,
-    addedNative: 5000n,
-    token: {
-      address: '0x0000000000000000000000000000000000000000',
-      amount: parseEther('1'),
-      symbol: 'ETH',
-      name: 'Ether',
-      chainId: 1n,
-      decimals: 18,
-      priceIn: [],
-      marketDataIn: [],
-      flags: {
-        onGasTank: false,
-        rewardsType: null,
-        canTopUpGasTank: true,
-        isFeeToken: true
-      }
-    }
-  }
-]
-
-const bannerTestEstimation: FullEstimationSummary = {
-  providerEstimation: {
-    gasUsed: 10000n,
-    feePaymentOptions: bannerTestFeePaymentOptions
-  },
-  ambireEstimation: {
-    deploymentGas: 0n,
-    gasUsed: 10000n,
-    feePaymentOptions: bannerTestFeePaymentOptions,
-    ambireAccountNonce: Number(EOA_SIMULATION_NONCE),
-    flags: {}
-  },
-  flags: {},
-  updatedAt: Date.now()
-}
-
-const bannerTestGasPrices: GasSpeeds = {
-  slow: {
-    maxFeePerGas: toBeHex(200n) as Hex,
-    maxPriorityFeePerGas: toBeHex(100n) as Hex
-  },
-  medium: {
-    maxFeePerGas: toBeHex(400n) as Hex,
-    maxPriorityFeePerGas: toBeHex(200n) as Hex
-  },
-  fast: {
-    maxFeePerGas: toBeHex(600n) as Hex,
-    maxPriorityFeePerGas: toBeHex(300n) as Hex
-  },
-  ape: {
-    maxFeePerGas: toBeHex(800n) as Hex,
-    maxPriorityFeePerGas: toBeHex(400n) as Hex
-  }
-}
-
 const initDappVerificationBannerTest = async (
   dapp: Dapp,
   { isPermit2 = false }: { isPermit2?: boolean } = {}
@@ -718,9 +658,73 @@ const initDappVerificationBannerTest = async (
     }
   ]
 
-  return init(eoaAccount, accountOp, eoaSigner, bannerTestEstimation, bannerTestGasPrices, false, {
-    dapps: getDappVerificationTestDapps()
-  })
+  const feePaymentOptions = [
+    {
+      paidBy: eoaAccount.addr,
+      availableAmount: 1000000000000000000n,
+      gasUsed: 0n,
+      addedNative: 5000n,
+      token: {
+        address: '0x0000000000000000000000000000000000000000',
+        amount: parseEther('1'),
+        symbol: 'ETH',
+        name: 'Ether',
+        chainId: 1n,
+        decimals: 18,
+        priceIn: [],
+        marketDataIn: [],
+        flags: {
+          onGasTank: false,
+          rewardsType: null,
+          canTopUpGasTank: true,
+          isFeeToken: true
+        }
+      }
+    }
+  ]
+
+  return init(
+    eoaAccount,
+    accountOp,
+    eoaSigner,
+    {
+      providerEstimation: {
+        gasUsed: 10000n,
+        feePaymentOptions
+      },
+      ambireEstimation: {
+        deploymentGas: 0n,
+        gasUsed: 10000n,
+        feePaymentOptions,
+        ambireAccountNonce: Number(EOA_SIMULATION_NONCE),
+        flags: {}
+      },
+      flags: {},
+      updatedAt: Date.now()
+    },
+    {
+      slow: {
+        maxFeePerGas: toBeHex(200n) as Hex,
+        maxPriorityFeePerGas: toBeHex(100n) as Hex
+      },
+      medium: {
+        maxFeePerGas: toBeHex(400n) as Hex,
+        maxPriorityFeePerGas: toBeHex(200n) as Hex
+      },
+      fast: {
+        maxFeePerGas: toBeHex(600n) as Hex,
+        maxPriorityFeePerGas: toBeHex(300n) as Hex
+      },
+      ape: {
+        maxFeePerGas: toBeHex(800n) as Hex,
+        maxPriorityFeePerGas: toBeHex(400n) as Hex
+      }
+    },
+    false,
+    {
+      dapps: getDappVerificationTestDapps()
+    }
+  )
 }
 
 describe('SignAccountOp Controller ', () => {

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -4,9 +4,19 @@ import { hexlify, randomBytes } from 'ethers'
 
 import { describe, expect, jest, test } from '@jest/globals'
 
+import {
+  blacklistedDapp,
+  customDapp,
+  failedDapp,
+  getDappVerificationTestDapps,
+  getDappRequestData,
+  loadingDapp,
+  verifiedDapp
+} from '../../../test/helpers/dapps'
 import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { Account, IAccountsController } from '../../interfaces/account'
+import { DAPP_VERIFICATION_BANNER_IDS, IDappsController } from '../../interfaces/dapp'
 import { Hex } from '../../interfaces/hex'
 import { IInviteController } from '../../interfaces/invite'
 import { IKeystoreController, Key, KeystoreSignerInterface } from '../../interfaces/keystore'
@@ -77,6 +87,12 @@ const messageToSign: Message = {
   signature: null
 }
 
+const dapp = {
+  name: 'Test Dapp',
+  icon: 'https://test-dapp.com/icon.png',
+  url: 'https://Test-Dapp.com'
+}
+
 describe('SignMessageController', () => {
   let signMessageController: ISignMessageController
   let keystoreCtrl: IKeystoreController
@@ -84,12 +100,15 @@ describe('SignMessageController', () => {
   let networksCtrl: INetworksController
   let providersCtrl: IProvidersController
   let inviteCtrl: IInviteController
+  let dappsCtrl: IDappsController
 
   beforeAll(async () => {
     const { mainCtrl } = await makeMainController(
       async (storageCtrl) => {
         await storageCtrl.set('accounts', [account])
         await storageCtrl.set('selectedAccount', account.addr)
+        await storageCtrl.set('dappsV2', getDappVerificationTestDapps())
+        await storageCtrl.set('lastDappsUpdateVersion', '1.0.0')
       },
       { skipAccountStateLoad: false, overrides: { keystoreSigners: { internal: InternalSigner } } }
     )
@@ -98,6 +117,7 @@ describe('SignMessageController', () => {
     providersCtrl = mainCtrl.providers
     accountsCtrl = mainCtrl.accounts
     inviteCtrl = mainCtrl.invite
+    dappsCtrl = mainCtrl.dapps
   })
 
   beforeEach(async () => {
@@ -107,7 +127,9 @@ describe('SignMessageController', () => {
       networksCtrl,
       accountsCtrl,
       {},
-      inviteCtrl
+      inviteCtrl,
+      undefined,
+      dappsCtrl
     )
   })
 
@@ -188,5 +210,55 @@ describe('SignMessageController', () => {
 
     signMessageController.removeAccountData(account.addr)
     expect(signMessageController.isInitialized).toBeFalsy()
+  })
+
+  describe('dapp verification banners', () => {
+    test('should return loading banners', () => {
+      signMessageController.dapp = getDappRequestData(loadingDapp)
+
+      expect(signMessageController.banners).toEqual([
+        {
+          id: DAPP_VERIFICATION_BANNER_IDS.LOADING,
+          type: 'warning',
+          text: "We're still verifying the app. Please wait, or make sure you trust it before signing requests."
+        }
+      ])
+    })
+
+    test('should return failed verification banners', () => {
+      signMessageController.dapp = getDappRequestData(failedDapp)
+
+      expect(signMessageController.banners).toEqual([
+        {
+          id: DAPP_VERIFICATION_BANNER_IDS.FAILED_TO_GET_OR_UNKNOWN,
+          type: 'warning',
+          text: "We couldn't verify the app. Make sure you trust it before signing requests."
+        }
+      ])
+    })
+
+    test('should return blacklisted banners', () => {
+      signMessageController.dapp = getDappRequestData(blacklistedDapp)
+
+      expect(signMessageController.banners).toEqual([
+        {
+          id: DAPP_VERIFICATION_BANNER_IDS.BLACKLISTED,
+          type: 'error',
+          text: "This app didn't pass our safety check. Proceed at your own risk."
+        }
+      ])
+    })
+
+    test('should not return not-in-catalog banners', () => {
+      signMessageController.dapp = getDappRequestData(customDapp)
+
+      expect(signMessageController.banners).toEqual([])
+    })
+
+    test('should not return banners when the dapp is verified and in the default catalog', () => {
+      signMessageController.dapp = getDappRequestData(verifiedDapp)
+
+      expect(signMessageController.banners).toEqual([])
+    })
   })
 })

--- a/test/helpers/dapps.ts
+++ b/test/helpers/dapps.ts
@@ -1,0 +1,102 @@
+import type { Dapp } from '../../src/interfaces/dapp'
+
+export const makeDapp = ({
+  id,
+  name,
+  url,
+  ...overrides
+}: Pick<Dapp, 'id' | 'name' | 'url'> & Partial<Dapp>): Dapp => ({
+  id,
+  name,
+  url,
+  description: '',
+  icon: null,
+  category: null,
+  tvl: null,
+  twitter: null,
+  geckoId: null,
+  chainIds: [1],
+  isConnected: false,
+  isFeatured: false,
+  isCustom: false,
+  chainId: 1,
+  favorite: false,
+  blacklisted: 'VERIFIED',
+  ...overrides
+})
+
+export const verifiedDapp = makeDapp({
+  id: 'verified-dapp.com',
+  name: 'Verified Dapp',
+  url: 'https://verified-dapp.com',
+  blacklisted: 'VERIFIED'
+})
+
+export const loadingDapp = makeDapp({
+  id: 'loading-dapp.com',
+  name: 'Loading Dapp',
+  url: 'https://loading-dapp.com',
+  blacklisted: 'LOADING'
+})
+
+export const failedDapp = makeDapp({
+  id: 'failed-dapp.com',
+  name: 'Failed Dapp',
+  url: 'https://failed-dapp.com',
+  blacklisted: 'FAILED_TO_GET'
+})
+
+export const blacklistedDapp = makeDapp({
+  id: 'blacklisted-dapp.com',
+  name: 'Blacklisted Dapp',
+  url: 'https://blacklisted-dapp.com',
+  blacklisted: 'BLACKLISTED'
+})
+
+export const customDapp = makeDapp({
+  id: 'custom-dapp.com',
+  name: 'Custom Dapp',
+  url: 'https://custom-dapp.com',
+  blacklisted: 'VERIFIED',
+  isCustom: true
+})
+
+export const getDappVerificationTestDapps = () => [
+  makeDapp({
+    id: 'verified-dapp.com',
+    name: 'Verified Dapp',
+    url: 'https://verified-dapp.com',
+    blacklisted: 'VERIFIED'
+  }),
+  makeDapp({
+    id: 'loading-dapp.com',
+    name: 'Loading Dapp',
+    url: 'https://loading-dapp.com',
+    blacklisted: 'LOADING'
+  }),
+  makeDapp({
+    id: 'failed-dapp.com',
+    name: 'Failed Dapp',
+    url: 'https://failed-dapp.com',
+    blacklisted: 'FAILED_TO_GET'
+  }),
+  makeDapp({
+    id: 'blacklisted-dapp.com',
+    name: 'Blacklisted Dapp',
+    url: 'https://blacklisted-dapp.com',
+    blacklisted: 'BLACKLISTED'
+  }),
+  makeDapp({
+    id: 'custom-dapp.com',
+    name: 'Custom Dapp',
+    url: 'https://custom-dapp.com',
+    blacklisted: 'VERIFIED',
+    isCustom: true
+  })
+]
+
+export const getDappRequestData = (dapp: Dapp) => ({
+  name: dapp.name,
+  icon: dapp.icon || '',
+  url: dapp.url
+})


### PR DESCRIPTION
- Fix: Verification for dApps not present in the default catalog was never reachable. Updated the logic to return the appropriate banner.
- Add: Integration tests for DappsController->getDappVerificationBanner().
- Add: Unit tests for SignAccountOpController and SignMessageController getDappVerificationBanner(). Here, we implemented unit tests because the main logic is already covered by the DappsController tests, and in both controllers we only test the branching logic.