### PR TITLE
Fixes/clear signing cases

### DIFF
--- a/src/libs/humanizer/erc7730/humanize.ts
+++ b/src/libs/humanizer/erc7730/humanize.ts
@@ -1,7 +1,6 @@
 import {
   formatUnits,
   FunctionFragment,
-  getAddress,
   Interface,
   isAddress,
   isHexString,
@@ -15,17 +14,17 @@ import { Message } from '../../../interfaces/userRequest'
 import { AccountOp } from '../../accountOp/accountOp'
 import { Call } from '../../accountOp/types'
 import {
+  HumanizerCallModule,
   HumanizerErc7730Row,
   HumanizerErc7730Visualization,
-  HumanizerCallModule,
   HumanizerMeta,
   HumanizerVisualization,
   HumanizerWarning,
   IrCall,
   IrMessage
 } from '../interfaces'
-import AllowanceModule, { getSetAllowanceResetText } from '../modules/Allowance'
 import { aaveHumanizer } from '../modules/Aave'
+import AllowanceModule, { getSetAllowanceResetText } from '../modules/Allowance'
 import { decodeGeneralAdapterCall } from '../modules/Bundler3/generalAdapter'
 import { getDelegateCallWarning, getSafeHumanization } from '../modules/Safe'
 import { genericErc20Humanizer } from '../modules/Tokens'
@@ -37,7 +36,6 @@ import {
   getText,
   getToken
 } from '../utils'
-import { getAbiBytesCalldataWithPadding, multiSendInterface } from './calldata'
 import { SAFE_TX_PRIMARY_TYPE } from './consts'
 import { getEip712EncodeType, getEip712EncodeTypeHashFromString } from './eip712'
 import {
@@ -671,7 +669,7 @@ const getCalldataRows = (
   const amountValues = resolveCalldataParam(field, context, base, 'amountPath', 'amount')
   const accountAddr = resolvePath('#.@.accountAddr', context, context.root)
   const nestedRowLabel =
-    field.label?.trim().toLowerCase() === 'call' ? '' : field.label ?? field.path ?? ''
+    field.label?.trim().toLowerCase() === 'call' ? '' : (field.label ?? field.path ?? '')
 
   return values.reduce<HumanizerErc7730Row[] | null>((acc, calldata, index) => {
     if (!acc) return null
@@ -895,41 +893,6 @@ const getSafeTxCallFromMessage = (message: Message): Call | null => {
   }
 }
 
-const getSafeTxRejectTitle = (message: Message): string | null => {
-  if (message.content.kind !== 'typedMessage') return null
-  if (message.content.primaryType !== SAFE_TX_PRIMARY_TYPE) return null
-
-  const { to, value, data, operation, nonce } = message.content.message
-  const { verifyingContract } = message.content.domain
-  if (nonce === undefined) return null
-  if (typeof to !== 'string' || !isAddress(to)) return null
-  if (typeof verifyingContract !== 'string' || !isAddress(verifyingContract)) return null
-  if (getAddress(to) !== getAddress(verifyingContract)) return null
-  if (toBigIntOrNull(operation ?? 0) !== 0n) return null
-  if (toBigIntOrNull(value ?? 0) !== 0n) return null
-  if (typeof data !== 'string' || data.toLowerCase() !== '0x') return null
-
-  return `Reject Safe transaction with nonce ${valueToText(nonce)}`
-}
-
-const replaceErc7730Title = (
-  fullVisualization: HumanizerVisualization[] | null,
-  title: string | null
-): HumanizerVisualization[] | null => {
-  if (!title) return fullVisualization
-
-  return (
-    fullVisualization?.map((visualization) =>
-      visualization.type === 'erc7730'
-        ? {
-            ...visualization,
-            title
-          }
-        : visualization
-    ) || null
-  )
-}
-
 const getKnownFunctionName = (call: Call): string | null => {
   const selector = call.data?.slice(0, 10).toLowerCase()
   if (!selector) return null
@@ -1041,14 +1004,12 @@ const getSafeCallFallbackVisualization = (
         ? { ...visualization, content: String(visualization.content) }
         : visualization
     )
-  const rows: HumanizerErc7730Row[] = value.length
-    ? [
-        {
-          label: action.content,
-          value
-        }
-      ]
-    : []
+  const rows: HumanizerErc7730Row[] = [
+    {
+      label: action.content,
+      value: value.length || !call.to ? value : [getAddressVisualization(call.to)]
+    }
+  ]
   if (!rows.length) return null
 
   const visualization = getErc7730Visualization(action.content, rows)
@@ -1360,12 +1321,11 @@ export const humanizeMessageWithErc7730 = (
     fullVisualization && message.content.primaryType === SAFE_TX_PRIMARY_TYPE
       ? replaceSafeTxTransactionRow(fullVisualization, message, chainId, resolvedDescriptor)
       : fullVisualization
-  const titledVisualization = replaceErc7730Title(safeTxVisualization, getSafeTxRejectTitle(message))
 
-  return titledVisualization?.length
+  return safeTxVisualization?.length
     ? {
         ...message,
-        fullVisualization: titledVisualization,
+        fullVisualization: safeTxVisualization,
         warnings: getSafeTxMessageWarnings(message),
         canHideDropdownArrow: true
       }

--- a/src/libs/humanizer/erc7730/humanize.ts
+++ b/src/libs/humanizer/erc7730/humanize.ts
@@ -34,7 +34,8 @@ import {
   getChain,
   getErc7730Visualization,
   getText,
-  getToken
+  getToken,
+  uintToAddress
 } from '../utils'
 import { SAFE_TX_PRIMARY_TYPE } from './consts'
 import { getEip712EncodeType, getEip712EncodeTypeHashFromString } from './eip712'
@@ -70,6 +71,7 @@ type VisibilityResult = {
 
 const MAX_INTERPOLATED_VALUE_LENGTH = 80
 const MAX_NESTED_CALLDATA_DEPTH = 4
+const ABI_WORD_HEX_LENGTH = 64
 
 const isMapReference = (value: unknown): value is Erc7730MapReference =>
   isPlainObject(value) && typeof value.map === 'string' && typeof value.keyPath === 'string'
@@ -128,6 +130,15 @@ const getPathSegments = (path: string): string[] => {
 const normalizeSegmentIndex = (index: number, length: number): number =>
   index < 0 ? length + index : index
 
+const bigintToAbiWordHex = (value: bigint): string | null => {
+  if (value < 0n) return null
+
+  const hex = value.toString(16)
+  if (hex.length > ABI_WORD_HEX_LENGTH) return null
+
+  return hex.padStart(ABI_WORD_HEX_LENGTH, '0')
+}
+
 const readBracketSegment = (source: unknown, segment: string): unknown => {
   if (!segment.startsWith('[') || !segment.endsWith(']')) return undefined
 
@@ -142,9 +153,17 @@ const readBracketSegment = (source: unknown, segment: string): unknown => {
   }
 
   if (separatorIndex === bracketContent.lastIndexOf(':')) {
-    if (typeof source !== 'string') return undefined
+    const hex =
+      typeof source === 'string'
+        ? source.startsWith('0x')
+          ? source.slice(2)
+          : source
+        : typeof source === 'bigint'
+          ? bigintToAbiWordHex(source)
+          : null
 
-    const hex = source.startsWith('0x') ? source.slice(2) : source
+    if (hex === null) return undefined
+
     if (hex.length % 2 !== 0) return undefined
 
     const startText = bracketContent.slice(0, separatorIndex)
@@ -482,6 +501,15 @@ const getTokenAddressFromField = (
   const tokenAddress = tokenPath ?? tokenParam
 
   if (hasTokenSource && isNativeTokenReference(tokenAddress)) return ZeroAddress
+  if (typeof tokenAddress === 'bigint') {
+    const uintAddress = uintToAddress(tokenAddress)
+
+    return nativeAddresses.some(
+      (address) => eToNative(address).toLowerCase() === eToNative(uintAddress).toLowerCase()
+    )
+      ? ZeroAddress
+      : eToNative(uintAddress)
+  }
   if (typeof tokenAddress !== 'string' || !isAddress(tokenAddress)) return null
 
   return nativeAddresses.some(
@@ -520,7 +548,9 @@ const getEnumValue = (
   if (!isPlainObject(enumDefinition)) return null
 
   const values = isPlainObject(enumDefinition.values) ? enumDefinition.values : enumDefinition
-  const enumValue = values[valueToText(value)]
+  const enumKey =
+    typeof value === 'string' && isHexString(value) ? toBigIntOrNull(value)?.toString() : undefined
+  const enumValue = values[enumKey || valueToText(value)]
 
   return typeof enumValue === 'string' ? enumValue : null
 }
@@ -532,6 +562,8 @@ const formatFieldValue = (
   base: unknown
 ): HumanizerVisualization[] => {
   if (field.format === 'addressName' || field.format === 'interoperableAddressName') {
+    if (typeof value === 'bigint') return [getAddressVisualization(uintToAddress(value))]
+
     return typeof value === 'string' && isAddress(value)
       ? [getAddressVisualization(value)]
       : [getText(valueToText(value))]
@@ -872,6 +904,76 @@ const formatToVisualizations = (
   if (!rows) return null
 
   return [getErc7730Visualization(intent, rows, dapp)]
+}
+
+const isOneInchFillOrderFormat = (formatKey: string, descriptorPath?: string) =>
+  !!descriptorPath?.includes('registry/1inch/') && formatKey.startsWith('fillOrder(')
+
+const getUintAddressValue = (value: unknown): string | null => {
+  if (typeof value === 'bigint') return uintToAddress(value)
+  if (typeof value === 'string' && isAddress(value)) return value
+
+  return null
+}
+
+const getOneInchFillOrderSwapVisualization = (
+  match: DescriptorFormatMatch,
+  context: FormatContext,
+  fullVisualization: HumanizerVisualization[],
+  dapp?: Call['dapp']
+): HumanizerVisualization[] | null => {
+  if (!isOneInchFillOrderFormat(match.formatKey, context.descriptorPath)) return fullVisualization
+
+  const order = match.values.order
+  if (!isPlainObject(order)) return fullVisualization
+
+  const maker = getUintAddressValue(order.maker)
+  const makerAsset = getUintAddressValue(order.makerAsset)
+  const takerAsset = getUintAddressValue(order.takerAsset)
+  const makingAmount = toBigIntOrNull(order.makingAmount)
+  const takingAmount = toBigIntOrNull(order.takingAmount)
+
+  if (!maker || !makerAsset || !takerAsset || makingAmount === null || takingAmount === null) {
+    return fullVisualization
+  }
+
+  const metadata = context.root['@']
+  const accountAddr = isPlainObject(metadata) ? metadata.accountAddr : undefined
+  const isMakerAccount =
+    typeof accountAddr === 'string' && maker.toLowerCase() === accountAddr.toLowerCase()
+  const outgoingToken = isMakerAccount ? makerAsset : takerAsset
+  const outgoingAmount = isMakerAccount ? makingAmount : toBigIntOrNull(match.values.amount)
+  const incomingToken = isMakerAccount ? takerAsset : makerAsset
+  const incomingAmount = isMakerAccount ? takingAmount : makingAmount
+
+  if (outgoingAmount === null) return fullVisualization
+
+  const oneInchVisualization = fullVisualization.find(
+    (visualization): visualization is HumanizerVisualization & HumanizerErc7730Visualization =>
+      visualization.type === 'erc7730'
+  )
+  const additionalRows =
+    oneInchVisualization?.rows.filter(
+      (row) => !row.value.some((value) => value.type === 'token')
+    ) || []
+
+  return [
+    getErc7730Visualization(
+      oneInchVisualization?.title || 'Fill order',
+      [
+        {
+          label: 'Amount to Send',
+          value: [getToken(outgoingToken, outgoingAmount, context.chainId)]
+        },
+        {
+          label: 'Minimum to Receive',
+          value: [getToken(incomingToken, incomingAmount, context.chainId)]
+        },
+        ...additionalRows
+      ],
+      dapp
+    )
+  ]
 }
 
 const getSafeTxCallFromMessage = (message: Message): Call | null => {
@@ -1282,11 +1384,14 @@ export const humanizeCallWithErc7730 = (
     nestedCalldataDepth
   }
   const fullVisualization = formatToVisualizations(match.format, context, call.dapp)
+  const normalizedVisualization = fullVisualization
+    ? getOneInchFillOrderSwapVisualization(match, context, fullVisualization, call.dapp)
+    : null
 
-  return fullVisualization?.length
+  return normalizedVisualization?.length
     ? {
         ...call,
-        fullVisualization,
+        fullVisualization: normalizedVisualization,
         warnings: dedupeWarnings(getSafeCallWarnings(call, accountAddr))
       }
     : null

--- a/src/libs/humanizer/erc7730/humanize.ts
+++ b/src/libs/humanizer/erc7730/humanize.ts
@@ -1,6 +1,7 @@
 import {
   formatUnits,
   FunctionFragment,
+  getAddress,
   Interface,
   isAddress,
   isHexString,
@@ -894,6 +895,41 @@ const getSafeTxCallFromMessage = (message: Message): Call | null => {
   }
 }
 
+const getSafeTxRejectTitle = (message: Message): string | null => {
+  if (message.content.kind !== 'typedMessage') return null
+  if (message.content.primaryType !== SAFE_TX_PRIMARY_TYPE) return null
+
+  const { to, value, data, operation, nonce } = message.content.message
+  const { verifyingContract } = message.content.domain
+  if (nonce === undefined) return null
+  if (typeof to !== 'string' || !isAddress(to)) return null
+  if (typeof verifyingContract !== 'string' || !isAddress(verifyingContract)) return null
+  if (getAddress(to) !== getAddress(verifyingContract)) return null
+  if (toBigIntOrNull(operation ?? 0) !== 0n) return null
+  if (toBigIntOrNull(value ?? 0) !== 0n) return null
+  if (typeof data !== 'string' || data.toLowerCase() !== '0x') return null
+
+  return `Reject Safe transaction with nonce ${valueToText(nonce)}`
+}
+
+const replaceErc7730Title = (
+  fullVisualization: HumanizerVisualization[] | null,
+  title: string | null
+): HumanizerVisualization[] | null => {
+  if (!title) return fullVisualization
+
+  return (
+    fullVisualization?.map((visualization) =>
+      visualization.type === 'erc7730'
+        ? {
+            ...visualization,
+            title
+          }
+        : visualization
+    ) || null
+  )
+}
+
 const getKnownFunctionName = (call: Call): string | null => {
   const selector = call.data?.slice(0, 10).toLowerCase()
   if (!selector) return null
@@ -1324,11 +1360,12 @@ export const humanizeMessageWithErc7730 = (
     fullVisualization && message.content.primaryType === SAFE_TX_PRIMARY_TYPE
       ? replaceSafeTxTransactionRow(fullVisualization, message, chainId, resolvedDescriptor)
       : fullVisualization
+  const titledVisualization = replaceErc7730Title(safeTxVisualization, getSafeTxRejectTitle(message))
 
-  return safeTxVisualization?.length
+  return titledVisualization?.length
     ? {
         ...message,
-        fullVisualization: safeTxVisualization,
+        fullVisualization: titledVisualization,
         warnings: getSafeTxMessageWarnings(message),
         canHideDropdownArrow: true
       }

--- a/src/libs/humanizer/erc7730/registry.ts
+++ b/src/libs/humanizer/erc7730/registry.ts
@@ -51,6 +51,9 @@ const safeSingletonPromises = new Map<string, Promise<string | null>>()
 const safeExecTransactionInterface = new Interface(execTransactionAbi)
 const erc20ApproveInterface = new Interface(['function approve(address _spender, uint256 _value)'])
 const erc20TransferInterface = new Interface(['function transfer(address _to, uint256 _value)'])
+const permit2ApproveInterface = new Interface([
+  'function approve(address token, address spender, uint160 amount, uint48 expiration)'
+])
 const ABI_WORD_HEX_LENGTH = 64
 const CALLDATA_SELECTOR_HEX_LENGTH = 10
 const EXEC_TRANSACTION_STATIC_WORDS = 10
@@ -291,13 +294,13 @@ const ERC20_TRANSFER_DESCRIPTOR: Erc7730ResolvedDescriptor = {
   }
 }
 
-const PERMIT2_APPROVE_DESCRIPTOR: Erc7730ResolvedDescriptor = {
-  path: 'built-in/permit2-approve',
+const getPermit2ApproveDescriptor = (path: string, intent: string): Erc7730ResolvedDescriptor => ({
+  path,
   descriptor: {
     display: {
       formats: {
         'approve(address token, address spender, uint160 amount, uint48 expiration)': {
-          intent: 'Approve',
+          intent,
           fields: [
             {
               path: '#.spender',
@@ -324,7 +327,14 @@ const PERMIT2_APPROVE_DESCRIPTOR: Erc7730ResolvedDescriptor = {
       }
     }
   }
-}
+})
+
+const PERMIT2_APPROVE_DESCRIPTOR = getPermit2ApproveDescriptor('built-in/permit2-approve', 'Approve')
+
+const PERMIT2_REVOKE_APPROVAL_DESCRIPTOR = getPermit2ApproveDescriptor(
+  'built-in/permit2-revoke-approval',
+  'Revoke approval'
+)
 
 const fetchCachedIndex = async <T>({
   path,
@@ -550,7 +560,13 @@ const getBuiltInDescriptorForCall = (call: Call): Erc7730ResolvedDescriptor | nu
     call.to.toLowerCase() === PERMIT2_ADDRESS &&
     selector === PERMIT2_APPROVE_SELECTOR
   ) {
-    return PERMIT2_APPROVE_DESCRIPTOR
+    try {
+      const [, , amount] = permit2ApproveInterface.decodeFunctionData('approve', call.data)
+
+      return amount === 0n ? PERMIT2_REVOKE_APPROVAL_DESCRIPTOR : PERMIT2_APPROVE_DESCRIPTOR
+    } catch {
+      return PERMIT2_APPROVE_DESCRIPTOR
+    }
   }
 
   return null

--- a/src/libs/humanizer/erc7730/registry.ts
+++ b/src/libs/humanizer/erc7730/registry.ts
@@ -51,6 +51,9 @@ const safeSingletonPromises = new Map<string, Promise<string | null>>()
 const safeExecTransactionInterface = new Interface(execTransactionAbi)
 const erc20ApproveInterface = new Interface(['function approve(address _spender, uint256 _value)'])
 const erc20TransferInterface = new Interface(['function transfer(address _to, uint256 _value)'])
+const ABI_WORD_HEX_LENGTH = 64
+const CALLDATA_SELECTOR_HEX_LENGTH = 10
+const EXEC_TRANSACTION_STATIC_WORDS = 10
 
 /**
  * A helper function to use in the tests only
@@ -563,6 +566,95 @@ const getTypedMessageChainId = (message: Message): bigint | null => {
   }
 }
 
+const getAbiWord = (data: string, wordIndex: number): string | null => {
+  const wordStart = CALLDATA_SELECTOR_HEX_LENGTH + wordIndex * ABI_WORD_HEX_LENGTH
+  const wordEnd = wordStart + ABI_WORD_HEX_LENGTH
+  if (data.length < wordEnd) return null
+
+  return data.slice(wordStart, wordEnd)
+}
+
+const getAbiWordAsBigInt = (data: string, wordIndex: number): bigint | null => {
+  const word = getAbiWord(data, wordIndex)
+  if (!word) return null
+
+  try {
+    return BigInt(`0x${word}`)
+  } catch {
+    return null
+  }
+}
+
+const getAbiWordAsAddress = (data: string, wordIndex: number): string | null => {
+  const word = getAbiWord(data, wordIndex)
+  if (!word) return null
+
+  const address = `0x${word.slice(-40)}`
+  return isAddress(address) ? getAddress(address) : null
+}
+
+const getAbiBytesAtOffset = (data: string, offset: bigint): string | null => {
+  if (offset < BigInt(EXEC_TRANSACTION_STATIC_WORDS * 32)) return null
+  if (offset > BigInt(Number.MAX_SAFE_INTEGER)) return null
+
+  const lengthStart = CALLDATA_SELECTOR_HEX_LENGTH + Number(offset) * 2
+  const lengthEnd = lengthStart + ABI_WORD_HEX_LENGTH
+  if (data.length < lengthEnd) return null
+
+  let byteLength: bigint
+  try {
+    byteLength = BigInt(`0x${data.slice(lengthStart, lengthEnd)}`)
+  } catch {
+    return null
+  }
+
+  if (byteLength > BigInt(Number.MAX_SAFE_INTEGER)) return null
+
+  const valueStart = lengthEnd
+  const valueEnd = valueStart + Number(byteLength) * 2
+  if (data.length < valueEnd) return null
+
+  return `0x${data.slice(valueStart, valueEnd)}`
+}
+
+const getSafeTxCallsFromExecTransactionHead = (call: Call): Call[] | null => {
+  if (!call.data || !isHexString(call.data)) return null
+
+  const selector = call.data.slice(0, CALLDATA_SELECTOR_HEX_LENGTH).toLowerCase()
+  if (selector !== safeExecTransactionInterface.getFunction('execTransaction')?.selector) {
+    return null
+  }
+
+  const to = getAbiWordAsAddress(call.data, 0)
+  const value = getAbiWordAsBigInt(call.data, 1)
+  const dataOffset = getAbiWordAsBigInt(call.data, 2)
+  const operation = getAbiWordAsBigInt(call.data, 3)
+  if (!to || value === null || dataOffset === null || operation === null) return null
+
+  const data = getAbiBytesAtOffset(call.data, dataOffset)
+  if (data === null) return null
+
+  if (operation === 0n) return [{ to, data, value }]
+  if (operation !== 1n) return null
+
+  try {
+    const multiSendDecoded = multiSendInterface.decodeFunctionData(
+      'multiSend',
+      getAbiBytesCalldataWithPadding(data)
+    )
+    const transactionsHex = multiSendDecoded[0]
+    if (typeof transactionsHex !== 'string') return null
+
+    return decodeMultiSend(transactionsHex).map((transaction) => ({
+      to: transaction.to,
+      data: transaction.data,
+      value: transaction.value
+    }))
+  } catch {
+    return null
+  }
+}
+
 const getSafeTxCallsFromExecTransactionCall = (call: Call): Call[] | null => {
   if (!call.data || !isHexString(call.data)) return null
 
@@ -601,7 +693,7 @@ const getSafeTxCallsFromExecTransactionCall = (call: Call): Call[] | null => {
       value: transaction.value
     }))
   } catch {
-    return null
+    return getSafeTxCallsFromExecTransactionHead(call)
   }
 }
 

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -1526,6 +1526,80 @@ describe('ERC-7730 descriptors', () => {
     ])
   })
 
+  test('humanizes a Safe execTransaction reject call with ERC-7730', async () => {
+    const safeProxy = '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce'
+    const safeSingleton = '0x29fcb43b46531bca003ddc8fcb67ffe91900c762'
+    const safeExecAccountOp: AccountOp = {
+      ...accountOp,
+      chainId: 8453n,
+      calls: [
+        {
+          to: safeProxy,
+          value: 0n,
+          data: '0x6a761202000000000000000000000000714fd3db837e72bd49b8eda02b8f4d53dfdde5ce000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000829829d2364ba9c5fc4e5dae8915dc34bcfe2c6f3198d5d616cc3163362339f1c729972967c47cb4a0fc74a996e3e431628e43e6838c821a7c933dff90a31656771c000000000000000000000000E691cDAbc7dC1CD2138e21F75caF0bd048696133000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000'
+        }
+      ]
+    }
+    const provider = {
+      getStorage: jest.fn(async (address: string) => {
+        expect(address.toLowerCase()).toBe(safeProxy)
+
+        return ethers.zeroPadValue(safeSingleton, 32)
+      })
+    }
+    const descriptorPath = 'registry/safe/calldata-SafeL2-1.4.1.json'
+    const callRelayer = async (path: string, method?: string, body?: any) => {
+      if (path === '/v2/erc7730/account-op') {
+        expect(method).toBe('GET')
+
+        return {
+          success: true,
+          data: {
+            [`eip155:8453:${safeSingleton}`]: descriptorPath
+          },
+          errorState: []
+        }
+      }
+
+      if (path === '/v2/erc7730/fetch-descriptor') {
+        expect(method).toBe('POST')
+        expect(body).toEqual({ descriptorPath: `/${descriptorPath}` })
+
+        return {
+          success: true,
+          display: {
+            formats: {}
+          }
+        }
+      }
+
+      throw new Error(`Unexpected ERC-7730 relayer call: ${path}`)
+    }
+
+    const descriptors = await fetchErc7730DescriptorsForAccountOp(safeExecAccountOp, {
+      callRelayer,
+      provider: provider as any
+    })
+    const irCalls = humanizeAccountOp(safeExecAccountOp, { erc7730Descriptors: descriptors })
+
+    expect(provider.getStorage).toHaveBeenCalledTimes(1)
+    expect(descriptors[0]?.safeTxTransactionsOnly).toBe(true)
+    expect(irCalls[0]!.fullVisualization?.[0]).toMatchObject({
+      type: 'erc7730',
+      title: 'Reject Safe transaction',
+      rows: [
+        {
+          value: [
+            expect.objectContaining({
+              type: 'erc7730',
+              title: 'Reject currently queued transaction'
+            })
+          ]
+        }
+      ]
+    })
+  })
+
   test('fetches the EIP-712 descriptor index through the relayer', async () => {
     const registryPath = 'registry/test/eip712-relayer-permit.json'
     const permitMessage = {

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -1586,7 +1586,7 @@ describe('ERC-7730 descriptors', () => {
     expect(descriptors[0]?.safeTxTransactionsOnly).toBe(true)
     expect(irCalls[0]!.fullVisualization?.[0]).toMatchObject({
       type: 'erc7730',
-      title: 'Reject Safe transaction',
+      title: 'Execute a Safe{Wallet} Transaction',
       rows: [
         {
           value: [
@@ -2030,7 +2030,7 @@ describe('ERC-7730 descriptors', () => {
     ])
   })
 
-  test('humanizes a SafeTx reject message title with its nonce', async () => {
+  test('humanizes a SafeTx reject message with ERC-7730', async () => {
     const safeProxy = '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce'
     const safeTxMessage = {
       fromRequestId: 1,
@@ -2107,7 +2107,7 @@ describe('ERC-7730 descriptors', () => {
 
     expect(irMessage.fullVisualization?.[0]).toMatchObject({
       type: 'erc7730',
-      title: 'Reject Safe transaction with nonce 85'
+      title: 'Safe'
     })
   })
 

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -1956,6 +1956,87 @@ describe('ERC-7730 descriptors', () => {
     ])
   })
 
+  test('humanizes a SafeTx reject message title with its nonce', async () => {
+    const safeProxy = '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce'
+    const safeTxMessage = {
+      fromRequestId: 1,
+      accountAddr: accountOp.accountAddr,
+      content: {
+        kind: 'typedMessage',
+        types: {
+          EIP712Domain: [
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' }
+          ],
+          SafeTx: [
+            { type: 'address', name: 'to' },
+            { type: 'uint256', name: 'value' },
+            { type: 'bytes', name: 'data' },
+            { type: 'uint8', name: 'operation' },
+            { type: 'uint256', name: 'safeTxGas' },
+            { type: 'uint256', name: 'baseGas' },
+            { type: 'uint256', name: 'gasPrice' },
+            { type: 'address', name: 'gasToken' },
+            { type: 'address', name: 'refundReceiver' },
+            { type: 'uint256', name: 'nonce' }
+          ]
+        },
+        domain: {
+          verifyingContract: safeProxy,
+          chainId: 8453
+        },
+        message: {
+          to: safeProxy,
+          value: '0',
+          data: '0x',
+          operation: 0,
+          baseGas: '0',
+          gasPrice: '0',
+          gasToken: ZeroAddress,
+          refundReceiver: ZeroAddress,
+          nonce: 85,
+          safeTxGas: '0'
+        },
+        primaryType: 'SafeTx'
+      },
+      signature: null,
+      chainId: 8453n
+    }
+
+    const irMessage = humanizeMessage(safeTxMessage as any, {
+      erc7730Descriptor: {
+        descriptor: {
+          display: {
+            formats: {
+              'SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)':
+                {
+                  intent: 'Safe',
+                  fields: [
+                    { path: 'operation', label: 'Operation type' },
+                    {
+                      path: 'data',
+                      label: 'Transaction',
+                      format: 'calldata',
+                      params: { calleePath: '#.to' }
+                    },
+                    { path: 'safeTxGas', label: 'Gas amount' },
+                    { path: 'gasPrice', label: 'Gas price' },
+                    { path: 'gasToken', label: 'Gas token', format: 'addressName' },
+                    { path: 'refundReceiver', label: 'Gas receiver', format: 'addressName' }
+                  ]
+                }
+            }
+          }
+        }
+      }
+    })
+
+    expect(irMessage.fullVisualization?.[0]).toMatchObject({
+      type: 'erc7730',
+      title: 'Reject Safe transaction with nonce 85'
+    })
+  })
+
   test('humanizes a SafeTx owner change with the Safe singleton descriptor fallback', async () => {
     const safeProxy = '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce'
     const safeSingleton = '0x29fcb43b46531bca003ddc8fcb67ffe91900c762'

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -621,6 +621,121 @@ describe('ERC-7730 descriptors', () => {
       ]
     ])
   })
+  test('resolves uint byte slices and uint-encoded token addresses', async () => {
+    const maker = '0x4446adc0b8136ffc55ddb7a488ba5509ace2a5ef'
+    const oneInchAccountOp = {
+      ...accountOp,
+      accountAddr: maker,
+      chainId: 8453n,
+      calls: [
+        {
+          to: '0x111111125421cA6dc452d289314280a0f8842A65',
+          value: 0n,
+          data: '0x9fda64bd000000000000000000000000000000000000000053dc0eddc512ea796b81a63b0000000000000000000000004446adc0b8136ffc55ddb7a488ba5509ace2a5ef0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000cbb7c0000ab88b473b1f5afd9ef808440eed33bf00000000000000000000000042000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000ca300000000000000000000000000000000000000000000000000042025afe2dc9a0000000000000000000000000000ae9d1b006a213db339b4b62d38e514a03b78971de43fda13dd255b976f1a611cc28cfcd418db951a07e107a85a0aa534ef8cf175f9598b8fdfd328af71786a6fe537d7e29938372c7b39e9fc0109c7029de300000000000000000000000000000000000000000000000000042025afe2dc9a6000000000000000000000000000000000000000000000000000000000000000ab0003904a82836d'
+        }
+      ]
+    }
+    const makerAsset = '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf'
+    const takerAsset = '0x4200000000000000000000000000000000000006'
+
+    const irCalls = humanizeAccountOp(oneInchAccountOp, {
+      erc7730Descriptors: {
+        0: {
+          path: 'registry/1inch/calldata-AggregationRouterV6.json',
+          descriptor: {
+            metadata: {
+              enums: {
+                takerTraits: {
+                  '96': 'Unwrap'
+                }
+              }
+            },
+            display: {
+              definitions: {
+                makingAmount: {
+                  label: 'Order purchasing amt',
+                  format: 'tokenAmount',
+                  params: {}
+                },
+                takingAmount: {
+                  label: 'Order selling amount',
+                  format: 'tokenAmount',
+                  params: {}
+                },
+                fillAmount: {
+                  label: 'Amount to sell',
+                  format: 'tokenAmount',
+                  params: {}
+                },
+                takerTraits: {
+                  label: 'Additional action',
+                  format: 'enum',
+                  params: {
+                    $ref: '$.metadata.enums.takerTraits'
+                  }
+                }
+              },
+              formats: {
+                'fillOrder((uint256 salt, uint256 maker, uint256 receiver, uint256 makerAsset, uint256 takerAsset, uint256 makingAmount, uint256 takingAmount, uint256 makerTraits) order, bytes32 r, bytes32 vs, uint256 amount, uint256 takerTraits)':
+                  {
+                    intent: 'Fill order',
+                    fields: [
+                      {
+                        path: 'order.takingAmount',
+                        $ref: '$.display.definitions.takingAmount',
+                        params: {
+                          tokenPath: 'order.takerAsset'
+                        },
+                        visible: 'always'
+                      },
+                      {
+                        path: 'order.makingAmount',
+                        $ref: '$.display.definitions.makingAmount',
+                        params: {
+                          tokenPath: 'order.makerAsset'
+                        },
+                        visible: 'always'
+                      },
+                      {
+                        path: 'amount',
+                        $ref: '$.display.definitions.fillAmount',
+                        params: {
+                          tokenPath: 'order.takerAsset'
+                        },
+                        visible: 'always'
+                      },
+                      {
+                        path: 'takerTraits.[:1]',
+                        $ref: '$.display.definitions.takerTraits'
+                      }
+                    ]
+                  }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getErc7730Visualization('Fill order', [
+          {
+            label: 'Amount to Send',
+            value: [getToken(makerAsset, 3235n, 8453n)]
+          },
+          {
+            label: 'Minimum to Receive',
+            value: [getToken(takerAsset, 1161246143601818n, 8453n)]
+          },
+          {
+            label: 'Additional action',
+            value: [getText('Unwrap')]
+          }
+        ])
+      ]
+    ])
+  })
   test('treats missing token references in tokenAmount descriptors as native token', async () => {
     const uniswapRouter = '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45'
     const tokenIn = transactions.erc20[1]!.to

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -1225,6 +1225,50 @@ describe('ERC-7730 descriptors', () => {
     ])
   })
 
+  test('uses revoke wording for standard ERC-7730 Permit2 approvals with a zero amount', async () => {
+    const baseCbBtc = '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf'
+    const permit2 = '0x000000000022D473030F116dDEE9F6B43aC78BA3'
+    const universalRouter = '0xFdf682F51FE81Aa4898F0AE2163d8A55c127fbC7'
+    const permit2ApproveInterface = new ethers.Interface([
+      'function approve(address token, address spender, uint160 amount, uint48 expiration)'
+    ])
+    const revokePermitAccountOp: AccountOp = {
+      ...accountOp,
+      chainId: 8453n,
+      calls: [
+        {
+          to: permit2,
+          value: 0n,
+          data: permit2ApproveInterface.encodeFunctionData('approve', [
+            baseCbBtc,
+            universalRouter,
+            0n,
+            0x6a2c1c44n
+          ])
+        }
+      ]
+    }
+    const descriptors = await fetchErc7730DescriptorsForAccountOp(revokePermitAccountOp)
+    const irCalls = humanizeAccountOp(revokePermitAccountOp, { erc7730Descriptors: descriptors })
+
+    expect(descriptors[0]?.path).toBe('built-in/permit2-revoke-approval')
+    expect(irCalls[0]!.fullVisualization?.[0]).toMatchObject({
+      type: 'erc7730',
+      title: 'Revoke approval',
+      rows: [
+        {
+          label: 'Spender',
+          value: [expect.objectContaining({ address: universalRouter.toLowerCase() })]
+        },
+        {
+          label: 'Amount',
+          value: [expect.objectContaining({ address: baseCbBtc.toLowerCase(), value: 0n })]
+        },
+        { label: 'Approval expires' }
+      ]
+    })
+  })
+
   test('uses the standard ERC-7730 transfer descriptor for ERC-20 transfers', async () => {
     const usdt = '0xdac17f958d2ee523a2206206994597c13d831ec7'
     const recipient = '0x46705dfff24256421a05d056c29e81bdc09723b8'

--- a/src/libs/humanizer/modules/Safe/index.ts
+++ b/src/libs/humanizer/modules/Safe/index.ts
@@ -207,10 +207,34 @@ const SafeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[]): IrC
     [toFunctionSelector(execTransactionAbi[0])]: (call: HexIrCall): IrCall | undefined => {
       if (!call.to) return
       if (call.value) return
-      const { args } = decodeFunctionData({ abi: execTransactionAbi, data: call.data })
-      const [to, value, data, operation] = args
+      let args: unknown[]
 
-      const safeSpecificHumanization = getSafeHumanization(accOp.accountAddr, to, value, data)
+      try {
+        args = [...decodeFunctionData({ abi: execTransactionAbi, data: call.data }).args]
+      } catch {
+        return
+      }
+
+      const [to, value, data, operation] = args
+      if (typeof to !== 'string') return
+      if (typeof data !== 'string') return
+      if (typeof value !== 'bigint' && typeof value !== 'number' && typeof value !== 'string')
+        return
+      if (
+        typeof operation !== 'bigint' &&
+        typeof operation !== 'number' &&
+        typeof operation !== 'string'
+      )
+        return
+      const bigintValue = BigInt(value)
+      const bigintOperation = BigInt(operation)
+
+      const safeSpecificHumanization = getSafeHumanization(
+        accOp.accountAddr,
+        to,
+        bigintValue,
+        data
+      )
       const fullVisualization = [
         getAction('Execute a Safe{WALLET} transaction'),
         getLabel('from'),
@@ -219,9 +243,9 @@ const SafeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[]): IrC
         getAddressVisualization(to)
       ]
 
-      if (value)
+      if (bigintValue)
         fullVisualization.push(
-          ...[getLabel('and'), getAction('Send'), getToken(zeroAddress, value)]
+          ...[getLabel('and'), getAction('Send'), getToken(zeroAddress, bigintValue)]
         )
 
       const warnings: HumanizerWarning[] = []
@@ -232,7 +256,7 @@ const SafeModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[]): IrC
         if (safeSpecificHumanization.warnings) warnings.push(...safeSpecificHumanization.warnings)
       }
 
-      const delegateCallWarnings = getDelegateCallWarning(operation, to)
+      const delegateCallWarnings = getDelegateCallWarning(bigintOperation, to)
       if (delegateCallWarnings.length) warnings.push(...delegateCallWarnings)
 
       return { ...call, fullVisualization, warnings }


### PR DESCRIPTION
## Summary

- Add ERC-7730 humanization support for Safe reject transactions, including SafeTx typed messages and Safe `execTransaction` calls.
- Improve Safe transaction decoding by falling back to ABI head parsing when normal decoding cannot decode nested/multisend calldata.
- Detect Permit2 zero-amount approvals as revoke approvals and show `Revoke approval` wording.
- Improve ERC-7730 value handling for uint-encoded addresses, bigint address formatting, byte slices, and hex enum values.
- Normalize 1inch `fillOrder` humanization into clear swap rows: amount to send, minimum to receive, plus any non-token metadata rows.
- Harden Safe module `execTransaction` decoding and delegate-call warning handling.

## Testing

- Added/updated humanizer tests for Safe reject humanization, Permit2 revoke approvals, 1inch orders, uint byte slices, and Safe ERC-7730 fallback handling