### PR TITLE
Debug/ Extension performance with huge storage

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -493,6 +493,8 @@ export class ActivityController extends EventEmitter implements IActivityControl
 
     this.emitUpdate()
 
+    const backfillStart = Date.now()
+
     // find ops with no balance changes recorded and backfill them;
     // no need to console.log anything in the catch statement here
     // as error handling is handled in backfillAccountOpBalanceChangesAndPersist.
@@ -503,7 +505,14 @@ export class ActivityController extends EventEmitter implements IActivityControl
         op.balanceChanges === undefined
     )
     if (opsWithNoBalanceChanges.length)
-      this.backfillAccountOpBalanceChangesAndPersist(opsWithNoBalanceChanges).catch((e) => null)
+      this.backfillAccountOpBalanceChangesAndPersist(opsWithNoBalanceChanges)
+        .then(() => {
+          const backfillEnd = Date.now()
+          console.log(
+            `Debug: finished backfilling balance changes for account ${filters.account} in ${(backfillEnd - backfillStart) / 1000} seconds`
+          )
+        })
+        .catch((e) => null)
   }
 
   setDashboardBannersSeen(sessionId: string, accountAddr: string) {
@@ -559,7 +568,13 @@ export class ActivityController extends EventEmitter implements IActivityControl
   }
 
   private async persistAccountsOps() {
+    const start = Date.now()
     await this.#storage.set('accountsOps', this.#accountsOps)
+    console.log(
+      'Debug: called storage set for accountsOps: persistAccountsOps (took',
+      Date.now() - start,
+      'ms)'
+    )
     await this.syncFilteredAccountsOps()
     this.emitUpdate()
   }
@@ -679,6 +694,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
     await this.syncFilteredAccountsOps()
 
     await this.#storage.set('accountsOps', this.#accountsOps)
+    console.log('Debug: called storage set for accountsOps: addAccountOp')
     this.emitUpdate()
   }
 
@@ -862,6 +878,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
    * as we're persisting the state right after the operation
    */
   async backfillAccountOpBalanceChangesAndPersist(accountOps: SubmittedAccountOp[]) {
+    console.log('Debug: backfilling balance changes for account ops:', accountOps)
     await Promise.all(accountOps.map((accOp) => this.backfillAccountOpBalanceChanges(accOp)))
     await this.persistAccountsOps()
   }
@@ -983,6 +1000,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
       }
     >
   > {
+    console.log('Debug: updating accounts ops statuses for addresses:', accountAddresses)
     const selectedAddr = this.#selectedAccount.account?.addr
     // ensure ops are always updated for selected account if no addresses are passed
     const uniqueAddresses = Array.from(
@@ -1017,6 +1035,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
       receipts?: BalanceChangesReceipt[]
     }>
   ) {
+    console.log('Debug: executing balance changes tasks for account ops:', balanceChangesTasks)
     await Promise.all(
       balanceChangesTasks.map(
         ({ accountOp, network, tokenAddrs, receiptBlockNumber, prevBlockNumber, receipts }) =>
@@ -1348,9 +1367,25 @@ export class ActivityController extends EventEmitter implements IActivityControl
       await this.persistAccountsOps()
     }
 
+    console.log(
+      'Debug: starting to execute balance changes tasks for account:',
+      accountAddr,
+      balanceChangesTasks
+    )
+    const executeStartTime = Date.now()
+
     // record the balance changes but do not await them
     // no need to console.log errors in the catch() as it's handled inside
-    this.#executeBalanceChanges(balanceChangesTasks).catch((e) => null)
+    this.#executeBalanceChanges(balanceChangesTasks)
+      .catch((e) => null)
+      .then(() => {
+        const executeEndTime = Date.now()
+        const executionTime = (executeEndTime - executeStartTime) / 1000
+        console.log(
+          `Debug: finished executing balance changes tasks for account ${accountAddr} in ${executionTime} seconds:`,
+          balanceChangesTasks
+        )
+      })
 
     return {
       shouldEmitUpdate,
@@ -1438,6 +1473,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
     await this.syncSignedMessages()
 
     await this.#storage.set('accountsOps', this.#accountsOps)
+    console.log('Debug: called storage set for accountsOps: removeAccountData')
     await this.#storage.set('signedMessages', this.#signedMessages)
 
     this.emitUpdate()

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -1036,6 +1036,9 @@ export class ActivityController extends EventEmitter implements IActivityControl
     }>
   ) {
     console.log('Debug: executing balance changes tasks for account ops:', balanceChangesTasks)
+    // THIS FIXES PERFORMANCE. UNCOMMENT TO TEST
+    // if (balanceChangesTasks.length === 0) return
+
     await Promise.all(
       balanceChangesTasks.map(
         ({ accountOp, network, tokenAddrs, receiptBlockNumber, prevBlockNumber, receipts }) =>

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -761,6 +761,8 @@ export class MainController extends EventEmitter implements IMainController {
   }
 
   async #selectAccount(toAccountAddr: string | null) {
+    const start = Date.now()
+    console.log('Debug: main.#selectAccount started', start)
     if (!toAccountAddr) {
       await this.selectedAccount.setAccount(null)
 
@@ -812,6 +814,7 @@ export class MainController extends EventEmitter implements IMainController {
       this.dapps.broadcastDappSessionEvent('accountsChanged', [toAccountAddr]),
       this.forceEmitUpdate()
     ])
+    console.log('Debug: main.#selectAccount finished', Date.now(), 'took', Date.now() - start, 'ms')
   }
 
   async #onAccountPickerSuccess() {

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -1274,12 +1274,12 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       maxDataAgeMs?: number
       isManualUpdate?: boolean
     }
-  ): Promise<[boolean, FormattedPortfolioDiscoveryResponse | null]> {
+  ): Promise<['success' | 'fail' | 'skipped', FormattedPortfolioDiscoveryResponse | null]> {
     const { maxDataAgeMs, isManualUpdate, defiMaxDataAgeMs } = portfolioProps
     const accountState = this.#state[account.addr]
 
     // Can occur if the account is removed while updateSelectedAccount is in progress
-    if (!accountState) return [false, null]
+    if (!accountState) return ['fail', null]
 
     if (!accountState[network.chainId.toString()]) {
       // isLoading must be false here, otherwise canSkipUpdate will return true
@@ -1292,7 +1292,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       maxDataAgeMs
     )
 
-    if (canSkipUpdate) return [true, null]
+    if (canSkipUpdate) return ['skipped', null]
 
     this.#setNetworkLoading(account.addr, network.chainId.toString(), true)
     const state = accountState[network.chainId.toString()]!
@@ -1416,7 +1416,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       }
 
       this.emitUpdate()
-      return [true, discoveryData]
+      return ['success', discoveryData]
     } catch (e: any) {
       this.emitError({
         level: 'silent',
@@ -1442,7 +1442,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       }
       this.emitUpdate()
 
-      return [false, null]
+      return ['fail', null]
     }
   }
 
@@ -1783,7 +1783,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
           const baseAcc = state ? getBaseAccount(selectedAccount, state, network) : null
 
-          const [isSuccessful, discoveryResponse] = await this.updatePortfolioState(
+          const [updateStatus, discoveryResponse] = await this.updatePortfolioState(
             selectedAccount,
             network,
             portfolioLib,
@@ -1808,7 +1808,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           )
 
           // Learn tokens and nfts from the portfolio lib
-          if (isSuccessful && accountState[network.chainId.toString()]?.result) {
+          if (updateStatus === 'success' && accountState[network.chainId.toString()]?.result) {
             const networkResult = accountState[network.chainId.toString()]!.result
             const { erc20s, erc721s } = networkResult?.toBeLearned || {}
             let shouldUpdateLearnedInStorage = false

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -189,7 +189,13 @@ export class SelectedAccountController extends EventEmitter implements ISelected
     if (!account) {
       await this.#storage.remove('selectedAccount')
     } else {
+      const start = Date.now()
       await this.#storage.set('selectedAccount', account.addr)
+      console.log(
+        'Debug: called storage set for selectedAccount: setAccount (took',
+        Date.now() - start,
+        'ms)'
+      )
     }
   }
 

--- a/src/controllers/storage/storage.ts
+++ b/src/controllers/storage/storage.ts
@@ -398,6 +398,7 @@ export class StorageController extends EventEmitter implements IStorageControlle
       migratedNetworksWithPositionsByAccounts
     )
     await this.#storage.set('accountsOps', migratedAccountsOps)
+    console.log('Debug: called storage set for accountsOps: storage.ts')
     await this.#storage.set('signedMessages', migratedSignedMessages)
     await this.#storage.set('passedMigrations', [
       ...new Set([...passedMigrations, 'migrateNetworkIdToChainId'])
@@ -442,6 +443,7 @@ export class StorageController extends EventEmitter implements IStorageControlle
   }
 
   async set<K extends keyof StorageProps>(key: K, value: StorageProps[K]) {
+    console.log('Debug: set called with', key, 'has queue', !!this.#storageUpdateQueue)
     await this.#storageMigrationsPromise
     this.#storageUpdateQueue = this.#storageUpdateQueue.then(async () => {
       try {


### PR DESCRIPTION
## Note:
I'm away next week. The goal of this PR is to preserve what I've been debugging.

Related to https://github.com/AmbireTech/ambire-app/issues/7085 and https://github.com/AmbireTech/ambire-app/issues/7157

`Colleague` = name of the colleague

We debugged this with Colleague and here is the data we have:
- The issues started in https://github.com/AmbireTech/ambire-app/releases/tag/v6.7.0 (and can be reproduced with all subsequent versions)
- Going back to https://github.com/AmbireTech/ambire-app/releases/tag/v6.6.2 fixes it
- Removing the `#executeBalanceChanges`, introduced in https://github.com/AmbireTech/ambire-common/pull/2332/changes fixes it too
- His storage is ~250MB 

So, what's the reason? `#executeBalanceChanges` is not being awaited, so how is `withStatus('selectAccount'...` slowed down?

The call flow goes like this:
main.selectAccount -> accountsOpsStatusesInterval.restart({ runImmediately: true } -> updateAccountsOpsStatuses -> executeBalanceChanges -> storage.set() -> stringify

Stringify is sync and blocks the main thread for ~5 seconds on my end (and even more on Colleague's machine)

## How to generate a ton of accountOps to test this
Just execute this in the browser console in a new chrome profile (MUST FILL THE ACCOUNTS ARRAY FIRST!!)
[createOps.js](https://github.com/user-attachments/files/28149150/createOps.js)

## How to fix this:
executeBalanceChanges calls `persistAccountsOps` (which calls `storage.set()`) even if `balanceChangesTasks.length === 0`. We should fix this, which will fix `removeAccount` and `selectAccount` 

## To discuss:
Imo, there is a bigger problem here - yes, the extension has unlimited storage access, but if it blocks the main thread like this, then maybe we should consider fixing this. Yes, not many users will have this many account ops, but what if someone is farming daily, has many accounts and uses multiple networks? The extension will get slower with time, and we will never experience this while developing.

## What I still can't comprehend
For some reason, setting `selectedAccount` via the console takes 1.5s on his extension instance, while it takes 1ms on prod on the same machine. On my end, even with 350MB storage, selecting an account takes ~5ms.

This cannot be explained by `stringify`, because it's not called when using the console. Also, if `storage.set` takes this much time just because of the size, why is it so fast on my end, and why is the problem resolved with an older version and when the code is commented out??? :thinking: 

Note: nothing written in this description is based on assumptions. Everything is a fact that I've proven locally or on Colleague's machine