### PR TITLE
Fix/ `defiApps` `getTotal` always returns 0

### DIFF
--- a/src/libs/portfolio/helpers.test.ts
+++ b/src/libs/portfolio/helpers.test.ts
@@ -276,6 +276,13 @@ describe('Portfolio helpers', () => {
 
       expect(total.usd).toBe(150.05)
     })
+    it('Returns the defi total when there are no tokens', () => {
+      const defiState = structuredClone(PORTFOLIO_STATE['1']?.result?.defiPositions!)
+
+      const total = getTotal([], defiState)
+
+      expect(total.usd).toBeGreaterThan(0)
+    })
   })
   describe('getHintsError', () => {
     it('NoApiHintsError is returned if there are no previous hints', () => {

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -571,6 +571,12 @@ export const getTotal = (
     )
   }
 
+  // In case the user doesn't have any tokens or the function is calculating for the custom
+  // network `defiApps` that doesn't have any tokens
+  if (!Object.keys(tokensTotal).length && Object.keys(defiTotal).length > 0) {
+    return defiTotal
+  }
+
   return Object.keys(tokensTotal).reduce((cur, key) => {
     // eslint-disable-next-line no-param-reassign
     cur[key] = (tokensTotal[key] || 0) + (defiTotal[key] || 0)


### PR DESCRIPTION
Very simple - defi apps don't have tokens and `Object.keys(tokensTotal)` had no effect

## How to reproduce:
1. Add an account with a polymarket/hyperliquid position
2. Compare the balance to debank `https://debank.com/profile/ADDR`
3. DM me for an address if you need one