### PR TITLE
Fix/ `domains.resolveENSDomain` saves invalid ENS

### DIFF
--- a/src/controllers/domains/domains.ts
+++ b/src/controllers/domains/domains.ts
@@ -136,12 +136,11 @@ export class DomainsController extends EventEmitter implements IDomainsControlle
         : undefined
     })
       .then(async ({ address, avatar }) => {
-        this.domainToAddresses[domain] = {
-          address: address ? getAddress(address) : undefined,
-          type: isNamoshiDomain ? 'namoshi' : 'ens'
-        }
-
         if (address) {
+          this.domainToAddresses[domain] = {
+            address: getAddress(address),
+            type: isNamoshiDomain ? 'namoshi' : 'ens'
+          }
           this.#saveResolvedDomain({
             address,
             ensAvatar: avatar,


### PR DESCRIPTION
## How to reproduce:
1. Open transfer
2. Input `smith.eth` (in v2 it will result in a green input field, but '' address)
<img width="2357" height="572" alt="image" src="https://github.com/user-attachments/assets/151c89ec-e2ca-4e8b-ae15-dc913b9faf85" />
