### PR TITLE
Email vault banner: remove interface variant used only in dead code

### DIFF
--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -91,9 +91,6 @@ export type Action = (
       actionName: 'reload-selected-account'
     }
   | {
-      actionName: 'dismiss-email-vault'
-    }
-  | {
       actionName: 'dismiss-7702-banner'
       meta: { accountAddr: string }
     }


### PR DESCRIPTION
Since the email vault banners have been removed, this is not needed anymore


I am intentionally leaving the getter `banners()` in the email vault controller, because we will use it to prompt users to remove their recovery