### PR TITLE
Refactor/ AI PR reviews and fix security reviews

### DIFF
--- a/.github/workflows/general-review.yml
+++ b/.github/workflows/general-review.yml
@@ -20,9 +20,8 @@ jobs:
       pull-requests: write
       # This MUST be read!
       contents: read
-    uses: ./.github/workflows/pr-agent-review.yml
+    uses: ./.github/workflows/pr-agent.yml
     with:
-      review_name: General review
       model: openrouter/moonshotai/kimi-k2.6
       fallback_models: '["openrouter/anthropic/claude-sonnet-4.6"]'
       extra_instructions: |

--- a/.github/workflows/general-review.yml
+++ b/.github/workflows/general-review.yml
@@ -12,25 +12,36 @@ jobs:
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'review') ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event.sender.type != 'Bot' && 
+      (github.event.sender.type != 'Bot' &&
       github.event_name == 'issue_comment' &&
-      contains(github.event.comment.body, '/review'))
-    runs-on: ubuntu-latest
+      contains(github.event.comment.body, '/review') &&
+      !contains(github.event.comment.body, '/security-review'))
     permissions:
       pull-requests: write
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Run General PR Agent
-        uses: The-PR-Agent/pr-agent@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENROUTER__KEY: ${{ secrets.OPENROUTER__KEY }}
-          CONFIG__MODEL: "openrouter/moonshotai/kimi-k2.6"
-          # Without auto_review=true we cannot have triggers such as
-          # workflow_dispatch and PR label
-          github_action_config.auto_review: "true"
-          github_action_config.auto_describe: "false"
-          github_action_config.auto_improve: "false"
+      # This MUST be read!
+      contents: read
+    uses: ./.github/workflows/pr-agent-review.yml
+    with:
+      review_name: General review
+      model: openrouter/moonshotai/kimi-k2.6
+      fallback_models: '["openrouter/anthropic/claude-sonnet-4.6"]'
+      extra_instructions: |
+        You are reviewing changes in a security-sensitive Web3 browser extension wallet.
+        Focus on the diff in front of you and assess it for correctness, security, reliability, and maintainability.
+        Prioritize issues such as:
+        - Requests without error handling and timeouts
+        - Inefficient algorithms or data structures
+        - Inconsistent naming conventions or formatting
+        - Unnecessary complexity or duplication
+        - Missing comments or documentation for complex logic
+        - Unhandled exceptions and edge cases
+        - Swallowed errors and edge case return statements that should at least log an error
+        - Concurrent modifications to state that may result in race conditions
+        - Unhandled degradations when interacting with external services and APIs
+        - Decimal precision handling and bigint conversions
+        - Unhandled pending operations (e.g., submitting twice, not awaiting async calls, etc.)
+        - Partial updates that leave the state inconsistent
+        - Improper cleanup of subscriptions, timers, and event listeners
+        Be constructive, concise, and actionable. Keep feedback grounded in the actual changes rather than using a fixed checklist.
+    secrets:
+      OPENROUTER_KEY: ${{ secrets.OPENROUTER__KEY }}

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -29,6 +29,9 @@ on:
       OPENROUTER_KEY:
         required: true
 
+env:
+  PR_AGENT_IMAGE: pragent/pr-agent@sha256:9e9b48cf83d94aedbb251aa7e03a630450afe642eb517156e1ddde7cef2d76ff # 0.36.0
+
 jobs:
   review:
     runs-on: ubuntu-latest
@@ -36,25 +39,29 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install pr-agent
-        # IT MUST be pinned to a commit and NOT a tag as tags are mutable and have been used in hacks
-        run: pip install --quiet "git+https://github.com/The-PR-Agent/pr-agent@sha256:ffe1f89a4dafc7d8e88b9cf010a3233e30b49f43"
-
       # Note: PR Agent can swallow errors on many levels
       # There is a way to take a snapshot of the last comment id before the workflow
       # and check if there is a new comment after it's done. Not implemented as it sounds too
       # hackish, but we should keep it in mind
       - name: Run review
+        id: pragent
         env:
+          PR_URL: ${{ steps.pre.outputs.pr_url }}
           GITHUB__USER_TOKEN: ${{ github.token }}
-          GITHUB__DEPLOYMENT_TYPE: user
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_KEY }}
-          CONFIG__GIT_PROVIDER: github
           CONFIG__MODEL: ${{ inputs.model }}
           CONFIG__FALLBACK_MODELS: ${{ inputs.fallback_models }}
           PR_REVIEWER__EXTRA_INSTRUCTIONS: ${{ inputs.extra_instructions }}
-        run: python -m pr_agent.cli --pr_url "${{ steps.pre.outputs.pr_url }}" review
+        run: |
+          docker run --rm \
+            --read-only --tmpfs /tmp \
+            --cap-drop=ALL --security-opt no-new-privileges \
+            -e GITHUB__USER_TOKEN \
+            -e GITHUB__DEPLOYMENT_TYPE=user \
+            -e OPENROUTER__KEY \
+            -e CONFIG__GIT_PROVIDER=github \
+            -e CONFIG__MODEL \
+            -e CONFIG__FALLBACK_MODELS \
+            -e PR_REVIEWER__EXTRA_INSTRUCTIONS \
+            "$PR_AGENT_IMAGE" \
+            --pr_url "$PR_URL" review

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,60 @@
+# Reusable PR review workflow
+#
+# It allows us to reuse the CLI logic, which in turn allows us to have a custom /security-review
+# command. Triggers are not customizable through the action
+
+name: PR Agent Review (reusable)
+
+on:
+  workflow_call:
+    # These are the "params" of the workflow
+    inputs:
+      review_name:
+        description: Human-readable name used in failure comments (e.g. "General review")
+        type: string
+        default: PR review
+      model:
+        description: Primary model
+        type: string
+        required: true
+      fallback_models:
+        description: 'Fallback models as a TOML/JSON list string, e.g. ["openrouter/..."]'
+        type: string
+        default: '[]'
+      extra_instructions:
+        description: Reviewer extra_instructions for this review type
+        type: string
+        default: ""
+    secrets:
+      OPENROUTER_KEY:
+        required: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pr-agent
+        # IT MUST be pinned to a commit and NOT a tag as tags are mutable and have been used in hacks
+        run: pip install --quiet "git+https://github.com/The-PR-Agent/pr-agent@sha256:ffe1f89a4dafc7d8e88b9cf010a3233e30b49f43"
+
+      # Note: PR Agent can swallow errors on many levels
+      # There is a way to take a snapshot of the last comment id before the workflow
+      # and check if there is a new comment after it's done. Not implemented as it sounds too
+      # hackish, but we should keep it in mind
+      - name: Run review
+        env:
+          GITHUB__USER_TOKEN: ${{ github.token }}
+          GITHUB__DEPLOYMENT_TYPE: user
+          OPENROUTER__KEY: ${{ secrets.OPENROUTER_KEY }}
+          CONFIG__GIT_PROVIDER: github
+          CONFIG__MODEL: ${{ inputs.model }}
+          CONFIG__FALLBACK_MODELS: ${{ inputs.fallback_models }}
+          PR_REVIEWER__EXTRA_INSTRUCTIONS: ${{ inputs.extra_instructions }}
+        run: python -m pr_agent.cli --pr_url "${{ steps.pre.outputs.pr_url }}" review

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -9,10 +9,6 @@ on:
   workflow_call:
     # These are the "params" of the workflow
     inputs:
-      review_name:
-        description: Human-readable name used in failure comments (e.g. "General review")
-        type: string
-        default: PR review
       model:
         description: Primary model
         type: string
@@ -39,6 +35,25 @@ jobs:
       pull-requests: write
       contents: read
     steps:
+      - name: Resolve PR
+        id: pre
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let prNumber =
+              context.payload.pull_request?.number ??
+              (context.payload.issue?.pull_request ? context.payload.issue.number : null);
+            if (!prNumber && context.eventName === 'workflow_dispatch') {
+              const branch = context.ref.replace('refs/heads/', '');
+              const { data: prs } = await github.rest.pulls.list({
+                ...context.repo, state: 'open',
+                head: `${context.repo.owner}:${branch}`,
+              });
+              prNumber = prs[0]?.number ?? null;
+            }
+            if (!prNumber) return core.setFailed('No pull request resolved for this event');
+            core.setOutput('pr_url',
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`);
       # Note: PR Agent can swallow errors on many levels
       # There is a way to take a snapshot of the last comment id before the workflow
       # and check if there is a new comment after it's done. Not implemented as it sounds too

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -19,9 +19,8 @@ jobs:
       pull-requests: write
       # This MUST be read!
       contents: read
-    uses: ./.github/workflows/pr-agent-review.yml
+    uses: ./.github/workflows/pr-agent.yml
     with:
-      review_name: Security review
       model: openrouter/anthropic/claude-opus-4.7
       fallback_models: '["openrouter/openai/gpt-5.5"]'
       extra_instructions: |

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -12,61 +12,36 @@ jobs:
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'security-review') ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event.sender.type != 'Bot' && 
+      (github.event.sender.type != 'Bot' &&
       github.event_name == 'issue_comment' &&
       contains(github.event.comment.body, '/security-review'))
-    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v6
-
-      # PR-Agent does not recognize "/security-review" as a native command.
-      # We rewrite the event JSON so the agent sees "/review" instead.
-      # How this works is:
-      # 1. Only this workflow runs because of the if statement
-      # 2. It replaces /security-review with /review
-      # 3. It replaces the extra instructions
-      - name: Rewrite event payload for PR-Agent
-        if: github.event_name == 'issue_comment'
-        run: |
-          jq '(.comment.body // "") |= sub("/security-review"; "/review"; "i")' \
-            "$GITHUB_EVENT_PATH" > "$GITHUB_EVENT_PATH.tmp" && \
-          mv "$GITHUB_EVENT_PATH.tmp" "$GITHUB_EVENT_PATH"
-
-      - name: Run Security PR Agent
-        uses: The-PR-Agent/pr-agent@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENROUTER__KEY: ${{ secrets.OPENROUTER__KEY }}
-          CONFIG__MODEL: "openrouter/anthropic/claude-opus-4.7"
-          # Without auto_review=true we cannot have triggers such as
-          # workflow_dispatch and PR label
-          github_action_config.auto_review: "true"
-          github_action_config.auto_describe: "false"
-          github_action_config.auto_improve: "false"
-          pr_reviewer.fallback_models: ['openrouter/openai/gpt-5.5']
-          pr_reviewer.extra_instructions: |
-           You are reviewing changes in a security-sensitive Web3 browser extension wallet. Focus exclusively on security, privacy, and compliance risks. Ignore style, performance, or general quality issues unless they have direct security impact.
-
-            Key areas to examine:
-            - Sensitive data exposure or hard-coded secrets
-            - Insecure deserialization, cryptographic issues
-            - Improper access control
-            - Entropy source quality
-            - BigNumber / integer overflow or precision loss in value calculations
-            - External communication to content-script/inpage-script/mobile app
-            - Input validation, sanitization, and output encoding
-            - Logging of sensitive information
-            - Changes in key areas like: keystore, signing logic, encryption and safety features
-            - Edge cases in features that ensure the security of the user (e.g., phishing detection, transaction safety checks, etc.)
-
-            For every finding:
-            - State the severity (Critical / High / Medium / Low)
-            - Quote the exact vulnerable code
-            - Explain the risk clearly
-            - Provide concrete remediation steps or code fixes
-
-            Be thorough and precise.
+      # This MUST be read!
+      contents: read
+    uses: ./.github/workflows/pr-agent-review.yml
+    with:
+      review_name: Security review
+      model: openrouter/anthropic/claude-opus-4.7
+      fallback_models: '["openrouter/openai/gpt-5.5"]'
+      extra_instructions: |
+        You are reviewing changes in a security-sensitive Web3 browser extension wallet. Focus exclusively on security, privacy, and compliance risks. Ignore style, performance, or general quality issues unless they have direct security impact.
+        Key areas to examine:
+        - Sensitive data exposure or hard-coded secrets
+        - Insecure deserialization, cryptographic issues
+        - Improper access control
+        - Entropy source quality
+        - BigNumber / integer overflow or precision loss in value calculations
+        - External communication to content-script/inpage-script/mobile app
+        - Input validation, sanitization, and output encoding
+        - Logging of sensitive information
+        - Changes in key areas like: keystore, signing logic, encryption and safety features
+        - Edge cases in features that ensure the security of the user (e.g., phishing detection, transaction safety checks, etc.)
+        For every finding:
+        - State the severity (Critical / High / Medium / Low)
+        - Quote the exact vulnerable code
+        - Explain the risk clearly
+        - Provide concrete remediation steps or code fixes
+        Be thorough and precise.
+    secrets:
+      OPENROUTER_KEY: ${{ secrets.OPENROUTER__KEY }}

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,8 +1,9 @@
+# Shared PR-Agent settings for both workflows
+# Per-workflow settings (model, fallback_models, extra_instructions) live in the
+# workflow callers (e.g. .github/workflows/pr-review.yml).
+
 [config]
 response_language = "en"
-
-# Fallback to Sonnet in case Kimi is unavailable.
-fallback_models=["openrouter/anthropic/claude-sonnet-4.6"]
 
 # ─────────────────────────────────────────────
 # Token & Cost Guardrails
@@ -11,11 +12,14 @@ fallback_models=["openrouter/anthropic/claude-sonnet-4.6"]
 # The models support 256k+; we clamp to 256k
 # to prevent runaway costs while leaving room for deep reviews.
 custom_model_max_tokens = 256000
+# Global prompt-token cap applied on top of the model's capability
+# (effective budget = min(max_model_tokens, custom_model_max_tokens)).
+# Default is 32000, which silently clipped large diffs; align it with
+# custom_model_max_tokens so the full context window is usable.
+max_model_tokens = 256000
 
 # Increase timeout from default 120s → 300s (5 min).
-# Security reviews with large diffs on heavy models need headroom.
 ai_timeout = 300
-
 # If a diff is too large, clip it rather than skipping entirely.
 large_patch_policy = "clip"
 
@@ -28,7 +32,6 @@ glob = [
     "**/*.lock",
     "**/package-lock.json",
     "**/yarn.lock",
-
     # Build artifacts & deps
     "artifacts/**",
     "cache/**",
@@ -36,71 +39,44 @@ glob = [
     "node_modules/**",
     "dist/**",
     "patches/**",
-
     # Minified assets
     "**/*.min.js",
     "**/*.min.css",
-
     # Logs
     "*.log",
-
     # Tests
     "**/*.test.ts",
     "**/*.spec.ts",
     "**/*.test.js",
     "**/*.spec.js",
-
     # Generated / declaration files
     "**/*.d.ts",
-
     # CI/CD
     "**/.github/**",
 ]
 
 # ─────────────────────────────────────────────
-# General Review Settings (/review)
+# Review Settings shared by /review and /security-review
 # ─────────────────────────────────────────────
 [pr_reviewer]
-extra_instructions = """
-You are reviewing changes in a security-sensitive Web3 browser extension wallet.
-
-Focus on the diff in front of you and assess it for correctness, security, reliability, and maintainability.
-
-Prioritize issues such as:
-- Requests without error handling and timeouts
-- Inefficient algorithms or data structures
-- Inconsistent naming conventions or formatting
-- Unnecessary complexity or duplication
-- Missing comments or documentation for complex logic
-- Unhandled exceptions and edge cases
-- Swallowed errors and edge case return statements that should at least log an error
-- Concurrent modifications to state that may result in race conditions
-- Unhandled degradations when interacting with external services and APIs
-- Decimal precision handling and bigint conversions
-- Unhandled pending operations (e.g., submitting twice, not awaiting async calls, etc.)
-- Partial updates that leave the state inconsistent
-- Improper cleanup of subscriptions, timers, and event listeners
-
-Be constructive, concise, and actionable. Keep feedback grounded in the actual changes rather than using a fixed checklist.
-"""
-
-# UX: update the same comment on re-run instead of posting a new one.
-persistent_comment = true
-
-# Post a final "Review completed" message so devs know the agent is done.
+# Post a NEW review comment on every run instead of editing the previous one.
+persistent_comment = false
 final_update_message = true
 
 # Publish even when there are no major findings (avoids silent failures).
 publish_output_no_suggestions = true
 
-# Enable built-in security sub-section even in general reviews (defense in depth).
+# Enable built-in security sub-section even in general reviews.
 require_security_review = true
 
 # Also scan for missing tests, TODOs, and ticket references.
 require_tests_review = true
 require_todo_scan = true
 require_estimate_effort_to_review = true
-require_ticket_analysis_review = true
+
+# The repo has no issues
+require_ticket_analysis_review = false
+extract_issue_from_branch = false
 
 # Keep the review header but suppress noisy help text.
 enable_intro_text = true

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,6 @@
 # Shared PR-Agent settings for both workflows
 # Per-workflow settings (model, fallback_models, extra_instructions) live in the
-# workflow callers (e.g. .github/workflows/pr-review.yml).
+# workflow callers (e.g. .github/workflows/general-review.yml).
 
 [config]
 response_language = "en"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -49,10 +49,6 @@ glob = [
     "**/*.spec.ts",
     "**/*.test.js",
     "**/*.spec.js",
-    # Generated / declaration files
-    "**/*.d.ts",
-    # CI/CD
-    "**/.github/**",
 ]
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## Changes: 

**Security reviews work now.** `/security-review` is not a command PR-Agent recognizes, so the previous workflow (which rewrote the event payload to trick the agent) never reliably triggered the review logic. The workflows now invoke
the PR-Agent CLI directly with an explicit `--pr_url ... review`, so trigger phrases (`/review`, `/security-review`, labels, manual dispatch) are handled purely by GitHub Actions conditions and PR-Agent never parses the comment. The shared logic lives in a reusable workflow, so both review flavors (and other repos later) use the same code with different models/instructions.

**Issue/ticket fetching disabled.** The repo has no GitHub issues, so PR-Agent's issue lookups always 404'd (and triggered a logging crash inside PR-Agent). Disabled via `require_ticket_analysis_review = false` and `extract_issue_from_branch = false`.

**Each review posts a new comment.** Previously reviews updated the existing comment (`persistent_comment = true`), which made the history hard to follow on PRs with many re-reviews. Now every run adds a fresh comment.

**Fixed the token cap that silently broke reviews.** PR-Agent defaults to `max_model_tokens = 32000`, which clipped diffs well below Kimi's actual context window; combined with reasoning-token exhaustion this caused runs that produced no review at all. The cap is now aligned with `custom_model_max_tokens` (256k). Also fixed `fallback_models` being set under the wrong config section, where it was silently ignored.

Supply-chain hardening included: PR-Agent runs from a Docker image pinned by immutable digest, actions are pinned by commit SHA, and the workflow token is scoped to `pull-requests: write` + `contents: read` (no push access).

## Known limitation

PR-Agent does not reliably propagate failures via exit codes (upstream issue The-PR-Agent/pr-agent#1053), so a failed run can still end "green" without posting a review. I haven't found a non-hacky fix for this yet - for now we'll monitor for missing review comments manually, and revisit if upstream improves error propagation or a clean solution turns up.