### PR TITLE
When we select a token from the dashboard, change the network in swap&bridge to that network

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -380,6 +380,24 @@ describe('SwapAndBridge Controller', () => {
     )
     expect(swapAndBridgeController.fromChainId).toEqual(10)
   })
+  test('should sync toChainId to the preselected from token chain when no to token is provided', async () => {
+    const preselectedToken = PORTFOLIO_TOKENS[1]!
+
+    swapAndBridgeController.reset()
+    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS, {
+      preselectedToken: {
+        address: preselectedToken.address,
+        chainId: preselectedToken.chainId
+      }
+    })
+
+    expect(swapAndBridgeController.fromSelectedToken?.address).toEqual(preselectedToken.address)
+    expect(swapAndBridgeController.fromChainId).toEqual(Number(preselectedToken.chainId))
+    expect(swapAndBridgeController.toChainId).toEqual(Number(preselectedToken.chainId))
+
+    swapAndBridgeController.reset()
+    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
+  })
   test('should update toChainId', (done) => {
     let emitCounter = 0
     const unsubscribe = swapAndBridgeController.onUpdate(async () => {

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1107,7 +1107,9 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
         {
           fromSelectedToken: nextFromSelectedToken,
           toSelectedTokenAddr: preselectedToToken?.address,
-          toChainId: preselectedToToken?.chainId,
+          toChainId:
+            preselectedToToken?.chainId ??
+            (preselectedToken ? nextFromSelectedToken?.chainId : undefined),
           fromAmount
         },
         {


### PR DESCRIPTION
Problem:  
I selected a token in the dashboard -> clicked -> swap & bridge for that token -> went to the swap & bridge screen, but the network of the token I selected differs from the chosen on in swap & bridge

Fix:  
Make it the same