### PR TITLE
Fix/ allow the humanizer to decode txns with non-strict encoding

### DIFF
--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -393,3 +393,108 @@ describe('with (Account | Key)[] arg', () => {
     compareHumanizerVisualizations(irCalls, expectedVisualizations)
   })
 })
+
+// Non-strict / dirty-bytes ABI encoding: the 12 leading zero bytes that pad a 20-byte
+// address to a 32-byte ABI slot (or the 31 zero bytes that pad a bool) are replaced with
+// non-zero random values. Some on-chain calldata produced by buggy or non-standard
+// encoders contains such garbage padding, and the humanizer must either decode it
+// correctly or degrade gracefully instead of throwing.
+describe('non-strict encoding / dirty bytes', () => {
+  // 12 random non-zero bytes used to corrupt the address-slot padding
+  const dirtyPadding = 'deadbeefcafe12345678abcd'
+
+  const usdtAddress = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+  const nftAddress = '0x59468516a8259058bad1ca5f8f4bff190d30e066'
+  const spender = '46705dfff24256421a05d056c29e81bdc09723b8'
+  // deliberately not accountOp.accountAddr so transferFrom takes the "Move" path
+  const sender = 'c89b38119c58536d818f3bf19a9e3870828c1994'
+
+  // Standard ABI value slot for 10^9 (0x3b9aca00)
+  const valueSlot = '000000000000000000000000000000000000000000000000000000003b9aca00'
+
+  beforeEach(() => {
+    accountOp.calls = []
+  })
+
+  test('approve with dirty address padding decodes correctly', () => {
+    // approve(address _spender, uint256 _value)
+    // Dirty: the 12 leading zero bytes of the spender slot are replaced with random bytes
+    const data = `0x095ea7b3${dirtyPadding}${spender}${valueSlot}`
+
+    accountOp.calls = [{ to: usdtAddress, value: 0n, data }]
+
+    const irCalls = humanizeAccountOp(accountOp)
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken(usdtAddress, 1000000000n),
+        getLabel('to'),
+        getAddressVisualization(`0x${spender}`)
+      ]
+    ])
+  })
+
+  test('transfer with dirty address padding decodes correctly', () => {
+    // transfer(address _to, uint256 _value)
+    // Dirty: the 12 leading zero bytes of the recipient slot are replaced with random bytes
+    const data = `0xa9059cbb${dirtyPadding}${spender}${valueSlot}`
+
+    accountOp.calls = [{ to: usdtAddress, value: 0n, data }]
+
+    const irCalls = humanizeAccountOp(accountOp)
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('Send'),
+        getToken(usdtAddress, 1000000000n),
+        getLabel('to'),
+        getAddressVisualization(`0x${spender}`)
+      ]
+    ])
+  })
+
+  test('transferFrom with dirty address padding on the from-slot decodes correctly', () => {
+    // transferFrom(address _from, address _to, uint256 _value)
+    // Dirty: the 12 leading zero bytes of the _from slot are replaced with random bytes;
+    // _to slot uses standard zero padding
+    const cleanAddressSlot = (addr: string) => `000000000000000000000000${addr}`
+    const data =
+      `0x23b872dd` +
+      `${dirtyPadding}${sender}` + // dirty _from slot
+      cleanAddressSlot(spender) + // clean _to slot
+      valueSlot
+
+    accountOp.calls = [{ to: usdtAddress, value: 0n, data }]
+
+    const irCalls = humanizeAccountOp(accountOp)
+    // _from !== accountOp.accountAddr and _to !== accountOp.accountAddr → Move
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('Move'),
+        getToken(usdtAddress, 1000000000n),
+        getLabel('from'),
+        getAddressVisualization(`0x${sender}`),
+        getLabel('to'),
+        getAddressVisualization(`0x${spender}`)
+      ]
+    ])
+  })
+
+  test('setApprovalForAll with dirty bool padding falls back gracefully', () => {
+    // setApprovalForAll(address operator, bool approved)
+    // Dirty: the bool slot uses 0xff instead of the valid 0x01, which viem rejects
+    // as an invalid boolean. The module should throw and the humanizer should degrade
+    // to the generic fallback visualization rather than crashing.
+    const data =
+      `0xa22cb465` +
+      `000000000000000000000000${spender}` + // operator slot (clean)
+      `00000000000000000000000000000000000000000000000000000000000000ff` // dirty bool (0xff)
+
+    accountOp.calls = [{ to: nftAddress, value: 0n, data }]
+
+    const irCalls = humanizeAccountOp(accountOp)
+    compareHumanizerVisualizations(irCalls, [
+      [getAction('Interacting'), getLabel('with'), getAddressVisualization(nftAddress)]
+    ])
+  })
+})

--- a/src/libs/humanizer/index.ts
+++ b/src/libs/humanizer/index.ts
@@ -118,6 +118,7 @@ const humanizeAccountOp = (_accountOp: AccountOp): IrCall[] => {
     try {
       currentCalls = hm(accountOp, currentCalls, humanizerInfo as HumanizerMeta)
     } catch (error) {
+      console.log(hm.name)
       console.error(error)
       // No action is needed here; we only set `currentCalls` if the module successfully resolves the calls.
     }

--- a/src/libs/humanizer/index.ts
+++ b/src/libs/humanizer/index.ts
@@ -118,7 +118,6 @@ const humanizeAccountOp = (_accountOp: AccountOp): IrCall[] => {
     try {
       currentCalls = hm(accountOp, currentCalls, humanizerInfo as HumanizerMeta)
     } catch (error) {
-      console.log(hm.name)
       console.error(error)
       // No action is needed here; we only set `currentCalls` if the module successfully resolves the calls.
     }

--- a/src/libs/humanizer/modules/Tokens/tokens.ts
+++ b/src/libs/humanizer/modules/Tokens/tokens.ts
@@ -1,126 +1,148 @@
-import { Interface, ZeroAddress } from 'ethers'
+import { parseAbi, decodeFunctionData, toFunctionSelector, zeroAddress } from 'viem'
 
 import { AccountOp } from '../../../accountOp/accountOp'
-import { ERC20, ERC721 } from '../../const/abis'
 import { HumanizerCallModule, IrCall } from '../../interfaces'
-import { getAction, getAddressVisualization, getLabel, getToken } from '../../utils'
+import {
+  HexIrCall,
+  getAction,
+  getAddressVisualization,
+  getLabel,
+  getToken,
+  isHexCall
+} from '../../utils'
 
-const ERC721_INTERFACE = new Interface(ERC721)
-const ERC20_INTERFACE = new Interface(ERC20)
+// Narrowed ABIs — defined once at module level, used for typed decoding
+const erc721ApproveAbi = parseAbi(['function approve(address to, uint256 tokenId)'])
+const erc721SetApprovalForAllAbi = parseAbi([
+  'function setApprovalForAll(address operator, bool approved)'
+])
+const erc721SafeTransferFromAbi = parseAbi([
+  'function safeTransferFrom(address from, address to, uint256 tokenId)'
+])
+const erc721TransferFromAbi = parseAbi([
+  'function transferFrom(address from, address to, uint256 tokenId)'
+])
 
-// @TODO merge this with the  erc20 humanizer module as sometimes
-// we see no difference between the two
+const erc20ApproveAbi = parseAbi([
+  'function approve(address _spender, uint256 _value) returns (bool)'
+])
+const erc20TransferAbi = parseAbi(['function transfer(address _to, uint256 _value) returns (bool)'])
+const erc20TransferFromAbi = parseAbi([
+  'function transferFrom(address _from, address _to, uint256 _value) returns (bool)'
+])
+const erc20IncreaseAllowanceAbi = parseAbi([
+  'function increaseAllowance(address spender, uint256 addedValue) returns (bool)'
+])
+const erc20DecreaseAllowanceAbi = parseAbi([
+  'function decreaseAllowance(address spender, uint256 subtractedValue) returns (bool)'
+])
+
 export const genericErc721Humanizer: HumanizerCallModule = (
   accountOp: AccountOp,
   currentIrCalls: IrCall[]
 ) => {
-  const nftTransferVisualization = (call: IrCall) => {
+  const nftTransferVisualization = (
+    call: HexIrCall,
+    abi: typeof erc721SafeTransferFromAbi | typeof erc721TransferFromAbi
+  ) => {
     if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-    const args = ERC721_INTERFACE.parseTransaction(call)?.args.toArray() || []
-    return args[0] === accountOp.accountAddr
-      ? [
-          getAction('Send'),
-          getToken(call.to, args[2]),
-          getLabel('to'),
-          getAddressVisualization(args[1])
-        ]
+    const { args } = decodeFunctionData({ abi, data: call.data })
+    const [from, to, tokenId] = args
+    return from === accountOp.accountAddr
+      ? [getAction('Send'), getToken(call.to, tokenId), getLabel('to'), getAddressVisualization(to)]
       : [
           getAction('Transfer'),
-          getToken(call.to, args[2]),
+          getToken(call.to, tokenId),
           getLabel('from'),
-          getAddressVisualization(args[0]),
+          getAddressVisualization(from),
           getLabel('to'),
-          getAddressVisualization(args[1])
+          getAddressVisualization(to)
         ]
   }
-  const matcher = {
-    [ERC721_INTERFACE.getFunction('approve')?.selector!]: (call: IrCall) => {
+
+  const matcher: Record<string, (call: HexIrCall) => any> = {
+    [toFunctionSelector(erc721ApproveAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const args = ERC721_INTERFACE.parseTransaction(call)?.args.toArray() || []
-      return args[0] === ZeroAddress
-        ? [getAction('Revoke approval'), getLabel('for'), getToken(call.to, args[1])]
+      const { args } = decodeFunctionData({ abi: erc721ApproveAbi, data: call.data })
+      const [to, tokenId] = args
+      return to === zeroAddress
+        ? [getAction('Revoke approval'), getLabel('for'), getToken(call.to, tokenId)]
         : [
             getAction('Grant approval'),
             getLabel('for'),
-            getToken(call.to, args[1]),
+            getToken(call.to, tokenId),
             getLabel('to'),
-            getAddressVisualization(args[0])
+            getAddressVisualization(to)
           ]
     },
-    [ERC721_INTERFACE.getFunction('setApprovalForAll')?.selector!]: (call: IrCall) => {
+    [toFunctionSelector(erc721SetApprovalForAllAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const args = ERC721_INTERFACE.parseTransaction(call)?.args.toArray() || []
-      return args[1]
+      const { args } = decodeFunctionData({
+        abi: erc721SetApprovalForAllAbi,
+        data: call.data
+      })
+      const [operator, approved] = args
+      return approved
         ? [
             getAction('Grant approval', { warning: true }),
             getLabel('for all NFTs of'),
             getAddressVisualization(call.to),
             getLabel('to'),
-            getAddressVisualization(args[0])
+            getAddressVisualization(operator)
           ]
         : [
             getAction('Revoke approval'),
             getLabel('for all nfts from'),
             getAddressVisualization(call.to),
             getLabel('for'),
-            getAddressVisualization(args[0])
+            getAddressVisualization(operator)
           ]
     },
-    // not in tests
-    [ERC721_INTERFACE.getFunction('safeTransferFrom', ['address', 'address', 'uint256'])
-      ?.selector!]: nftTransferVisualization,
-    // [`${
-    //   ERC721_INTERFACE.getFunction('safeTransferFrom', ['address', 'address', 'uint256', 'bytes'])
-    //     ?.selector
-    // }`]: nftTransferVisualization,
-    [ERC721_INTERFACE.getFunction('transferFrom', ['address', 'address', 'uint256'])?.selector!]:
-      nftTransferVisualization
+    [toFunctionSelector(erc721SafeTransferFromAbi[0])]: (call) =>
+      nftTransferVisualization(call, erc721SafeTransferFromAbi),
+    [toFunctionSelector(erc721TransferFromAbi[0])]: (call) =>
+      nftTransferVisualization(call, erc721TransferFromAbi)
   }
 
-  const newCalls = currentIrCalls.map((call) => {
+  return currentIrCalls.map((call) => {
     if (!call.to) return call
-    // could do additional check if it is actually NFT contract
+    if (!isHexCall(call)) return call
     const selector = call.data.substring(0, 10)
-    return matcher[selector]
-      ? {
-          ...call,
-          fullVisualization: matcher[selector](call)
-        }
-      : call
+    return matcher[selector] ? { ...call, fullVisualization: matcher[selector](call) } : call
   })
-  return newCalls
 }
 
 export const genericErc20Humanizer = (
   { accountAddr }: { accountAddr: string },
   currentIrCalls: IrCall[]
 ): IrCall[] => {
-  const matcher = {
-    [ERC20_INTERFACE.getFunction('approve')?.selector!]: (call: IrCall) => {
+  const matcher: Record<string, (call: HexIrCall) => any> = {
+    [toFunctionSelector(erc20ApproveAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const args = ERC20_INTERFACE.parseTransaction(call)?.args.toArray() || []
-      return args[1] !== BigInt(0)
+      const { args } = decodeFunctionData({ abi: erc20ApproveAbi, data: call.data })
+      const [spender, value] = args
+      return value !== 0n
         ? [
             getAction('Grant approval'),
             getLabel('for'),
-            getToken(call.to, args[1]),
+            getToken(call.to, value),
             getLabel('to'),
-            getAddressVisualization(args[0])
+            getAddressVisualization(spender)
           ]
         : [
             getAction('Revoke approval'),
-            getToken(call.to, args[1]),
+            getToken(call.to, value),
             getLabel('for'),
-            getAddressVisualization(args[0])
+            getAddressVisualization(spender)
           ]
     },
-    [ERC20_INTERFACE.getFunction('increaseAllowance')?.selector!]: (call: IrCall) => {
+    [toFunctionSelector(erc20IncreaseAllowanceAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const { spender, addedValue } = ERC20_INTERFACE.decodeFunctionData(
-        'increaseAllowance',
-        call.data
-      )
-
+      const { args } = decodeFunctionData({
+        abi: erc20IncreaseAllowanceAbi,
+        data: call.data
+      })
+      const [spender, addedValue] = args
       return [
         getAction('Increase allowance'),
         getLabel('of'),
@@ -129,14 +151,13 @@ export const genericErc20Humanizer = (
         getToken(call.to, addedValue)
       ]
     },
-
-    [ERC20_INTERFACE.getFunction('decreaseAllowance')?.selector!]: (call: IrCall) => {
+    [toFunctionSelector(erc20DecreaseAllowanceAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const { spender, subtractedValue } = ERC20_INTERFACE.decodeFunctionData(
-        'decreaseAllowance',
-        call.data
-      )
-
+      const { args } = decodeFunctionData({
+        abi: erc20DecreaseAllowanceAbi,
+        data: call.data
+      })
+      const [spender, subtractedValue] = args
       return [
         getAction('Decrease allowance'),
         getLabel('of'),
@@ -145,55 +166,50 @@ export const genericErc20Humanizer = (
         getToken(call.to, subtractedValue)
       ]
     },
-    [ERC20_INTERFACE.getFunction('transfer')?.selector!]: (call: IrCall) => {
+    [toFunctionSelector(erc20TransferAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-
-      const args = ERC20_INTERFACE.parseTransaction(call)?.args.toArray() || []
+      const { args } = decodeFunctionData({ abi: erc20TransferAbi, data: call.data })
+      const [to, value] = args
       return [
         getAction('Send'),
-        getToken(call.to, args[1]),
+        getToken(call.to, value),
         getLabel('to'),
-        getAddressVisualization(args[0])
+        getAddressVisualization(to)
       ]
     },
-    [ERC20_INTERFACE.getFunction('transferFrom')?.selector!]: (call: IrCall) => {
+    [toFunctionSelector(erc20TransferFromAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const args = ERC20_INTERFACE.parseTransaction(call)?.args.toArray() || []
-      if (args[0] === accountAddr) {
+      const { args } = decodeFunctionData({ abi: erc20TransferFromAbi, data: call.data })
+      const [from, to, value] = args
+      if (from === accountAddr)
         return [
           getAction('Transfer'),
-          getToken(call.to, args[2]),
+          getToken(call.to, value),
           getLabel('to'),
-          getAddressVisualization(args[1])
+          getAddressVisualization(to)
         ]
-      }
-      if (args[1] === accountAddr) {
+      if (to === accountAddr)
         return [
           getAction('Take'),
-          getToken(call.to, args[2]),
+          getToken(call.to, value),
           getLabel('from'),
-          getAddressVisualization(args[0])
+          getAddressVisualization(from)
         ]
-      }
       return [
         getAction('Move'),
-        getToken(call.to, args[2]),
+        getToken(call.to, value),
         getLabel('from'),
-        getAddressVisualization(args[0]),
+        getAddressVisualization(from),
         getLabel('to'),
-        getAddressVisualization(args[1])
+        getAddressVisualization(to)
       ]
     }
   }
-  const newCalls = currentIrCalls.map((call) => {
-    const sigHash = call.data.substring(0, 10)
+
+  return currentIrCalls.map((call) => {
     if (!call.to) return call
-    return matcher[sigHash]
-      ? {
-          ...call,
-          fullVisualization: matcher[sigHash](call)
-        }
-      : call
+    if (!isHexCall(call)) return call
+    const sigHash = call.data.substring(0, 10)
+    return matcher[sigHash] ? { ...call, fullVisualization: matcher[sigHash](call) } : call
   })
-  return newCalls
 }

--- a/src/libs/humanizer/utils.ts
+++ b/src/libs/humanizer/utils.ts
@@ -1,6 +1,13 @@
-import { getAddress, isAddress, ZeroAddress } from 'ethers'
+import { getAddress, isAddress, isHex, zeroAddress, type Hex } from 'viem'
 
-import { HumanizerMeta, HumanizerVisualization, HumanizerWarning } from './interfaces'
+import { HumanizerMeta, HumanizerVisualization, HumanizerWarning, IrCall } from './interfaces'
+
+export type HexIrCall = IrCall & { data: Hex }
+
+/** Type guard that narrows an IrCall to one with a valid hex data field. */
+export function isHexCall(call: IrCall): call is HexIrCall {
+  return isHex(call.data)
+}
 
 export function getWarning(
   content: string,
@@ -11,8 +18,11 @@ export function getWarning(
 }
 export const randomId = (): number => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
 
-export function getLabel(content: string, isBold?: boolean): HumanizerVisualization {
-  return { type: 'label', content, id: randomId(), isBold }
+export function getLabel(
+  content: string | bigint | number,
+  isBold?: boolean
+): HumanizerVisualization {
+  return { type: 'label', content: content.toString(), id: randomId(), isBold }
 }
 export function getAction(
   content: string,
@@ -126,4 +136,4 @@ export const uintToAddress = (uint: bigint): string =>
   `0x${BigInt(uint).toString(16).slice(-40).padStart(40, '0')}`
 
 export const eToNative = (address: string): string =>
-  address.slice(2).toLocaleLowerCase() === 'e'.repeat(40) ? ZeroAddress : address
+  address.slice(2).toLocaleLowerCase() === 'e'.repeat(40) ? zeroAddress : address


### PR DESCRIPTION
The goal is to not allow humanizer bypassing like [the reported here](https://ambiretech.slack.com/archives/C0644227TAP/p1779545278204989)

## How to exploit 
Make a normal approve tx but replace a zero from the padding of the address argument with any other hex character. That would cause the ethers decoding to fail, resulting in no humanization for the approve

## The fix
replace the ethers decoding with viem decoding that allows humanization of the data

## How to test
Click sign on [this tx](https://transact.swiss-knife.xyz/send-tx?chainId=10&calldata=0x095ea7b30000a00000000000000000000b2c639c533813f4aa9d7837caf62653d097ff850000000000000000000000000000000000000000000000000000000000000001&to=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85) which is has a zero padding byte changed in the beginning 
If there is humanization, it is fixed