### PR TITLE
Feature: Portfolio add low-value token helpers for dashboard collapse

### DIFF
--- a/src/libs/portfolio/lowValueTokens.test.ts
+++ b/src/libs/portfolio/lowValueTokens.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { AssetType } from '../defiPositions/types'
+import { TokenResult } from './interfaces'
+import {
+  getDashboardTokenCount,
+  getTokenUnitPriceUSD,
+  isLowValueToken,
+  partitionLowValueTokens,
+  shouldCollapseLowValueTokens,
+  shouldExcludeFromLowValueCollapse
+} from './lowValueTokens'
+
+const createToken = (overrides: Partial<TokenResult> = {}): TokenResult =>
+  ({
+    symbol: 'TEST',
+    name: 'Test Token',
+    decimals: 18,
+    address: '0x0000000000000000000000000000000000000001',
+    chainId: 1n,
+    amount: 1000000000000000000n,
+    priceIn: [{ baseCurrency: 'usd', price: 1 }],
+    marketDataIn: [],
+    flags: {
+      onGasTank: false,
+      rewardsType: null,
+      canTopUpGasTank: false,
+      isFeeToken: false
+    },
+    ...overrides
+  }) as TokenResult
+
+describe('lowValueTokens', () => {
+  describe('getTokenUnitPriceUSD', () => {
+    it('returns null when there is no USD price', () => {
+      expect(getTokenUnitPriceUSD(createToken({ priceIn: [] }))).toBeNull()
+      expect(
+        getTokenUnitPriceUSD(createToken({ priceIn: [{ baseCurrency: 'eur', price: 1 }] }))
+      ).toBeNull()
+    })
+
+    it('returns the USD unit price when available', () => {
+      expect(
+        getTokenUnitPriceUSD(createToken({ priceIn: [{ baseCurrency: 'usd', price: 0.5 }] }))
+      ).toBe(0.5)
+    })
+  })
+
+  describe('isLowValueToken', () => {
+    it('treats tokens without price as low-value', () => {
+      expect(isLowValueToken(createToken({ priceIn: [] }))).toBe(true)
+    })
+
+    it('does not treat cheap tokens as low-value when the holding is meaningful', () => {
+      expect(
+        isLowValueToken(createToken({ priceIn: [{ baseCurrency: 'usd', price: 0.01 }] }))
+      ).toBe(false)
+      expect(
+        isLowValueToken(
+          createToken({
+            priceIn: [{ baseCurrency: 'usd', price: 0.009 }],
+            amount: 100000000000000000000n // 100 tokens ≈ $0.90
+          })
+        )
+      ).toBe(false)
+    })
+
+    it('does not treat tokens above $0.01 balance as low-value', () => {
+      expect(
+        isLowValueToken(createToken({ priceIn: [{ baseCurrency: 'usd', price: 0.011 }] }))
+      ).toBe(false)
+    })
+
+    it('treats tokens with a balance below $0.01 as low-value even when unit price is higher', () => {
+      expect(
+        isLowValueToken(
+          createToken({
+            priceIn: [{ baseCurrency: 'usd', price: 1 }],
+            amount: 1000000000000000n // 0.001 tokens
+          })
+        )
+      ).toBe(true)
+    })
+  })
+
+  describe('shouldCollapseLowValueTokens', () => {
+    it('returns false below the threshold and true at or above it', () => {
+      expect(shouldCollapseLowValueTokens(99)).toBe(false)
+      expect(shouldCollapseLowValueTokens(100)).toBe(true)
+      expect(shouldCollapseLowValueTokens(250)).toBe(true)
+    })
+  })
+
+  describe('shouldExcludeFromLowValueCollapse', () => {
+    it('excludes pending simulation and rewards tokens', () => {
+      expect(
+        shouldExcludeFromLowValueCollapse(createToken({ amount: 1n, amountPostSimulation: 2n }))
+      ).toBe(true)
+      expect(
+        shouldExcludeFromLowValueCollapse(
+          createToken({ flags: { ...createToken().flags, rewardsType: 'wallet-rewards' } })
+        )
+      ).toBe(true)
+      expect(shouldExcludeFromLowValueCollapse(createToken())).toBe(false)
+    })
+  })
+
+  describe('getDashboardTokenCount', () => {
+    it('excludes gas tank and borrowed DeFi tokens from the count', () => {
+      const tokens = [
+        createToken(),
+        createToken({ flags: { ...createToken().flags, onGasTank: true } }),
+        createToken({
+          flags: { ...createToken().flags, defiTokenType: AssetType.Borrow }
+        })
+      ]
+
+      expect(getDashboardTokenCount(tokens)).toBe(1)
+    })
+  })
+
+  describe('partitionLowValueTokens', () => {
+    it('splits tokens and sums the collapsed USD balance', () => {
+      const tokens = [
+        createToken({
+          address: '0x1',
+          priceIn: [{ baseCurrency: 'usd', price: 1 }],
+          amount: 2000000000000000000n
+        }),
+        createToken({
+          address: '0x2',
+          priceIn: [{ baseCurrency: 'usd', price: 0.01 }],
+          amount: 100000000000000000n // 0.1 tokens ≈ $0.001
+        }),
+        createToken({
+          address: '0x4',
+          priceIn: [{ baseCurrency: 'usd', price: 0.01 }],
+          amount: 1000000000000000000n // 1 token = $0.01, stays visible
+        }),
+        createToken({
+          address: '0x3',
+          priceIn: []
+        })
+      ]
+
+      const { visible, lowValue, lowValueTotalUsd } = partitionLowValueTokens(tokens)
+
+      expect(visible).toHaveLength(2)
+      expect(lowValue).toHaveLength(2)
+      expect(lowValueTotalUsd).toBeCloseTo(0.001)
+    })
+  })
+})

--- a/src/libs/portfolio/lowValueTokens.ts
+++ b/src/libs/portfolio/lowValueTokens.ts
@@ -1,0 +1,65 @@
+import { AssetType } from '../defiPositions/types'
+import { getTokenBalanceInUSD } from './helpers'
+import { TokenResult } from './interfaces'
+
+export const LOW_VALUE_TOKEN_PRICE_THRESHOLD_USD = 0.01
+export const LOW_VALUE_COLLAPSE_MIN_TOKEN_COUNT = 100
+
+export const getTokenUnitPriceUSD = (token: TokenResult): number | null => {
+  const usdPriceEntry = token.priceIn.find(
+    ({ baseCurrency }) => baseCurrency.toLowerCase() === 'usd'
+  )
+
+  if (!usdPriceEntry) return null
+
+  return usdPriceEntry.price
+}
+
+export const isLowValueToken = (token: TokenResult): boolean => {
+  const unitPrice = getTokenUnitPriceUSD(token)
+
+  // No USD price — nothing meaningful to show per row.
+  if (unitPrice === null) return true
+
+  // Collapse by position value, not unit price. A $0.005 token with a large
+  // balance can still be a meaningful holding and must stay visible.
+  // Matches the "<$0.01" display rule used in formatDecimals for portfolio balances.
+  return getTokenBalanceInUSD(token) < LOW_VALUE_TOKEN_PRICE_THRESHOLD_USD
+}
+
+export const shouldCollapseLowValueTokens = (tokenCount: number): boolean =>
+  tokenCount >= LOW_VALUE_COLLAPSE_MIN_TOKEN_COUNT
+
+export const shouldExcludeFromLowValueCollapse = (token: TokenResult): boolean => {
+  if (
+    typeof token.amountPostSimulation === 'bigint' &&
+    token.amountPostSimulation !== BigInt(token.amount)
+  ) {
+    return true
+  }
+
+  if (token.flags.rewardsType) return true
+
+  return false
+}
+
+export const getDashboardTokenCount = (tokens: TokenResult[]): number =>
+  tokens.filter((token) => !token.flags.onGasTank && token.flags.defiTokenType !== AssetType.Borrow)
+    .length
+
+export const partitionLowValueTokens = (tokens: TokenResult[]) => {
+  const visible: TokenResult[] = []
+  const lowValue: TokenResult[] = []
+
+  tokens.forEach((token) => {
+    if (isLowValueToken(token)) {
+      lowValue.push(token)
+    } else {
+      visible.push(token)
+    }
+  })
+
+  const lowValueTotalUsd = lowValue.reduce((total, token) => total + getTokenBalanceInUSD(token), 0)
+
+  return { visible, lowValue, lowValueTotalUsd }
+}


### PR DESCRIPTION
paired with: https://github.com/AmbireTech/ambire-app/pull/7183

## Changelog
### Added
 - `src/libs/portfolio/lowValueTokens.ts` — shared helpers for collapsing low-value tokens on the dashboard:
   - `isLowValueToken` — treats a token as low-value when it has no USD price, or when holding value is below $0.01 (not unit price alone, so cheap tokens with a meaningful balance stay visible).
   - `shouldCollapseLowValueTokens` — enables collapse only when the account has ≥ 100 dashboard tokens.
shouldExcludeFromLowValueCollapse — keeps tokens out of collapse when they have a pending simulation balance change or are rewards tokens. 
   - `getDashboardTokenCount` — counts tokens for the collapse gate, excluding gas-tank and borrowed DeFi positions.
partitionLowValueTokens — splits tokens into visible vs low-value groups and returns the combined USD total for the collapsed group.
 - `src/libs/portfolio/lowValueTokens.test.ts` — unit tests for the above behavior.