### PR TITLE
Configure swap slippage settings as they were far too strict

### DIFF
--- a/src/libs/swapAndBridge/consts.ts
+++ b/src/libs/swapAndBridge/consts.ts
@@ -1,0 +1,7 @@
+export const lifi = 'lifi'
+export const socket = 'socket'
+export const squid = 'squid'
+
+export const SwapProviders = [lifi, socket, squid] as const
+
+export type SwapProviderName = (typeof SwapProviders)[number]

--- a/src/libs/swapAndBridge/swapAndBridge.test.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.test.ts
@@ -3,8 +3,9 @@ import { parseUnits } from 'ethers'
 import { describe, expect, test } from '@jest/globals'
 import { Token as LiFiToken } from '@lifi/types'
 
-import { SwapAndBridgeQuote } from '../../interfaces/swapAndBridge'
-import { calculateAmountWarnings, getIsBridgeRoute } from './swapAndBridge'
+import { SwapAndBridgeQuote, SwapAndBridgeToToken } from '../../interfaces/swapAndBridge'
+import { TokenResult } from '../portfolio'
+import { calculateAmountWarnings, getIsBridgeRoute, getSlippage } from './swapAndBridge'
 
 // Helper function to create a mock route for testing
 const createMockRoute = ({
@@ -87,7 +88,128 @@ const createMockRoute = ({
   }
 }
 
+const createMockSlippageToken = (symbol: string): TokenResult => ({
+  address: '0x0000000000000000000000000000000000000000',
+  amount: 0n,
+  chainId: 1n,
+  decimals: 18,
+  flags: {
+    canTopUpGasTank: false,
+    isFeeToken: false,
+    onGasTank: false,
+    rewardsType: null
+  },
+  marketDataIn: [],
+  name: symbol,
+  priceIn: [{ baseCurrency: 'usd', price: 1 }],
+  symbol
+})
+
+const createMockToToken = (symbol: string, chainId = 1): SwapAndBridgeToToken => ({
+  address: '0x0000000000000000000000000000000000000000',
+  chainId,
+  decimals: 18,
+  name: symbol,
+  symbol
+})
+
 describe('swapAndBridge lib', () => {
+  describe('getSlippage', () => {
+    const eth = createMockSlippageToken('ETH')
+    const usdc = createMockSlippageToken('USDC')
+
+    test('uses low slippage for same-chain stable pairs', () => {
+      expect(
+        getSlippage({
+          fromAsset: usdc,
+          toAsset: createMockToToken('USDT'),
+          fromChainId: 1,
+          toChainId: 1,
+          provider: 'lifi',
+          isWrapOrUnwrap: false
+        })
+      ).toBe('0.002')
+    })
+
+    test('uses standard slippage for same-chain volatile routes', () => {
+      expect(
+        getSlippage({
+          fromAsset: eth,
+          toAsset: createMockToToken('WALLET'),
+          fromChainId: 1,
+          toChainId: 1,
+          provider: 'lifi',
+          isWrapOrUnwrap: false
+        })
+      ).toBe('0.005')
+    })
+
+    test('uses standard slippage for cross-chain stable routes', () => {
+      expect(
+        getSlippage({
+          fromAsset: usdc,
+          toAsset: createMockToToken('USDC', 42161),
+          fromChainId: 1,
+          toChainId: 42161,
+          provider: 'lifi',
+          isWrapOrUnwrap: false
+        })
+      ).toBe('0.005')
+    })
+
+    test('uses higher slippage for cross-chain volatile routes', () => {
+      expect(
+        getSlippage({
+          fromAsset: eth,
+          toAsset: createMockToToken('WALLET', 42161),
+          fromChainId: 1,
+          toChainId: 42161,
+          provider: 'lifi',
+          isWrapOrUnwrap: false
+        })
+      ).toBe('0.01')
+    })
+
+    test('converts defaults to Socket percentage units', () => {
+      expect(
+        getSlippage({
+          fromAsset: eth,
+          toAsset: createMockToToken('WALLET', 42161),
+          fromChainId: 1,
+          toChainId: 42161,
+          provider: 'socket',
+          isWrapOrUnwrap: false
+        })
+      ).toBe('1')
+    })
+
+    test('converts defaults to Squid percentage units', () => {
+      expect(
+        getSlippage({
+          fromAsset: eth,
+          toAsset: createMockToToken('WALLET', 5115),
+          fromChainId: 1,
+          toChainId: 5115,
+          provider: 'squid',
+          isWrapOrUnwrap: false
+        })
+      ).toBe('1')
+    })
+
+    test('keeps wrap and unwrap slippage at the provider minimum', () => {
+      expect(
+        getSlippage({
+          fromAsset: eth,
+          toAsset: createMockToToken('WETH'),
+          fromChainId: 1,
+          toChainId: 1,
+          provider: 'squid',
+          isWrapOrUnwrap: true
+        })
+      ).toBe('0.01')
+    })
+  })
+
   describe('getIsBridgeRoute', () => {
     test('should treat same-chain Squid routes as bridge-like routes', () => {
       const selectedRoute = createMockRoute({

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -14,7 +14,6 @@ import {
   BRIDGE_STATUS_INTERVAL,
   UPDATE_SWAP_AND_BRIDGE_QUOTE_INTERVAL
 } from '../../consts/intervals'
-import { getTokenUsdAmount } from '../../controllers/signAccountOp/helper'
 import { Account, AccountOnchainState } from '../../interfaces/account'
 import { Fetch } from '../../interfaces/fetch'
 import { Network } from '../../interfaces/network'
@@ -572,21 +571,63 @@ const isNoFeeToken = (chainId: number, tokenAddr: string) => {
   return false
 }
 
-const getSlippage = (
-  fromAsset: TokenResult,
-  fromAmount: bigint,
-  upperBoundary: string,
-  delimeter: number
-) => {
-  // make sure the slippage doesn't exceed 100$
-  // we do so by having a base of 0.005
-  // to have a slippage of 100$, we need a fromAmountInUsd of at least 20000$,
-  // so each time the from amount makes a jump of 20000$, we lower
-  // the slippage by half
-  const fromAmountInUsd = getTokenUsdAmount(fromAsset, fromAmount)
-  return Number(fromAmountInUsd) < 400
-    ? upperBoundary
-    : (delimeter / Math.ceil(Number(fromAmountInUsd) / 20000)).toPrecision(2)
+type SlippageProvider = 'lifi' | 'socket' | 'squid'
+
+const STABLE_TOKEN_SYMBOLS = new Set([
+  'DAI',
+  'FDUSD',
+  'FRAX',
+  'GHO',
+  'LUSD',
+  'PYUSD',
+  'TUSD',
+  'USDC',
+  'USDC.E',
+  'USDE',
+  'USDP',
+  'USDT',
+  'USDT.E',
+  'USDS',
+  'XDAI'
+])
+
+const SQUID_MIN_SLIPPAGE_PERCENT = 0.01
+
+const getIsStableToken = (token: { symbol: string }) =>
+  STABLE_TOKEN_SYMBOLS.has(token.symbol.trim().toUpperCase())
+
+const formatProviderSlippage = (provider: SlippageProvider, slippagePercent: number) => {
+  const providerSlippage =
+    provider === 'lifi'
+      ? slippagePercent / 100
+      : Math.max(slippagePercent, SQUID_MIN_SLIPPAGE_PERCENT)
+
+  return providerSlippage.toString()
+}
+
+const getSlippage = ({
+  fromAsset,
+  toAsset,
+  fromChainId,
+  toChainId,
+  provider,
+  isWrapOrUnwrap
+}: {
+  fromAsset: TokenResult
+  toAsset: SwapAndBridgeToToken
+  fromChainId: number
+  toChainId: number
+  provider: SlippageProvider
+  isWrapOrUnwrap: boolean
+}) => {
+  const isCrossChain = fromChainId !== toChainId
+  const isStablePair = getIsStableToken(fromAsset) && getIsStableToken(toAsset)
+
+  if (isWrapOrUnwrap) return formatProviderSlippage(provider, SQUID_MIN_SLIPPAGE_PERCENT)
+  if (isCrossChain) return formatProviderSlippage(provider, isStablePair ? 0.5 : 1)
+  if (isStablePair) return formatProviderSlippage(provider, 0.2)
+
+  return formatProviderSlippage(provider, 0.5)
 }
 
 export const calculateAmountWarnings = (

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -46,6 +46,8 @@ import { TokenResult } from '../portfolio'
 import { getTokenBalanceInUSD } from '../portfolio/helpers'
 import { getSanitizedAmount } from '../transfer/amount'
 
+import type { SwapProviderName } from '@/libs/swapAndBridge/consts'
+
 /**
  * Maps banned (or outdated) token addresses to their "valid" replacements,
  * "valid" meaning Swap & Bridge gives more relevant results with these replacements.
@@ -571,9 +573,7 @@ const isNoFeeToken = (chainId: number, tokenAddr: string) => {
   return false
 }
 
-type SlippageProvider = 'lifi' | 'socket' | 'squid'
-
-const STABLE_TOKEN_SYMBOLS = new Set([
+const STABLE_TOKEN_SYMBOLS = [
   'DAI',
   'FDUSD',
   'FRAX',
@@ -588,17 +588,31 @@ const STABLE_TOKEN_SYMBOLS = new Set([
   'USDT',
   'USDT.E',
   'USDS',
-  'XDAI'
-])
+  'XDAI',
+  'BUSD',
+  'GUSD',
+  'RLUSD',
+  'USD1',
+  'sUSDS',
+  'sDAI',
+  'sUSDe',
+  'sfrxUSD',
+  'USDY',
+  'sGHO',
+  'USD₮',
+  'EURe',
+  'EURc',
+  'GBPe'
+]
 
 const SQUID_MIN_SLIPPAGE_PERCENT = 0.01
 
 const getIsStableToken = (token: { symbol: string }) =>
-  STABLE_TOKEN_SYMBOLS.has(token.symbol.trim().toUpperCase())
+  STABLE_TOKEN_SYMBOLS.includes(token.symbol.trim().toUpperCase())
 
-const formatProviderSlippage = (provider: SlippageProvider, slippagePercent: number) => {
+const formatProviderSlippage = (provider: SwapProviderName, slippagePercent: number) => {
   const providerSlippage =
-    provider === 'lifi'
+    provider !== 'squid'
       ? slippagePercent / 100
       : Math.max(slippagePercent, SQUID_MIN_SLIPPAGE_PERCENT)
 
@@ -617,7 +631,7 @@ const getSlippage = ({
   toAsset: SwapAndBridgeToToken
   fromChainId: number
   toChainId: number
-  provider: SlippageProvider
+  provider: SwapProviderName
   isWrapOrUnwrap: boolean
 }) => {
   const isCrossChain = fromChainId !== toChainId

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -475,7 +475,14 @@ export class LiFiAPI implements SwapProvider {
       fromAddress: userAddress,
       toAddress: userAddress,
       options: {
-        slippage: getSlippage(fromAsset, fromAmount, '0.01', 0.005),
+        slippage: getSlippage({
+          fromAsset,
+          toAsset,
+          fromChainId,
+          toChainId,
+          provider: 'lifi',
+          isWrapOrUnwrap
+        }),
         maxPriceImpact: '0.50',
         order: sort === 'time' ? 'FASTEST' : 'CHEAPEST',
         integrator: 'ambire-extension-prod',

--- a/src/services/lifi/api.ts
+++ b/src/services/lifi/api.ts
@@ -1,11 +1,12 @@
+import { lifi, SwapProviderName } from '@/libs/swapAndBridge/consts'
 import { CITREA_CHAIN_ID } from '@/services/squid/constants'
 import {
   ExtendedChain as LiFiExtendedChain,
-  Step as LiFiIncludedStep,
+  LiFiStep,
   Route as LiFiRoute,
   RoutesResponse as LiFiRoutesResponse,
   StatusResponse as LiFiRouteStatusResponse,
-  LiFiStep,
+  Step as LiFiIncludedStep,
   Token as LiFiToken,
   TokensResponse as LiFiTokensResponse,
   ToolError
@@ -150,7 +151,7 @@ const normalizeLiFiRouteToSwapAndBridgeRoute = (
     : undefined
 
   return {
-    providerId: 'lifi',
+    providerId: lifi,
     routeId: route.id,
     fromChainId: route.fromChainId,
     toChainId: route.toChainId,
@@ -212,7 +213,7 @@ const normalizeLiFiStepToSwapAndBridgeSendTxRequest = (
 }
 
 export class LiFiAPI implements SwapProvider {
-  id: string = 'lifi'
+  id: SwapProviderName = lifi
 
   name: string = 'LiFi'
 
@@ -480,7 +481,7 @@ export class LiFiAPI implements SwapProvider {
           toAsset,
           fromChainId,
           toChainId,
-          provider: 'lifi',
+          provider: this.id,
           isWrapOrUnwrap
         }),
         maxPriceImpact: '0.50',

--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -21,6 +21,7 @@ import {
 import {
   addCustomTokensIfNeeded,
   convertNullAddressToZeroAddressIfNeeded,
+  getSlippage,
   isNoFeeToken
 } from '../../libs/swapAndBridge/swapAndBridge'
 import { CITREA_CHAIN_ID } from '../squid/constants'
@@ -289,7 +290,15 @@ export class SocketAPI implements SwapProvider {
       inputAmount: fromAmount.toString(),
       receiverAddress: userAddress,
       useInbox: 'true',
-      enableManual: 'true'
+      enableManual: 'true',
+      slippage: getSlippage({
+        fromAsset,
+        toAsset,
+        fromChainId,
+        toChainId,
+        provider: 'socket',
+        isWrapOrUnwrap
+      })
     })
     const feeTakerAddress = AMBIRE_FEE_TAKER_ADDRESSES[fromChainId]
     const shouldIncludeConvenienceFee =

--- a/src/services/socket/api.ts
+++ b/src/services/socket/api.ts
@@ -1,5 +1,7 @@
 import { getAddress } from 'ethers'
 
+import { socket, SwapProviderName } from '@/libs/swapAndBridge/consts'
+
 import SwapAndBridgeProviderApiError from '../../classes/SwapAndBridgeProviderApiError'
 import { CustomResponse, Fetch, RequestInitWithCustomHeaders } from '../../interfaces/fetch'
 import {
@@ -56,7 +58,7 @@ const normalizeOutgoingSocketTokenAddress = (address: string) =>
   )
 
 export class SocketAPI implements SwapProvider {
-  id: string = 'socket'
+  id: SwapProviderName = socket
 
   name = 'Socket'
 
@@ -296,7 +298,7 @@ export class SocketAPI implements SwapProvider {
         toAsset,
         fromChainId,
         toChainId,
-        provider: 'socket',
+        provider: this.id,
         isWrapOrUnwrap
       })
     })
@@ -388,7 +390,7 @@ export class SocketAPI implements SwapProvider {
 
         return {
           ...steps[0],
-          providerId: 'socket',
+          providerId: this.id,
           outputValueInUsd: route.output.valueInUsd,
           routeId: route.quoteId,
           disabled,

--- a/src/services/squid/api.ts
+++ b/src/services/squid/api.ts
@@ -1,5 +1,7 @@
 import { getAddress, ZeroAddress } from 'ethers'
 
+import { squid, SwapProviderName } from '@/libs/swapAndBridge/consts'
+
 import SwapAndBridgeProviderApiError from '../../classes/SwapAndBridgeProviderApiError'
 import { CustomResponse, Fetch, RequestInitWithCustomHeaders } from '../../interfaces/fetch'
 import {
@@ -130,7 +132,7 @@ const normalizeSquidRouteToSwapAndBridgeRoute = ({
   }
 
   return {
-    providerId: 'squid',
+    providerId: squid,
     routeId: route.quoteId,
     fromChainId,
     toChainId,
@@ -163,7 +165,7 @@ const normalizeSquidRouteToSwapAndBridgeRoute = ({
 }
 
 export class SquidAPI implements SwapProvider {
-  id: string = 'squid'
+  id: SwapProviderName = squid
 
   name: string = 'Squid'
 
@@ -376,7 +378,7 @@ export class SquidAPI implements SwapProvider {
           toAsset,
           fromChainId,
           toChainId,
-          provider: 'squid',
+          provider: this.id,
           isWrapOrUnwrap
         })
       ),

--- a/src/services/squid/api.ts
+++ b/src/services/squid/api.ts
@@ -370,7 +370,16 @@ export class SquidAPI implements SwapProvider {
       toChain: toChainId.toString(),
       toToken: normalizeOutgoingSquidTokenAddress(toTokenAddress),
       toAddress: userAddress,
-      slippage: Number(getSlippage(fromAsset, fromAmount, '1', 0.5)),
+      slippage: Number(
+        getSlippage({
+          fromAsset,
+          toAsset,
+          fromChainId,
+          toChainId,
+          provider: 'squid',
+          isWrapOrUnwrap
+        })
+      ),
       quoteOnly: false
     }
 


### PR DESCRIPTION
## Summary

Updates Swap & Bridge slippage defaults to be route-aware instead of shrinking tolerance based on trade size.

Previously, `getSlippage()` reduced slippage as the USD amount increased, which made large trades increasingly hard to execute and could even produce values below provider minimums. The new logic chooses defaults from pre-quote route intent:

- wrap / unwrap: `0.01%`
- same-chain stable pair: `0.2%`
- same-chain volatile pair: `0.5%`
- cross-chain stable pair: `0.5%`
- cross-chain volatile pair: `1%`

The helper also now handles provider-specific units:
- LI.FI receives decimal slippage, e.g. `0.005`
- Socket/Bungee and Squid receive percentage slippage, e.g. `0.5`

## Changes

- Refactored `getSlippage()` to accept route context instead of amount-based boundaries.
- Added provider-specific slippage formatting for LI.FI, Socket/Bungee, and Squid.
- Added Socket/Bungee quote slippage support.
- Added focused tests for route-aware defaults and provider unit conversion.

## Testing

- `npm run jest -- swapAndBridge.test.ts`
- `npx prettier --check src/libs/swapAndBridge/swapAndBridge.ts src/services/lifi/api.ts src/services/squid/api.ts src/services/socket/api.ts src/libs/swapAndBridge/swapAndBridge.test.ts`
- `yarn extension:type:check-new`