### PR TITLE
Banners/ requirments for all, not only surveys

### DIFF
--- a/src/controllers/banner/banner.test.ts
+++ b/src/controllers/banner/banner.test.ts
@@ -7,7 +7,7 @@ import { Banner } from '../../interfaces/banner'
 import { StorageController } from '../storage/storage'
 import { ANSWERED_SURVEYS_STORAGE_KEY, SurveyController } from '../survey/survey'
 import { UiController } from '../ui/ui'
-import { BannerController } from './banner'
+import { AccountData, BannerController } from './banner'
 
 const prepareTest = async () => {
   const storage = new StorageController(produceMemoryStore())
@@ -18,7 +18,8 @@ const prepareTest = async () => {
     fetch: fetch as any,
     relayerUrl: '',
     storage,
-    ui: new UiController({ uiManager })
+    ui: new UiController({ uiManager }),
+    dismissBanner: () => {}
   })
   const bannersCtrl = new BannerController(
     storage,
@@ -54,40 +55,36 @@ describe('BannerController', () => {
     expect(controller.bannersData.banners).toHaveLength(1)
     expect(controller.bannersData.banners[0]!.id).toBe('test-banner')
   })
-  it('should add a banner', async () => {
-    const { bannersCtrl: controller, surveyCtrl } = await prepareTest()
+  it('should enforce requirements', async () => {
+    const { bannersCtrl: controller } = await prepareTest()
     ;[
       {
         id: 'test-banner1',
         title: 'Test Banner',
         type: 'info',
-        actions: [
-          { actionName: 'survey', meta: { surveyId: '', requirements: { maxBalanceTotal: 9 } } }
-        ]
+        actions: [{ actionName: 'survey', meta: { surveyId: '' } }],
+        meta: { requirements: { maxBalanceTotal: 9 } }
       } as Banner,
       {
         id: 'test-banner2',
         title: 'Test Banner',
         type: 'info',
-        actions: [
-          { actionName: 'survey', meta: { surveyId: '', requirements: { minBalanceTotal: 11 } } }
-        ]
+        actions: [{ actionName: 'survey', meta: { surveyId: '' } }],
+        meta: { requirements: { minBalanceTotal: 11 } }
       } as Banner,
       {
         id: 'test-banner3',
         title: 'Test Banner',
         type: 'info',
-        actions: [
-          { actionName: 'survey', meta: { surveyId: '', requirements: { minTxnsTotal: 11 } } }
-        ]
+        actions: [{ actionName: 'survey', meta: { surveyId: '' } }],
+        meta: { requirements: { minTxnsTotal: 11 } }
       } as Banner,
       {
         id: 'test-banner4',
         title: 'Test Banner',
         type: 'info',
-        actions: [
-          { actionName: 'survey', meta: { surveyId: '', requirements: { minTxnsTotal: 11 } } }
-        ]
+        actions: [{ actionName: 'survey', meta: { surveyId: '' } }],
+        meta: { requirements: { minTxnsTotal: 11 } }
       } as Banner
     ].forEach((banner: Banner) => {
       controller.addBanner(banner)
@@ -102,16 +99,18 @@ describe('BannerController', () => {
         {
           actionName: 'survey',
           meta: {
-            surveyId: '',
-            requirements: {
-              minTxnsTotal: 9,
-              maxTxnsTotal: 10,
-              minBalanceTotal: 9,
-              maxBalanceTotal: 11
-            }
+            surveyId: ''
           }
         }
-      ]
+      ],
+      meta: {
+        requirements: {
+          minTxnsTotal: 9,
+          maxTxnsTotal: 10,
+          minBalanceTotal: 9,
+          maxBalanceTotal: 11
+        }
+      }
     })
     expect(controller.bannersData.banners).toHaveLength(1)
   })
@@ -198,6 +197,60 @@ describe('BannerController', () => {
     controller.addBanner(banner)
 
     expect(controller.bannersData.banners).toHaveLength(0) // Should be removed due to expiration
+  })
+  it('should display a banner regardless of keys when shouldHaveKeys requirement is not given', async () => {
+    const accData: AccountData = {
+      status: 'has-selected-account',
+      address: ZeroAddress,
+      hasKeys: false,
+      numberOfTransactions: 10,
+      totalUsdBalance: 10,
+      isBalanceReady: true
+    }
+    const storage = new StorageController(produceMemoryStore())
+    const { uiManager } = mockUiManager()
+    const surveyCtrl = new SurveyController({
+      fetch: fetch as any,
+      relayerUrl: '',
+      storage,
+      ui: new UiController({ uiManager }),
+      dismissBanner: () => {}
+    })
+    const bannersCtrl = new BannerController(
+      storage,
+      () => {
+        return accData
+      },
+      surveyCtrl,
+      '1.0.0'
+    )
+    await bannersCtrl.initialLoadPromise
+
+    const banners: Banner[] = [
+      {
+        id: 'no-keys-requirement-banner',
+        title: 'No Keys Requirement Banner',
+        type: 'info',
+        actions: []
+      },
+      {
+        id: 'has-keys-requirement-banner',
+        title: 'No Keys Requirement Banner',
+        type: 'info',
+        actions: [],
+        meta: { requirements: { shouldHaveKeys: true } }
+      }
+    ]
+    bannersCtrl.addBanner(banners[0]!)
+    expect(bannersCtrl.bannersData.banners).toHaveLength(1)
+    await bannersCtrl.dismissBanner(banners[0]!.id)
+
+    bannersCtrl.addBanner(banners[1]!)
+    expect(bannersCtrl.bannersData.banners).toHaveLength(0)
+    accData.hasKeys = true
+    expect(bannersCtrl.bannersData.banners).toHaveLength(1)
+
+    await bannersCtrl.dismissBanner(banners[1]!.id)
   })
   it('should not add a dismissed banner', async () => {
     const { bannersCtrl: controller } = await prepareTest()

--- a/src/controllers/banner/banner.ts
+++ b/src/controllers/banner/banner.ts
@@ -74,23 +74,27 @@ export class BannerController extends EventEmitter implements IBannerController 
     this.emitUpdate()
   }
 
-  #notSurveyOrValidSurvey(banner: Banner, accData: AccountData) {
-    if (!banner.actions || !banner.actions[0]) return true
-    let action = banner.actions[0]
-    // if not survey return it
-    if (action.actionName !== 'survey') return true
+  #shouldShowBanner(banner: Banner, accData: AccountData) {
+    // when survey, enforce survey controller data to be loaded
+    if (banner.actions?.[0]?.actionName === 'survey') {
+      if (!this.#survey.isReady) return false
+      if (this.#survey.isSurveyAnswered(banner.actions[0].meta.surveyId)) return false
+    }
+
+    if (accData.status === 'no-selected-account') return false
+
     const {
       minBalanceTotal,
       maxBalanceTotal,
       minTxnsTotal,
       maxTxnsTotal,
       minAppVersion,
-      whitelistedAddresses
-    } = action.meta.requirements
-    // do not display surveys when there is no selected acc
-    if (accData.status === 'no-selected-account') return false
+      whitelistedAddresses,
+      shouldHaveKeys
+    } = banner.meta?.requirements || {}
+
     if (whitelistedAddresses && !whitelistedAddresses.includes(accData.address)) return false
-    if (!accData.hasKeys) return false
+    if (shouldHaveKeys && !accData.hasKeys) return false
     if (
       minBalanceTotal !== undefined &&
       (accData.totalUsdBalance < minBalanceTotal || !accData.isBalanceReady)
@@ -107,9 +111,6 @@ export class BannerController extends EventEmitter implements IBannerController 
     if (minTxnsTotal !== undefined && accData.numberOfTransactions < minTxnsTotal) return false
     if (maxTxnsTotal !== undefined && accData.numberOfTransactions > maxTxnsTotal) return false
     if (minAppVersion && this.#appVersion < minAppVersion) return false
-    if (!this.#survey.isReady) return false
-
-    if (this.#survey.isSurveyAnswered(action.meta.surveyId)) return false
 
     return true
   }
@@ -127,10 +128,9 @@ export class BannerController extends EventEmitter implements IBannerController 
   get bannersData(): { banners: Banner[]; account: string | null } {
     // Always return one banner at a time
     const accData = this.#getAccountData()
-
     return {
       banners: this.#getValidBanners(this.#banners)
-        .filter((b) => this.#notSurveyOrValidSurvey(b, accData))
+        .filter((b) => this.#shouldShowBanner(b, accData))
         .slice(0, this.maxBannerCount),
       account: accData.status === 'has-selected-account' ? accData.address : null
     }

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -988,7 +988,7 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           ? [
               {
                 actionName: 'survey',
-                meta: { surveyId: banner.surveyId, requirements: banner.require || {} }
+                meta: { surveyId: banner.surveyId }
               }
             ]
           : banner.url
@@ -1012,7 +1012,8 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         type: banner.type || 'updates',
         meta: {
           startTime: startTimeNumber,
-          endTime: endTimeNumber
+          endTime: endTimeNumber,
+          requirements: banner.require
         },
         ...(banner.text && { text: banner.text }),
         ...(banner.title && { title: banner.title }),

--- a/src/interfaces/banner.ts
+++ b/src/interfaces/banner.ts
@@ -19,6 +19,16 @@ export type BannerCategory =
   | 'temp-seed-not-confirmed'
   | 'old-account'
 
+interface BannerRequirements {
+  minBalanceTotal?: number
+  maxBalanceTotal?: number
+  minTxnsTotal?: number
+  maxTxnsTotal?: number
+  minAppVersion?: string
+  whitelistedAddresses?: string[]
+  shouldHaveKeys?: boolean
+}
+
 export interface Banner {
   id: number | string
   type: BannerType | MarketingBannerTypes
@@ -32,6 +42,7 @@ export interface Banner {
     accountAddr?: string
     startTime?: number
     endTime?: number
+    requirements?: BannerRequirements
     [key: string]: any
   }
 }
@@ -109,20 +120,7 @@ export type Action = (
       actionName: 'dismiss-defi-positions-banner'
     }
   | { actionName: 'open-link'; meta: { url: string } }
-  | {
-      actionName: 'survey'
-      meta: {
-        surveyId: string
-        requirements: {
-          minBalanceTotal?: number
-          maxBalanceTotal?: number
-          minTxnsTotal?: number
-          maxTxnsTotal?: number
-          minAppVersion?: string
-          whitelistedAddresses?: string[]
-        }
-      }
-    }
+  | { actionName: 'survey'; meta: { surveyId: string } }
 ) & {
   label?: string
 }


### PR DESCRIPTION
requires: https://github.com/AmbireTech/relayer/pull/1812

## Meaningful changes:
- normal marketing banners will get displayed depending on requirements from the backend, just like the surveys
- All surveys will be visible, regardless of user keys, just like marketing banners, except when the backend requests keys 

## To test
- Use staging relayer
- There will be 1 banner for everybody - should be visible to all accs
- 1 banner only for users with keys - not visible to all accs
- 1 banner only for vitalik.eth, regardless of keys

## TODO
 - [ ] deploy prod