### PR TITLE
Add a fallback URL for fetching pimlico gas prices

### DIFF
--- a/src/services/bundlers/pimlico.ts
+++ b/src/services/bundlers/pimlico.ts
@@ -1,5 +1,8 @@
 /* eslint-disable class-methods-use-this */
 
+import { RPCProvider } from '@/interfaces/provider'
+import { getRpcProvider } from '@/services/provider'
+
 import { BUNDLER, PIMLICO } from '../../consts/bundlers'
 import { Network } from '../../interfaces/network'
 import { Bundler } from './bundler'
@@ -16,9 +19,35 @@ export class Pimlico extends Bundler {
     return `https://api.pimlico.io/v2/${network.chainId}/rpc?apikey=${API_KEY}`
   }
 
+  /**
+   * Pimlico has a second API url used for fallback purposes that skips
+   * cloudflare. We will use it as a fallback to retry automatically
+   * when the original URL fails
+   */
+  protected getFallbackProvider(network: Network): RPCProvider {
+    const API_KEY = process.env.REACT_APP_PIMLICO_API_KEY || ''
+
+    if (!API_KEY) {
+      throw new Error('Pimlico API key is not set')
+    }
+
+    const url = `https://api-direct.pimlico.io/v2/${network.chainId}/rpc?apikey=${API_KEY}`
+    return getRpcProvider([url], network.chainId)
+  }
+
   protected async getGasPrice(network: Network): Promise<GasSpeeds> {
     const provider = this.getProvider(network)
-    const prices: any = await provider.send('pimlico_getUserOperationGasPrice', [])
+
+    // try main URL; retry with fallback on failure
+    let prices: any
+    try {
+      prices = await provider.send('pimlico_getUserOperationGasPrice', [])
+    } catch (e) {
+      console.log('fallback to api-direct')
+      const fallbackProvider = this.getFallbackProvider(network)
+      prices = await fallbackProvider.send('pimlico_getUserOperationGasPrice', [])
+    }
+
     prices.medium = prices.standard
     prices.ape = prices.fast
     delete prices.standard


### PR DESCRIPTION
We get a lot of pimlico gas prices errros. We fallback to the second available pimlico api url in case of a gas price fetch failure. That's about all