### PR TITLE
Requests/ fix do not allow 712 messages with wrong inner data types

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -659,4 +659,84 @@ describe('RequestsController ', () => {
       ).resolves.toBeUndefined()
     })
   })
+
+  describe('eth_signTypedData_v4 typed data validation', () => {
+    const FROM = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+
+    const VALID_TYPED_DATA = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' }
+        ],
+        Mail: [
+          { name: 'from', type: 'address' },
+          { name: 'to', type: 'address' },
+          { name: 'contents', type: 'string' }
+        ]
+      },
+      primaryType: 'Mail',
+      domain: { name: 'Test Mail', version: '1', chainId: 1 },
+      message: {
+        from: '0xa07D75aacEFd11b425AF7181958F0F85c312f143',
+        to: '0x6C0937c7a04487573673a47F22E4Af9e96b91ecd',
+        contents: 'Hello!'
+      }
+    }
+
+    const buildSignTypedDataRequest = (
+      controller: Awaited<ReturnType<typeof prepareTest>>['controller'],
+      typedData: object
+    ) =>
+      controller.build({
+        type: 'dappRequest',
+        params: {
+          request: {
+            method: 'eth_signTypedData_v4',
+            params: [FROM, JSON.stringify(typedData)],
+            session: MOCK_SESSION
+          },
+          dappPromise: {
+            id: 'testID',
+            resolve: () => {},
+            reject: () => {},
+            session: MOCK_SESSION
+          }
+        }
+      })
+
+    test('rejects when primaryType is missing from types', async () => {
+      const { controller } = await prepareTest(true)
+      const typedData = {
+        ...VALID_TYPED_DATA,
+        types: { EIP712Domain: VALID_TYPED_DATA.types.EIP712Domain }
+      }
+      await expect(buildSignTypedDataRequest(controller, typedData)).rejects.toThrow(
+        'The primary data type is missing from the provided types'
+      )
+    })
+
+    test('rejects when message contents do not match the declared types', async () => {
+      const { controller } = await prepareTest(true)
+      const typedData = {
+        ...VALID_TYPED_DATA,
+        message: {
+          from: 'not-a-valid-address',
+          to: '0x6C0937c7a04487573673a47F22E4Af9e96b91ecd',
+          contents: 'Hello!'
+        }
+      }
+      await expect(buildSignTypedDataRequest(controller, typedData)).rejects.toThrow(
+        'The message contents did not match the provided types.'
+      )
+    })
+
+    test('accepts valid typed data and creates a typedMessage user request', async () => {
+      const { controller } = await prepareTest(true)
+      await expect(buildSignTypedDataRequest(controller, VALID_TYPED_DATA)).resolves.toBeUndefined()
+      expect(controller.userRequests.length).toBe(1)
+      expect(controller.userRequests[0]!.kind).toBe('typedMessage')
+    })
+  })
 })

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -82,7 +82,7 @@ import {
   SignAccountOpController
 } from '../signAccountOp/signAccountOp'
 import { SwapAndBridgeFormStatus } from '../swapAndBridge/swapAndBridge'
-import { isHex } from 'viem'
+import { hashTypedData, isHex } from 'viem'
 
 const STATUS_WRAPPED_METHODS = {
   buildSwapAndBridgeUserRequest: 'INITIAL'
@@ -1261,6 +1261,23 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         throw ethErrors.rpc.methodNotSupported(
           'Invalid typedData format - only typedData v4 is supported'
         )
+      }
+
+      if (!typedData.types[typedData.primaryType])
+        throw ethErrors.rpc.invalidParams(
+          'The primary data type is missing from the provided types'
+        )
+      try {
+        // we ignore the result because we only care if the func will fail
+        hashTypedData({
+          types: typedData.types,
+          primaryType: typedData.primaryType,
+          message: typedData.message,
+          domain: typedData.domain
+        })
+      } catch (e) {
+        console.log(e)
+        throw ethErrors.rpc.invalidParams('The message contents did not match the provided types.')
       }
 
       if (


### PR DESCRIPTION
This will disallow all 712 messages. who's structured message data does not adhere to the types specified in `types`

issue reported here: https://ambiretech.slack.com/archives/C0644227TAP/p1779551155585349

## To test
Paste this in the console, it should throw error (the problem is that the spender is in decimal format)
```
await window.ethereum.request({
  method: "eth_signTypedData_v4",
  params: [
    "0x6969174FD72466430a46e18234D0b530c9FD5f49",
    JSON.stringify({
  types: {
    EIP712Domain: [
      { name: "name", type: "string" },
      { name: "version", type: "string" },
      { name: "chainId", type: "uint256" },
      { name: "verifyingContract", type: "address" },
    ],
    Permit: [
      { name: "owner", type: "address" },
      { name: "spender", type: "address" },
      { name: "value", type: "uint256" },
      { name: "nonce", type: "uint256" },
      { name: "deadline", type: "uint256" },
    ],
  },
  primaryType: "Permit",
  domain: {
    name: "USD Coin",
    version: "2",
    chainId: 1,
    verifyingContract: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
  },
  message: {
    owner: "0x6969174FD72466430a46e18234D0b530c9FD5f49",
    spender: "2343603977537236480955220184427470178753794377",
    value: "133700",
    nonce: "0",
    deadline:
      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
  },
}),
  ],
});
```