### PR TITLE
Feature/display safe hashes

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -320,6 +320,8 @@ export class SignAccountOpController
 
   hardwareWalletSigningRequest: HardwareWalletSigningRequest | null = null
 
+  safeEip712Data: unknown | null = null
+
   // We track the status of token discovery logic (main.traceCall)
   // to ensure the "SignificantBalanceDecrease" banner is displayed correctly.
   // The latest/pending portfolio balance is essential for calculating balance differences.
@@ -452,6 +454,7 @@ export class SignAccountOpController
     this.#phishing = phishing
     this.fromRequestId = fromRequestId
     this.#accountOp = structuredClone(accountOp)
+    this.#updateSafeEip712Data()
     this.#setSpeedUpGasPrices()
 
     if (this.#accountOp.signature && this.#accountOp.txnId) {
@@ -544,6 +547,47 @@ export class SignAccountOpController
       ...this.#accountOp,
       ...accountOp,
       id: hasUpdatedCalls ? generateUuid() : this.#accountOp.id
+    }
+    this.#updateSafeEip712Data()
+  }
+
+  #getSafeSigningData(accountState: AccountOnchainState) {
+    const safeTxn = getSafeTxn(this.accountOp, accountState)
+    const typedData = (this.baseAccount as Safe).getTxnTypedData(safeTxn)
+    const safeTxnHash = getSafeTxnHash(typedData)
+
+    return {
+      safeTxn,
+      typedData,
+      safeTxnHash,
+      signingRequest: getEIP712SigningRequest({ ...typedData, safeTxHash: safeTxnHash })
+    }
+  }
+
+  #updateSafeEip712Data() {
+    if (!this.account.safeCreation) {
+      this.safeEip712Data = null
+      return
+    }
+
+    const accountState =
+      this.#accounts.accountStates[this.account.addr]?.[this.#network.chainId.toString()]
+    if (!accountState) {
+      this.safeEip712Data = null
+      return
+    }
+
+    try {
+      this.safeEip712Data = getSigningRequestDisplayData(
+        this.#getSafeSigningData(accountState).signingRequest
+      )
+    } catch (error) {
+      this.safeEip712Data = null
+      this.emitError({
+        message: 'Error calculating Safe EIP-712 data',
+        error: error instanceof Error ? error : new Error(String(error)),
+        level: 'silent'
+      })
     }
   }
 
@@ -2736,11 +2780,10 @@ export class SignAccountOpController
         if (safeSigner.init)
           safeSigner.init(this.#externalSignerControllers[this.accountOp.signingKeyType])
 
-        const safeTxn = getSafeTxn(this.accountOp, accountState)
-        const typedData = (this.baseAccount as Safe).getTxnTypedData(safeTxn)
-        const safeTxnHash = getSafeTxnHash(typedData)
+        const { safeTxn, typedData, safeTxnHash, signingRequest } =
+          this.#getSafeSigningData(accountState)
         const signature = (await this.#withHardwareWalletSigningRequest(
-          getEIP712SigningRequest({ ...typedData, safeTxHash: safeTxnHash }),
+          signingRequest,
           () => safeSigner.signTypedData(typedData)
         )) as Hex
         nowSignedSigs.push(signature)
@@ -3696,7 +3739,8 @@ export class SignAccountOpController
       threshold: this.threshold,
       canBroadcast: this.canBroadcast,
       hasSafeApiFailed: this.hasSafeApiFailed,
-      hardwareWalletSigningRequest: this.hardwareWalletSigningRequest
+      hardwareWalletSigningRequest: this.hardwareWalletSigningRequest,
+      safeEip712Data: this.safeEip712Data
     }
   }
 }

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -148,6 +148,48 @@ describe('SignMessageController', () => {
     expect(signMessageController.signer).toBeUndefined()
   })
 
+  test('should expose Safe EIP-712 data when initializing a Safe message', async () => {
+    const safeAccount: Account = {
+      ...account,
+      safeCreation: {
+        factoryAddr: account.addr as Hex,
+        singleton: account.addr as Hex,
+        saltNonce: '0x00',
+        setupData: '0x',
+        version: '1.4.1'
+      }
+    }
+    const safeAccountsCtrl = {
+      initialLoadPromise: Promise.resolve(),
+      accounts: [safeAccount],
+      getOrFetchAccountOnChainState: jest.fn().mockResolvedValue({
+        importedAccountKeys: []
+      })
+    } as unknown as IAccountsController
+    const safeSignMessageController = new SignMessageController(
+      keystoreCtrl,
+      providersCtrl,
+      networksCtrl,
+      safeAccountsCtrl,
+      {},
+      inviteCtrl
+    )
+
+    await safeSignMessageController.init({
+      messageToSign: { ...messageToSign, accountAddr: safeAccount.addr }
+    })
+
+    expect(safeSignMessageController.safeEip712Data).toMatchObject({
+      primaryType: 'SafeMessage',
+      safeMessageHash: expect.stringMatching(/^0x/),
+      domainHash: expect.stringMatching(/^0x/),
+      messageHash: expect.stringMatching(/^0x/)
+    })
+
+    safeSignMessageController.reset()
+    expect(safeSignMessageController.safeEip712Data).toBeNull()
+  })
+
   test('should not initialize with an invalid message kind', async () => {
     const invalidMessageToSign: Message = {
       id: 1,

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -553,6 +553,77 @@ describe('SignMessageController', () => {
 
     getSignerSpy.mockRestore() // cleans up the spy
   })
+
+  test('should expose hardware wallet EIP-712 data while signing a typed message', async () => {
+    const signingKeyAddr = account.addr
+    const dummySignature =
+      '0x5b2dce98c7179051d21407be04bcd088243cd388ed51c4c64ccae115ca8787d85cff933dcde45220c3adfcc40f7958305e195dbd4c54580dfbf61e43438cbe9a1c'
+    const typedMessageToSign: Message = {
+      fromRequestId: 3,
+      accountAddr: account.addr,
+      chainId: 1n,
+      signature: null,
+      content: {
+        kind: 'typedMessage',
+        domain: {
+          chainId: 1,
+          verifyingContract: account.addr
+        },
+        types: {
+          EIP712Domain: [
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' }
+          ],
+          Message: [{ name: 'contents', type: 'string' }]
+        },
+        primaryType: 'Message',
+        message: {
+          contents: 'Sign me'
+        }
+      }
+    }
+    let resolveSignature!: (signature: string) => void
+    let notifySigningStarted!: () => void
+    const signingStarted = new Promise<void>((resolve) => {
+      notifySigningStarted = resolve
+    })
+    const mockSigner = {
+      signTypedData: jest.fn().mockImplementation(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveSignature = resolve
+            notifySigningStarted()
+          })
+      ),
+      key: { addr: signingKeyAddr, type: 'internal', dedicatedToOneSA: true, meta: {} }
+    }
+
+    // @ts-expect-error spy on the getSigner method and mock its implementation
+    const getSignerSpy = jest.spyOn(keystoreCtrl, 'getSigner').mockResolvedValue(mockSigner)
+
+    await signMessageController.init({ messageToSign: typedMessageToSign })
+    signMessageController.setSigners([{ addr: signingKeyAddr, type: 'internal' }])
+
+    const signPromise = signMessageController.sign()
+    await signingStarted
+
+    expect(signMessageController.hardwareWalletSigningRequest).toMatchObject({
+      type: 'eip-712',
+      data: {
+        primaryType: 'Message',
+        domainHash: expect.stringMatching(/^0x/),
+        messageHash: expect.stringMatching(/^0x/)
+      }
+    })
+
+    resolveSignature(dummySignature)
+    await signPromise
+
+    expect(signMessageController.hardwareWalletSigningRequest).toBeNull()
+
+    getSignerSpy.mockRestore()
+  })
+
   test('removeAccountData', async () => {
     await signMessageController.init({ messageToSign })
     expect(signMessageController.isInitialized).toBeTruthy()

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -22,6 +22,7 @@ import {
 } from '../../interfaces/keystore'
 import { INetworksController, Network } from '../../interfaces/network'
 import { IProvidersController } from '../../interfaces/provider'
+import type { HardwareWalletSigningRequest } from '../../interfaces/signAccountOp'
 import {
   ISignMessageController,
   SignMessageStatus,
@@ -96,6 +97,8 @@ export class SignMessageController
   isHumanizing = false
 
   safeEip712Data: unknown | null = null
+
+  hardwareWalletSigningRequest: HardwareWalletSigningRequest | null = null
 
   signedMessage: SignedMessage | null = null
 
@@ -246,6 +249,7 @@ export class SignMessageController
     this.humanizedMessage = undefined
     this.isHumanizing = false
     this.safeEip712Data = null
+    this.hardwareWalletSigningRequest = null
     this.signedMessage = null
     this.#account = undefined
     this.network = undefined
@@ -283,6 +287,38 @@ export class SignMessageController
         error: error instanceof Error ? error : new Error(String(error)),
         level: 'silent'
       })
+    }
+  }
+
+  #setHardwareWalletSigningRequest(request: HardwareWalletSigningRequest | null) {
+    let serializedRequestData: unknown = null
+
+    try {
+      if (request) serializedRequestData = getSigningRequestDisplayData(request)
+    } catch {
+      serializedRequestData = null
+    }
+
+    this.hardwareWalletSigningRequest =
+      request && serializedRequestData !== null
+        ? {
+            ...request,
+            data: serializedRequestData
+          }
+        : null
+    this.emitUpdate()
+  }
+
+  async #withHardwareWalletSigningRequest<T>(
+    request: HardwareWalletSigningRequest,
+    sign: () => Promise<T>
+  ) {
+    this.#setHardwareWalletSigningRequest(request)
+
+    try {
+      return await sign()
+    } finally {
+      this.#setHardwareWalletSigningRequest(null)
     }
   }
 
@@ -468,7 +504,8 @@ export class SignMessageController
             this.#account,
             accountState,
             this.signer,
-            this.#invite.isOG
+            this.#invite.isOG,
+            (request, sign) => this.#withHardwareWalletSigningRequest(request, sign)
           )
           this.signatures.push(signed.signature)
           this.signed.push(signerKey.addr)
@@ -509,7 +546,8 @@ export class SignMessageController
             accountState,
             this.signer,
             this.network,
-            this.#invite.isOG
+            this.#invite.isOG,
+            (request, sign) => this.#withHardwareWalletSigningRequest(request, sign)
           )
           this.signatures.push(signed.signature)
           this.signed.push(signerKey.addr)
@@ -649,6 +687,7 @@ export class SignMessageController
    */
   cancelSignReq() {
     this.statuses.sign = 'INITIAL'
+    this.hardwareWalletSigningRequest = null
     this.emitUpdate()
   }
 

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -36,9 +36,15 @@ import {
   sortSigs
 } from '../../libs/safe/safe'
 import {
+  getEIP712SigningRequest,
+  getSigningRequestDisplayData
+} from '../../libs/signingRequest/signingRequest'
+import {
   getAppFormatted,
+  getEIP712Hash,
   getEIP712Signature,
   getPlainTextSignature,
+  getSafeMessageTypedData,
   getVerifyMessageSignature,
   verifyMessage
 } from '../../libs/signMessage/signMessage'
@@ -88,6 +94,8 @@ export class SignMessageController
   humanizedMessage?: IrMessage
 
   isHumanizing = false
+
+  safeEip712Data: unknown | null = null
 
   signedMessage: SignedMessage | null = null
 
@@ -196,6 +204,7 @@ export class SignMessageController
       }
 
       if (this.#account.safeCreation) {
+        this.#updateSafeEip712Data()
         const notSigned = getImportedSignersThatHaveNotSigned(
           this.signed,
           accountState.importedAccountKeys.map((k) => k.addr)
@@ -236,6 +245,7 @@ export class SignMessageController
     this.messageToSign = null
     this.humanizedMessage = undefined
     this.isHumanizing = false
+    this.safeEip712Data = null
     this.signedMessage = null
     this.#account = undefined
     this.network = undefined
@@ -244,6 +254,36 @@ export class SignMessageController
     this.signer = undefined
     this.status = SignMessageStatus.Initial
     this.emitUpdate()
+  }
+
+  #updateSafeEip712Data() {
+    if (!this.#account?.safeCreation || !this.messageToSign || !this.network) {
+      this.safeEip712Data = null
+      return
+    }
+
+    const { content } = this.messageToSign
+
+    try {
+      const message = content.kind === 'typedMessage' ? content : content.message
+      const typedData = getSafeMessageTypedData(
+        message,
+        this.network.chainId,
+        this.#account.addr as Hex
+      )
+      const safeMessageHash = getEIP712Hash(typedData)
+
+      this.safeEip712Data = getSigningRequestDisplayData(
+        getEIP712SigningRequest({ ...typedData, safeMessageHash })
+      )
+    } catch (error) {
+      this.safeEip712Data = null
+      this.emitError({
+        message: 'Error calculating Safe EIP-712 data',
+        error: error instanceof Error ? error : new Error(String(error)),
+        level: 'silent'
+      })
+    }
   }
 
   #startHumanization() {

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -496,17 +496,10 @@ export async function getPlainTextSignature(
 
   if (!!account.safeCreation) {
     // Safe always signs a typed data, even if plain sig
-    const typedData = getSafeTypedDataForIsValidSignature(
-      network.chainId,
-      account.addr as Hex,
-      hashMessage(getBytes(messageHex))
-    )
+    const typedData = getSafeMessageTypedData(messageHex, network.chainId, account.addr as Hex)
     return {
       signature: (await signer.signTypedData(typedData)) as Hex,
-      hash: `0x${TypedDataUtils.eip712Hash(
-        adaptTypedMessageForMetaMaskSigUtil({ ...typedData }),
-        SignTypedDataVersion.V4
-      ).toString('hex')}`
+      hash: getEIP712Hash(typedData)
     }
   }
 
@@ -574,20 +567,10 @@ export async function getEIP712Signature(
 
   if (!!account.safeCreation) {
     // Safe wraps the EIP-712 message in it's own EIP-712
-    const typedData = getSafeTypedDataForIsValidSignature(
-      network.chainId,
-      account.addr as Hex,
-      `0x${TypedDataUtils.eip712Hash(
-        adaptTypedMessageForMetaMaskSigUtil({ ...message }),
-        SignTypedDataVersion.V4
-      ).toString('hex')}`
-    )
+    const typedData = getSafeMessageTypedData(message, network.chainId, account.addr as Hex)
     return {
       signature: (await signer.signTypedData(typedData)) as Hex,
-      hash: `0x${TypedDataUtils.eip712Hash(
-        adaptTypedMessageForMetaMaskSigUtil({ ...typedData }),
-        SignTypedDataVersion.V4
-      ).toString('hex')}`
+      hash: getEIP712Hash(typedData)
     }
   }
 
@@ -856,3 +839,22 @@ export const getSafeTypedDataForIsValidSignature = (
     primaryType: 'SafeMessage'
   }
 }
+
+export const getEIP712Hash = (typedData: TypedMessageUserRequest['meta']['params']): Hex =>
+  `0x${TypedDataUtils.eip712Hash(
+    adaptTypedMessageForMetaMaskSigUtil({ ...typedData }),
+    SignTypedDataVersion.V4
+  ).toString('hex')}`
+
+export const getSafeMessageTypedData = (
+  message:
+    | PlainTextMessageUserRequest['meta']['params']['message']
+    | TypedMessageUserRequest['meta']['params'],
+  chainId: bigint,
+  safeAddr: Hex
+): TypedMessageUserRequest['meta']['params'] =>
+  getSafeTypedDataForIsValidSignature(
+    chainId,
+    safeAddr,
+    typeof message === 'string' ? hashMessage(getBytes(message)) : getEIP712Hash(message)
+  )

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -27,6 +27,7 @@ import { Hex } from '../../interfaces/hex'
 import { KeystoreSignerInterface } from '../../interfaces/keystore'
 import { Network } from '../../interfaces/network'
 import { SafeTx } from '../../interfaces/safe'
+import type { HardwareWalletSigningRequest } from '../../interfaces/signAccountOp'
 import { EIP7702Signature } from '../../interfaces/signatures'
 import { PlainTextMessageUserRequest, TypedMessageUserRequest } from '../../interfaces/userRequest'
 import isSameAddr from '../../utils/isSameAddr'
@@ -96,6 +97,17 @@ interface AmbireReadableOperation {
   nonce: bigint
   calls: { to: Hex; value: bigint; data: Hex }[]
 }
+
+type WithHardwareWalletSigningRequest = <T>(
+  request: HardwareWalletSigningRequest,
+  sign: () => Promise<T>
+) => Promise<T>
+
+const signWithHardwareWalletSigningRequest = <T>(
+  request: HardwareWalletSigningRequest,
+  sign: () => Promise<T>,
+  withHardwareWalletSigningRequest?: WithHardwareWalletSigningRequest
+) => (withHardwareWalletSigningRequest ? withHardwareWalletSigningRequest(request, sign) : sign())
 
 export const adaptTypedMessageForMetaMaskSigUtil = (
   typedMessage: TypedMessageUserRequest['meta']['params']
@@ -490,7 +502,8 @@ export async function getPlainTextSignature(
   account: Account,
   accountState: AccountOnchainState,
   signer: KeystoreSignerInterface,
-  isOG = false
+  isOG = false,
+  withHardwareWalletSigningRequest?: WithHardwareWalletSigningRequest
 ): Promise<{ signature: Hex; hash?: Hex }> {
   const dedicatedToOneSA = signer.key.dedicatedToOneSA
 
@@ -498,12 +511,23 @@ export async function getPlainTextSignature(
     // Safe always signs a typed data, even if plain sig
     const typedData = getSafeMessageTypedData(messageHex, network.chainId, account.addr as Hex)
     return {
-      signature: (await signer.signTypedData(typedData)) as Hex,
+      signature: (await signWithHardwareWalletSigningRequest(
+        { type: 'eip-712', data: typedData },
+        () => signer.signTypedData(typedData),
+        withHardwareWalletSigningRequest
+      )) as Hex,
       hash: getEIP712Hash(typedData)
     }
   }
 
-  if (!account.creation) return { signature: (await signer.signMessage(messageHex)) as Hex }
+  if (!account.creation)
+    return {
+      signature: (await signWithHardwareWalletSigningRequest(
+        { type: 'message', data: { message: messageHex } },
+        () => signer.signMessage(messageHex),
+        withHardwareWalletSigningRequest
+      )) as Hex
+    }
 
   if (!accountState.isV2) {
     const lowercaseHexAddrWithout0x = hexlify(toUtf8Bytes(account.addr.toLowerCase().slice(2)))
@@ -528,12 +552,28 @@ export async function getPlainTextSignature(
       )
     }
 
-    return { signature: wrapUnprotected(await signer.signMessage(messageHex)) as Hex }
+    return {
+      signature: wrapUnprotected(
+        await signWithHardwareWalletSigningRequest(
+          { type: 'message', data: { message: messageHex } },
+          () => signer.signMessage(messageHex),
+          withHardwareWalletSigningRequest
+        )
+      ) as Hex
+    }
   }
 
   // if it's safe, we proceed
   if (dedicatedToOneSA) {
-    return { signature: wrapUnprotected(await signer.signMessage(messageHex)) as Hex }
+    return {
+      signature: wrapUnprotected(
+        await signWithHardwareWalletSigningRequest(
+          { type: 'message', data: { message: messageHex } },
+          () => signer.signMessage(messageHex),
+          withHardwareWalletSigningRequest
+        )
+      ) as Hex
+    }
   }
 
   // in case of only_standard priv key, we transform the data
@@ -543,7 +583,15 @@ export async function getPlainTextSignature(
   // could be phishing him into approving an Ambire Op without him
   // knowing
   const typedData = getTypedData(network!.chainId, account.addr, hashMessage(getBytes(messageHex)))
-  return { signature: wrapStandard(await signer.signTypedData(typedData)) as Hex }
+  return {
+    signature: wrapStandard(
+      await signWithHardwareWalletSigningRequest(
+        { type: 'eip-712', data: typedData },
+        () => signer.signTypedData(typedData),
+        withHardwareWalletSigningRequest
+      )
+    ) as Hex
+  }
 }
 
 export async function getEIP712Signature(
@@ -552,7 +600,8 @@ export async function getEIP712Signature(
   accountState: AccountOnchainState,
   signer: KeystoreSignerInterface,
   network: Network,
-  isOG = false
+  isOG = false,
+  withHardwareWalletSigningRequest?: WithHardwareWalletSigningRequest
 ): Promise<{ signature: Hex; hash?: Hex }> {
   if (!message.types.EIP712Domain) {
     throw new Error(
@@ -569,12 +618,23 @@ export async function getEIP712Signature(
     // Safe wraps the EIP-712 message in it's own EIP-712
     const typedData = getSafeMessageTypedData(message, network.chainId, account.addr as Hex)
     return {
-      signature: (await signer.signTypedData(typedData)) as Hex,
+      signature: (await signWithHardwareWalletSigningRequest(
+        { type: 'eip-712', data: typedData },
+        () => signer.signTypedData(typedData),
+        withHardwareWalletSigningRequest
+      )) as Hex,
       hash: getEIP712Hash(typedData)
     }
   }
 
-  if (!account.creation) return { signature: (await signer.signTypedData(message)) as Hex }
+  if (!account.creation)
+    return {
+      signature: (await signWithHardwareWalletSigningRequest(
+        { type: 'eip-712', data: message },
+        () => signer.signTypedData(message),
+        withHardwareWalletSigningRequest
+      )) as Hex
+    }
 
   if (!accountState.isV2) {
     const asString = JSON.stringify(message).toLowerCase()
@@ -597,7 +657,15 @@ export async function getEIP712Signature(
       )
     }
 
-    return { signature: wrapUnprotected(await signer.signTypedData(message)) as Hex }
+    return {
+      signature: wrapUnprotected(
+        await signWithHardwareWalletSigningRequest(
+          { type: 'eip-712', data: message },
+          () => signer.signTypedData(message),
+          withHardwareWalletSigningRequest
+        )
+      ) as Hex
+    }
   }
 
   // we do not allow signers who are not dedicated to one account to sign eip-712
@@ -626,11 +694,25 @@ export async function getEIP712Signature(
       )
     )
     const ambireOperation = getTypedData(ambireReadableOperation.chainId, account.addr, hash)
-    const signature = wrapStandard(await signer.signTypedData(ambireOperation))
+    const signature = wrapStandard(
+      await signWithHardwareWalletSigningRequest(
+        { type: 'eip-712', data: ambireOperation },
+        () => signer.signTypedData(ambireOperation),
+        withHardwareWalletSigningRequest
+      )
+    )
     return { signature: wrapWallet(signature, account.addr) as Hex }
   }
 
-  return { signature: wrapUnprotected(await signer.signTypedData(message)) as Hex }
+  return {
+    signature: wrapUnprotected(
+      await signWithHardwareWalletSigningRequest(
+        { type: 'eip-712', data: message },
+        () => signer.signTypedData(message),
+        withHardwareWalletSigningRequest
+      )
+    ) as Hex
+  }
 }
 
 // get the typedData for the first ERC-4337 deploy txn

--- a/src/libs/signingRequest/signingRequest.test.ts
+++ b/src/libs/signingRequest/signingRequest.test.ts
@@ -1,0 +1,48 @@
+import { TypedDataEncoder, ZeroAddress } from 'ethers'
+
+import { describe, expect, test } from '@jest/globals'
+
+import { Hex } from '../../interfaces/hex'
+import { SafeTx } from '../../interfaces/safe'
+import { getSafeTxnHash } from '../safe/safe'
+import { getSafeTypedData } from '../signMessage/signMessage'
+import { getEIP712SigningRequest, getSigningRequestDisplayData } from './signingRequest'
+
+const safeAddr = '0x1111111111111111111111111111111111111111' as Hex
+const safeTxn: SafeTx = {
+  to: '0x2222222222222222222222222222222222222222',
+  value: '0x01',
+  data: '0x',
+  operation: 0,
+  safeTxGas: '0x00',
+  baseGas: '0x00',
+  gasPrice: '0x00',
+  gasToken: ZeroAddress as Hex,
+  refundReceiver: ZeroAddress as Hex,
+  nonce: '0x02'
+}
+
+describe('signing request display data', () => {
+  test('includes the Safe transaction and EIP-712 hashes in a serializable preview', () => {
+    const typedData = getSafeTypedData(1n, safeAddr, safeTxn)
+    const safeTxHash = getSafeTxnHash(typedData)
+    const displayData = getSigningRequestDisplayData(
+      getEIP712SigningRequest({ ...typedData, safeTxHash })
+    )
+    const typesWithoutDomain = Object.fromEntries(
+      Object.entries(typedData.types).filter(([typeName]) => typeName !== 'EIP712Domain')
+    )
+
+    expect(displayData).toEqual({
+      ...typedData,
+      safeTxHash,
+      domainHash: TypedDataEncoder.hashDomain(typedData.domain),
+      messageHash: TypedDataEncoder.hashStruct(
+        typedData.primaryType,
+        typesWithoutDomain,
+        typedData.message
+      )
+    })
+    expect(() => JSON.stringify(displayData)).not.toThrow()
+  })
+})

--- a/src/libs/signingRequest/signingRequest.test.ts
+++ b/src/libs/signingRequest/signingRequest.test.ts
@@ -1,11 +1,16 @@
-import { TypedDataEncoder, ZeroAddress } from 'ethers'
+import { getBytes, hashMessage, hexlify, toUtf8Bytes, TypedDataEncoder, ZeroAddress } from 'ethers'
 
 import { describe, expect, test } from '@jest/globals'
 
 import { Hex } from '../../interfaces/hex'
 import { SafeTx } from '../../interfaces/safe'
 import { getSafeTxnHash } from '../safe/safe'
-import { getSafeTypedData } from '../signMessage/signMessage'
+import {
+  getEIP712Hash,
+  getSafeMessageTypedData,
+  getSafeTypedData,
+  getSafeTypedDataForIsValidSignature
+} from '../signMessage/signMessage'
 import { getEIP712SigningRequest, getSigningRequestDisplayData } from './signingRequest'
 
 const safeAddr = '0x1111111111111111111111111111111111111111' as Hex
@@ -44,5 +49,56 @@ describe('signing request display data', () => {
       )
     })
     expect(() => JSON.stringify(displayData)).not.toThrow()
+  })
+
+  test('includes the Safe message and EIP-712 hashes in a serializable preview', () => {
+    const message = hexlify(toUtf8Bytes('Sign me')) as Hex
+    const typedData = getSafeMessageTypedData(message, 1n, safeAddr)
+    const safeMessageHash = getEIP712Hash(typedData)
+    const displayData = getSigningRequestDisplayData(
+      getEIP712SigningRequest({ ...typedData, safeMessageHash })
+    )
+    const typesWithoutDomain = Object.fromEntries(
+      Object.entries(typedData.types).filter(([typeName]) => typeName !== 'EIP712Domain')
+    )
+
+    expect(typedData).toEqual(
+      getSafeTypedDataForIsValidSignature(1n, safeAddr, hashMessage(getBytes(message)))
+    )
+    expect(displayData).toEqual({
+      ...typedData,
+      safeMessageHash,
+      domainHash: TypedDataEncoder.hashDomain(typedData.domain),
+      messageHash: TypedDataEncoder.hashStruct(
+        typedData.primaryType,
+        typesWithoutDomain,
+        typedData.message
+      )
+    })
+    expect(() => JSON.stringify(displayData)).not.toThrow()
+  })
+
+  test('wraps an EIP-712 message in the Safe message typed data', () => {
+    const message = {
+      domain: {
+        chainId: '1',
+        verifyingContract: safeAddr
+      },
+      types: {
+        EIP712Domain: [
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' }
+        ],
+        Message: [{ name: 'contents', type: 'string' }]
+      },
+      message: {
+        contents: 'Sign me'
+      },
+      primaryType: 'Message'
+    }
+
+    expect(getSafeMessageTypedData(message, 1n, safeAddr)).toEqual(
+      getSafeTypedDataForIsValidSignature(1n, safeAddr, getEIP712Hash(message))
+    )
   })
 })


### PR DESCRIPTION
## Summary

Expose the exact EIP-712 data and hashes used when signing Safe transactions and messages.

## Changes

- Add serializable Safe transaction and message previews with:
  - Safe transaction or message hash
  - domain hash
  - message hash
  - full EIP-712 typed data
- Expose previews from `SignAccountOpController` and `SignMessageController`.
- Expose the active signing request while message signing is in progress so hardware wallet UIs can display the exact payload.
- Reuse shared helpers for Safe message typed-data generation and EIP-712 hashing.
- Clear temporary hardware signing data after completion, cancellation, and reset.
- Add coverage for Safe previews, Safe message wrapping, and hardware signing request lifecycle.

## Verification

- [x] `npm run jest -- src/libs/signingRequest/signingRequest.test.ts --runInBand`
- [x] `npm run jest -- src/controllers/signMessage/signMessage.test.ts --runInBand`
- [x] `git diff --check origin/v2...HEAD`