### PR TITLE
Fix bundler failure warning + drop redundant fee error

### DIFF
--- a/src/controllers/estimation/estimation.ts
+++ b/src/controllers/estimation/estimation.ts
@@ -215,7 +215,9 @@ export class EstimationController extends EventEmitter {
       this.estimationRetryError = null
       this.availableFeeOptions = this.#getAvailableFeeOptions(baseAcc, op)
       this.#notFatalBundlerError =
-        estimation.bundler instanceof Error ? estimation.bundler : undefined
+        estimation.bundler instanceof Error
+          ? new Error(estimation.bundler.message, { cause: '4337_ESTIMATION' })
+          : undefined
     } else {
       this.estimation = null
       this.error = estimation instanceof Error ? estimation : estimation.criticalError
@@ -268,8 +270,8 @@ export class EstimationController extends EventEmitter {
     if (this.#notFatalBundlerError?.cause === '4337_ESTIMATION') {
       warnings.push({
         id: 'bundler-failure',
-        title:
-          'You can proceed safely, but fee payment options are limited due to temporary provider issues'
+        title: 'Fee options are temporarily limited',
+        text: 'Use the "Retry" button to try again, or pay the fee with the native token"'
       })
     }
 

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1020,11 +1020,6 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
           errors.push({
             title: `Currently, ${this.feeTokenResult?.symbol} is unavailable as a fee token as we're experiencing troubles fetching its price. Please select another or contact support`
           })
-        } else {
-          errors.push({
-            title:
-              'Unable to estimate the transaction fee. Please try changing the fee token or contact support.'
-          })
         }
       }
     }

--- a/src/libs/errorHumanizer/errors.ts
+++ b/src/libs/errorHumanizer/errors.ts
@@ -147,6 +147,12 @@ const BROADCAST_OR_ESTIMATION_ERRORS: ErrorHumanizerError[] = [
     message:
       'the swap has expired. Return to the app and reinitiate the swap if you wish to proceed.'
   },
+  // Permit2 / AllowanceHolder: SignatureExpired(uint256 signatureDeadline)
+  {
+    reasons: ['0xcd21db4f'],
+    message:
+      'the token permit or signed approval has expired (Permit2 / AllowanceHolder). Open the dapp again and submit a fresh approval or quote so the signature deadline is renewed.'
+  },
   {
     reasons: ['0x7b36c479'],
     message:


### PR DESCRIPTION
Paired with: https://github.com/AmbireTech/ambire-app/pull/7122

Changelog:
- Tag bundler estimation errors with 4337_ESTIMATION for non-fatal handling.
- Shorter bundler warning + Retry / native-token hint.
- Remove generic “unable to estimate fee” error when it’s not the fee-token price case.
- Humanize Permit2 / AllowanceHolder signature expired (0xcd21db4f).