### PR TITLE
Fix / Jumper dApp new domain

### DIFF
--- a/src/consts/dapps/dapps.ts
+++ b/src/consts/dapps/dapps.ts
@@ -17,6 +17,7 @@ export const dappIdsToBeRemoved = new Set([
   'core.app', // not supported,
   'new.bungee.exchange', // got left hanging since Bungee moved to bungee.exchange
   'multitx.bungee.exchange', // got left hanging since Bungee moved to bungee.exchange
+  'jumper.exchange', // jumper.exchange was moved to jumper.xyz
   // unsupported or outdated protocols returned by DefiLlama
   'bridge.base.org',
   'binance.com',


### PR DESCRIPTION
Fix: If a user had previously connected to jumper.exchange, the dApp info was not being updated after the migration to the new domain (jumper.xyz). As a result, the dApp appeared duplicated in the connected dApps list. To resolve this, we now remove the old domain entry.

Closes https://github.com/AmbireTech/ambire-app/issues/7123.