### PR TITLE
Fix: return fallback networks if no other providers work

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -484,7 +484,10 @@ export class MainController extends EventEmitter implements IMainController {
       storage: this.storage,
       phishing: this.phishing,
       dapps: this.dapps,
-      swapProvider: new SwapProviderParallelExecutor([LiFiProvider, SocketProvider, SquidProvider]),
+      swapProvider: new SwapProviderParallelExecutor(
+        [LiFiProvider, SocketProvider, SquidProvider],
+        () => this.networks.networks.map((network) => ({ chainId: Number(network.chainId) }))
+      ),
       relayerUrl,
       portfolioUpdate: (chainsToUpdate: Network['chainId'][]) => {
         if (chainsToUpdate.length) {

--- a/src/services/swapIntegrators/swapProviderParallelExecutor.test.ts
+++ b/src/services/swapIntegrators/swapProviderParallelExecutor.test.ts
@@ -12,12 +12,53 @@ const lifiApi = new LiFiAPI({ fetch, apiKey: '' })
 const swapProviderParallelExecutor = new SwapProviderParallelExecutor([socketApi, lifiApi])
 
 describe('Swap Provider Parallel execution', () => {
+  const createProvider = (getSupportedChains: SwapProvider['getSupportedChains']) =>
+    ({
+      id: 'test-provider',
+      name: 'Test Provider',
+      isHealthy: null,
+      supportedChains: null,
+      updateHealth: jest.fn(),
+      resetHealth: jest.fn(),
+      getSupportedChains,
+      getToTokenList: jest.fn(),
+      getToken: jest.fn(),
+      startRoute: jest.fn(),
+      quote: jest.fn(),
+      getRouteStatus: jest.fn()
+    } as unknown as SwapProvider)
+
   it('Fetch chains successfully and make sure there are no duplicates', async () => {
     const chainIds = await swapProviderParallelExecutor.getSupportedChains()
     const ids = chainIds.map((item) => item.chainId)
     const uniqueIds = new Set(ids)
     expect(uniqueIds.size).toBe(ids.length)
   })
+
+  it('Falls back to active networks when supported chains are fewer than 10', async () => {
+    const provider = createProvider(async () => [{ chainId: 1 }])
+    const fallbackSupportedChains = [{ chainId: 1 }, { chainId: 10 }, { chainId: 137 }]
+    const executor = new SwapProviderParallelExecutor([provider], () => fallbackSupportedChains)
+
+    await expect(executor.getSupportedChains()).resolves.toEqual(fallbackSupportedChains)
+  })
+
+  it('Times out supported chains requests after 10 seconds', async () => {
+    jest.useFakeTimers()
+
+    try {
+      const provider = createProvider(() => new Promise(() => {}))
+      const fallbackSupportedChains = [{ chainId: 1 }]
+      const executor = new SwapProviderParallelExecutor([provider], () => fallbackSupportedChains)
+      const supportedChainsPromise = executor.getSupportedChains()
+
+      await jest.advanceTimersByTimeAsync(10000)
+      await expect(supportedChainsPromise).resolves.toEqual(fallbackSupportedChains)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   it('Fetch to token list successfully and make sure there are no duplicate tokens', async () => {
     const toTokenList = await swapProviderParallelExecutor.getToTokenList({
       fromChainId: 10,

--- a/src/services/swapIntegrators/swapProviderParallelExecutor.ts
+++ b/src/services/swapIntegrators/swapProviderParallelExecutor.ts
@@ -11,6 +11,8 @@ import {
 } from '../../interfaces/swapAndBridge'
 import wait, { waitWithAbort } from '../../utils/wait'
 
+const GET_SUPPORTED_CHAINS_TIMEOUT = 10000
+
 export class SwapProviderParallelExecutor {
   id: string = 'parallel'
 
@@ -20,11 +22,17 @@ export class SwapProviderParallelExecutor {
 
   #providers: SwapProvider[]
 
+  #getFallbackSupportedChains?: () => SwapAndBridgeSupportedChain[]
+
   // Added for compatibility with the type
   supportedChains: SwapProvider['supportedChains'] = []
 
-  constructor(providers: SwapProvider[]) {
+  constructor(
+    providers: SwapProvider[],
+    getFallbackSupportedChains?: () => SwapAndBridgeSupportedChain[]
+  ) {
     this.#providers = providers
+    this.#getFallbackSupportedChains = getFallbackSupportedChains
   }
 
   /**
@@ -184,15 +192,40 @@ export class SwapProviderParallelExecutor {
     return (provider[method] as any)(...args)
   }
 
+  async #getSupportedChainsWithTimeout(
+    provider: SwapProvider
+  ): Promise<SwapAndBridgeSupportedChain[] | Error> {
+    const waitPromise = waitWithAbort(GET_SUPPORTED_CHAINS_TIMEOUT)
+
+    try {
+      return await Promise.race([
+        provider.getSupportedChains().catch((e) => e),
+        waitPromise.promise.then(() => new Error('Get supported chains timeout'))
+      ])
+    } finally {
+      if (waitPromise.abort) waitPromise.abort()
+    }
+  }
+
   async getSupportedChains(): Promise<SwapAndBridgeSupportedChain[]> {
-    const chainIds = await this.#fetchFromAll<SwapAndBridgeSupportedChain[]>(
-      (provider: SwapProvider) => provider.getSupportedChains().catch((e) => e)
+    const promises = this.#providers.map((provider: SwapProvider) =>
+      this.#getSupportedChainsWithTimeout(provider)
     )
+    const fetchResults = await Promise.all(promises)
+    const chainIds = fetchResults
+      .filter((r): r is SwapAndBridgeSupportedChain[] => !(r instanceof Error))
+      .flat()
 
     // filter duplicates
-    return [
+    const uniqueChainIds = [
       ...new Map(chainIds.map((item: SwapAndBridgeSupportedChain) => [item.chainId, item])).values()
     ]
+
+    if (uniqueChainIds.length < 10 && this.#getFallbackSupportedChains) {
+      return this.#getFallbackSupportedChains()
+    }
+
+    return uniqueChainIds
   }
 
   async getToTokenList({


### PR DESCRIPTION
We add a 10s timeout for each provider to return its supported networks. After, we give the fallback networks if they are < 10