### PR TITLE
Return the correct txnId to the dapp in the case of a 4337 txnId replacement

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -1416,7 +1416,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
       if (counter >= 30) return activityAccountOp.txnId
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      await wait(1200)
+      await wait(2000)
       return this.getConfirmedTxId(submittedAccountOp, counter + 1)
     }
 

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -1416,7 +1416,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
       if (counter >= 30) return activityAccountOp.txnId
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      await wait(1000)
+      await wait(1200)
       return this.getConfirmedTxId(submittedAccountOp, counter + 1)
     }
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1021,6 +1021,8 @@ export class MainController extends EventEmitter implements IMainController {
     const txnId = await this.activity.getConfirmedTxId(submittedAccountOp)
     dappHandlers.forEach((handler) => {
       if (txnId) {
+        // for MultipleTxns, the correct txnId is passed to the handler;
+        // otherwise, use the confirmed txnId
         const finalTxnId =
           submittedAccountOp.identifiedBy.type === 'MultipleTxns' ? handler.txnId || txnId : txnId
 
@@ -1753,7 +1755,13 @@ export class MainController extends EventEmitter implements IMainController {
       if (dappPromise.meta.isWalletSendCalls) {
         dappPromise.resolve({ hash: getDappIdentifier(submittedAccountOp) })
       } else {
-        dappHandlers.push({ promise: dappPromise, txnId: submittedAccountOp.txnId })
+        // if the submittedAccountOp identifier is MultipleTxns,
+        // the txnId for the dappPromise will be in the call itself
+        const submittedCall = submittedAccountOp.calls.find(
+          (call) => call.dappPromiseId === dappPromise.id
+        )
+
+        dappHandlers.push({ promise: dappPromise, txnId: submittedCall?.txnId })
       }
     })
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1026,8 +1026,6 @@ export class MainController extends EventEmitter implements IMainController {
         const finalTxnId =
           submittedAccountOp.identifiedBy.type === 'MultipleTxns' ? handler.txnId || txnId : txnId
 
-        // If the call has a txnId, resolve the promise with it.
-        // This could happen when an EOA account is broadcasting multiple transactions.
         handler.promise.resolve({ hash: finalTxnId })
       } else {
         handler.promise.reject(

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1021,9 +1021,12 @@ export class MainController extends EventEmitter implements IMainController {
     const txnId = await this.activity.getConfirmedTxId(submittedAccountOp)
     dappHandlers.forEach((handler) => {
       if (txnId) {
+        const finalTxnId =
+          submittedAccountOp.identifiedBy.type === 'MultipleTxns' ? handler.txnId || txnId : txnId
+
         // If the call has a txnId, resolve the promise with it.
         // This could happen when an EOA account is broadcasting multiple transactions.
-        handler.promise.resolve({ hash: handler.txnId || txnId })
+        handler.promise.resolve({ hash: finalTxnId })
       } else {
         handler.promise.reject(
           ethErrors.rpc.transactionRejected({


### PR DESCRIPTION
If there'a a 4337 txnId replacement, we ran the risk of returning an incorrect txnId to the dapp