### PR TITLE
Fix / Portfolio clear simulation error

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -680,7 +680,17 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
       const networkState = this.#state[accountAddr][chainId.toString()]!
 
-      if (!networkState.result) return
+      // The simulation error is no longer relevant once its simulated balances are removed.
+      // Keeping it would leave the portfolio balance in a warning state.
+      const clearedSimulationError = !!networkState.criticalError?.simulationErrorMsg
+      if (clearedSimulationError) {
+        delete networkState.criticalError
+      }
+
+      if (!networkState.result) {
+        if (clearedSimulationError) this.emitUpdate()
+        return
+      }
 
       networkState.result.tokens = networkState.result.tokens.map((token) => {
         const { amountPostSimulation, simulationAmount, ...rest } = token


### PR DESCRIPTION
Fix: Clear the simulation error when overriding simulation results, as it is no longer relevant and falsely marks the portfolio with a critical error. This could happen if the simulation fails on SignAccountOpScreen, we hit Reject and override the simulation results (remove them from the portfolio), but keep the simulation error in the critical error state, which marks the dashboard balance as warned.