### PR TITLE
Disallow wrong 712 domain chain

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -738,5 +738,45 @@ describe('RequestsController ', () => {
       expect(controller.userRequests.length).toBe(1)
       expect(controller.userRequests[0]!.kind).toBe('typedMessage')
     })
+
+    test('rejects when domain.chainId does not match the current network chainId', async () => {
+      const { controller } = await prepareTest(true)
+      const typedData = {
+        ...VALID_TYPED_DATA,
+        domain: { ...VALID_TYPED_DATA.domain, chainId: 999 }
+      }
+      await expect(buildSignTypedDataRequest(controller, typedData)).rejects.toThrow(
+        'The domain chainId (999) does not match the current network chainId (1)'
+      )
+    })
+
+    test('replaces domain.chainId with current network chainId when domain.chainId is 0', async () => {
+      const { controller } = await prepareTest(true)
+      const typedData = {
+        ...VALID_TYPED_DATA,
+        domain: { ...VALID_TYPED_DATA.domain, chainId: 0 }
+      }
+      await expect(buildSignTypedDataRequest(controller, typedData)).resolves.toBeUndefined()
+      expect(controller.userRequests.length).toBe(1)
+      const req = controller.userRequests[0]! as any
+      expect(req.meta.params.domain.chainId).toBe(1n)
+    })
+
+    test('accepts typed data with no domain.chainId regardless of current network', async () => {
+      const { controller } = await prepareTest(true)
+      const typedData = {
+        ...VALID_TYPED_DATA,
+        types: {
+          ...VALID_TYPED_DATA.types,
+          EIP712Domain: VALID_TYPED_DATA.types.EIP712Domain.filter((f) => f.name !== 'chainId')
+        },
+        domain: { name: VALID_TYPED_DATA.domain.name, version: VALID_TYPED_DATA.domain.version }
+      }
+      await expect(buildSignTypedDataRequest(controller, typedData)).resolves.toBeUndefined()
+      expect(controller.userRequests.length).toBe(1)
+      const req = controller.userRequests[0]! as any
+      expect(req.kind).toBe('typedMessage')
+      expect(req.meta.params.domain.chainId).toBe(1n)
+    })
   })
 })

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1260,6 +1260,13 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         )
       }
 
+      const domainChainId = BigInt(typedData.domain.chainId || 0)
+      if (domainChainId !== 0n && domainChainId !== network.chainId)
+        throw ethErrors.rpc.invalidRequest(
+          `The domain chainId (${typedData.domain.chainId}) does not match the current network chainId (${network.chainId})`
+        )
+      typedData.domain.chainId = network.chainId
+
       if (!typedData.types[typedData.primaryType])
         throw ethErrors.rpc.invalidParams(
           'The primary data type is missing from the provided types'
@@ -1276,13 +1283,6 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         console.log(e)
         throw ethErrors.rpc.invalidParams('The message contents did not match the provided types.')
       }
-
-      const domainChainId = BigInt(typedData.domain.chainId || 0)
-      if (domainChainId !== 0n && domainChainId !== network.chainId)
-        throw ethErrors.rpc.invalidRequest(
-          `The domain chainId (${typedData.domain.chainId}) does not match the current network chainId (${network.chainId})`
-        )
-      typedData.domain.chainId = network.chainId
 
       if (
         msgAddress === this.#selectedAccount.account.addr &&

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1277,6 +1277,13 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         throw ethErrors.rpc.invalidParams('The message contents did not match the provided types.')
       }
 
+      const domainChainId = BigInt(typedData.domain.chainId || 0)
+      if (domainChainId !== 0n && domainChainId !== network.chainId)
+        throw ethErrors.rpc.invalidRequest(
+          `The domain chainId (${typedData.domain.chainId}) does not match the current network chainId (${network.chainId})`
+        )
+      typedData.domain.chainId = network.chainId
+
       if (
         msgAddress === this.#selectedAccount.account.addr &&
         (typedData.primaryType === 'AmbireOperation' || !!typedData.types.AmbireOperation)
@@ -1295,7 +1302,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
             primaryType: typedData.primaryType
           },
           accountAddr: msgAddress,
-          chainId: network.chainId
+          chainId: typedData.domain.chainId
         },
         dappPromises: [{ ...dappPromise, session: request.session, meta: {} }]
       } as TypedMessageUserRequest


### PR DESCRIPTION
Resolves: https://github.com/ambireTech/ambire-app/issues/7254
## When a dapp requests a 712 signature, we now check the chainId of the domain

## Copies raby's and MM behavior:
- when chainId is missing, assume it should be the same as the current chain
- when chainId is 0 assume it is the same as the current hcain
- else when it is not correct throw error for the dapp to handle
- when correct do everything as expected 

## To test
try this with all 3 wallets
send712Request()
send712Request(0)
send712Request(RANDOM_CHAIN_ID)
send712Request(CURRENT_CHAIN_ID)

this is the function you can copy paste in the console:
```js
const send712Request = async (chainId) => {
  if (!window.ethereum) {
    throw new Error("No wallet found");
  }

  const [account] = await ethereum.request({
    method: "eth_requestAccounts",
  });

  const domain = {
    name: "MyDapp",
    version: "1",
    chainId,
    verifyingContract: "0x0000000000000000000000000000000000000000",
  };

  const types = {
    EIP712Domain: [
      { name: "name", type: "string" },
      { name: "version", type: "string" },
      { name: "chainId", type: "uint256" },
      { name: "verifyingContract", type: "address" },
    ],
    Message: [
      { name: "contents", type: "string" },
      { name: "timestamp", type: "uint256" },
    ],
  };

  const message = {
    contents: "Hello from EIP-712",
    timestamp: Math.floor(Date.now() / 1000),
  };

  const data = JSON.stringify({
    domain,
    types,
    primaryType: "Message",
    message,
  });

  const signature = await ethereum.request({
    method: "eth_signTypedData_v4",
    params: [account, data],
  });

  console.log("Address:", account);
  console.log("Signature:", signature);
}
```