### PR TITLE
Fix: duplication (by filtering blacklisted tokens, e.g. EURe) from activity balance changes going forward

### DIFF
--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -182,11 +182,14 @@ const getBalanceChangeTokenAddrsFromReceipts = async (
   accountOp: SubmittedAccountOp,
   receipts: TransactionReceipt[]
 ) => {
-  const foundTokens = (
-    await Promise.all(
-      receipts.map((receipt) => getTransferLogTokens(receipt.logs, accountOp.accountAddr))
-    )
-  ).flat()
+  const foundTokens = filterStaticBlacklistedAddrs(
+    (
+      await Promise.all(
+        receipts.map((receipt) => getTransferLogTokens(receipt.logs, accountOp.accountAddr))
+      )
+    ).flat(),
+    accountOp.chainId
+  )
 
   return getBalanceChangeTokenAddresses(foundTokens, accountOp.chainId)
 }
@@ -1270,7 +1273,10 @@ export class ActivityController extends EventEmitter implements IActivityControl
                   }
 
                   const foundTokens = isSuccess
-                    ? await getTransferLogTokens(receipt.logs, accountOp.accountAddr)
+                    ? filterStaticBlacklistedAddrs(
+                        await getTransferLogTokens(receipt.logs, accountOp.accountAddr),
+                        accountOp.chainId
+                      )
                     : []
                   if (foundTokens.length)
                     this.#portfolio.addTokensToBeLearned(foundTokens, accountOp.chainId)

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -39,6 +39,7 @@ import {
 } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus, Call } from '../../libs/accountOp/types'
 import { getTransferLogTokens } from '../../libs/logsParser/parseLogs'
+import { filterStaticBlacklistedAddrs } from '../../libs/portfolio/blacklist'
 import { ScamFilter } from '../../libs/scamFilter'
 import { parseLogs } from '../../libs/userOperation/userOperation'
 import { getDebugTraceTransaction } from '../../utils/debugTransaction'
@@ -790,7 +791,10 @@ export class ActivityController extends EventEmitter implements IActivityControl
     }
 
     try {
-      const foundTokens = await getTransferLogTokens(receipt.logs, accountAddr)
+      const foundTokens = filterStaticBlacklistedAddrs(
+        await getTransferLogTokens(receipt.logs, accountAddr),
+        chainId
+      )
       if (shouldLearnTokens) {
         const scamFilter = new ScamFilter({ fetch: this.#fetch, network })
         const tokensWithAPrice = await scamFilter.filterTokensWithoutAPrice(foundTokens)

--- a/src/libs/portfolio/blacklist.test.ts
+++ b/src/libs/portfolio/blacklist.test.ts
@@ -1,0 +1,12 @@
+import { filterStaticBlacklistedAddrs } from './blacklist'
+
+describe('portfolio blacklist', () => {
+  it('filters static blacklisted addresses', () => {
+    const blacklistedToken = '0x3231Cb76718CDeF2155FC47b5286d82e6eDA273f'
+    const allowedToken = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+
+    expect(filterStaticBlacklistedAddrs([blacklistedToken, allowedToken], 1n)).toEqual([
+      allowedToken
+    ])
+  })
+})

--- a/src/libs/portfolio/blacklist.ts
+++ b/src/libs/portfolio/blacklist.ts
@@ -1,0 +1,48 @@
+import type { TokenBlacklist } from './interfaces'
+
+/**
+ * Static list of tokens to exclude from display, keyed by chainId.
+ * Addresses MUST BE CHECKSUMMED.
+ * Symbol patterns are matched case-insensitively as substrings.
+ */
+export const STATIC_BLACKLIST: Omit<TokenBlacklist, 'updatedAt'> = {
+  blacklistAddrs: {
+    // Gnosis Chain (xDAI)
+    '100': [
+      '0xcB444e90D8198415266c6a2724b7900fb12FC56E' // EURe - Duplicate
+    ],
+    // Polygon
+    '137': [
+      '0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6', // EURe (Monerium EUR emoney) - Excluded due to regulatory restrictions and limited utility in the app
+      '0x0B91B07bEb67333225A5bA0259D55AeE10E3A578' // MNEP - scam token
+    ],
+    // Ethereum Mainnet
+    '1': [
+      '0x3231Cb76718CDeF2155FC47b5286d82e6eDA273f' // EURe - Duplicate
+    ],
+    // Hyper EVM
+    '999': [
+      '0x94e8396e0869c9F2200760aF0621aFd240E1CF38' // wstHYPE - Excluded because it's a duplicate of stHYPE
+    ],
+    // Andromeda
+    '1088': [
+      '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000' // METIS as an ERC-20 token - Excluded because it's a duplicate of the native token
+    ],
+    // Optimism
+    '10': [
+      '0xDfA2d3a0d32F870D87f8A0d7AA6b9CdEB7bc5AdB' // sUSD - Duplicate of 0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9
+    ]
+  },
+  blacklistBySymbols: ['https', 'www.']
+}
+
+export const filterStaticBlacklistedAddrs = (tokenAddrs: string[], chainId: bigint) => {
+  const staticBlacklistedAddrs = STATIC_BLACKLIST.blacklistAddrs[chainId.toString()] || []
+  if (!staticBlacklistedAddrs.length) return tokenAddrs
+
+  const staticBlacklistedAddrsLower = new Set(
+    staticBlacklistedAddrs.map((addr) => addr.toLowerCase())
+  )
+
+  return tokenAddrs.filter((addr) => !staticBlacklistedAddrsLower.has(addr.toLowerCase()))
+}

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -12,6 +12,7 @@ import { Network } from '../../interfaces/network'
 import { RPCProvider } from '../../interfaces/provider'
 import { Deployless, fromDescriptor } from '../deployless/deployless'
 import batcher from './batcher'
+import { STATIC_BLACKLIST } from './blacklist'
 import { geckoRequestBatcher, geckoResponseIdentifier } from './gecko'
 import { getNFTs, getTokens } from './getOnchainBalances'
 import {
@@ -29,49 +30,12 @@ import {
   Limits,
   LimitsOptions,
   PortfolioLibGetResult,
-  TokenBlacklist,
   TokenDataCache,
   TokenDataCacheValue,
   TokenError,
   TokenResult
 } from './interfaces'
 import { flattenResults, paginate } from './pagination'
-
-/**
- * Static list of tokens to exclude from display, keyed by chainId.
- * Addresses MUST BE CHECKSUMMED.
- * Symbol patterns are matched case-insensitively as substrings.
- */
-export const STATIC_BLACKLIST: Omit<TokenBlacklist, 'updatedAt'> = {
-  blacklistAddrs: {
-    // Gnosis Chain (xDAI)
-    '100': [
-      '0xcB444e90D8198415266c6a2724b7900fb12FC56E' // EURe - Duplicate
-    ],
-    // Polygon
-    '137': [
-      '0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6', // EURe (Monerium EUR emoney) - Excluded due to regulatory restrictions and limited utility in the app
-      '0x0B91B07bEb67333225A5bA0259D55AeE10E3A578' // MNEP - scam token
-    ],
-    // Ethereum Mainnet
-    '1': [
-      '0x3231Cb76718CDeF2155FC47b5286d82e6eDA273f' // EURe - Duplicate
-    ],
-    // Hyper EVM
-    '999': [
-      '0x94e8396e0869c9F2200760aF0621aFd240E1CF38' // wstHYPE - Excluded because it's a duplicate of stHYPE
-    ],
-    // Andromeda
-    '1088': [
-      '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000' // METIS as an ERC-20 token - Excluded because it's a duplicate of the native token
-    ],
-    // Optimism
-    '10': [
-      '0xDfA2d3a0d32F870D87f8A0d7AA6b9CdEB7bc5AdB' // sUSD - Duplicate of 0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9
-    ]
-  },
-  blacklistBySymbols: ['https', 'www.']
-}
 
 export const LIMITS: Limits = {
   // we have to be conservative with erc721Tokens because if we pass 30x20 (worst case) tokenIds, that's 30x20 extra words which is 19kb


### PR DESCRIPTION
Problem: Eure was being shown twice in the activity cards as it's filtered from the portfolio (its blacklisted address), but not in activity. So we filter it in activity as well

Fixes: https://github.com/AmbireTech/ambire-app/issues/7222