### PR TITLE
Fix/ dapp requests crash the sign acc op screen

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -538,4 +538,125 @@ describe('RequestsController ', () => {
     const json = controller.toJSON()
     expect(json).toBeDefined()
   })
+
+  describe('call data and "to" field validation', () => {
+    const FROM = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+    const VALID_TO = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+
+    const buildEthSendTx = (
+      controller: Awaited<ReturnType<typeof prepareTest>>['controller'],
+      txParams: { from: string; to?: string; value?: string; data?: string }
+    ) =>
+      controller.build({
+        type: 'dappRequest',
+        params: {
+          request: {
+            method: 'eth_sendTransaction',
+            params: [txParams],
+            session: MOCK_SESSION
+          },
+          dappPromise: {
+            id: 'testID',
+            resolve: () => {},
+            reject: () => {},
+            session: MOCK_SESSION
+          }
+        }
+      })
+
+    const buildWalletSendCalls = (
+      controller: Awaited<ReturnType<typeof prepareTest>>['controller'],
+      calls: { to?: string; value?: string; data?: string }[]
+    ) =>
+      controller.build({
+        type: 'dappRequest',
+        params: {
+          request: {
+            method: 'wallet_sendCalls',
+            params: [{ from: FROM, chainId: '0x1', calls }],
+            session: MOCK_SESSION
+          },
+          dappPromise: {
+            id: 'testID',
+            resolve: () => {},
+            reject: () => {},
+            session: MOCK_SESSION
+          }
+        }
+      })
+
+    test('rejects eth_sendTransaction with odd-length hex data', async () => {
+      const { controller } = await prepareTest(true)
+
+      await expect(
+        buildEthSendTx(controller, { from: FROM, to: VALID_TO, value: '0x0', data: '0x1' })
+      ).rejects.toThrow('A call has uneven number of character in the hex data.')
+    })
+
+    test('rejects eth_sendTransaction with non-hex data (even length, no 0x prefix)', async () => {
+      const { controller } = await prepareTest(true)
+
+      // Even length so it passes the odd-length check; no 0x prefix so isHex returns false
+      await expect(
+        buildEthSendTx(controller, { from: FROM, to: VALID_TO, value: '0x0', data: 'aabbccdd' })
+      ).rejects.toThrow('A call has invalid data.')
+    })
+
+    test('rejects eth_sendTransaction with invalid "to" address', async () => {
+      const { controller } = await prepareTest(true)
+
+      await expect(
+        buildEthSendTx(controller, { from: FROM, to: 'not-an-address', value: '0x0' })
+      ).rejects.toThrow('A call has invalid "to" field ')
+    })
+
+    test('accepts eth_sendTransaction without a "to" field (contract deployment)', async () => {
+      const { controller } = await prepareTest(true)
+
+      await expect(
+        buildEthSendTx(controller, { from: FROM, value: '0x0', data: '0x6080604052' })
+      ).resolves.toBeUndefined()
+    })
+
+    test('accepts eth_sendTransaction without a data field', async () => {
+      const { controller } = await prepareTest(true)
+
+      await expect(
+        buildEthSendTx(controller, { from: FROM, to: VALID_TO, value: '0x0' })
+      ).resolves.toBeUndefined()
+    })
+
+    test('rejects wallet_sendCalls when any call has odd-length hex data', async () => {
+      const { controller } = await prepareTest(true)
+
+      await expect(
+        buildWalletSendCalls(controller, [
+          { to: VALID_TO, value: '0x0', data: '0x1234' },
+          { to: VALID_TO, value: '0x0', data: '0x1' }
+        ])
+      ).rejects.toThrow('A call has uneven number of character in the hex data.')
+    })
+
+    test('rejects wallet_sendCalls when any call has an invalid "to" address', async () => {
+      const { controller } = await prepareTest(true)
+
+      await expect(
+        buildWalletSendCalls(controller, [
+          { to: VALID_TO, value: '0x0' },
+          { to: 'bad-address', value: '0x0' }
+        ])
+      ).rejects.toThrow('A call has invalid "to" field ')
+    })
+
+    test('accepts wallet_sendCalls where a call omits "to" (contract deployment within batch)', async () => {
+      const { controller } = await prepareTest(true)
+
+      await expect(
+        buildWalletSendCalls(controller, [
+          { to: VALID_TO, value: '0x0' },
+          { value: '0x0', data: '0x6080604052' }
+        ])
+      ).resolves.toBeUndefined()
+    })
+  })
 })

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import { ethErrors } from 'eth-rpc-errors'
-import { getAddress, getBigInt, hexlify, TypedDataDomain, TypedDataField } from 'ethers'
+import { getAddress, getBigInt, hexlify, TypedDataDomain, TypedDataField, isAddress } from 'ethers'
 import { v4 as uuidv4 } from 'uuid'
 
 import { EIP712TypedData } from '@safe-global/types-kit'
@@ -1085,6 +1085,14 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       let calls: AccountOp['calls'] = isWalletSendCalls
         ? request.params[0].calls
         : [request.params[0]]
+
+      if (calls.some(({ data }) => data.length % 2 === 1))
+        throw ethErrors.rpc.invalidParams('A call has uneven number of character in the hex data.')
+
+      // we are checking if to exists, because if it does not the call is a
+      // valid contract  deployment
+      if (calls.some(({ to }) => to && !isAddress(to)))
+        throw ethErrors.rpc.invalidParams('A call has invalid "to" field ')
 
       calls = calls.map((c) => ({
         ...c,

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -82,6 +82,7 @@ import {
   SignAccountOpController
 } from '../signAccountOp/signAccountOp'
 import { SwapAndBridgeFormStatus } from '../swapAndBridge/swapAndBridge'
+import { isHex } from 'viem'
 
 const STATUS_WRAPPED_METHODS = {
   buildSwapAndBridgeUserRequest: 'INITIAL'
@@ -1086,8 +1087,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         ? request.params[0].calls
         : [request.params[0]]
 
-      if (calls.some(({ data }) => data.length % 2 === 1))
+      if (calls.some(({ data }) => data && data.length % 2 === 1))
         throw ethErrors.rpc.invalidParams('A call has uneven number of character in the hex data.')
+      if (calls.some(({ data }) => data && !isHex(data)))
+        throw ethErrors.rpc.invalidParams('A call has invalid data.')
 
       // we are checking if to exists, because if it does not the call is a
       // valid contract  deployment


### PR DESCRIPTION
resolves: https://github.com/ambireTech/ambire-app/issues/6495
## Problem
When a dapp requests tx signing with call.data.length being an odd number the sign acc op crashes

## Solution
We should not allow such data to even enter the extension

## How to test
Try to [sign this](https://transact.swiss-knife.xyz/send-tx?chainId=10&calldata=0x123&to=0x47cd7e91c3cbaaf266369fe8518345fc4fc12935)