### PR TITLE
Fix/ `#createOrUpdateCallsUserRequest` doesn't throw in case of invalid call.to address

### DIFF
--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1805,7 +1805,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
                 ...calls.map((call) => ({
                   ...call,
                   id: uuidv4(),
-                  to: getAddress(call.to),
+                  // `to` is falsy in contract deployment transactions
+                  to: !!call.to ? getAddress(call.to) : call.to,
                   data: call.data || '0x',
                   value: call.value ? getBigInt(call.value) : 0n
                 }))
@@ -1894,7 +1895,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
                   ...calls.map((call) => ({
                     ...call,
                     id: uuidv4(),
-                    to: getAddress(call.to),
+                    // `to` is falsy in contract deployment transactions
+                    to: !!call.to ? getAddress(call.to) : call.to,
                     data: call.data || '0x',
                     value: call.value ? getBigInt(call.value) : 0n
                   }))

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1805,7 +1805,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
                 ...calls.map((call) => ({
                   ...call,
                   id: uuidv4(),
-                  to: call.to,
+                  to: getAddress(call.to),
                   data: call.data || '0x',
                   value: call.value ? getBigInt(call.value) : 0n
                 }))
@@ -1894,7 +1894,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
                   ...calls.map((call) => ({
                     ...call,
                     id: uuidv4(),
-                    to: call.to,
+                    to: getAddress(call.to),
                     data: call.data || '0x',
                     value: call.value ? getBigInt(call.value) : 0n
                   }))


### PR DESCRIPTION
Makes the extension reject calls with invalid checksum (lowercase are okay)

<img width="1160" height="795" alt="image" src="https://github.com/user-attachments/assets/1f0211a4-4a0d-420c-ace4-925086d5c295" />
