### PR TITLE
Fix/activity card duplication prevention

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -128,6 +128,22 @@ const internalAccountOpHasTxnId = (accountOp: SubmittedAccountOp, txnId: string)
 const externalAccountOpHasTxnId = (accountOp: SubmittedAccountOpLike, txnId: string) =>
   normalizeTxnId(accountOp.txnId) === normalizeTxnId(txnId)
 
+/**
+ * Fix address checksum problems as sometimes addresses are left out
+ * only because they are not saved properly checksummed
+ */
+const getAccountOpsForAccountAndChain = <T>(
+  accountOps: { [account: string]: { [network: string]: T[] } },
+  accountAddr: string,
+  chainIdString: string
+) => {
+  const accountKey = Object.keys(accountOps).find(
+    (key) => key.toLowerCase() === accountAddr.toLowerCase()
+  )
+
+  return accountKey ? accountOps[accountKey]?.[chainIdString] || [] : []
+}
+
 const getBalanceChangeWindowFromReceipts = (
   accountOp: SubmittedAccountOp,
   receipts: TransactionReceipt[]
@@ -647,9 +663,16 @@ export class ActivityController extends EventEmitter implements IActivityControl
     // a duplication guard
     const chainIdString = chainId.toString()
     const hasExistingAccountOpWithTxnId = () => {
-      const internalAccountOps = this.#accountsOps[accountAddr]?.[chainIdString] || []
-      const existingExternalAccountOps =
-        this.#externalAccountOps[accountAddr]?.[chainIdString] || []
+      const internalAccountOps = getAccountOpsForAccountAndChain(
+        this.#accountsOps,
+        accountAddr,
+        chainIdString
+      )
+      const existingExternalAccountOps = getAccountOpsForAccountAndChain(
+        this.#externalAccountOps,
+        accountAddr,
+        chainIdString
+      )
 
       return (
         internalAccountOps.some((accountOp) => internalAccountOpHasTxnId(accountOp, txnId)) ||
@@ -731,6 +754,8 @@ export class ActivityController extends EventEmitter implements IActivityControl
     } catch (error) {
       submittedAccountOpLike.balanceChanges = undefined
     }
+
+    if (hasExistingAccountOpWithTxnId()) return
 
     if (!this.#externalAccountOps[accountAddr]) this.#externalAccountOps[accountAddr] = {}
     if (!this.#externalAccountOps[accountAddr]![chainIdString]) {

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -116,31 +116,47 @@ const getPreviousBlockNumber = (blockNumber: number) => (blockNumber > 0 ? block
 
 const normalizeTxnId = (txnId?: string | null) => txnId?.toLowerCase()
 
+/**
+ * Take all txnIds from the account op
+ * - normal case: accountOp.txnId
+ * - MultipleTxns case: each call.txnId
+ */
+const getInternalAccountOpTxnIds = (accountOp: SubmittedAccountOp) => {
+  return [accountOp.txnId, ...accountOp.calls.map((call) => call.txnId)].filter(
+    (txnId): txnId is string => !!txnId
+  )
+}
+
 const internalAccountOpHasTxnId = (accountOp: SubmittedAccountOp, txnId: string) => {
   const normalizedTxnId = normalizeTxnId(txnId)
 
-  return (
-    normalizeTxnId(accountOp.txnId) === normalizedTxnId ||
-    accountOp.calls.some((call) => normalizeTxnId(call.txnId) === normalizedTxnId)
+  return getInternalAccountOpTxnIds(accountOp).some(
+    (internalTxnId) => normalizeTxnId(internalTxnId) === normalizedTxnId
   )
 }
 
 const externalAccountOpHasTxnId = (accountOp: SubmittedAccountOpLike, txnId: string) =>
   normalizeTxnId(accountOp.txnId) === normalizeTxnId(txnId)
 
+const isAccountOpFinalized = (accountOp: SubmittedAccountOp) =>
+  accountOp.status !== AccountOpStatus.BroadcastedButNotConfirmed &&
+  accountOp.status !== AccountOpStatus.Pending
+
 /**
  * Fix address checksum problems as sometimes addresses are left out
  * only because they are not saved properly checksummed
  */
+const getAccountOpsAccountKey = <T>(
+  accountOps: { [account: string]: { [network: string]: T[] } },
+  accountAddr: string
+) => Object.keys(accountOps).find((key) => key.toLowerCase() === accountAddr.toLowerCase())
+
 const getAccountOpsForAccountAndChain = <T>(
   accountOps: { [account: string]: { [network: string]: T[] } },
   accountAddr: string,
   chainIdString: string
 ) => {
-  const accountKey = Object.keys(accountOps).find(
-    (key) => key.toLowerCase() === accountAddr.toLowerCase()
-  )
-
+  const accountKey = getAccountOpsAccountKey(accountOps, accountAddr)
   return accountKey ? accountOps[accountKey]?.[chainIdString] || [] : []
 }
 
@@ -546,6 +562,49 @@ export class ActivityController extends EventEmitter implements IActivityControl
     await this.#storage.set('accountsOps', this.#accountsOps)
     await this.syncFilteredAccountsOps()
     this.emitUpdate()
+  }
+
+  /**
+   * We could have this case:
+   * 1. We have a BroadcastedButNotConfirmed account op with an accountOp.txnId that's not the final, confirmed txnId
+   * 2. While we have this pending account op, getLogs() finds the confirmed transactions. Its txnId differs from the BroadcastedButNotConfirmed accountOp, so it gets added successfully, skipping the duplication guard
+   * 3. The BroadcastedButNotConfirmed loop completes, changes the accountOp.txnId to the real one, but it's too late as the externalAccountOp has already been added.
+   * That's why we're running back and cleaning up already added externalAccountOps with the same txnId
+   */
+  async #removeExternalAccountOpsMatchingInternalOps(accountOps: SubmittedAccountOp[]) {
+    let hasRemovedExternalAccountOps = false
+
+    accountOps.filter(isAccountOpFinalized).forEach((accountOp) => {
+      const externalAccountOpsAccountKey = getAccountOpsAccountKey(
+        this.#externalAccountOps,
+        accountOp.accountAddr
+      )
+      if (!externalAccountOpsAccountKey) return
+
+      const chainIdString = accountOp.chainId.toString()
+      const externalAccountOps =
+        this.#externalAccountOps[externalAccountOpsAccountKey]?.[chainIdString]
+      if (!externalAccountOps?.length) return
+
+      const internalTxnIds = new Set(
+        getInternalAccountOpTxnIds(accountOp).map((txnId) => normalizeTxnId(txnId))
+      )
+      if (!internalTxnIds.size) return
+
+      const filteredExternalAccountOps = externalAccountOps.filter((externalAccountOp) => {
+        const externalTxnId = normalizeTxnId(externalAccountOp.txnId)
+        return !externalTxnId || !internalTxnIds.has(externalTxnId)
+      })
+
+      if (filteredExternalAccountOps.length === externalAccountOps.length) return
+
+      this.#externalAccountOps[externalAccountOpsAccountKey]![chainIdString] =
+        filteredExternalAccountOps
+      hasRemovedExternalAccountOps = true
+    })
+
+    if (hasRemovedExternalAccountOps)
+      await this.#storage.set('externalAccountOps', this.#externalAccountOps)
   }
 
   async filterSignedMessages(
@@ -1284,6 +1343,8 @@ export class ActivityController extends EventEmitter implements IActivityControl
     // if there are balanceChangesTasks, shouldEmitUpdate will be true
     // so they will get saved
     if (shouldEmitUpdate) {
+      // remove duplicates if encountered during a race condition
+      await this.#removeExternalAccountOpsMatchingInternalOps(updatedAccountsOps)
       await this.persistAccountsOps()
     }
 

--- a/src/controllers/activity/externalAccountOps.test.ts
+++ b/src/controllers/activity/externalAccountOps.test.ts
@@ -106,6 +106,41 @@ describe('ActivityController external account ops', () => {
     expect(data.externalAccountOps).toBeUndefined()
   })
 
+  it('does not add an external account op when the same account is keyed with different casing', async () => {
+    const txnId = `0x${'d'.repeat(64)}`
+    const provider = {
+      getTransaction: jest.fn(),
+      getBlock: jest.fn()
+    }
+    const { data, storage } = createStorage({
+      accountsOps: {
+        [accountAddr]: {
+          [chainId.toString()]: [
+            {
+              accountAddr,
+              chainId,
+              txnId,
+              calls: []
+            }
+          ]
+        }
+      }
+    })
+    const controller = createController(storage, provider)
+
+    await controller.addExternalAccountOp({
+      accountAddr: accountAddr.toLowerCase(),
+      chainId,
+      txnId,
+      receipt: buildReceipt(txnId)
+    })
+
+    expect(provider.getTransaction).not.toHaveBeenCalled()
+    expect(provider.getBlock).not.toHaveBeenCalled()
+    expect(storage.set).not.toHaveBeenCalled()
+    expect(data.externalAccountOps).toBeUndefined()
+  })
+
   it('does not add an external account op when the txnId already exists on an internal account op call', async () => {
     const txnId = `0x${'b'.repeat(64)}`
     const provider = {

--- a/src/controllers/activity/externalAccountOps.test.ts
+++ b/src/controllers/activity/externalAccountOps.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals'
 
 import { Storage } from '../../interfaces/storage'
+import { AccountOpStatus } from '../../libs/accountOp/types'
 import { ActivityController } from './activity'
 
 const accountAddr = '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5'
@@ -26,7 +27,10 @@ const createDeferred = () => {
   return { promise, resolve }
 }
 
-const createStorage = (initialData: Record<string, any> = {}) => {
+const createStorage = (
+  initialData: Record<string, any> = {},
+  { delayFirstExternalAccountOpsSet = true } = {}
+) => {
   const data: Record<string, any> = initialData
   const firstExternalAccountOpsSet = createDeferred()
   let externalAccountOpsSetCalls = 0
@@ -38,7 +42,9 @@ const createStorage = (initialData: Record<string, any> = {}) => {
 
       if (key === 'externalAccountOps') {
         externalAccountOpsSetCalls += 1
-        if (externalAccountOpsSetCalls === 1) await firstExternalAccountOpsSet.promise
+        if (delayFirstExternalAccountOpsSet && externalAccountOpsSetCalls === 1) {
+          await firstExternalAccountOpsSet.promise
+        }
       }
 
       return null
@@ -52,19 +58,42 @@ const createStorage = (initialData: Record<string, any> = {}) => {
   return { data, firstExternalAccountOpsSet, storage }
 }
 
-const createController = (storage: Storage, provider: any) =>
+const createController = (
+  storage: Storage,
+  provider: any,
+  callRelayer: any = jest.fn(async () => undefined)
+) =>
   new ActivityController(
     storage as any,
     jest.fn() as any,
-    jest.fn(),
+    callRelayer,
     { initialLoadPromise: Promise.resolve(), accounts: [] } as any,
     { initialLoadPromise: Promise.resolve(), account: { addr: accountAddr } } as any,
     { providers: { [chainId.toString()]: provider } } as any,
     { networks: [{ chainId }], isInitialized: true } as any,
     {
-      getTokenBalancesOnBlock: jest.fn(async () => {
-        throw new Error('skip balance changes in this test')
-      })
+      addTokensToBeLearned: jest.fn(),
+      getTokenBalancesOnBlock: jest.fn(async () => [
+        [
+          '0x',
+          {
+            address: '0x0000000000000000000000000000000000000000',
+            amount: 0n,
+            chainId,
+            decimals: 18,
+            flags: {
+              canTopUpGasTank: false,
+              isFeeToken: true,
+              onGasTank: false,
+              rewardsType: null
+            },
+            marketDataIn: [],
+            name: 'Ether',
+            priceIn: [],
+            symbol: 'ETH'
+          }
+        ]
+      ])
     } as any,
     {} as any,
     jest.fn(async () => undefined)
@@ -216,6 +245,74 @@ describe('ActivityController external account ops', () => {
     expect(data.externalAccountOps[accountAddr][chainId.toString()]).toEqual([
       existingExternalAccountOp
     ])
+  })
+
+  it('removes an external account op when a pending internal op resolves to the same txnId', async () => {
+    const provisionalTxnId = `0x${'1'.repeat(64)}`
+    const confirmedTxnId = `0x${'2'.repeat(64)}`
+    const unrelatedTxnId = `0x${'3'.repeat(64)}`
+    const provider = {
+      getTransaction: jest.fn(async () => null),
+      getTransactionReceipt: jest.fn(async (txnId: string) =>
+        txnId === confirmedTxnId ? buildReceipt(confirmedTxnId) : null
+      )
+    }
+    const callRelayer = jest.fn(async () => ({ data: { txId: confirmedTxnId } }))
+    const externalAccountOpToRemove = {
+      accountAddr,
+      chainId,
+      txnId: confirmedTxnId,
+      calls: []
+    }
+    const unrelatedExternalAccountOp = {
+      accountAddr,
+      chainId,
+      txnId: unrelatedTxnId,
+      calls: []
+    }
+    const { data, storage } = createStorage(
+      {
+        accountsOps: {
+          [accountAddr]: {
+            [chainId.toString()]: [
+              {
+                id: 'pending-op',
+                accountAddr,
+                chainId,
+                nonce: 1n,
+                calls: [],
+                txnId: provisionalTxnId,
+                status: AccountOpStatus.BroadcastedButNotConfirmed,
+                timestamp: 1700000000,
+                identifiedBy: {
+                  type: 'Relayer',
+                  identifier: 'relayer-transaction-id'
+                }
+              }
+            ]
+          }
+        },
+        externalAccountOps: {
+          [accountAddr]: {
+            [chainId.toString()]: [externalAccountOpToRemove, unrelatedExternalAccountOp]
+          }
+        }
+      },
+      { delayFirstExternalAccountOpsSet: false }
+    )
+    const controller = createController(storage, provider, callRelayer)
+
+    const result = await controller.updateAccountsOpsStatuses([accountAddr])
+
+    expect(result[accountAddr]!.updatedAccountsOps).toHaveLength(1)
+    expect(data.accountsOps[accountAddr][chainId.toString()][0].txnId).toBe(confirmedTxnId)
+    expect(data.accountsOps[accountAddr][chainId.toString()][0].status).toBe(
+      AccountOpStatus.Success
+    )
+    expect(data.externalAccountOps[accountAddr][chainId.toString()]).toEqual([
+      unrelatedExternalAccountOp
+    ])
+    expect(storage.set).toHaveBeenCalledWith('externalAccountOps', data.externalAccountOps)
   })
 
   it('queues same-tick addExternalAccountOp calls to avoid overlapping writes', async () => {


### PR DESCRIPTION
 We could have this case:
   1. We have a BroadcastedButNotConfirmed account op with an accountOp.txnId that's not the final, confirmed txnId
   2. While we have this pending account op, getLogs() finds the confirmed transactions. Its txnId differs from the BroadcastedButNotConfirmed accountOp, so it gets added successfully, skipping the duplication guard
   3. The BroadcastedButNotConfirmed loop completes, changes the accountOp.txnId to the real one, but it's too late as the externalAccountOp has already been added.

That's why we're running back and cleaning up already added externalAccountOps with the same txnId
