### PR TITLE
Config / Fix all auto-fixable (and easily fixable) linting problems after the ESLint v9 migration

### DIFF
--- a/src/classes/session.ts
+++ b/src/classes/session.ts
@@ -99,7 +99,6 @@ export class Session {
         get: (target: { [providerId: string]: number }, prop: string) => {
           // When accessing an unknown providerId, initialize it with the default requestId = -1
           if (!(prop in target)) {
-            // eslint-disable-next-line no-param-reassign
             target[prop] = -1
           }
           return target[prop]

--- a/src/consts/derivation.ts
+++ b/src/consts/derivation.ts
@@ -27,7 +27,6 @@ export const LEGACY_POPULAR_DERIVATION_TEMPLATE = "m/44'/60'/0'/<account>"
  */
 export const BIP44_STANDARD_TESTNET_DERIVATION_TEMPLATE = "m/44'/1'/0'/0/<account>"
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export type HD_PATH_TEMPLATE_TYPE =
   | typeof BIP44_STANDARD_DERIVATION_TEMPLATE
   | typeof BIP44_LEDGER_DERIVATION_TEMPLATE

--- a/src/controllers/accountPicker/accountPicker.test.ts
+++ b/src/controllers/accountPicker/accountPicker.test.ts
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import { Wallet } from 'ethers'
 
-/* eslint-disable no-new */
 import { describe, expect, test } from '@jest/globals'
 
 import { suppressConsoleBeforeEach } from '../../../test/helpers/console'

--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -962,7 +962,7 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     while (currentPage <= maxPages) {
       // TODO: Flag that excludes getting smart account key addresses
       // Load the accounts for the current page
-      // eslint-disable-next-line no-await-in-loop
+
       await this.setPage({
         page: currentPage,
         pageSize: this.pageSize,
@@ -1108,7 +1108,7 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     const smartAccountsPromises: Promise<DerivedAccountWithoutNetworkMeta | null>[] = []
     // Replace the parallel getKeys with foreach to prevent issues with Ledger,
     // which can only handle one request at a time.
-    // eslint-disable-next-line no-restricted-syntax
+
     for (const [index, smartAccKey] of smartAccKeys.entries()) {
       const slot = startIdx + (index + 1)
       const indexWithOffset = slot - 1 + SMART_ACCOUNT_SIGNER_KEY_DERIVATION_OFFSET
@@ -1139,7 +1139,7 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
       )
 
       // Yield to event loop to keep UI responsive
-      // eslint-disable-next-line no-await-in-loop
+
       await new Promise((resolve) => setTimeout(resolve, 0))
     }
 
@@ -1150,7 +1150,6 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
 
     accounts.push(...smartAccounts)
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const [index, basicAccKey] of basicAccKeys.entries()) {
       const slot = startIdx + (index + 1)
       // The EOA (basic) account on this slot

--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -120,7 +120,6 @@ export class AccountsController extends EventEmitter implements IAccountsControl
       this.emitError.bind(this)
     )
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })
@@ -272,7 +271,7 @@ export class AccountsController extends EventEmitter implements IAccountsControl
 
   async #addAccounts(accounts: Account[] = []) {
     if (!accounts.length) return
-    // eslint-disable-next-line no-param-reassign
+
     accounts = accounts.map((a) => ({ ...a, addr: getAddress(a.addr) }))
     const alreadyAddedAddressSet = new Set(this.accounts.map((account) => account.addr))
     const newAccountsNotAddedYet = accounts.filter((acc) => !alreadyAddedAddressSet.has(acc.addr))

--- a/src/controllers/activity/activity.test.ts
+++ b/src/controllers/activity/activity.test.ts
@@ -541,9 +541,7 @@ describe('Activity Controller ', () => {
         }
       ] as submittedAccountOp.SubmittedAccountOp[]
 
-      // eslint-disable-next-line no-restricted-syntax
       for (const accountOp of accountsOps) {
-        // eslint-disable-next-line no-await-in-loop
         await controller.addAccountOp(accountOp)
       }
 
@@ -760,7 +758,6 @@ describe('Activity Controller ', () => {
       expect(controller.banners[0]!.category).toBe('pending-to-be-confirmed-acc-ops')
       const spy = jest.spyOn(submittedAccountOp, 'updateOpStatus')
       spy.mockImplementationOnce((op) => {
-        // eslint-disable-next-line no-param-reassign
         op.status = AccountOpStatus.Rejected
         return op
       })
@@ -893,9 +890,7 @@ describe('Activity Controller ', () => {
         }
       })
 
-      // eslint-disable-next-line no-restricted-syntax
       for (const ao of accountsOps) {
-        // eslint-disable-next-line no-await-in-loop
         await controller.addAccountOp(ao)
       }
 
@@ -969,9 +964,7 @@ describe('Activity Controller ', () => {
         nonce: BigInt(key)
       }))
 
-      // eslint-disable-next-line no-restricted-syntax
       for (const ao of accountsOps) {
-        // eslint-disable-next-line no-await-in-loop
         await controller.addAccountOp(ao)
       }
 
@@ -1068,9 +1061,7 @@ describe('Activity Controller ', () => {
         signature: key.toString()
       }))
 
-      // eslint-disable-next-line no-restricted-syntax
       for (const sm of signedMessages) {
-        // eslint-disable-next-line no-await-in-loop
         await controller.addSignedMessage(sm, '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5')
       }
 

--- a/src/controllers/activity/activity.ts
+++ b/src/controllers/activity/activity.ts
@@ -1173,7 +1173,7 @@ export class ActivityController extends EventEmitter implements IActivityControl
               }
 
               const txnId = fetchTxnIdResult.txnId as string
-              // eslint-disable-next-line no-param-reassign
+
               accountOp.txnId = txnId
               txIds.push(txnId)
             } else {
@@ -1203,15 +1203,14 @@ export class ActivityController extends EventEmitter implements IActivityControl
                     isIdentifiedByUserOpHash(accountOp.identifiedBy) &&
                     txnId
                   ) {
-                    // eslint-disable-next-line no-await-in-loop
                     const frontRanTxnId = await fetchFrontRanTxnId(
                       accountOp.identifiedBy,
                       txnId,
                       network
                     )
-                    // eslint-disable-next-line no-param-reassign
+
                     accountOp.txnId = frontRanTxnId
-                    // eslint-disable-next-line no-await-in-loop
+
                     receipt = await provider.getTransactionReceipt(frontRanTxnId)
                     if (!receipt) return
                   }
@@ -1256,7 +1255,6 @@ export class ActivityController extends EventEmitter implements IActivityControl
                   }
 
                   if (accountOp.isSingletonDeploy && receipt.status) {
-                    // eslint-disable-next-line no-await-in-loop
                     await this.#onContractsDeployed(network)
                   }
 
@@ -1282,13 +1280,10 @@ export class ActivityController extends EventEmitter implements IActivityControl
                     this.#portfolio.addTokensToBeLearned(foundTokens, accountOp.chainId)
                   foundTokens.forEach((tokenAddr) => foundTokensForBalanceChanges.add(tokenAddr))
 
-                  // eslint-disable-next-line no-param-reassign
                   accountOp.blockNumber = receipt.blockNumber
 
-                  // eslint-disable-next-line no-param-reassign
                   accountOp.blockHash = receipt.blockHash
 
-                  // eslint-disable-next-line no-param-reassign
                   accountOp.gasUsed = toBeHex(receipt.gasUsed)
 
                   // Add accounts that are recipients of the AccountOp
@@ -1306,15 +1301,15 @@ export class ActivityController extends EventEmitter implements IActivityControl
                   // update the chain if a receipt has been received as otherwise, we're
                   // left hanging with a pending portfolio balance
                   chainsToUpdate.add(network.chainId)
-                  // eslint-disable-next-line no-continue
+
                   continue
                 }
 
                 // if there's no receipt, confirm there's a txn
                 // if there's no txn and 15 minutes have passed, declare it a failure
-                // eslint-disable-next-line no-await-in-loop
+
                 const txn = txnId ? await provider.getTransaction(txnId) : null
-                // eslint-disable-next-line no-continue
+
                 if (txn) continue
                 await declareStuckIfFiveMinsPassed(accountOp)
               }
@@ -1511,7 +1506,6 @@ export class ActivityController extends EventEmitter implements IActivityControl
       // if the receipt cannot be confirmed after a lot of retries, continue on
       if (counter >= 30) return activityAccountOp.txnId
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       await wait(2000)
       return this.getConfirmedTxId(submittedAccountOp, counter + 1)
     }
@@ -1546,14 +1540,13 @@ export class ActivityController extends EventEmitter implements IActivityControl
         timestamp: op.timestamp
       }))
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const acc of this.#accounts.accounts) {
       const addr = acc.addr
       const accountOps = this.#accountsOps[addr]
 
       if (!accountOps) {
         this.#bannersByAccount.set(addr, [])
-        // eslint-disable-next-line no-continue
+
         continue
       }
 

--- a/src/controllers/autoLogin/autoLogin.test.ts
+++ b/src/controllers/autoLogin/autoLogin.test.ts
@@ -45,7 +45,6 @@ const prepareTest = async (
 }
 
 const generateSiweMessage = (
-  // eslint-disable-next-line default-param-last
   overrides: Partial<CreateSiweMessageParameters> = {},
   modifyFunc?: (message: string) => string
 ) => {

--- a/src/controllers/autoLogin/autoLogin.ts
+++ b/src/controllers/autoLogin/autoLogin.ts
@@ -114,7 +114,6 @@ export class AutoLoginController extends EventEmitter implements IAutoLoginContr
       invite
     )
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })

--- a/src/controllers/banner/banner.ts
+++ b/src/controllers/banner/banner.ts
@@ -49,7 +49,6 @@ export class BannerController extends EventEmitter implements IBannerController 
     this.#getAccountData = getAccountData
     this.#appVersion = appVersion
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })

--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -1,7 +1,5 @@
-/* eslint-disable no-await-in-loop */
-
 import { suppressConsole } from '../../../test/helpers/console'
-/* eslint-disable prettier/prettier */
+
 import { makeMainController } from '../../../test/helpers/mainController'
 import { waitForFnToBeCalledAndExecuted } from '../../../test/recurringTimeout'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'

--- a/src/controllers/contractInfo/contractInfo.ts
+++ b/src/controllers/contractInfo/contractInfo.ts
@@ -53,7 +53,6 @@ export class ContractInfoController extends EventEmitter implements IContractInf
     this.#featureFlag = featureFlags
     this.#cenaUrl = cenaUrl
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })

--- a/src/controllers/dapps/dapps.ts
+++ b/src/controllers/dapps/dapps.ts
@@ -29,7 +29,7 @@ import { IEventEmitterRegistryController } from '../../interfaces/eventEmitter'
 import { Fetch } from '../../interfaces/fetch'
 import { Messenger } from '../../interfaces/messenger'
 import { INetworksController } from '../../interfaces/network'
-/* eslint-disable no-restricted-syntax */
+
 import { IPhishingController } from '../../interfaces/phishing'
 import { IStorageController } from '../../interfaces/storage'
 import { IUiController, View } from '../../interfaces/ui'
@@ -44,7 +44,7 @@ import {
   unifyDefiLlamaDappUrl
 } from '../../libs/dapps/helpers'
 import { networkChainIdToHex } from '../../libs/networks/networks'
-/* eslint-disable no-continue */
+
 import { fetchWithTimeout } from '../../utils/fetch'
 import EventEmitter from '../eventEmitter/eventEmitter'
 
@@ -151,7 +151,6 @@ export class DappsController extends EventEmitter implements IDappsController {
       }
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })

--- a/src/controllers/emailVault/emailVault.test.ts
+++ b/src/controllers/emailVault/emailVault.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { expect } from '@jest/globals'
 
 import { relayerUrl } from '../../../test/config'

--- a/src/controllers/emailVault/emailVault.ts
+++ b/src/controllers/emailVault/emailVault.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this */
-/* eslint-disable no-await-in-loop */
 import crypto from 'crypto'
 
 import { Banner } from '../../interfaces/banner'

--- a/src/controllers/estimation/estimation.ts
+++ b/src/controllers/estimation/estimation.ts
@@ -82,7 +82,7 @@ export class EstimationController extends EventEmitter {
 
     return baseAcc.getAvailableFeeOptions(
       estimation,
-      // eslint-disable-next-line no-nested-ternary
+
       estimation.ambireEstimation
         ? estimation.ambireEstimation.feePaymentOptions
         : estimation.providerEstimation
@@ -234,7 +234,7 @@ export class EstimationController extends EventEmitter {
       // continue on error here as the flags are more like app helpers
       this.#accounts
         .updateAccountState(op.accountAddr, 'pending', [op.chainId])
-        // eslint-disable-next-line no-console
+
         .catch((e) => console.error(e))
     }
 

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 import { v4 as uuidv4 } from 'uuid'
 
 import { ErrorRef, IEventEmitterRegistryController, Statuses } from '../../interfaces/eventEmitter'
@@ -83,16 +82,15 @@ export default class EventEmitter {
     await wait(1)
 
     // Passing `true` to the cb will bypass React batching
-    // eslint-disable-next-line no-restricted-syntax
+
     for (const i of this.#callbacksWithId) i.cb(true)
-    // eslint-disable-next-line no-restricted-syntax
+
     for (const cb of this.#callbacks) cb(true)
   }
 
   protected emitUpdate() {
-    // eslint-disable-next-line no-restricted-syntax
     for (const i of this.#callbacksWithId) i.cb()
-    // eslint-disable-next-line no-restricted-syntax
+
     for (const cb of this.#callbacks) cb()
   }
 
@@ -123,9 +121,8 @@ export default class EventEmitter {
    *     and the controller updates its own state), use `emitUpdate()` or `forceEmitUpdate()`.
    */
   protected propagateUpdate(forceEmit?: boolean) {
-    // eslint-disable-next-line no-restricted-syntax
     for (const i of this.#callbacksWithId) i.cb(forceEmit)
-    // eslint-disable-next-line no-restricted-syntax
+
     for (const cb of this.#callbacks) cb(forceEmit)
   }
 
@@ -137,9 +134,8 @@ export default class EventEmitter {
       this.#errors
     )
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const i of this.#errorCallbacksWithId) i.cb(error)
-    // eslint-disable-next-line no-restricted-syntax
+
     for (const cb of this.#errorCallbacks) cb(error)
   }
 

--- a/src/controllers/invite/invite.ts
+++ b/src/controllers/invite/invite.ts
@@ -5,7 +5,6 @@ import { IStorageController } from '../../interfaces/storage'
 import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import EventEmitter from '../eventEmitter/eventEmitter'
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export enum INVITE_STATUS {
   UNVERIFIED = 'UNVERIFIED',
   VERIFIED = 'VERIFIED'

--- a/src/controllers/keystore/keystore.test.ts
+++ b/src/controllers/keystore/keystore.test.ts
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-/* eslint-disable class-methods-use-this */
-/* eslint-disable @typescript-eslint/no-useless-constructor */
-/* eslint-disable max-classes-per-file */
 
 import { ethers, hexlify, randomBytes, Wallet } from 'ethers'
 
@@ -68,7 +65,6 @@ class InternalSigner {
 class LedgerSigner {
   key
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   constructor(_key: Key) {
     this.key = _key
   }

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -1,6 +1,3 @@
-/* eslint-disable class-methods-use-this */
-/* eslint-disable new-cap */
-/* eslint-disable @typescript-eslint/no-shadow */
 import aes from 'aes-js'
 import {
   decryptWithPrivateKey,
@@ -708,7 +705,6 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
 
     const newKeys: StoredKey[] = uniqueKeysToAdd
       .map(({ addr, type, label, privateKey, dedicatedToOneSA, meta }) => {
-        // eslint-disable-next-line no-param-reassign
         privateKey = privateKey.substring(0, 2) === '0x' ? privateKey.substring(2) : privateKey
 
         // Set up the cipher

--- a/src/controllers/main/main.test.ts
+++ b/src/controllers/main/main.test.ts
@@ -77,7 +77,7 @@ describe('Main Controller ', () => {
     //   JSON.stringify(controller.emailVault.emailVaultStates[email].availableSecrets, null, 2)
     // )
     void controller.emailVault?.uploadKeyStoreSecret('unufri@ambire.com')
-    // eslint-disable-next-line no-promise-executor-return
+
     await new Promise((resolve) => {
       if (controller.emailVault) {
         const unsubscribe = controller.emailVault.onUpdate(() => {
@@ -115,7 +115,6 @@ describe('Main Controller ', () => {
     let retries = 0
 
     while (!controller.isReady && retries < 20) {
-      // eslint-disable-next-line no-await-in-loop
       await wait(100)
       retries++
     }
@@ -140,7 +139,6 @@ describe('Main Controller ', () => {
 
     let retries2 = 0
     while (controller.accountPicker.accountsLoading && retries2 < 20) {
-      // eslint-disable-next-line no-await-in-loop
       await wait(100)
       retries2++
     }

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -13,7 +13,7 @@ import { LOCKED_EXTENSION_PORTFOLIO_UPDATE_INTERVAL } from '@/consts/intervals'
 import { AccountPickerController } from '@/controllers/accountPicker/accountPicker'
 import { AccountsController } from '@/controllers/accounts/accounts'
 import { ActivityController } from '@/controllers/activity/activity'
-/* eslint-disable no-await-in-loop */
+
 import { SignedMessage } from '@/controllers/activity/types'
 import { AddressBookController } from '@/controllers/addressBook/addressBook'
 import { AutoLoginController } from '@/controllers/autoLogin/autoLogin'
@@ -44,7 +44,7 @@ import { SurveyController } from '@/controllers/survey/survey'
 import { SwapAndBridgeController } from '@/controllers/swapAndBridge/swapAndBridge'
 import { TransactionManagerController } from '@/controllers/transaction/transactionManager'
 import { TransferController } from '@/controllers/transfer/transfer'
-/* eslint-disable no-underscore-dangle */
+
 import { TransfersScannerController } from '@/controllers/transfersScanner/transfersScanner'
 import { UiController } from '@/controllers/ui/ui'
 import { Account, IAccountsController } from '@/interfaces/account'
@@ -837,7 +837,6 @@ export class MainController extends EventEmitter implements IMainController {
     await this.keystore.addKeysExternallyStored(this.accountPicker.readyToAddKeys.external)
 
     if (this.accountPicker.readyToRemoveAccounts) {
-      // eslint-disable-next-line no-restricted-syntax
       for (const acc of this.accountPicker.readyToRemoveAccounts) {
         await this.#removeAccount(acc.addr)
       }
@@ -872,7 +871,7 @@ export class MainController extends EventEmitter implements IMainController {
         localCall.status = AccountOpStatus.BroadcastedButNotConfirmed
         return localCall
       })
-      // eslint-disable-next-line no-param-reassign
+
       submittedAccountOp.calls = calls
 
       const userRequest = this.requests.userRequests.find((r) => r.id === fromRequestId)

--- a/src/controllers/networks/networks.test.ts
+++ b/src/controllers/networks/networks.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
 import { describe, expect, test } from '@jest/globals'
 
 import { makeMainController } from '../../../test/helpers/mainController'

--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -112,7 +112,6 @@ export class NetworksController extends EventEmitter implements INetworksControl
     this.#onAddOrUpdateNetworks = onAddOrUpdateNetworks
     this.#onReady = onReady
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })
@@ -148,7 +147,6 @@ export class NetworksController extends EventEmitter implements INetworksControl
       .filter((item, index, self) => self.findIndex((i) => i.chainId === item.chainId) === index) // unique by chainId (predefined with priority)
 
     return uniqueNetworksByChainId.map((network) => {
-      // eslint-disable-next-line no-param-reassign
       network.features = getFeaturesByNetworkProperties(
         {
           isSAEnabled: network.isSAEnabled,
@@ -489,7 +487,6 @@ export class NetworksController extends EventEmitter implements INetworksControl
           const info = { ...(networkToAddOrUpdate.info as NetworkInfo) }
           const { feeOptions } = info
 
-          // eslint-disable-next-line no-param-reassign
           delete (info as any).feeOptions
           this.#networks[stringChainId] = {
             ...this.#networks[stringChainId],
@@ -521,7 +518,6 @@ export class NetworksController extends EventEmitter implements INetworksControl
 
                 const { feeOptions } = info as NetworkInfo
 
-                // eslint-disable-next-line no-param-reassign
                 delete (info as any).feeOptions
                 this.#networks[stringChainId] = {
                   ...(this.#networks[stringChainId] as Network),

--- a/src/controllers/phishing/phishing.ts
+++ b/src/controllers/phishing/phishing.ts
@@ -1,6 +1,5 @@
-/* eslint-disable no-nested-ternary */
 import { getDomain } from 'tldts'
-/* eslint-disable no-param-reassign */
+
 import { zeroAddress } from 'viem'
 
 import { RecurringTimeout } from '../../classes/recurringTimeout/recurringTimeout'
@@ -16,7 +15,7 @@ import { BlacklistedStatus, IPhishingController } from '../../interfaces/phishin
 import { IStorageController } from '../../interfaces/storage'
 import { IUiController } from '../../interfaces/ui'
 import { getDappIdFromUrl } from '../../libs/dapps/helpers'
-/* eslint-disable no-restricted-syntax */
+
 import { fetchWithTimeout } from '../../utils/fetch'
 import EventEmitter from '../eventEmitter/eventEmitter'
 
@@ -115,7 +114,6 @@ export class PhishingController extends EventEmitter implements IPhishingControl
         this.#updatePhishingInterval.restart({ timeout: PHISHING_INACTIVE_UPDATE_INTERVAL })
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })
@@ -334,7 +332,7 @@ export class PhishingController extends EventEmitter implements IPhishingControl
 
     dappsToFetch.forEach(({ dappId }) => {
       this.#domainsBlacklistedStatus.set(
-        dappId, // eslint-disable-next-line no-nested-ternary
+        dappId,
         !domainsBlacklistedStatus || domainsBlacklistedStatus[dappId] === undefined
           ? 'FAILED_TO_GET'
           : domainsBlacklistedStatus[dappId]
@@ -456,7 +454,7 @@ export class PhishingController extends EventEmitter implements IPhishingControl
     addressesToFetch.forEach((addr) => {
       this.#addressesBlacklistedStatus.set(
         addr,
-        // eslint-disable-next-line no-nested-ternary
+
         !addressesBlacklistedStatus || addressesBlacklistedStatus[addr] === undefined
           ? 'FAILED_TO_GET'
           : addressesBlacklistedStatus[addr]

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 import { getAddress, ZeroAddress } from 'ethers'
 
 import {
@@ -15,7 +14,7 @@ import {
 } from '../../interfaces/account'
 import { Banner, IBannerController } from '../../interfaces/banner'
 import { IEventEmitterRegistryController } from '../../interfaces/eventEmitter'
-/* eslint-disable @typescript-eslint/no-use-before-define */
+
 import { IFeatureFlagsController } from '../../interfaces/featureFlags'
 import { Fetch } from '../../interfaces/fetch'
 import { IKeystoreController } from '../../interfaces/keystore'
@@ -25,7 +24,7 @@ import { IProvidersController, RPCProviders } from '../../interfaces/provider'
 import { IStorageController } from '../../interfaces/storage'
 import { isBasicAccount } from '../../libs/account/account'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
-/* eslint-disable @typescript-eslint/no-shadow */
+
 import { AccountOp } from '../../libs/accountOp/accountOp'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
@@ -93,8 +92,6 @@ import { PORTFOLIO_LIB_ERROR_NAMES } from '../../libs/portfolio/portfolio'
 import { BindedRelayerCall, relayerCall } from '../../libs/relayerCall/relayerCall'
 import { isInternalChain } from '../../libs/selectedAccount/selectedAccount'
 import EventEmitter from '../eventEmitter/eventEmitter'
-
-/* eslint-disable @typescript-eslint/no-shadow */
 
 const LEARNED_UNOWNED_LIMITS = {
   erc20s: 20,
@@ -731,7 +728,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     this.#queue[accountAddr][chainId.toString()] = this.#queue?.[accountAddr]?.[
       chainId.toString()
     ]!.then(updatePromise).catch((error) => {
-      // eslint-disable-next-line no-console
       console.error(error)
       return updatePromise()
     })
@@ -849,9 +845,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       !libForKey ||
       !libForKey.provider ||
       libForKey.provider.destroyed ||
-      // eslint-disable-next-line no-underscore-dangle
       libForKey.provider?._getConnection().url !==
-        // eslint-disable-next-line no-underscore-dangle
         providers[network.chainId.toString()]?._getConnection().url
     ) {
       try {
@@ -1014,7 +1008,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           : new Date(banner.startTime).getTime()
 
       const formattedBanner: Banner = {
-        // eslint-disable-next-line no-underscore-dangle
         id: banner.id || banner._id,
         type: banner.type || 'updates',
         meta: {
@@ -1230,7 +1223,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         this.tokenDataCache[chainId.toString()] || new Map<string, [number, TokenDataCacheValue]>()
 
       for (const [key, priceData] of Object.entries(response.prices)) {
-        // eslint-disable-next-line no-continue
         if (!priceData || !('price' in priceData) || !('baseCurrency' in priceData)) continue
 
         networkTokenDataCache.set(key, [
@@ -1862,7 +1854,6 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         this.#queue[accountId][network.chainId.toString()] = this.#queue?.[accountId]?.[
           network.chainId.toString()
         ]!.then(updatePromise).catch((error) => {
-          // eslint-disable-next-line no-console
           console.error(error)
           return updatePromise()
         })

--- a/src/controllers/providers/providers.ts
+++ b/src/controllers/providers/providers.ts
@@ -1,6 +1,5 @@
 import { Contract } from 'ethers'
 
-/* eslint-disable no-underscore-dangle */
 import { IEventEmitterRegistryController, Statuses } from '../../interfaces/eventEmitter'
 import { Network } from '../../interfaces/network'
 import { IProvidersController, RPCProvider, RPCProviders } from '../../interfaces/provider'
@@ -116,7 +115,6 @@ export class ProvidersController extends EventEmitter implements IProvidersContr
       }
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { ethErrors } from 'eth-rpc-errors'
 import { getAddress, getBigInt, hexlify, TypedDataDomain, TypedDataField, isAddress } from 'ethers'
 import { v4 as uuidv4 } from 'uuid'
@@ -381,7 +380,6 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
     let hasTxInProgressErrorShown = false
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const req of reqs) {
       const { kind, meta, dappPromises } = req
 
@@ -706,11 +704,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         })
       }
 
-      // eslint-disable-next-line no-restricted-syntax
       for (const r of this.userRequests) {
         if (r.kind === 'walletAddEthereumChain') {
           const chainId = r.meta.params[0].chainId
-          // eslint-disable-next-line no-continue
+
           if (!chainId) continue
 
           const network = this.#networks.networks.find((n) => n.chainId === BigInt(chainId))
@@ -787,10 +784,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
     const activeRouteIdsToRemove = [...paramActiveRouteIds]
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const callId of callIds) {
       const request = findRequestByCall((c) => c.id === callId)
-      // eslint-disable-next-line no-continue
+
       if (!request) continue
 
       const call = request.signAccountOp.accountOp.calls.find((c) => c.id === callId)
@@ -804,20 +800,17 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           activeRouteIdsToRemove.push(call.activeRouteId)
         }
 
-        // eslint-disable-next-line no-continue
         continue
       }
 
-      // eslint-disable-next-line no-continue
       if (!call) continue
 
       await rejectAndCleanup(request, [call.id])
     }
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const activeRouteId of activeRouteIdsToRemove) {
       const request = findRequestByCall((c) => c.activeRouteId === activeRouteId)
-      // eslint-disable-next-line no-continue
+
       if (!request) continue
 
       const callIdsToRemove = request.signAccountOp.accountOp.calls
@@ -825,7 +818,6 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         .map((c) => c.id)
         .filter(Boolean) as string[]
 
-      // eslint-disable-next-line no-continue
       if (callIdsToRemove.length === 0) continue
 
       await rejectAndCleanup(request, callIdsToRemove)

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import { formatEther, getAddress, isAddress } from 'ethers'
 
 import { STK_WALLET, UNI_V3_WALLET_WETH_POOL, WALLET_TOKEN } from '../../consts/addresses'
@@ -99,7 +98,6 @@ export class SelectedAccountController extends EventEmitter implements ISelected
     this.#autoLogin = autoLogin
     this.#banner = banner
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.initialLoadPromise = this.#load().finally(() => {
       this.initialLoadPromise = undefined
     })

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1,8 +1,5 @@
-/* eslint-disable no-continue */
-/* eslint-disable no-restricted-syntax */
 /* eslint-disable @typescript-eslint/brace-style */
-/* eslint-disable no-await-in-loop */
-/* eslint-disable class-methods-use-this */
+
 import {
   AbiCoder,
   formatEther,
@@ -2249,7 +2246,6 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
     return this.#keystore.getAccountKeys(feePayer)
   }
 
-  // eslint-disable-next-line class-methods-use-this
   get speedOptions() {
     return Object.values(FeeSpeed) as string[]
   }
@@ -2414,7 +2410,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         if (counter === 0) {
           await this.#accounts
             .updateAccountState(this.accountOp.accountAddr, 'pending', [this.accountOp.chainId])
-            // eslint-disable-next-line no-console
+
             .catch((e) => console.error(e))
           return this.#getInitialUserOp(true, eip7702Auth, 1)
         }
@@ -2519,7 +2515,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
       // continue on error as this is an attempt for an UX improvement
       await this.#accounts
         .updateAccountState(this.accountOp.accountAddr, 'pending', [this.accountOp.chainId])
-        // eslint-disable-next-line no-console
+
         .catch((e) => console.error(e))
     }
 
@@ -3128,9 +3124,8 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
           this.#callRelayer(`/v2/eoaSubmitTxn/${accountOp.chainId}`, 'POST', {
             rawTxn: signedTxn
           }).catch((e: any) => {
-            // eslint-disable-next-line no-console
             console.log('failed to record EOA txn to relayer', accountOp.chainId)
-            // eslint-disable-next-line no-console
+
             console.log(e)
           })
         }
@@ -3147,7 +3142,6 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
           txnId: multipleTxnsBroadcastRes[multipleTxnsBroadcastRes.length - 1]?.hash
         }
       } catch (error: any) {
-        // eslint-disable-next-line no-console
         console.error('Error broadcasting', error)
         // for multiple txn cases
         // if a batch of 5 txn is sent to Ledger for sign but the user reject
@@ -3423,7 +3417,7 @@ export class SignAccountOpController extends EventEmitter implements ISignAccoun
         if (!this.hasCustomGasPrices) {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.#silentGasPriceUpdate()
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+
           this.#simulateAndEstimateOrSimulateInterval.restart({ runImmediately: true })
         }
       } else if (originalMessage.includes('Failed to fetch') && isRelayer) {

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this */
-
 import { hexlify, randomBytes } from 'ethers'
 
 import { describe, expect, jest, test } from '@jest/globals'

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -446,7 +446,7 @@ export class SignMessageController extends EventEmitter implements ISignMessageC
           // signature is from a key that has privs to the account
           signer: this.messageToSign.accountAddr,
           signature: getVerifyMessageSignature(signature, this.#account, accountState),
-          // eslint-disable-next-line no-nested-ternary
+
           ...(this.messageToSign.content.kind === 'message' ||
           this.messageToSign.content.kind === 'siwe'
             ? { message: hexStringToUint8Array(this.messageToSign.content.message) }

--- a/src/controllers/storage/storage.ts
+++ b/src/controllers/storage/storage.ts
@@ -3,7 +3,7 @@ import { BIP44_STANDARD_DERIVATION_TEMPLATE } from '../../consts/derivation'
 import { IAccountPickerController } from '../../interfaces/accountPicker'
 import { Dapp } from '../../interfaces/dapp'
 import { EmailVaultData } from '../../interfaces/emailVault'
-/* eslint-disable no-restricted-syntax */
+
 import { IEventEmitterRegistryController, Statuses } from '../../interfaces/eventEmitter'
 import { IKeystoreController, StoredKey } from '../../interfaces/keystore'
 import { IStorageController, Storage, StorageProps } from '../../interfaces/storage'
@@ -39,7 +39,7 @@ export class StorageController extends EventEmitter implements IStorageControlle
     super(eventEmitterRegistry)
 
     this.#storage = storage
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+
     this.#storageMigrationsPromise = this.#loadMigrations()
   }
 
@@ -510,9 +510,8 @@ export class StorageController extends EventEmitter implements IStorageControlle
 
     let page = 1
     while (page <= 10) {
-      // eslint-disable-next-line no-await-in-loop
       await accountPicker.setPage({ page })
-      // eslint-disable-next-line no-await-in-loop
+
       await accountPicker.findAndSetLinkedAccountsPromise
 
       const matchingAddresses = accountPicker.allKeysOnPage.filter((k) =>

--- a/src/controllers/swapAndBridge/socketApiMock.ts
+++ b/src/controllers/swapAndBridge/socketApiMock.ts
@@ -6,7 +6,6 @@ import {
   SwapAndBridgeSendTxRequest
 } from '../../interfaces/swapAndBridge'
 
-/* eslint-disable class-methods-use-this */
 export class SocketAPIMock {
   id = 'socket'
 
@@ -440,7 +439,6 @@ export class SocketAPIMock {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getRouteStatus({ txHash }: { txHash: string }) {
     return { status: 'completed', txnId: txHash }
   }

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1,6 +1,5 @@
 import { formatUnits, getAddress, isAddress, parseUnits, ZeroAddress } from 'ethers'
 
-/* eslint-disable no-await-in-loop */
 import { getAccountNetworks } from '@/libs/networks/networks'
 
 import EmittableError from '../../classes/EmittableError'
@@ -355,7 +354,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     this.#onBroadcastFailed = onBroadcastFailed
     this.#ui = ui
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.#initialLoadPromise = this.#load().finally(() => {
       this.#initialLoadPromise = undefined
     })
@@ -713,7 +711,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       // remove activeRoutes errors from the previous session
       this.activeRoutes.forEach((r) => {
         if (r.routeStatus !== 'failed') {
-          // eslint-disable-next-line no-param-reassign
           delete r.error
         }
       })
@@ -723,7 +720,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
         // update the activeRoute.route prop for the new session
         this.activeRoutes.forEach((r) => {
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.updateActiveRoute(r.activeRouteId, undefined, true)
         })
       }
@@ -731,7 +727,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
     this.sessionIds.push(sessionId)
     // do not await the health status check to prevent UI freeze while fetching
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+
     this.#serviceProviderAPI.updateHealth()
     await this.updatePortfolioTokenList(structuredClone(this.#selectedAccount.portfolio.tokens), {
       preselectedToken: preselectedFromToken,

--- a/src/controllers/transaction/controllers/intent.ts
+++ b/src/controllers/transaction/controllers/intent.ts
@@ -95,7 +95,6 @@ export class IntentController extends EventEmitter {
   // return hasRelevantChanges
   // }
 
-  // eslint-disable-next-line class-methods-use-this
   // public async getQuotes(inputs: any, options?: any) {
   //   // await this.dependencies.interopSDK.getQuotes()
   //   return new Promise((resolve) => {

--- a/src/controllers/transaction/transactionFormState.ts
+++ b/src/controllers/transaction/transactionFormState.ts
@@ -584,7 +584,6 @@ export class TransactionFormState extends EventEmitter {
       // remove activeRoutes errors from the previous session
       this.activeRoutes.forEach((r) => {
         if (r.routeStatus !== 'failed') {
-          // eslint-disable-next-line no-param-reassign
           delete r.error
         }
       })
@@ -594,7 +593,6 @@ export class TransactionFormState extends EventEmitter {
 
         // update the activeRoute.route prop for the new session
         this.activeRoutes.forEach((r) => {
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.updateActiveRoute(r.activeRouteId, undefined, true)
         })
       }

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
 import { ZeroAddress, formatUnits } from 'ethers'
 
 import { expect } from '@jest/globals'

--- a/src/controllers/transfersScanner/transfersScanner.ts
+++ b/src/controllers/transfersScanner/transfersScanner.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { Log, TransactionReceipt } from 'ethers'
 
 import { IActivityController } from '../../interfaces/activity'

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -3,10 +3,10 @@ import { Transaction, TypedDataField } from 'ethers'
 import { EIP7702Auth } from '../consts/7702'
 import { HD_PATH_TEMPLATE_TYPE } from '../consts/derivation'
 // TODO: Handle better to prevent dep cycle
-// eslint-disable-next-line import/no-cycle
+
 import { GasFeePayment } from '../libs/accountOp/accountOp'
 // TODO: Handle better to prevent dep cycle
-// eslint-disable-next-line import/no-cycle
+
 import { Call } from '../libs/accountOp/types'
 import { getHdPathFromTemplate } from '../utils/hdPath'
 import { Account } from './account'
@@ -15,7 +15,7 @@ import { Hex } from './hex'
 import { Network } from './network'
 import { EIP7702Signature } from './signatures'
 // TODO: Handle better to prevent dep cycle
-// eslint-disable-next-line import/no-cycle
+
 import { TypedMessageUserRequest } from './userRequest'
 
 export type IKeystoreController = ControllerInterface<

--- a/src/libs/account/BaseAccount.ts
+++ b/src/libs/account/BaseAccount.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Account, AccountOnchainState } from '../../interfaces/account'
 import { IActivityController } from '../../interfaces/activity'

--- a/src/libs/account/EOA.ts
+++ b/src/libs/account/EOA.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ZeroAddress } from 'ethers'
 

--- a/src/libs/account/EOA7702.ts
+++ b/src/libs/account/EOA7702.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { Interface, ZeroAddress } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'

--- a/src/libs/account/Safe.ts
+++ b/src/libs/account/Safe.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { AbiCoder, concat, Interface, ZeroAddress } from 'ethers'
 

--- a/src/libs/account/V1.ts
+++ b/src/libs/account/V1.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Interface, ZeroAddress } from 'ethers'
 

--- a/src/libs/account/V2.ts
+++ b/src/libs/account/V2.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Interface, ZeroAddress } from 'ethers'
 

--- a/src/libs/account/account.test.ts
+++ b/src/libs/account/account.test.ts
@@ -1,6 +1,5 @@
 import { ethers, ZeroAddress } from 'ethers'
 
-/* eslint-disable no-new */
 import { describe, expect, test } from '@jest/globals'
 
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'

--- a/src/libs/account/account.ts
+++ b/src/libs/account/account.ts
@@ -343,7 +343,7 @@ export function hasBecomeSmarter(account: Account, state: AccountStates) {
   const networks = Object.keys(state[account.addr]!)
   for (let i = 0; i < networks.length; i++) {
     const onChainState = state[account.addr]![networks[i]!]
-    // eslint-disable-next-line no-continue
+
     if (!onChainState) continue
 
     if (onChainState.isSmarterEoa) return true

--- a/src/libs/accountOp/hyperEvmBalanceChanges.ts
+++ b/src/libs/accountOp/hyperEvmBalanceChanges.ts
@@ -153,7 +153,7 @@ const mapWithConcurrency = async <T, R>(
     while (nextIndex < items.length) {
       const currentIndex = nextIndex
       nextIndex += 1
-      // eslint-disable-next-line no-await-in-loop
+
       results[currentIndex] = await mapper(items[currentIndex]!)
     }
   })

--- a/src/libs/accountOp/submittedAccountOp.ts
+++ b/src/libs/accountOp/submittedAccountOp.ts
@@ -313,7 +313,6 @@ export async function fetchTxnId(
   try {
     response = await callRelayer(`/v2/get-txn-id/${id}`)
   } catch (e) {
-    // eslint-disable-next-line no-console
     console.log(`relayer responded with an error when trying to find the txnId: ${e}`)
     return {
       status: 'not_found',
@@ -348,27 +347,22 @@ export function updateOpStatus(
 ): SubmittedAccountOp | null {
   if (opReference.identifiedBy.type === 'MultipleTxns') {
     const callIndex = getMultipleBroadcastUnconfirmedCallOrLast(opReference).callIndex
-    // eslint-disable-next-line no-param-reassign
+
     opReference.calls[callIndex]!.status = status
 
     // if there's a receipt, add the fee
     if (receipt) {
-      // eslint-disable-next-line no-param-reassign
       opReference.calls[callIndex]!.fee = {
         inToken: ZeroAddress,
         amount: receipt.fee
       }
 
-      // eslint-disable-next-line no-param-reassign
       opReference.calls[callIndex]!.blockHash = receipt.blockHash
 
-      // eslint-disable-next-line no-param-reassign
       opReference.calls[callIndex]!.blockNumber = receipt.blockNumber
 
-      // eslint-disable-next-line no-param-reassign
       opReference.calls[callIndex]!.blockHash = receipt.blockHash
 
-      // eslint-disable-next-line no-param-reassign
       opReference.calls[callIndex]!.gasUsed = toBeHex(receipt.gasUsed)
     }
 
@@ -376,7 +370,6 @@ export function updateOpStatus(
       (c) => c.status === AccountOpStatus.BroadcastedButNotConfirmed
     )
     if (!left) {
-      // eslint-disable-next-line no-param-reassign
       opReference.status = status
       return opReference
     }
@@ -386,7 +379,6 @@ export function updateOpStatus(
     return null
   }
 
-  // eslint-disable-next-line no-param-reassign
   opReference.status = status
   return opReference
 }

--- a/src/libs/accountState/accountState.ts
+++ b/src/libs/accountState/accountState.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import { concat } from 'ethers'
 
 import AmbireAccountState from '../../../contracts/compiled/AmbireAccountState.json'

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -369,7 +369,6 @@ export function getScamDetectedText(blacklistedItems: HumanizerVisualization[]) 
     label = isSingle ? 'token' : 'tokens'
   }
 
-  // eslint-disable-next-line no-nested-ternary
   const prefix = isSingle
     ? `The destination ${label}`
     : `${blacklistedItemsCount} of the destination ${label}`

--- a/src/libs/defiPositions/defiPositions.test.ts
+++ b/src/libs/defiPositions/defiPositions.test.ts
@@ -1,6 +1,5 @@
 import { ZeroAddress } from 'ethers'
 
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { describe, expect, test } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'

--- a/src/libs/defiPositions/defiPositions.ts
+++ b/src/libs/defiPositions/defiPositions.ts
@@ -265,11 +265,9 @@ const getFormattedApiPositions = (result: Omit<PositionsByProvider, 'source'>[])
         try {
           const isCustomAppChain = !p.chainId
           if (pos.additionalData.name === 'Deposit') {
-            // eslint-disable-next-line no-param-reassign
             pos.additionalData.name = 'Deposit pool'
 
             if (pos.additionalData.pool?.id) {
-              // eslint-disable-next-line no-param-reassign
               pos.additionalData.positionIndex = shortenAddress(pos.additionalData.pool.id, 11)
             }
           }

--- a/src/libs/defiPositions/defiPrices.ts
+++ b/src/libs/defiPositions/defiPrices.ts
@@ -41,9 +41,9 @@ export async function updatePositionsByProviderAssetPrices(
   const resp = await fetchWithTimeout(fetch, cenaUrl, {}, 3000)
   const body = await resp.json()
   if (resp.status !== 200) throw body
-  // eslint-disable-next-line no-prototype-builtins
+
   if (body.hasOwnProperty('message')) throw body
-  // eslint-disable-next-line no-prototype-builtins
+
   if (body.hasOwnProperty('error')) throw body
 
   const positionsByProviderWithPrices = positionsByProvider.map((posByProvider) => {

--- a/src/libs/deployless/deployless.ts
+++ b/src/libs/deployless/deployless.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import assert from 'assert'
 import {
   AbiCoder,
@@ -92,7 +91,6 @@ export class Deployless {
     this.abi = abi
 
     if (provider && provider instanceof JsonRpcProvider) {
-      // eslint-disable-next-line no-underscore-dangle
       this.providerUrl = provider._getConnection().url
       this.isProviderInvictus = this.providerUrl?.includes('invictus')
     }
@@ -109,7 +107,6 @@ export class Deployless {
     const isJsonRpcProvider =
       this.provider &&
       typeof (this.provider as JsonRpcProvider).send === 'function' &&
-      // eslint-disable-next-line no-underscore-dangle
       typeof (this.provider as JsonRpcProvider)._send === 'function'
 
     if (!isJsonRpcProvider) {

--- a/src/libs/entropyGenerator/entropyGenerator.ts
+++ b/src/libs/entropyGenerator/entropyGenerator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-bitwise */
 import { getBytes, keccak256, LangEn, Mnemonic, randomBytes } from 'ethers'
 
 // Custom entropy generator that enhances ethers' randomBytes by incorporating:

--- a/src/libs/errorDecoder/customErrors.ts
+++ b/src/libs/errorDecoder/customErrors.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-classes-per-file */
-
 import { isHexString } from 'ethers'
 
 import { BUNDLER } from '../../consts/bundlers'

--- a/src/libs/errorDecoder/errorDecoder.test.ts
+++ b/src/libs/errorDecoder/errorDecoder.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line max-classes-per-file
 import { concat, getBytes, zeroPadValue } from 'ethers'
 import { ethers } from 'hardhat'
 

--- a/src/libs/errorDecoder/handlers/bundler.ts
+++ b/src/libs/errorDecoder/handlers/bundler.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 
 class BundlerErrorHandler implements ErrorHandler {

--- a/src/libs/errorDecoder/handlers/custom.ts
+++ b/src/libs/errorDecoder/handlers/custom.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { ERROR_PREFIX, PANIC_ERROR_PREFIX } from '../constants'
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 

--- a/src/libs/errorDecoder/handlers/innerCallFailure.ts
+++ b/src/libs/errorDecoder/handlers/innerCallFailure.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { InnerCallFailureError } from '../customErrors'
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 

--- a/src/libs/errorDecoder/handlers/internal.ts
+++ b/src/libs/errorDecoder/handlers/internal.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 
 const CONNECTIVITY_REASONS = ['Failed to fetch', 'NetworkError', 'Failed to load']

--- a/src/libs/errorDecoder/handlers/panic.ts
+++ b/src/libs/errorDecoder/handlers/panic.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { AbiCoder, ErrorFragment } from 'ethers'
 
 import { PANIC_ERROR_PREFIX } from '../constants'

--- a/src/libs/errorDecoder/handlers/paymaster.ts
+++ b/src/libs/errorDecoder/handlers/paymaster.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 
 class PaymasterErrorHandler implements ErrorHandler {

--- a/src/libs/errorDecoder/handlers/relayer.ts
+++ b/src/libs/errorDecoder/handlers/relayer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { RELAYER_DOWN_MESSAGE, RelayerError } from '../../relayerCall/relayerCall'
 import { isReasonValid } from '../helpers'
 import { DecodedError, ErrorHandler, ErrorType } from '../types'

--- a/src/libs/errorDecoder/handlers/revert.ts
+++ b/src/libs/errorDecoder/handlers/revert.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { AbiCoder, ErrorFragment } from 'ethers'
 
 import { ERROR_PREFIX } from '../constants'

--- a/src/libs/errorDecoder/handlers/rpc.ts
+++ b/src/libs/errorDecoder/handlers/rpc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { isReasonValid } from '../helpers'
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 import { USER_REJECTED_TRANSACTION_ERROR_CODE } from './userRejection'
@@ -18,7 +17,6 @@ class RpcErrorHandler implements ErrorHandler {
       !data &&
       !!error.message &&
       !error?.message?.includes('rejected transaction') &&
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       error?.code !== undefined &&
       error.code !== USER_REJECTED_TRANSACTION_ERROR_CODE
     )

--- a/src/libs/errorDecoder/handlers/userRejection.ts
+++ b/src/libs/errorDecoder/handlers/userRejection.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { DecodedError, ErrorHandler, ErrorType } from '../types'
 
 export const USER_REJECTED_TRANSACTION_ERROR_CODE = 4001

--- a/src/libs/errorDecoder/helpers.ts
+++ b/src/libs/errorDecoder/helpers.ts
@@ -92,7 +92,6 @@ const getErrorCodeStringFromReason = (reason?: string, withSpace = true): string
 }
 
 function getDataFromError(error: Error): string {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const errorData =
     (error as any).data ?? (error as any).error?.data ?? (error as any)?.info?.error?.data
 

--- a/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
+++ b/src/libs/errorHumanizer/estimationErrorHumanizer.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line max-classes-per-file
 import { ethers } from 'hardhat'
 
 import { describe, expect } from '@jest/globals'

--- a/src/libs/errorHumanizer/humanizeCommonCases.test.ts
+++ b/src/libs/errorHumanizer/humanizeCommonCases.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line max-classes-per-file
 import { ethers } from 'hardhat'
 
 import { describe, expect } from '@jest/globals'

--- a/src/libs/estimate/estimateBundler.test.ts
+++ b/src/libs/estimate/estimateBundler.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
-/* eslint-disable max-classes-per-file */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { parseEther } from 'ethers'
@@ -273,7 +271,6 @@ describe('Bundler estimation tests', () => {
 describe('Bundler fallback tests', () => {
   suppressConsoleBeforeEach()
   class BrokenPimlico extends Pimlico {
-    // eslint-disable-next-line class-methods-use-this
     async estimate(userOperation: UserOperation, network: Network): Promise<BundlerEstimateResult> {
       throw new Error('Internal error from bundler')
     }

--- a/src/libs/estimate/estimateBundler.ts
+++ b/src/libs/estimate/estimateBundler.ts
@@ -1,7 +1,3 @@
-/* eslint-disable no-await-in-loop */
-/* eslint-disable no-continue */
-/* eslint-disable no-constant-condition */
-
 import { Interface, toBeHex } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
@@ -46,7 +42,6 @@ export async function fetchBundlerGasPrice(
       )
     })
   ]).catch(() => {
-    // eslint-disable-next-line no-console
     console.error(`fetchBundlerGasPrice for ${bundler.getName()} failed`)
     return Error('Failed to fetch bundler gas prices')
   })
@@ -89,7 +84,7 @@ async function estimate(
     } catch (error) {
       // we just can't decode the error because it's too custom
       // so it's better to continue forward with the original one
-      // eslint-disable-next-line no-console
+
       console.error(error)
     }
 
@@ -119,7 +114,6 @@ async function estimate(
       )
     })
   ]).catch(() => {
-    // eslint-disable-next-line no-console
     console.error(`estimation for ${bundler.getName()} failed, switching and retrying`)
     return new Error('Failed to fetch the bundler estimation', { cause: '4337_ESTIMATION' })
   })

--- a/src/libs/gasPrice/tests/MockProvider.ts
+++ b/src/libs/gasPrice/tests/MockProvider.ts
@@ -48,7 +48,7 @@ export default class MockProvider extends JsonRpcProvider {
       gasUsed: this.blockParams.gasUsed ?? 30000000n,
       miner: this.blockParams.miner ?? addressOne,
       extraData: this.blockParams.extraData ?? 'extra data',
-      /* eslint-disable no-prototype-builtins */
+
       baseFeePerGas: this.blockParams.hasOwnProperty('baseFeePerGas')
         ? this.blockParams.baseFeePerGas
         : parseUnits('1', 'gwei'),

--- a/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
+++ b/src/libs/humanizer/modules/AsciiModule/asciiModule.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { getBytes, toUtf8String, ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../../accountOp/accountOp'

--- a/src/libs/humanizer/modules/Curve/index.ts
+++ b/src/libs/humanizer/modules/Curve/index.ts
@@ -12,7 +12,6 @@ const curveModule: HumanizerCallModule = (_: AccountOp, calls: IrCall[]) => {
     address.toLowerCase() === '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' ? ZeroAddress : address
 
   const handleBasicSwap = (curveRoute: string[], amountIn: bigint, amountOut: bigint) => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const route = curveRoute.filter((a: string) => a !== ZeroAddress)
     const [inToken, outToken] = [route[0], route[route.length - 1]]
     return [
@@ -27,7 +26,6 @@ const curveModule: HumanizerCallModule = (_: AccountOp, calls: IrCall[]) => {
     [iface.getFunction(
       'exchange(address[11] _route, uint256[5][5] _swap_params, uint256 _amount, uint256 _expected, address[5] _pools)'
     )?.selector!]: (call: IrCall) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { _route, _amount, _expected } = iface.parseTransaction(call)!.args
       return handleBasicSwap(_route, _amount, _expected)
     }

--- a/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
+++ b/src/libs/humanizer/modules/FallbackHumanizer/fallBackHumanizer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { ZeroAddress } from 'ethers'
 
 import { AccountOp } from '../../../accountOp/accountOp'

--- a/src/libs/humanizer/modules/Lido/index.ts
+++ b/src/libs/humanizer/modules/Lido/index.ts
@@ -28,7 +28,6 @@ export const LidoModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[
 
     if (isAddress(call.to) && getAddress(call.to) === UNWRAP_CONTRACT_ADDR) {
       if (call.data.startsWith(unwrapIface.getFunction('requestWithdrawals')!.selector)) {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { _amounts, _owner } = unwrapIface.parseTransaction(call)!.args
         const amount = _amounts.reduce((acc: bigint, cur: bigint) => acc + cur, 0n)
         const fullVisualization = [getAction('Request withdraw'), getToken(ST_ETH_ADDRESS, amount)]
@@ -44,7 +43,7 @@ export const LidoModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[
         return { ...call, fullVisualization: [getAction('Claim withdrawal')] }
       }
       if (call.data.startsWith(unwrapIface.getFunction('claimWithdrawalsTo')!.selector)) {
-        // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-unused-vars
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { _requestIds, _hints, _recipient } = unwrapIface.parseTransaction(call)!.args
         const fullVisualization = [getAction('Claim withdrawal')]
         if (_recipient.toLowerCase() !== accOp.accountAddr.toLowerCase())

--- a/src/libs/humanizer/modules/ModuleProxyFactory/index.ts
+++ b/src/libs/humanizer/modules/ModuleProxyFactory/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Interface } from 'ethers'
 
 import { AccountOp } from '../../../accountOp/accountOp'

--- a/src/libs/humanizer/modules/TraderJoe/index.ts
+++ b/src/libs/humanizer/modules/TraderJoe/index.ts
@@ -17,7 +17,6 @@ const traderJoeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[])
     [iface.getFunction(
       'swapExactNATIVEForTokens(uint256 amountOutMin,(uint256[],uint8[],address[]) path,address to,uint256 deadline)'
     )?.selector!]: (call: IrCall) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { amountOutMin, path, to, deadline } = iface.parseTransaction(call)!.args
       const tokenOut = path[2][path[2].length - 1]
       return [
@@ -32,7 +31,6 @@ const traderJoeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[])
     [iface.getFunction(
       'swapNATIVEForExactTokens(uint256 amountOut,tuple(uint256[],uint8[],address[]) path,address to,uint256 deadline)'
     )?.selector!]: (call: IrCall) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { amountOut, path, to, deadline } = iface.parseTransaction(call)!.args
       const tokenOut = path[2][path[2].length - 1]
       return [
@@ -47,7 +45,6 @@ const traderJoeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[])
     [iface.getFunction(
       'swapExactTokensForNATIVE(uint256 amountIn,uint256 amountOutMinNATIVE,tuple(uint256[],uint8[],address[]) path,address to,uint256 deadline)'
     )?.selector!]: (call: IrCall) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { amountIn, amountOutMinNATIVE, path, to, deadline } =
         iface.parseTransaction(call)!.args
       return [
@@ -62,7 +59,6 @@ const traderJoeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[])
     [iface.getFunction(
       'swapTokensForExactNATIVE(uint256 amountNATIVEOut,uint256 amountInMax,tuple(uint256[],uint8[],address[]) path,address to,uint256 deadline)'
     )?.selector!]: (call: IrCall) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { amountNATIVEOut, amountInMax, path, to, deadline } =
         iface.parseTransaction(call)!.args
       return [
@@ -77,7 +73,6 @@ const traderJoeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[])
     [iface.getFunction(
       'swapExactTokensForTokens(uint256 amountIn,uint256 amountOutMin,tuple(uint256[],uint8[],address[]) path,address to,uint256 deadline)'
     )?.selector!]: (call: IrCall) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { amountIn, amountOutMin, path, to, deadline } = iface.parseTransaction(call)!.args
       return [
         getAction('Swap'),
@@ -91,7 +86,6 @@ const traderJoeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[])
     [iface.getFunction(
       'swapTokensForExactTokens(uint256 amountOut,uint256 amountInMax,tuple(uint256[],uint8[],address[]) path,address to,uint256 deadline)'
     )?.selector!]: (call: IrCall) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { amountOut, amountInMax, path, to, deadline } = iface.parseTransaction(call)!.args
       return [
         getAction('Swap up to'),

--- a/src/libs/humanizer/modules/Uniswap/utils.ts
+++ b/src/libs/humanizer/modules/Uniswap/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import { ZeroAddress } from 'ethers'
 
 import { networks } from '../../../../consts/networks'

--- a/src/libs/humanizer/modules/WALLET/WALLETSupplyController.ts
+++ b/src/libs/humanizer/modules/WALLET/WALLETSupplyController.ts
@@ -1,11 +1,9 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Interface } from 'ethers'
 
 import WALLETSupplyControllerABI from '../../../../../contracts/compiled/WALLETSupplyController.json'
 import { HumanizerVisualization, IrCall } from '../../interfaces'
 import { getAction, getLabel, getToken } from '../../utils'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const WALLETSupplyControllerMapping = (): {
   [key: string]: (arg1: IrCall) => HumanizerVisualization[]
 } => {
@@ -39,7 +37,7 @@ export const WALLETSupplyControllerMapping = (): {
           ]
         : [getAction('Claim rewards'), getLabel('in'), getToken(stakingPool, 0n)]
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     [iface.getFunction('mintVesting')?.selector!]: (): HumanizerVisualization[] => {
       return [getAction('Claim vested tokens')]
     }

--- a/src/libs/humanizer/modules/WALLET/index.ts
+++ b/src/libs/humanizer/modules/WALLET/index.ts
@@ -19,7 +19,7 @@ const WALLET_SUPPLY_CONTROLLER_MAPPING = WALLETSupplyControllerMapping()
 const STAKING_POOLS = StakingPools()
 
 const stkWalletIface = new Interface(StkWallet)
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 export const WALLETModule: HumanizerCallModule = (_: AccountOp, irCalls: IrCall[]) => {
   const matcher = {
     supplyController: WALLET_SUPPLY_CONTROLLER_MAPPING,

--- a/src/libs/keyIterator/keyIterator.test.ts
+++ b/src/libs/keyIterator/keyIterator.test.ts
@@ -1,6 +1,5 @@
 import { Wallet } from 'ethers'
 
-/* eslint-disable no-new */
 import { describe, expect, test } from '@jest/globals'
 
 import { BIP44_STANDARD_DERIVATION_TEMPLATE } from '../../consts/derivation'

--- a/src/libs/keyIterator/keyIterator.ts
+++ b/src/libs/keyIterator/keyIterator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable new-cap */
 import { HDNodeWallet, Mnemonic, Wallet } from 'ethers'
 
 import {
@@ -110,7 +109,6 @@ export class KeyIterator implements KeyIteratorInterface {
 
     const baseWallet = this.#getBaseWallet()
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const { from, to } of fromToArr) {
       if ((!from && from !== 0) || (!to && to !== 0) || !hdPathTemplate)
         throw new Error('keyIterator: invalid or missing arguments')
@@ -124,11 +122,9 @@ export class KeyIterator implements KeyIteratorInterface {
       }
 
       if (this.#seedPhrase && baseWallet) {
-        // eslint-disable-next-line no-await-in-loop
         for (let i = from; i <= to; i++) {
           // Yield to the event loop every 2 derivations to keep UI responsive
           if (i > from && i % 2 === 0) {
-            // eslint-disable-next-line no-await-in-loop
             await new Promise((resolve) => setTimeout(resolve, 0))
           }
           const path = getHdPathFromTemplate(hdPathTemplate, i)

--- a/src/libs/keystoreSigner/keystoreSigner.test.ts
+++ b/src/libs/keystoreSigner/keystoreSigner.test.ts
@@ -1,7 +1,6 @@
 import { computeAddress, concat, getBytes, hexlify, Wallet } from 'ethers'
 import { ecdsaRecover } from 'secp256k1'
 
-/* eslint-disable no-new */
 import { describe, expect, test } from '@jest/globals'
 
 import { EIP_7702_AMBIRE_ACCOUNT } from '../../consts/deploy'

--- a/src/libs/keystoreSigner/keystoreSigner.ts
+++ b/src/libs/keystoreSigner/keystoreSigner.ts
@@ -1,4 +1,3 @@
-/* eslint-disable new-cap */
 import {
   concat,
   encodeRlp,
@@ -90,7 +89,6 @@ export class KeystoreSigner implements KeystoreSignerInterface {
     return transactionRes
   }
 
-  // eslint-disable-next-line class-methods-use-this
   sign7702: KeystoreSignerInterface['sign7702'] = async ({ chainId, contract, nonce }) => {
     if (!this.#authorizationPrivkey) throw new Error('no key to perform sign')
 

--- a/src/libs/magicLink/magicLink.test.ts
+++ b/src/libs/magicLink/magicLink.test.ts
@@ -1,9 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable class-methods-use-this */
-/* eslint-disable @typescript-eslint/no-useless-constructor */
 import fetch from 'node-fetch'
 
-/* eslint-disable max-classes-per-file */
 import { describe, expect, test } from '@jest/globals'
 
 import { relayerUrl } from '../../../test/config'

--- a/src/libs/networks/networks.test.ts
+++ b/src/libs/networks/networks.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
 import { describe, expect, test } from '@jest/globals'
 
 import { networks as predefinedNetworks } from '../../consts/networks'

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { AbiCoder, Contract, Interface, toBeHex, ZeroAddress } from 'ethers'
 
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
@@ -308,7 +307,7 @@ export class Paymaster extends AbstractPaymaster {
         bytecode: acc.creation?.bytecode,
         salt: acc.creation?.salt,
         key: acc.associatedKeys[0],
-        // eslint-disable-next-line no-underscore-dangle
+
         rpcUrl: this.provider!._getConnection().url,
         bundler: userOp.bundler,
         swapSponsorship:

--- a/src/libs/polling/polling.ts
+++ b/src/libs/polling/polling.ts
@@ -34,7 +34,6 @@ export class Polling extends EventEmitter {
   ): Promise<T | null> {
     const execTimeout = pollingtime || 0
     const promise: T | null = await new Promise((resolve) =>
-      // eslint-disable-next-line no-promise-executor-return
       setTimeout(async () => {
         this.state = {
           isError: false,

--- a/src/libs/portfolio/gecko.ts
+++ b/src/libs/portfolio/gecko.ts
@@ -13,13 +13,12 @@ export function geckoResponseIdentifier(tokenAddr: string, network: Network): st
 export function geckoRequestBatcher(queue: QueueElement[]): Request[] {
   const segments: { [key: string]: any[] } = {}
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const queueItem of queue) {
     const geckoId = geckoIdMapper(queueItem.data.address, queueItem.data.network)
     // If we can't determine the Gecko platform ID, we shouldn't make a request to price (cena.ambire.com)
     // since it would return nothing.
     // This can happen when adding a custom network that doesn't have a CoinGecko platform ID.
-    // eslint-disable-next-line no-continue
+
     if (!geckoId && !queueItem.data.network.platformId) continue
 
     let segmentId: string = queueItem.data.baseCurrency

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -4,7 +4,7 @@ import { DEPLOYLESS_SIMULATION_FROM } from '../../consts/deploy'
 import { EOA_SIMULATION_NONCE } from '../../consts/deployless'
 import { Network } from '../../interfaces/network'
 import { getPendingBlockTagIfSupported } from '../../utils/getBlockTag'
-/* eslint-disable no-console */
+
 import { yieldToMain } from '../../utils/scheduler'
 import {
   getNotAmbireStateOverride,

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-cycle */
 import { Contract, formatUnits, ZeroAddress } from 'ethers'
 import { getAddress } from 'viem'
 
@@ -331,7 +330,7 @@ const limitConcurrency = async <T>(
   for (let i = 0; i < items.length; i += limit) {
     const batch = items.slice(i, i + limit)
     const batchPromises = batch.map(asyncFn)
-    // eslint-disable-next-line no-await-in-loop
+
     const batchResults = await Promise.allSettled(batchPromises)
 
     results.push(
@@ -510,7 +509,7 @@ export const getTotal = (
   const tokensTotal = t.reduce((cur: { [key: string]: number }, token: TokenResult) => {
     const localCur = cur // Add index signature to the type of localCur
     if (token.flags.isHidden && !includeHiddenTokens) return localCur
-    // eslint-disable-next-line no-restricted-syntax
+
     for (const x of token.priceIn) {
       const currentAmount = localCur[x.baseCurrency] || 0
 
@@ -526,7 +525,7 @@ export const getTotal = (
           'Amount:',
           tokenAmount
         )
-        // eslint-disable-next-line no-continue
+
         continue
       }
 
@@ -561,7 +560,6 @@ export const getTotal = (
           // stkWallet is an internal position, created from the stkWallet token
           if (positionsToExclude.includes(p.id) || p.id === 'stk-wallet') return
 
-          // eslint-disable-next-line no-param-reassign
           cur.usd += p.additionalData.positionInUSD || 0
         })
 
@@ -572,7 +570,6 @@ export const getTotal = (
   }
 
   return Object.keys(tokensTotal).reduce((cur, key) => {
-    // eslint-disable-next-line no-param-reassign
     cur[key] = (tokensTotal[key] || 0) + (defiTotal[key] || 0)
 
     return cur

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -1,6 +1,5 @@
-/* eslint-disable no-restricted-syntax */
 import { ZeroAddress } from 'ethers'
-/* eslint-disable guard-for-in */
+
 import { getAddress } from 'viem'
 
 import BalanceGetter from '../../../contracts/compiled/BalanceGetter.json'
@@ -284,7 +283,7 @@ export class Portfolio {
       const tokenDataHint = convertApiTokenDataToTokenDataCache(
         hints.externalApi?.prices[addr] || null
       )
-      // eslint-disable-next-line no-continue
+
       if (!tokenDataHint) continue
 
       tokenDataCache.set(addr, [start, tokenDataHint])

--- a/src/libs/proxyDeploy/bytecode.ts
+++ b/src/libs/proxyDeploy/bytecode.ts
@@ -18,7 +18,6 @@ export async function get4437Bytecode(network: Network, priLevels: PrivLevels[])
   try {
     provider.destroy()
   } catch (e) {
-    // eslint-disable-next-line no-console
     console.error(e)
   }
 

--- a/src/libs/relayerCall/relayerCall.ts
+++ b/src/libs/relayerCall/relayerCall.ts
@@ -1,5 +1,5 @@
 import { Fetch } from '../../interfaces/fetch'
-/* eslint-disable no-prototype-builtins */
+
 import { fetchWithTimeout } from '../../utils/fetch'
 import { parse, stringify } from '../richJson/richJson'
 

--- a/src/libs/richJson/richJson.test.ts
+++ b/src/libs/richJson/richJson.test.ts
@@ -74,7 +74,6 @@ describe('bigintJson', () => {
         ]
       }
 
-      // eslint-disable-next-line no-param-reassign
       data[`account-${current}`] = {
         accountAddr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
         accountOp,

--- a/src/libs/selectedAccount/errors.test.ts
+++ b/src/libs/selectedAccount/errors.test.ts
@@ -1,6 +1,6 @@
 import { networks } from '../../consts/networks'
 import { Network } from '../../interfaces/network'
-/* eslint-disable no-param-reassign */
+
 import { RPCProvider } from '../../interfaces/provider'
 import {
   SelectedAccountPortfolio,

--- a/src/libs/selectedAccount/selectedAccount.test.ts
+++ b/src/libs/selectedAccount/selectedAccount.test.ts
@@ -1,5 +1,5 @@
 import { AccountState } from '../portfolio/interfaces'
-/* eslint-disable @typescript-eslint/no-use-before-define */
+
 import { PORTFOLIO_STATE } from '../portfolio/testData'
 import { calculateSelectedAccountPortfolio, stripPortfolioState } from './selectedAccount'
 

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import {
   AbiCoder,
   concat,

--- a/src/libs/tracer/accessListCall.ts
+++ b/src/libs/tracer/accessListCall.ts
@@ -203,14 +203,13 @@ export async function createAccessListCall(
     return returned
   } catch (e: any) {
     console.error('Debug: eth_createAccessList error', e)
-    // eslint-disable-next-line no-underscore-dangle
+
     throw new ProviderError({ originalError: e, providerUrl: provider._getConnection()?.url })
   } finally {
     // Clean up the provider after usage
     try {
       provider.destroy()
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error(e)
     }
   }

--- a/src/libs/tracer/debugTraceCall.ts
+++ b/src/libs/tracer/debugTraceCall.ts
@@ -192,7 +192,6 @@ export async function debugTraceCall(
         }
       ])
       .catch((e) => {
-        // eslint-disable-next-line no-underscore-dangle
         throw new ProviderError({ originalError: e, providerUrl: provider._getConnection()?.url })
       })
 
@@ -243,7 +242,6 @@ export async function debugTraceCall(
   try {
     provider.destroy()
   } catch (e) {
-    // eslint-disable-next-line no-console
     console.error(e)
   }
 

--- a/src/libs/userOperation/fetchEntryPointNonce.ts
+++ b/src/libs/userOperation/fetchEntryPointNonce.ts
@@ -8,7 +8,6 @@ import { RPCProvider } from '../../interfaces/provider'
 export async function fetchNonce(account: Account, provider: RPCProvider): Promise<bigint | null> {
   const epInterface = new Interface(entryPointAbi)
   const failure = () => {
-    // eslint-disable-next-line no-console
     console.error('unable to fetch the entry point nonce, estimateBundler')
     return null
   }

--- a/src/libs/userOperation/userOperation.test.ts
+++ b/src/libs/userOperation/userOperation.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
 import { parseEther } from 'ethers'
 
 import { describe, expect, test } from '@jest/globals'

--- a/src/services/assetInfo/assetInfo.test.ts
+++ b/src/services/assetInfo/assetInfo.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import fetch from 'node-fetch'
 
 import { expect, jest } from '@jest/globals'

--- a/src/services/bundlers/biconomy.ts
+++ b/src/services/bundlers/biconomy.ts
@@ -1,6 +1,3 @@
-/* eslint-disable class-methods-use-this */
-/* eslint-disable no-console */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { BICONOMY, BUNDLER } from '../../consts/bundlers'
 import { Network } from '../../interfaces/network'
 import { Bundler } from './bundler'

--- a/src/services/bundlers/brokenBiconomyBroadcast.ts
+++ b/src/services/bundlers/brokenBiconomyBroadcast.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { Network } from '../../interfaces/network'

--- a/src/services/bundlers/brokenPimlicoBroadcast.ts
+++ b/src/services/bundlers/brokenPimlicoBroadcast.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { Network } from '../../interfaces/network'

--- a/src/services/bundlers/bundler.test.ts
+++ b/src/services/bundlers/bundler.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
 import { AbiCoder, Interface, keccak256, parseEther, toBeHex, Wallet } from 'ethers'
 import fetch from 'node-fetch'
 

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-syntax */
-/* eslint-disable class-methods-use-this */
 import { toBeHex } from 'ethers'
 
 import { BUNDLER } from '../../consts/bundlers'

--- a/src/services/bundlers/bundlerSwitcher.ts
+++ b/src/services/bundlers/bundlerSwitcher.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this */
-
 import { BUNDLER } from '../../consts/bundlers'
 import { Network } from '../../interfaces/network'
 import { BaseAccount } from '../../libs/account/BaseAccount'

--- a/src/services/bundlers/candide.ts
+++ b/src/services/bundlers/candide.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this */
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { toBeHex } from 'ethers'
 

--- a/src/services/bundlers/customBundler.ts
+++ b/src/services/bundlers/customBundler.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this */
-
 import { toBeHex } from 'ethers'
 import { createPublicClient, defineChain, http } from 'viem'
 import { BUNDLER, CUSTOM } from '../../consts/bundlers'
@@ -67,11 +65,10 @@ export class CustomBundler extends Bundler {
     const provider = this.getProvider(network)
 
     const status = await provider.send('eth_getUserOperationReceipt', [userOpHash]).catch((e) => {
-      // eslint-disable-next-line no-console
       console.log(
         `custom bundler with url ${this.getUrl(network)} failed to find the status of the user op`
       )
-      // eslint-disable-next-line no-console
+
       console.log(e)
 
       return null

--- a/src/services/bundlers/etherspot.ts
+++ b/src/services/bundlers/etherspot.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this */
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { BUNDLER, ETHERSPOT } from '../../consts/bundlers'
 import { Network } from '../../interfaces/network'
@@ -44,9 +42,8 @@ export class Etherspot extends Bundler {
     const provider = this.getProvider(network)
 
     const status = await provider.send('eth_getUserOperationReceipt', [userOpHash]).catch((e) => {
-      // eslint-disable-next-line no-console
       console.log('etherspot failed to find the status of the user op')
-      // eslint-disable-next-line no-console
+
       console.log(e)
 
       return null

--- a/src/services/bundlers/gelato.ts
+++ b/src/services/bundlers/gelato.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this */
-/* eslint-disable no-console */
 import { BUNDLER, GELATO } from '../../consts/bundlers'
 import { Network } from '../../interfaces/network'
 import { RPCProvider } from '../../interfaces/provider'
@@ -24,7 +22,6 @@ export class Gelato extends Bundler {
     const provider = getRpcProvider([this.getUrl(network)], network.chainId)
 
     const gelatoSend = async (method: string, params: Array<any> | Record<string, any>) => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       const response = await fetch(this.getUrl(network), {
         method: 'POST',
         headers: {
@@ -103,9 +100,8 @@ export class Gelato extends Bundler {
     const provider = this.getProvider(network)
 
     const status = await provider.send('eth_getUserOperationReceipt', [userOpHash]).catch((e) => {
-      // eslint-disable-next-line no-console
       console.log('gelato failed to find the status of the user op')
-      // eslint-disable-next-line no-console
+
       console.log(e)
 
       return null

--- a/src/services/bundlers/pimlico.ts
+++ b/src/services/bundlers/pimlico.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this */
-
 import { RPCProvider } from '@/interfaces/provider'
 import { getRpcProvider } from '@/services/provider'
 

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -266,7 +266,6 @@ export class LiFiAPI implements SwapProvider {
     this.#apiKeyActivatedTimestamp = undefined
   }
 
-  // eslint-disable-next-line class-methods-use-this
   async getHealth() {
     // Li.Fi's v1 API doesn't have a dedicated health endpoint
     return true
@@ -295,7 +294,7 @@ export class LiFiAPI implements SwapProvider {
   /**
    * Processes LiFi API responses and throws custom errors for various failures
    */
-  // eslint-disable-next-line class-methods-use-this
+
   async #handleResponse<T>({
     fetchPromise,
     errorPrefix

--- a/src/services/paymaster/FailedPaymasters.ts
+++ b/src/services/paymaster/FailedPaymasters.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 /*
  * a singleton for recording failed paymaster requests
  */

--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -83,7 +83,6 @@ export class SocketAPI implements SwapProvider {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   async getHealth() {
     // deprecated mechanism
     return true

--- a/src/services/squid/api.ts
+++ b/src/services/squid/api.ts
@@ -188,7 +188,6 @@ export class SquidAPI implements SwapProvider {
     if (integratorId) this.#headers['x-integrator-id'] = integratorId
   }
 
-  // eslint-disable-next-line class-methods-use-this
   async getHealth() {
     return true
   }
@@ -414,7 +413,6 @@ export class SquidAPI implements SwapProvider {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   async startRoute(route: SwapAndBridgeRoute): Promise<SwapAndBridgeSendTxRequest> {
     const rawRoute = route.rawRoute as SquidRoute
     const transactionRequest = rawRoute.transactionRequest

--- a/src/utils/hexStringToUint8Array.ts
+++ b/src/utils/hexStringToUint8Array.ts
@@ -1,7 +1,6 @@
 function hexStringToUint8Array(hexString: string) {
   // Remove '0x' prefix if present
   if (hexString.startsWith('0x')) {
-    // eslint-disable-next-line no-param-reassign
     hexString = hexString.slice(2)
   }
 

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-promise-executor-return */
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
Self-explanatory.

Mostly legacy disables that are no longer needed (prob when airbnb plugin was working).

With this we're down to: `✖ 521 problems (476 errors, 45 warnings)`.