### PR TITLE
Improve: activity refresh interval to make chains feel faster

### DIFF
--- a/src/controllers/continuousUpdates/continuousUpdates.test.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.test.ts
@@ -1,14 +1,16 @@
-import { suppressConsole } from '../../../test/helpers/console'
+import { Account } from '@/interfaces/account'
 
+import { suppressConsole } from '../../../test/helpers/console'
 import { makeMainController } from '../../../test/helpers/mainController'
 import { waitForFnToBeCalledAndExecuted } from '../../../test/recurringTimeout'
+import { ACTIVITY_REFRESH_INTERVAL } from '../../consts/intervals'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { SwapProviderParallelExecutor } from '../../services/swapIntegrators/swapProviderParallelExecutor'
 import wait from '../../utils/wait'
 import EventEmitter from '../eventEmitter/eventEmitter'
 import { MainController } from '../main/main'
 
-const accounts = [
+const accounts: Account[] = [
   {
     addr: '0xa07D75aacEFd11b425AF7181958F0F85c312f143',
     associatedKeys: ['0xd6e371526cdaeE04cd8AF225D42e37Bc14688D9E'],
@@ -17,6 +19,11 @@ const accounts = [
       bytecode:
         '0x7f28d4ea8f825adb036e9b306b2269570e63d2aa5bd10751437d98ed83551ba1cd7fa57498058891e98f45f8abb85dafbcd30f3d8b3ab586dfae2e0228bbb1de7018553d602d80604d3d3981f3363d3d373d3d3d363d732a2b85eb1054d6f0c6c2e37da05ed3e5fea684ef5af43d82803e903d91602b57fd5bf3',
       salt: '0x0000000000000000000000000000000000000000000000000000000000000001'
+    },
+    initialPrivileges: [],
+    preferences: {
+      label: '',
+      pfp: ''
     }
   },
   {
@@ -27,6 +34,11 @@ const accounts = [
       bytecode:
         '0x7f1e7646e4695bead8bb0596679b0caf3a7ff6c4e04d2ad79103c8fa61fb6337f47fa57498058891e98f45f8abb85dafbcd30f3d8b3ab586dfae2e0228bbb1de7018553d602d80604d3d3981f3363d3d373d3d3d363d732a2b85eb1054d6f0c6c2e37da05ed3e5fea684ef5af43d82803e903d91602b57fd5bf3',
       salt: '0x0000000000000000000000000000000000000000000000000000000000000001'
+    },
+    initialPrivileges: [],
+    preferences: {
+      label: '',
+      pfp: ''
     }
   },
   {
@@ -37,6 +49,11 @@ const accounts = [
       bytecode:
         '0x7f00000000000000000000000000000000000000000000000000000000000000017f02c94ba85f2ea274a3869293a0a9bf447d073c83c617963b0be7c862ec2ee44e553d602d80604d3d3981f3363d3d373d3d3d363d732a2b85eb1054d6f0c6c2e37da05ed3e5fea684ef5af43d82803e903d91602b57fd5bf3',
       salt: '0x2ee01d932ede47b0b2fb1b6af48868de9f86bfc9a5be2f0b42c0111cf261d04c'
+    },
+    initialPrivileges: [],
+    preferences: {
+      label: '',
+      pfp: ''
     }
   }
 ]
@@ -197,6 +214,65 @@ describe('ContinuousUpdatesController intervals', () => {
     mainCtrl.activity.emitUpdate()
     await jest.advanceTimersByTimeAsync(0)
     expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.stop).toHaveBeenCalled()
+  })
+
+  test('should gradually slow accountsOpsStatusesInterval from the network refresh interval', async () => {
+    const { mainCtrl } = await prepareTest()
+    await waitForMainCtrlReady(mainCtrl)
+
+    const network = mainCtrl.networks.networks.find(
+      ({ chainId }) => chainId === submittedAccountOp.chainId
+    )!
+    network.refreshInterval = 500
+
+    await mainCtrl.activity.addAccountOp(submittedAccountOp)
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(500)
+
+    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval)
+    expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(1500)
+
+    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval)
+    expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(2500)
+
+    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval)
+    expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(3500)
+
+    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval)
+    expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(4500)
+
+    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval)
+    expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(
+      ACTIVITY_REFRESH_INTERVAL
+    )
+
+    await waitForFnToBeCalledAndExecuted(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval)
+    expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(
+      ACTIVITY_REFRESH_INTERVAL
+    )
+
+    mainCtrl.continuousUpdates!.restartAccountsOpsStatusesInterval()
+    await jest.advanceTimersByTimeAsync(0)
+    expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(500)
+  })
+  ;[undefined, 0, -1, ACTIVITY_REFRESH_INTERVAL + 1000].forEach((refreshInterval) => {
+    test(`should use ACTIVITY_REFRESH_INTERVAL for an invalid or too large network refresh interval: ${refreshInterval}`, async () => {
+      const { mainCtrl } = await prepareTest()
+      await waitForMainCtrlReady(mainCtrl)
+
+      const network = mainCtrl.networks.networks.find(
+        ({ chainId }) => chainId === submittedAccountOp.chainId
+      )!
+      network.refreshInterval = refreshInterval
+
+      await mainCtrl.activity.addAccountOp(submittedAccountOp)
+      await jest.advanceTimersByTimeAsync(0)
+
+      expect(mainCtrl.continuousUpdates!.accountsOpsStatusesInterval.currentTimeout).toBe(
+        ACTIVITY_REFRESH_INTERVAL
+      )
+    })
   })
 
   test('should run updateAccountStateLatest and updateAccountStatePending', async () => {

--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -36,6 +36,17 @@ export class ContinuousUpdatesController extends EventEmitter {
     return this.#accountsOpsStatusesInterval
   }
 
+  restartAccountsOpsStatusesInterval({ runImmediately = false } = {}) {
+    const allBroadcastedButNotConfirmed = Object.values(
+      this.#main.activity.broadcastedButNotConfirmed
+    ).flat()
+
+    this.#accountsOpsStatusesInterval.restart({
+      timeout: this.#getAccountsOpsStatusesRefreshInterval(allBroadcastedButNotConfirmed),
+      runImmediately
+    })
+  }
+
   #accountStateLatestInterval: IRecurringTimeout
 
   get accountStateLatestInterval() {
@@ -188,7 +199,9 @@ export class ContinuousUpdatesController extends EventEmitter {
       ).flat()
 
       if (allBroadcastedButNotConfirmed.length) {
-        this.#accountsOpsStatusesInterval.start()
+        this.#accountsOpsStatusesInterval.start({
+          timeout: this.#getAccountsOpsStatusesRefreshInterval(allBroadcastedButNotConfirmed)
+        })
       } else {
         this.#accountsOpsStatusesInterval.stop()
       }
@@ -217,8 +230,35 @@ export class ContinuousUpdatesController extends EventEmitter {
   }
 
   async #updateAccountsOpsStatuses() {
-    await this.initialLoadPromise
-    await this.#main.updateAccountsOpsStatuses()
+    try {
+      await this.initialLoadPromise
+      await this.#main.updateAccountsOpsStatuses()
+    } finally {
+      this.#accountsOpsStatusesInterval.updateTimeout({
+        timeout: Math.min(
+          this.#accountsOpsStatusesInterval.currentTimeout + 1000,
+          ACTIVITY_REFRESH_INTERVAL
+        )
+      })
+    }
+  }
+
+  #getAccountsOpsStatusesRefreshInterval(accountOps: SubmittedAccountOp[]) {
+    return accountOps.reduce((refreshInterval, accountOp) => {
+      const networkRefreshInterval = this.#main.networks.networks.find(
+        ({ chainId }) => chainId === accountOp.chainId
+      )?.refreshInterval
+
+      if (
+        !networkRefreshInterval ||
+        !Number.isFinite(networkRefreshInterval) ||
+        networkRefreshInterval <= 0
+      ) {
+        return refreshInterval
+      }
+
+      return Math.min(refreshInterval, networkRefreshInterval)
+    }, ACTIVITY_REFRESH_INTERVAL)
   }
 
   async #updateAccountStateLatest() {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -13,7 +13,6 @@ import { LOCKED_EXTENSION_PORTFOLIO_UPDATE_INTERVAL } from '@/consts/intervals'
 import { AccountPickerController } from '@/controllers/accountPicker/accountPicker'
 import { AccountsController } from '@/controllers/accounts/accounts'
 import { ActivityController } from '@/controllers/activity/activity'
-
 import { SignedMessage } from '@/controllers/activity/types'
 import { AddressBookController } from '@/controllers/addressBook/addressBook'
 import { AutoLoginController } from '@/controllers/autoLogin/autoLogin'
@@ -44,7 +43,6 @@ import { SurveyController } from '@/controllers/survey/survey'
 import { SwapAndBridgeController } from '@/controllers/swapAndBridge/swapAndBridge'
 import { TransactionManagerController } from '@/controllers/transaction/transactionManager'
 import { TransferController } from '@/controllers/transfer/transfer'
-
 import { TransfersScannerController } from '@/controllers/transfersScanner/transfersScanner'
 import { UiController } from '@/controllers/ui/ui'
 import { Account, IAccountsController } from '@/interfaces/account'
@@ -789,7 +787,7 @@ export class MainController extends EventEmitter implements IMainController {
     await this.selectedAccount.setAccount(accountToSelect)
     this.#continuousUpdates?.updatePortfolioInterval.restart()
     this.#continuousUpdates?.accountStateLatestInterval.restart()
-    this.#continuousUpdates?.accountsOpsStatusesInterval.restart({ runImmediately: true })
+    this.#continuousUpdates?.restartAccountsOpsStatusesInterval({ runImmediately: true })
     this.swapAndBridge.updateActiveRoutesInterval.restart({ runImmediately: true })
     this.swapAndBridge.reset()
     this.transfer.reset({ destroyAccountOp: true })

--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -115,6 +115,10 @@ export interface Network {
   allowForce4337?: boolean
   disabled?: boolean
   customBundlerUrl?: string
+  /**
+   * Initial polling interval for pending account operation statuses.
+   */
+  refreshInterval?: number
 }
 
 export interface SupportedNetworks extends Network {
@@ -217,6 +221,10 @@ export type RelayerNetwork = {
     }
   }
   disabledByDefault?: boolean
+  /**
+   * Initial polling interval for pending account operation statuses.
+   */
+  refreshInterval?: number
 }
 
 export type RelayerNetworkConfigResponse = { [chainId: string]: RelayerNetwork }

--- a/src/libs/networks/networks.test.ts
+++ b/src/libs/networks/networks.test.ts
@@ -113,6 +113,7 @@ describe('Networks lib', () => {
       const relayerNetworksClone = structuredClone(MOCK_RELAYER_NETWORKS)
       relayerNetworksClone['1'].rpcUrls = ['https://new-rpc-url.com']
       relayerNetworksClone['1'].iconUrls = ['https://new-icon-url.com']
+      relayerNetworksClone['1']!.refreshInterval = 1000
       // This property shouldn't be updated as predefinedConfigVersion is the same
       relayerNetworksClone['1'].feeOptions.is1559 = false
 
@@ -129,6 +130,7 @@ describe('Networks lib', () => {
       ])
       // Icon urls are replaced
       expect(result2['1'].iconUrls).toEqual(['https://new-icon-url.com'])
+      expect(result2['1']!.refreshInterval).toBe(1000)
       expect(result2['1'].predefined).toBe(true)
       // Fee options are not updated as predefinedConfigVersion is the same
       expect(result2['1'].feeOptions.is1559).toBe(true)
@@ -223,6 +225,19 @@ describe('Networks lib', () => {
     })
     it('networksObj reference should not be modified', () => {
       expect(NEVER_MUTATE_NETWORKS_OBJ).toEqual(networksObj)
+    })
+    ;[0, -1, Number.POSITIVE_INFINITY].forEach((refreshInterval) => {
+      it(`Invalid refreshInterval values should not be added to networks: ${refreshInterval}`, () => {
+        const relayerNetworksClone = structuredClone(MOCK_RELAYER_NETWORKS)
+        relayerNetworksClone['1']!.refreshInterval = refreshInterval
+
+        const { mergedNetworks: result } = getNetworksUpdatedWithRelayerNetworks(
+          networksObj,
+          relayerNetworksClone
+        )
+
+        expect(result['1']!.refreshInterval).toBeUndefined()
+      })
     })
   })
 })

--- a/src/libs/networks/networks.ts
+++ b/src/libs/networks/networks.ts
@@ -509,6 +509,7 @@ export const getNetworksUpdatedWithRelayerNetworks = (
         rpcUrls: [...new Set([...relayerNetwork.rpcUrls, ...currentNetwork.rpcUrls])],
         suggestedRpcUrl: relayerNetwork.suggestedRpcUrl,
         suggestedRpcBatchCount: relayerNetwork.suggestedRpcBatchCount,
+        refreshInterval: relayerNetwork.refreshInterval,
         iconUrls: relayerNetwork.iconUrls,
         predefined: relayerNetwork.predefined
       }

--- a/src/utils/networks.ts
+++ b/src/utils/networks.ts
@@ -32,6 +32,7 @@ const rollProviderUrlsAndFindWorking = async (
   rpcUrls: string[],
   index: number
 ): Promise<string | null> => {
+  if (!rpcUrls[index]) return null
   const isProviderWorking = await checkIsRpcUrlWorking(rpcUrls[index])
 
   if (isProviderWorking) {
@@ -57,7 +58,7 @@ const convertToAmbireNetworkFormat = async (network: ChainlistNetwork): Promise<
 
     return !isApiKeyRequired
   })
-  const workingRpcUrl: string =
+  const workingRpcUrl: string | null =
     hardcodedRpcUrls[network.chainId.toString()] ??
     (await rollProviderUrlsAndFindWorking(freeHttpRpcUrls, 0))
 
@@ -88,7 +89,7 @@ const convertToAmbireNetworkFormat = async (network: ChainlistNetwork): Promise<
   return {
     name: network.name,
     chainId: BigInt(network.chainId),
-    rpcUrls: [workingRpcUrl ?? network.rpc[0]],
+    rpcUrls: [workingRpcUrl ?? network.rpc[0]!],
     explorerUrl: network.explorers[0]?.url || '',
     selectedRpcUrl: workingRpcUrl || '',
     platformId,
@@ -133,7 +134,8 @@ export const mapRelayerNetworkConfigToAmbireNetwork = (
     platformId,
     has7702,
     disabledByDefault,
-    rpcNoStateOverride
+    rpcNoStateOverride,
+    refreshInterval
   } = relayerNetwork
   const {
     native: {
@@ -213,6 +215,10 @@ export const mapRelayerNetworkConfigToAmbireNetwork = (
     hasRelayer,
     suggestedRpcUrl: relayerNetwork.selectedRpcUrl,
     suggestedRpcBatchCount: relayerNetwork.selectedRpcBatchCount,
+    refreshInterval:
+      typeof refreshInterval === 'number' && Number.isFinite(refreshInterval) && refreshInterval > 0
+        ? refreshInterval
+        : undefined,
     wrappedAddr,
     oldNativeAssetSymbols,
     feeOptions,


### PR DESCRIPTION
Improve the activity refresh interval and allow that config to be set from the relayer to make fast chains really feel faster