### PR TITLE
Config / Remove override existing EIP-7702 delegation warning

### DIFF
--- a/src/consts/signAccountOp/errorHandling.ts
+++ b/src/consts/signAccountOp/errorHandling.ts
@@ -27,13 +27,6 @@ const WARNINGS: { [key: string]: Warning } = {
     id: 'feeTokenPriceUnavailable',
     title: 'Unable to estimate the transaction fee in USD.'
   },
-  delegationDetected: {
-    id: 'delegationDetected',
-    title: 'Delegation detected',
-    text: 'The transaction you are about to sign will override the existing EIP-7702 delegation on your account. Are you sure you want to proceed?',
-    promptBefore: ['one-click-sign', 'sign'],
-    type: 'info'
-  },
   v1Acc: {
     id: 'v1Acc',
     title: 'You can only broadcast transactions for Ambire v1 accounts from an EOA'

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1142,30 +1142,6 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     if (significantBalanceDecreaseWarning) warnings.push(significantBalanceDecreaseWarning)
     if (unknownTokenWarnings) warnings.push(unknownTokenWarnings)
 
-    // if 7702 EOA that is not ambire
-    // and another delegation is there, show the warning
-    const broadcastOption = this.selectedOption
-      ? this.baseAccount.getBroadcastOption(this.selectedOption, {
-          op: this.accountOp,
-          isSponsored: this.isSponsored
-        })
-      : null
-    if (
-      'is7702' in this.baseAccount &&
-      this.baseAccount.is7702 &&
-      this.delegatedContract &&
-      this.delegatedContract !== ZeroAddress &&
-      this.delegatedContract?.toLowerCase() !== EIP_7702_AMBIRE_ACCOUNT.toLowerCase() &&
-      this.delegatedContract?.toLowerCase() !== EIP_7702_GRID_PLUS.toLowerCase() &&
-      this.delegatedContract?.toLowerCase() !== EIP_7702_KATANA.toLowerCase() &&
-      (!this.accountOp.meta || this.accountOp.meta.setDelegation === undefined) &&
-      (broadcastOption === BROADCAST_OPTIONS.byBundler ||
-        broadcastOption === BROADCAST_OPTIONS.delegation) &&
-      WARNINGS.delegationDetected
-    ) {
-      warnings.push(WARNINGS.delegationDetected)
-    }
-
     const accountState =
       this.#accounts.accountStates[this.account.addr]?.[this.#network.chainId.toString()]
     if (this.account.creation && !accountState?.isV2 && WARNINGS.v1Acc)


### PR DESCRIPTION
Self-explanatory. The consensus was this is too technical, unnecessary scary, reversible and other wallets override it silently too (MM, Rainbow).