### PR TITLE
Add: a 20% gas ovearhead when doing a MAX transfer to make sure RPC's don't reject the max transfer 

### DIFF
--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -151,7 +151,7 @@ describe('Transfer Controller', () => {
     })
 
     expect(transferController.amount).toBe(
-      formatUnits(nativeToken.amount - feeAmount, nativeToken.decimals)
+      formatUnits(nativeToken.amount - feeAmount - feeAmount / 5n, nativeToken.decimals)
     )
   })
   test('should set validation form messages', async () => {

--- a/src/libs/transfer/amount.test.ts
+++ b/src/libs/transfer/amount.test.ts
@@ -1,8 +1,8 @@
 import { getAmountAfterFeeReserve, getAmountAfterFeeSync } from './amount'
 
 describe('transfer amount helpers', () => {
-  test('should subtract the reserved fee from the transferable amount', () => {
-    expect(getAmountAfterFeeReserve(15_000_000n, 350_000n)).toBe(14_650_000n)
+  test('should subtract the reserved fee plus overhead from the transferable amount', () => {
+    expect(getAmountAfterFeeReserve(15_000_000n, 350_000n)).toBe(14_580_000n)
   })
 
   test('should never return a negative transferable amount', () => {
@@ -18,7 +18,7 @@ describe('transfer amount helpers', () => {
         shouldReserveFee: true,
         isMaxAmountSelected: false
       })
-    ).toBe(14_650_000n)
+    ).toBe(14_580_000n)
   })
 
   test('should preserve smaller manual amounts when fee reservation is needed', () => {
@@ -55,6 +55,6 @@ describe('transfer amount helpers', () => {
         shouldReserveFee: true,
         isMaxAmountSelected: true
       })
-    ).toBe(14_600_000n)
+    ).toBe(14_520_000n)
   })
 })

--- a/src/libs/transfer/amount.ts
+++ b/src/libs/transfer/amount.ts
@@ -1,5 +1,16 @@
+const FEE_RESERVE_OVERHEAD_BPS = 2000n
+const BPS = 10000n
+
+const getFeeWithReserveOverhead = (fee: bigint): bigint => {
+  if (fee === 0n) return 0n
+
+  return (fee * (BPS + FEE_RESERVE_OVERHEAD_BPS) + BPS - 1n) / BPS
+}
+
 const getAmountAfterFeeReserve = (amount: bigint, fee: bigint): bigint => {
-  return amount > fee ? amount - fee : 0n
+  const feeWithOverhead = getFeeWithReserveOverhead(fee)
+
+  return amount > feeWithOverhead ? amount - feeWithOverhead : 0n
 }
 
 const getAmountAfterFeeSync = ({

--- a/src/libs/transfer/amount.ts
+++ b/src/libs/transfer/amount.ts
@@ -4,6 +4,7 @@ const BPS = 10000n
 const getFeeWithReserveOverhead = (fee: bigint): bigint => {
   if (fee === 0n) return 0n
 
+  // here we do BPS - 1n for ceiling division, i.e. to round up 3.6 to 4
   return (fee * (BPS + FEE_RESERVE_OVERHEAD_BPS) + BPS - 1n) / BPS
 }
 


### PR DESCRIPTION
Closes: https://github.com/AmbireTech/ambire-app/issues/7223