### PR TITLE
Bug / Updating account state should not error out when there are no imported accounts

### DIFF
--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -225,6 +225,8 @@ export class ContinuousUpdatesController extends EventEmitter {
     await this.initialLoadPromise
     await this.#main.accounts.accountStateInitialLoadPromise
 
+    if (!this.#main.accounts.accounts.length) return // no accounts imported yet
+
     if (!this.#main.selectedAccount.account) {
       console.error('No selected account to latest state')
       return


### PR DESCRIPTION
Self-explanatory. Part of https://github.com/AmbireTech/ambire-app/issues/7180.