### PR TITLE
Fixes / Portfolio state clone

### DIFF
--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -226,14 +226,7 @@ export class SelectedAccountController extends EventEmitter implements ISelected
   updateSelectedAccountPortfolio(skipUpdate?: boolean) {
     if (!this.#portfolio || !this.account) return
 
-    // Use cloneDeep instead of structuredClone because the portfolio state can
-    // contain Error instances (criticalError/errors on a NetworkState). The
-    // WebView's JS engine on mobile cannot structuredClone Error objects and
-    // throws "Unable to deserialize data.", which surfaced as an opaque
-    // "Script error." in the Global handler. cloneDeep handles Error and BigInt.
-    const portfolioAccountState = cloneDeep(
-      this.#portfolio.getAccountPortfolioState(this.account.addr)
-    ) as AccountState
+    const portfolioAccountState = this.#portfolio.getAccountPortfolioState(this.account.addr)
 
     const newSelectedAccountPortfolio = calculateSelectedAccountPortfolio(
       portfolioAccountState,

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -1,7 +1,5 @@
 import { formatEther, getAddress, isAddress } from 'ethers'
 
-import { AccountState } from '@/libs/portfolio/interfaces'
-
 import { STK_WALLET, UNI_V3_WALLET_WETH_POOL, WALLET_TOKEN } from '../../consts/addresses'
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { Account, IAccountsController } from '../../interfaces/account'
@@ -23,7 +21,6 @@ import {
   getDefiPositionsOnDisabledNetworksForTheSelectedAccount
 } from '../../libs/banners/banners'
 import { AssetType } from '../../libs/defiPositions/types'
-import { cloneDeep } from '../../libs/richJson/richJson'
 import {
   getNetworksWithDeFiPositionsErrorErrors,
   getNetworksWithErrors,

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -1,5 +1,7 @@
 import { formatEther, getAddress, isAddress } from 'ethers'
 
+import { AccountState } from '@/libs/portfolio/interfaces'
+
 import { STK_WALLET, UNI_V3_WALLET_WETH_POOL, WALLET_TOKEN } from '../../consts/addresses'
 import { AMBIRE_ACCOUNT_FACTORY } from '../../consts/deploy'
 import { Account, IAccountsController } from '../../interfaces/account'
@@ -21,6 +23,7 @@ import {
   getDefiPositionsOnDisabledNetworksForTheSelectedAccount
 } from '../../libs/banners/banners'
 import { AssetType } from '../../libs/defiPositions/types'
+import { cloneDeep } from '../../libs/richJson/richJson'
 import {
   getNetworksWithDeFiPositionsErrorErrors,
   getNetworksWithErrors,
@@ -223,9 +226,14 @@ export class SelectedAccountController extends EventEmitter implements ISelected
   updateSelectedAccountPortfolio(skipUpdate?: boolean) {
     if (!this.#portfolio || !this.account) return
 
-    const portfolioAccountState = structuredClone(
+    // Use cloneDeep instead of structuredClone because the portfolio state can
+    // contain Error instances (criticalError/errors on a NetworkState). The
+    // WebView's JS engine on mobile cannot structuredClone Error objects and
+    // throws "Unable to deserialize data.", which surfaced as an opaque
+    // "Script error." in the Global handler. cloneDeep handles Error and BigInt.
+    const portfolioAccountState = cloneDeep(
       this.#portfolio.getAccountPortfolioState(this.account.addr)
-    )
+    ) as AccountState
 
     const newSelectedAccountPortfolio = calculateSelectedAccountPortfolio(
       portfolioAccountState,


### PR DESCRIPTION
* Remove redundant structuredClone of the portfolioAccountState in updateSelectedAccountPortfolio because it was causing global error on the mobile app when the portfolio state was containing Error instances (criticalError/errors on a NetworkState). WebView's JS engine on mobile cannot structuredClone Error objects and throws "Unable to deserialize data.", which surfaced as an opaque "Script error.". The other reason for the removal is that we do not mutate the portfolio state anymore in this function so no need to keep it there just to slow down the updates