### PR TITLE
Feature/default payment options

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -37,6 +37,7 @@ import { SafeController } from '@/controllers/safe/safe'
 import { SelectedAccountController } from '@/controllers/selectedAccount/selectedAccount'
 import { SignAccountOpType } from '@/controllers/signAccountOp/helper'
 import { OnboardingSuccessProps } from '@/controllers/signAccountOp/signAccountOp'
+import { SignAccountOpPreferenceController } from '@/controllers/signAccountOp/signAccountOpPreference'
 import { SignMessageController } from '@/controllers/signMessage/signMessage'
 import { StorageController } from '@/controllers/storage/storage'
 import { SurveyController } from '@/controllers/survey/survey'
@@ -132,6 +133,8 @@ export class MainController extends EventEmitter implements IMainController {
   // sub-controllers
 
   storage: IStorageController
+
+  signAccountOpPreference: SignAccountOpPreferenceController
 
   featureFlags: IFeatureFlagsController
 
@@ -241,6 +244,10 @@ export class MainController extends EventEmitter implements IMainController {
     this.#appVersion = appVersion
     this.fetch = fetch
     this.storage = new StorageController(this.#storageAPI, eventEmitterRegistry)
+    this.signAccountOpPreference = new SignAccountOpPreferenceController({
+      eventEmitterRegistry,
+      storage: this.storage
+    })
     this.featureFlags = new FeatureFlagsController(featureFlags, this.storage, eventEmitterRegistry)
     this.ui = new UiController({ eventEmitterRegistry, uiManager })
     this.invite = new InviteController({
@@ -483,6 +490,7 @@ export class MainController extends EventEmitter implements IMainController {
       networks: this.networks,
       activity: this.activity,
       storage: this.storage,
+      signAccountOpPreference: this.signAccountOpPreference,
       phishing: this.phishing,
       dapps: this.dapps,
       swapProvider: new SwapProviderParallelExecutor(
@@ -525,6 +533,7 @@ export class MainController extends EventEmitter implements IMainController {
     this.transfer = new TransferController(
       this.callRelayer,
       this.storage,
+      this.signAccountOpPreference,
       humanizerInfo as HumanizerMeta,
       this.selectedAccount,
       this.networks,
@@ -586,6 +595,7 @@ export class MainController extends EventEmitter implements IMainController {
       networks: this.networks,
       providers: this.providers,
       storage: this.storage,
+      signAccountOpPreference: this.signAccountOpPreference,
       selectedAccount: this.selectedAccount,
       keystore: this.keystore,
       transfer: this.transfer,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -585,6 +585,7 @@ export class MainController extends EventEmitter implements IMainController {
       accounts: this.accounts,
       networks: this.networks,
       providers: this.providers,
+      storage: this.storage,
       selectedAccount: this.selectedAccount,
       keystore: this.keystore,
       transfer: this.transfer,

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -126,6 +126,7 @@ const prepareTest = async (seedTestDapp = false) => {
       networks: mainCtrl.networks,
       keystore: mainCtrl.keystore,
       portfolio: mainCtrl.portfolio,
+      storage: mainCtrl.storage,
       externalSignerControllers: {},
       activity: mainCtrl.activity,
       account,

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -116,6 +116,7 @@ const prepareTest = async (seedTestDapp = false) => {
   }) => {
     await mainCtrl.accounts.initialLoadPromise
     await mainCtrl.networks.initialLoadPromise
+    await mainCtrl.signAccountOpPreference.initialLoadPromise
     const account = mainCtrl.accounts.accounts.find((a) => a.addr === addr)!
     const network = mainCtrl.networks.networks.find((n) => n.chainId === chainId)!
 
@@ -126,7 +127,7 @@ const prepareTest = async (seedTestDapp = false) => {
       networks: mainCtrl.networks,
       keystore: mainCtrl.keystore,
       portfolio: mainCtrl.portfolio,
-      storage: mainCtrl.storage,
+      signAccountOpPreference: mainCtrl.signAccountOpPreference,
       externalSignerControllers: {},
       activity: mainCtrl.activity,
       account,

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -23,6 +23,7 @@ import { IProvidersController } from '../../interfaces/provider'
 import { BuildRequest, IRequestsController } from '../../interfaces/requests'
 import { ISafeController } from '../../interfaces/safe'
 import { ISelectedAccountController } from '../../interfaces/selectedAccount'
+import { IStorageController } from '../../interfaces/storage'
 import {
   ISwapAndBridgeController,
   SwapAndBridgeActiveRoute,
@@ -129,6 +130,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
   #providers: IProvidersController
 
+  #storage: IStorageController
+
   #selectedAccount: ISelectedAccountController
 
   #keystore: IKeystoreController
@@ -211,6 +214,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     accounts,
     networks,
     providers,
+    storage,
     selectedAccount,
     keystore,
     transfer,
@@ -243,6 +247,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     accounts: IAccountsController
     networks: INetworksController
     providers: IProvidersController
+    storage: IStorageController
     selectedAccount: ISelectedAccountController
     keystore: IKeystoreController
     transfer: ITransferController
@@ -272,6 +277,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     this.#accounts = accounts
     this.#networks = networks
     this.#providers = providers
+    this.#storage = storage
     this.#selectedAccount = selectedAccount
     this.#keystore = keystore
     this.#transfer = transfer
@@ -1887,6 +1893,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           account,
           network,
           provider: this.#providers.providers[network.chainId.toString()]!,
+          storage: this.#storage,
           phishing: this.#phishing,
           dapps: this.#dapps,
           fromRequestId: requestId,

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -82,6 +82,7 @@ import {
   OnBroadcastSuccess,
   SignAccountOpController
 } from '../signAccountOp/signAccountOp'
+import { SignAccountOpPreferenceController } from '../signAccountOp/signAccountOpPreference'
 import { SwapAndBridgeFormStatus } from '../swapAndBridge/swapAndBridge'
 
 const STATUS_WRAPPED_METHODS = {
@@ -131,6 +132,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   #providers: IProvidersController
 
   #storage: IStorageController
+
+  #signAccountOpPreference: SignAccountOpPreferenceController
 
   #selectedAccount: ISelectedAccountController
 
@@ -215,6 +218,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     networks,
     providers,
     storage,
+    signAccountOpPreference,
     selectedAccount,
     keystore,
     transfer,
@@ -248,6 +252,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     networks: INetworksController
     providers: IProvidersController
     storage: IStorageController
+    signAccountOpPreference: SignAccountOpPreferenceController
     selectedAccount: ISelectedAccountController
     keystore: IKeystoreController
     transfer: ITransferController
@@ -278,6 +283,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     this.#networks = networks
     this.#providers = providers
     this.#storage = storage
+    this.#signAccountOpPreference = signAccountOpPreference
     this.#selectedAccount = selectedAccount
     this.#keystore = keystore
     this.#transfer = transfer
@@ -325,6 +331,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     await this.#selectedAccount.initialLoadPromise
     await this.#keystore.initialLoadPromise
     await this.#safe.initialLoadPromise
+    await this.#signAccountOpPreference.initialLoadPromise
   }
 
   get visibleUserRequests(): UserRequest[] {
@@ -1877,6 +1884,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       const network = this.#networks.networks.find((n) => n.chainId === meta.chainId)!
 
       const requestId = `${meta.accountAddr}-${meta.chainId}${meta.safeTxnProps?.txnId ? `-${meta.safeTxnProps?.txnId}` : ''}`
+      await this.#signAccountOpPreference.initialLoadPromise
       callUserRequest = {
         id: requestId,
         kind: 'calls',
@@ -1888,12 +1896,12 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           networks: this.#networks,
           keystore: this.#keystore,
           portfolio: this.#portfolio,
+          signAccountOpPreference: this.#signAccountOpPreference,
           externalSignerControllers: this.#externalSignerControllers,
           activity: this.#activity,
           account,
           network,
           provider: this.#providers.providers[network.chainId.toString()]!,
-          storage: this.#storage,
           phishing: this.#phishing,
           dapps: this.#dapps,
           fromRequestId: requestId,

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -79,6 +79,7 @@ import { SurveyController } from '../survey/survey'
 import { UiController } from '../ui/ui'
 import { getFeeSpeedIdentifier } from './helper'
 import { FeeSpeed, SigningStatus } from './signAccountOp'
+import { SignAccountOpPreferenceController } from './signAccountOpPreference'
 import { SignAccountOpTesterController } from './signAccountOpTester'
 
 paymasterFactory.init(relayerUrl, fetch, () => {})
@@ -402,6 +403,8 @@ const init = async (
   await storageCtrl.set('accounts', [account])
   await storageCtrl.set('selectedAccount', account.addr)
   if (options?.initialSetStorage) await options.initialSetStorage(storageCtrl)
+  const signAccountOpPreference = new SignAccountOpPreferenceController({ storage: storageCtrl })
+  await signAccountOpPreference.initialLoadPromise
   if (options?.dapps) {
     await storageCtrl.set('dappsV2', options.dapps)
     await storageCtrl.set('lastDappsUpdateVersion', '1.0.0')
@@ -644,7 +647,7 @@ const init = async (
     networks: networksCtrl,
     keystore,
     portfolio,
-    storage: storageCtrl,
+    signAccountOpPreference,
     externalSignerControllers: {},
     account,
     network,
@@ -665,7 +668,7 @@ const init = async (
     gasPrices: gasPricesOrMock
   })
 
-  return { controller, storageCtrl }
+  return { controller, storageCtrl, signAccountOpPreference }
 }
 
 const initDappVerificationBannerTest = async (
@@ -853,8 +856,7 @@ describe('SignAccountOp Controller ', () => {
     const { controller } = await initDefaultFeeSelection(undefined, {
       initialSetStorage: async (storageCtrl) => {
         await storageCtrl.set('signAccountOpFeeTokenPreference', {
-          preferGasTank: true,
-          erc20ByChainId: {}
+          '1': 'gasTank'
         })
       }
     })
@@ -866,17 +868,8 @@ describe('SignAccountOp Controller ', () => {
     const { controller, storageCtrl } = await initDefaultFeeSelection(undefined, {
       initialSetStorage: async (storage) => {
         await storage.set('signAccountOpFeeTokenPreference', {
-          preferGasTank: false,
-          erc20ByChainId: {
-            '1': {
-              address: usdcFeeToken.address,
-              symbol: usdcFeeToken.symbol
-            },
-            '137': {
-              address: nativeFeeTokenPolygon.address,
-              symbol: nativeFeeTokenPolygon.symbol
-            }
-          }
+          '1': usdcFeeToken.address,
+          '137': nativeFeeTokenPolygon.address
         })
       }
     })
@@ -888,21 +881,11 @@ describe('SignAccountOp Controller ', () => {
 
     const storedPreference = await storageCtrl.get('signAccountOpFeeTokenPreference')
     expect(storedPreference).toEqual({
-      preferGasTank: false,
-      erc20ByChainId: {
-        '1': {
-          address: usdcFeeToken.address,
-          symbol: usdcFeeToken.symbol
-        },
-        '137': {
-          address: nativeFeeTokenPolygon.address,
-          symbol: nativeFeeTokenPolygon.symbol
-        }
-      }
+      '1': usdcFeeToken.address,
+      '137': nativeFeeTokenPolygon.address
     })
     expect(controller.pendingFeeTokenPreference).toEqual({
-      preferGasTank: true,
-      erc20ByChainId: {}
+      '1': 'gasTank'
     })
   })
 
@@ -1765,7 +1748,6 @@ describe('Negative cases', () => {
       },
       true
     )
-    // @ts-expect-error
     controller.update({
       hasNewEstimation: true,
       feeToken: gasTankToken,

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -394,12 +394,14 @@ const init = async (
   options?: {
     dapps?: Dapp[]
     callRelayer?: BindedRelayerCall
+    initialSetStorage?: (storageCtrl: StorageController) => Promise<void>
   }
 ) => {
   const storage: Storage = produceMemoryStore()
   const storageCtrl = new StorageController(storage)
   await storageCtrl.set('accounts', [account])
   await storageCtrl.set('selectedAccount', account.addr)
+  if (options?.initialSetStorage) await options.initialSetStorage(storageCtrl)
   if (options?.dapps) {
     await storageCtrl.set('dappsV2', options.dapps)
     await storageCtrl.set('lastDappsUpdateVersion', '1.0.0')
@@ -642,6 +644,7 @@ const init = async (
     networks: networksCtrl,
     keystore,
     portfolio,
+    storage: storageCtrl,
     externalSignerControllers: {},
     account,
     network,
@@ -662,7 +665,7 @@ const init = async (
     gasPrices: gasPricesOrMock
   })
 
-  return { controller }
+  return { controller, storageCtrl }
 }
 
 const initDappVerificationBannerTest = async (
@@ -754,6 +757,143 @@ const initDappVerificationBannerTest = async (
 }
 
 describe('SignAccountOp Controller ', () => {
+  const defaultFeeSelectionGasPrices = {
+    slow: {
+      maxFeePerGas: toBeHex(200n) as Hex,
+      maxPriorityFeePerGas: toBeHex(100n) as Hex
+    },
+    medium: {
+      maxFeePerGas: toBeHex(400n) as Hex,
+      maxPriorityFeePerGas: toBeHex(200n) as Hex
+    },
+    fast: {
+      maxFeePerGas: toBeHex(600n) as Hex,
+      maxPriorityFeePerGas: toBeHex(300n) as Hex
+    },
+    ape: {
+      maxFeePerGas: toBeHex(800n) as Hex,
+      maxPriorityFeePerGas: toBeHex(400n) as Hex
+    }
+  }
+
+  const getDefaultFeeSelectionOptions = (nativeAvailableAmount = 1000000000000000000n) => [
+    {
+      paidBy: smartAccount.addr,
+      availableAmount: nativeAvailableAmount,
+      gasUsed: 25000n,
+      addedNative: 0n,
+      token: nativeFeeToken
+    },
+    {
+      paidBy: smartAccount.addr,
+      availableAmount: 1000000000000000000n,
+      gasUsed: 25000n,
+      addedNative: 0n,
+      token: gasTankToken
+    },
+    {
+      paidBy: smartAccount.addr,
+      availableAmount: 1000000000000000000n,
+      gasUsed: 25000n,
+      addedNative: 0n,
+      token: {
+        ...usdcFeeToken,
+        chainId: 1n
+      }
+    }
+  ]
+
+  const initDefaultFeeSelection = async (
+    feePaymentOptions = getDefaultFeeSelectionOptions(),
+    options?: Parameters<typeof init>[6]
+  ) => {
+    const { controller, storageCtrl } = await init(
+      smartAccount,
+      createAccountOp(smartAccount, 1n),
+      eoaSigner,
+      {
+        providerEstimation: {
+          gasUsed: 25000n,
+          feePaymentOptions
+        },
+        ambireEstimation: {
+          deploymentGas: 0n,
+          gasUsed: 25000n,
+          feePaymentOptions,
+          ambireAccountNonce: 0,
+          flags: {}
+        },
+        flags: {},
+        updatedAt: Date.now()
+      },
+      defaultFeeSelectionGasPrices,
+      false,
+      options
+    )
+
+    await wait(1)
+
+    return { controller, storageCtrl }
+  }
+
+  test('defaults fee payment to the network-native token before gas tank or ERC-20', async () => {
+    const { controller } = await initDefaultFeeSelection()
+
+    expect(controller.selectedOption?.token.address).toBe(nativeFeeToken.address)
+    expect(controller.selectedOption?.token.flags.onGasTank).toBe(false)
+  })
+
+  test('falls back to gas tank before ERC-20 when native cannot cover the fee', async () => {
+    const { controller } = await initDefaultFeeSelection(getDefaultFeeSelectionOptions(1n))
+
+    expect(controller.selectedOption?.token.flags.onGasTank).toBe(true)
+  })
+
+  test('uses gas tank as a saved default across chains', async () => {
+    const { controller } = await initDefaultFeeSelection(undefined, {
+      initialSetStorage: async (storageCtrl) => {
+        await storageCtrl.set('signAccountOpFeeTokenPreference', {
+          preferGasTank: true,
+          erc20ByChainId: {}
+        })
+      }
+    })
+
+    expect(controller.selectedOption?.token.flags.onGasTank).toBe(true)
+  })
+
+  test('uses a saved ERC-20 default only for the matching chain', async () => {
+    const { controller, storageCtrl } = await initDefaultFeeSelection(undefined, {
+      initialSetStorage: async (storage) => {
+        await storage.set('signAccountOpFeeTokenPreference', {
+          preferGasTank: false,
+          erc20ByChainId: {
+            '1': {
+              address: usdcFeeToken.address,
+              symbol: usdcFeeToken.symbol
+            },
+            '137': {
+              address: nativeFeeTokenPolygon.address,
+              symbol: nativeFeeTokenPolygon.symbol
+            }
+          }
+        })
+      }
+    })
+
+    expect(controller.selectedOption?.token.address).toBe(usdcFeeToken.address)
+    expect(controller.selectedOption?.token.symbol).toBe(usdcFeeToken.symbol)
+
+    await controller.setFeeTokenPreference(gasTankToken)
+    await wait(1)
+
+    const storedPreference = await storageCtrl.get('signAccountOpFeeTokenPreference')
+    expect(storedPreference).toEqual({
+      preferGasTank: true,
+      erc20ByChainId: {}
+    })
+  })
+
   test('Estimation race conditions are prevented', async () => {
     const { restore } = suppressConsole()
     const chainId = 137n

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -846,12 +846,6 @@ describe('SignAccountOp Controller ', () => {
     expect(controller.selectedOption?.token.flags.onGasTank).toBe(false)
   })
 
-  test('falls back to gas tank before ERC-20 when native cannot cover the fee', async () => {
-    const { controller } = await initDefaultFeeSelection(getDefaultFeeSelectionOptions(1n))
-
-    expect(controller.selectedOption?.token.flags.onGasTank).toBe(true)
-  })
-
   test('uses gas tank as a saved default across chains', async () => {
     const { controller } = await initDefaultFeeSelection(undefined, {
       initialSetStorage: async (storageCtrl) => {
@@ -885,7 +879,8 @@ describe('SignAccountOp Controller ', () => {
       '137': nativeFeeTokenPolygon.address
     })
     expect(controller.pendingFeeTokenPreference).toEqual({
-      '1': 'gasTank'
+      '1': 'gasTank',
+      '137': nativeFeeTokenPolygon.address
     })
   })
 

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -884,11 +884,23 @@ describe('SignAccountOp Controller ', () => {
     expect(controller.selectedOption?.token.address).toBe(usdcFeeToken.address)
     expect(controller.selectedOption?.token.symbol).toBe(usdcFeeToken.symbol)
 
-    await controller.setFeeTokenPreference(gasTankToken)
-    await wait(1)
+    controller.update({ pendingFeeTokenPreference: gasTankToken })
 
     const storedPreference = await storageCtrl.get('signAccountOpFeeTokenPreference')
     expect(storedPreference).toEqual({
+      preferGasTank: false,
+      erc20ByChainId: {
+        '1': {
+          address: usdcFeeToken.address,
+          symbol: usdcFeeToken.symbol
+        },
+        '137': {
+          address: nativeFeeTokenPolygon.address,
+          symbol: nativeFeeTokenPolygon.symbol
+        }
+      }
+    })
+    expect(controller.pendingFeeTokenPreference).toEqual({
       preferGasTank: true,
       erc20ByChainId: {}
     })

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -209,6 +209,7 @@ export type SignAccountOpUpdateProps = {
   customGasPrices?: GasSpeeds
   customGasLimit?: bigint
   feeToken?: TokenResult
+  pendingFeeTokenPreference?: TokenResult | null
   paidBy?: string
   paidByKeyType?: Key['type']
   speed?: FeeSpeed
@@ -304,6 +305,8 @@ export class SignAccountOpController
   feeTokenResult: TokenResult | null = null
 
   feeTokenPreference: SignAccountOpFeeTokenPreference = DEFAULT_FEE_TOKEN_PREFERENCE
+
+  pendingFeeTokenPreference: SignAccountOpFeeTokenPreference | null = null
 
   #isFeeTokenPreferenceLoaded: boolean = false
 
@@ -1007,6 +1010,73 @@ export class SignAccountOpController
     )
   }
 
+  #getFeeTokenPreference(feeToken: TokenResult) {
+    const nextPreference: SignAccountOpFeeTokenPreference = {
+      preferGasTank: this.feeTokenPreference.preferGasTank,
+      erc20ByChainId: { ...this.feeTokenPreference.erc20ByChainId }
+    }
+    const chainId = this.accountOp.chainId.toString()
+
+    if (feeToken.flags.onGasTank) {
+      // set the gas tank across chains, remove other tokens chosen
+      nextPreference.preferGasTank = true
+      nextPreference.erc20ByChainId = {}
+    } else if (feeToken.address === ZERO_ADDRESS) {
+      // set native across chains, remove other tokens chosen
+      nextPreference.preferGasTank = false
+      nextPreference.erc20ByChainId = {}
+    } else {
+      // set a chain specific option
+      nextPreference.erc20ByChainId[chainId] = {
+        address: feeToken.address,
+        symbol: feeToken.symbol
+      }
+    }
+
+    return nextPreference
+  }
+
+  #doesFeeTokenPreferenceMatchToken(
+    preference: SignAccountOpFeeTokenPreference,
+    feeToken: TokenResult
+  ) {
+    const chainId = this.accountOp.chainId.toString()
+
+    if (feeToken.flags.onGasTank) {
+      return preference.preferGasTank && !preference.erc20ByChainId[chainId]
+    }
+
+    if (feeToken.address === ZERO_ADDRESS) {
+      return !preference.preferGasTank && !preference.erc20ByChainId[chainId]
+    }
+
+    const chainPreference = preference.erc20ByChainId[chainId]
+
+    return (
+      !!chainPreference &&
+      chainPreference.address.toLowerCase() === feeToken.address.toLowerCase() &&
+      chainPreference.symbol.toLowerCase() === feeToken.symbol.toLowerCase()
+    )
+  }
+
+  async #persistPendingFeeTokenPreference() {
+    if (!this.pendingFeeTokenPreference) return
+
+    try {
+      this.feeTokenPreference = this.pendingFeeTokenPreference
+      this.pendingFeeTokenPreference = null
+      this.#isFeeTokenPreferenceLoaded = true
+      await this.#storage.set(FEE_TOKEN_PREFERENCE_STORAGE_KEY, this.feeTokenPreference)
+      this.emitUpdate()
+    } catch (error) {
+      this.emitError({
+        message: 'Error saving SignAccountOp fee token preference',
+        error: error instanceof Error ? error : new Error(String(error)),
+        level: 'silent'
+      })
+    }
+  }
+
   #setDefaults() {
     // Set the first signer as the default one.
     // If there are more available signers, the user will be able to select a different signer from the application.
@@ -1464,48 +1534,12 @@ export class SignAccountOpController
     this.#simulateAndEstimateOrSimulateInterval.restart({ runImmediately: true })
   }
 
-  async setFeeTokenPreference(feeToken: TokenResult) {
-    try {
-      const nextPreference: SignAccountOpFeeTokenPreference = {
-        preferGasTank: this.feeTokenPreference.preferGasTank,
-        erc20ByChainId: { ...this.feeTokenPreference.erc20ByChainId }
-      }
-      const chainId = this.accountOp.chainId.toString()
-
-      if (feeToken.flags.onGasTank) {
-        // set the gas tank across chains, remove other tokens chosen
-        nextPreference.preferGasTank = true
-        nextPreference.erc20ByChainId = {}
-      } else if (feeToken.address === ZERO_ADDRESS) {
-        // set native across chains, remove other tokens chosen
-        nextPreference.preferGasTank = false
-        nextPreference.erc20ByChainId = {}
-      } else {
-        // set a chain specific option
-        nextPreference.erc20ByChainId[chainId] = {
-          address: feeToken.address,
-          symbol: feeToken.symbol
-        }
-      }
-
-      this.feeTokenPreference = nextPreference
-      this.#isFeeTokenPreferenceLoaded = true
-      await this.#storage.set(FEE_TOKEN_PREFERENCE_STORAGE_KEY, nextPreference)
-      this.emitUpdate()
-    } catch (error) {
-      this.emitError({
-        message: 'Error saving SignAccountOp fee token preference',
-        error: error instanceof Error ? error : new Error(String(error)),
-        level: 'silent'
-      })
-    }
-  }
-
   update({
     gasPrices,
     customGasPrices,
     customGasLimit,
     feeToken,
+    pendingFeeTokenPreference,
     paidBy,
     speed,
     signingKeyAddr,
@@ -1665,12 +1699,24 @@ export class SignAccountOpController
         this.customGasLimit = customGasLimit
       }
 
+      if (typeof pendingFeeTokenPreference !== 'undefined') {
+        this.pendingFeeTokenPreference = pendingFeeTokenPreference
+          ? this.#getFeeTokenPreference(pendingFeeTokenPreference)
+          : null
+      }
+
       this.#syncSpeedUpFeeSelectionFromEstimation()
 
       if (feeToken && paidBy && !isSpeedUpTransaction) {
         this.#paidBy = paidBy
         this.feeTokenResult = feeToken
         this.#hasUserSelectedFeeOption = true
+        if (
+          this.pendingFeeTokenPreference &&
+          !this.#doesFeeTokenPreferenceMatchToken(this.pendingFeeTokenPreference, feeToken)
+        ) {
+          this.pendingFeeTokenPreference = null
+        }
 
         if (this.accountOp.gasFeePayment && this.accountOp.gasFeePayment.paidBy !== paidBy) {
           // Reset paidByKeyType if the payer has changed
@@ -1843,6 +1889,7 @@ export class SignAccountOpController
     this.selectedFeeSpeed = FeeSpeed.Fast
     this.#paidBy = null
     this.feeTokenResult = null
+    this.pendingFeeTokenPreference = null
     this.status = null
     this.signedTransactionsCount = null
     this.hardwareWalletSigningRequest = null
@@ -2799,6 +2846,8 @@ export class SignAccountOpController
       const message = `Unable to sign the transaction. During the preparation step, required account key information was found missing. ${RETRY_TO_INIT_ACCOUNT_OP_MSG}`
       return this.#emitSigningErrorAndResetToReadyToSign({ message })
     }
+
+    await this.#persistPendingFeeTokenPreference()
 
     const estimation = this.estimation.estimation as FullEstimationSummary
     const broadcastOption = this.accountOp.gasFeePayment.broadcastOption
@@ -3839,6 +3888,7 @@ export class SignAccountOpController
       feePayerKeyStoreKeys: this.feePayerKeyStoreKeys,
       feeToken: this.feeToken,
       feeTokenPreference: this.feeTokenPreference,
+      pendingFeeTokenPreference: this.pendingFeeTokenPreference,
       speedOptions: this.speedOptions,
       selectedOption: this.selectedOption,
       account: this.account,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -63,7 +63,6 @@ import {
   TraceCallDiscoveryStatus,
   Warning
 } from '../../interfaces/signAccountOp'
-import { IStorageController, StorageProps } from '../../interfaces/storage'
 import { UserRequest } from '../../interfaces/userRequest'
 import { getContractImplementation } from '../../libs/7702/7702'
 import {
@@ -157,6 +156,10 @@ import {
   getUnknownTokenWarning,
   SignAccountOpType
 } from './helper'
+import {
+  SignAccountOpFeeTokenPreference,
+  SignAccountOpPreferenceController
+} from './signAccountOpPreference'
 
 export enum SigningStatus {
   EstimationError = 'estimation-error',
@@ -231,10 +234,6 @@ export type OnBroadcastSuccess = (props: OnboardingSuccessProps) => Promise<void
 
 export type OnBroadcastFailed = (accountOp: AccountOp) => void
 
-export type SignAccountOpFeeTokenPreference = StorageProps['signAccountOpFeeTokenPreference']
-
-const FEE_TOKEN_PREFERENCE_STORAGE_KEY = 'signAccountOpFeeTokenPreference'
-
 export class SignAccountOpController
   extends HumanizationController
   implements ISignAccountOpController
@@ -249,7 +248,7 @@ export class SignAccountOpController
 
   #portfolio: IPortfolioController
 
-  #storage: IStorageController
+  #signAccountOpPreference: SignAccountOpPreferenceController
 
   #externalSignerControllers: ExternalSignerControllers
 
@@ -285,8 +284,6 @@ export class SignAccountOpController
 
   #paidBy: string | null = null
 
-  #hasUserSelectedFeeOption: boolean = false
-
   /**
    * The selected fee token the user is going to broadcast with.
    * This probably exists in selectedOption as well and it could
@@ -297,8 +294,6 @@ export class SignAccountOpController
   feeTokenPreference: SignAccountOpFeeTokenPreference = {}
 
   pendingFeeTokenPreference: SignAccountOpFeeTokenPreference | null = null
-
-  #isFeeTokenPreferenceLoaded: boolean = false
 
   selectedFeeSpeed: FeeSpeed | null = FeeSpeed.Fast
 
@@ -414,7 +409,7 @@ export class SignAccountOpController
     networks,
     keystore,
     portfolio,
-    storage,
+    signAccountOpPreference,
     externalSignerControllers,
     account,
     network,
@@ -436,7 +431,7 @@ export class SignAccountOpController
     networks: INetworksController
     keystore: IKeystoreController
     portfolio: IPortfolioController
-    storage: IStorageController
+    signAccountOpPreference: SignAccountOpPreferenceController
     externalSignerControllers: ExternalSignerControllers
     account: Account
     network: Network
@@ -457,7 +452,8 @@ export class SignAccountOpController
     this.#accounts = accounts
     this.#keystore = keystore
     this.#portfolio = portfolio
-    this.#storage = storage
+    this.#signAccountOpPreference = signAccountOpPreference
+    this.feeTokenPreference = this.#signAccountOpPreference.feeTokenPreference
     this.#externalSignerControllers = externalSignerControllers
     this.account = account
     const accountState = accounts.accountStates[account.addr]![network.chainId.toString()]! // ! is safe as otherwise, nothing will work
@@ -764,7 +760,6 @@ export class SignAccountOpController
   }
 
   #load() {
-    void this.#loadFeeTokenPreference()
     this.#setDefaults()
     this.humanize()
     this.learnTokens()
@@ -930,28 +925,6 @@ export class SignAccountOpController
     return this.estimation && this.estimation.isInitialized()
   }
 
-  async #loadFeeTokenPreference() {
-    try {
-      this.feeTokenPreference = await this.#storage.get(FEE_TOKEN_PREFERENCE_STORAGE_KEY, {})
-      this.#isFeeTokenPreferenceLoaded = true
-
-      if (!this.#hasUserSelectedFeeOption && this.estimation.status === EstimationStatus.Success) {
-        this.feeTokenResult = null
-        this.#paidBy = null
-        this.update({ hasNewEstimation: true })
-        return
-      }
-
-      this.emitUpdate()
-    } catch (error) {
-      this.emitError({
-        message: 'Error loading SignAccountOp fee token preference',
-        error: error instanceof Error ? error : new Error(String(error)),
-        level: 'silent'
-      })
-    }
-  }
-
   #isNativeFeeOption(option: FeePaymentOption) {
     return option.token.address === ZERO_ADDRESS && !option.token.flags.onGasTank
   }
@@ -975,9 +948,7 @@ export class SignAccountOpController
   #getDefaultFeeOption(options: FeePaymentOption[]) {
     const notDisabled = options.filter((option) => !this.#getIsFeeOptionDisabled(option))
     const selectableOptions = notDisabled.length ? notDisabled : options
-    const preferred = this.#isFeeTokenPreferenceLoaded
-      ? this.#getPreferredFeeOption(selectableOptions)
-      : undefined
+    const preferred = this.#getPreferredFeeOption(selectableOptions)
 
     if (preferred) return preferred
 
@@ -1019,8 +990,7 @@ export class SignAccountOpController
     try {
       this.feeTokenPreference = this.pendingFeeTokenPreference
       this.pendingFeeTokenPreference = null
-      this.#isFeeTokenPreferenceLoaded = true
-      await this.#storage.set(FEE_TOKEN_PREFERENCE_STORAGE_KEY, this.feeTokenPreference)
+      await this.#signAccountOpPreference.setFeeTokenPreference(this.feeTokenPreference)
       this.emitUpdate()
     } catch (error) {
       this.emitError({
@@ -1664,7 +1634,6 @@ export class SignAccountOpController
       if (feeToken && paidBy && !isSpeedUpTransaction) {
         this.#paidBy = paidBy
         this.feeTokenResult = feeToken
-        this.#hasUserSelectedFeeOption = true
         if (
           this.pendingFeeTokenPreference &&
           !this.#doesFeeTokenPreferenceMatchToken(this.pendingFeeTokenPreference, feeToken)

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -992,9 +992,10 @@ export class SignAccountOpController
     if (!this.pendingFeeTokenPreference) return
 
     try {
-      this.feeTokenPreference = this.pendingFeeTokenPreference
+      const nextFeeTokenPreference = this.pendingFeeTokenPreference
+      await this.#signAccountOpPreference.setFeeTokenPreference(nextFeeTokenPreference)
+      this.feeTokenPreference = nextFeeTokenPreference
       this.pendingFeeTokenPreference = null
-      await this.#signAccountOpPreference.setFeeTokenPreference(this.feeTokenPreference)
       this.emitUpdate()
     } catch (error) {
       this.emitError({

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -25,12 +25,7 @@ import {
 } from '../../classes/recurringTimeout/recurringTimeout'
 import { EIP7702Auth } from '../../consts/7702'
 import { FEE_COLLECTOR } from '../../consts/addresses'
-import {
-  EIP_7702_AMBIRE_ACCOUNT,
-  EIP_7702_GRID_PLUS,
-  EIP_7702_KATANA,
-  SINGLETON
-} from '../../consts/deploy'
+import { SINGLETON } from '../../consts/deploy'
 import gasTankFeeTokens from '../../consts/gasTankFeeTokens'
 import { ESTIMATE_UPDATE_INTERVAL, GAS_PRICE_UPDATE_INTERVAL } from '../../consts/intervals'
 import {
@@ -68,6 +63,7 @@ import {
   TraceCallDiscoveryStatus,
   Warning
 } from '../../interfaces/signAccountOp'
+import { IStorageController, StorageProps } from '../../interfaces/storage'
 import { UserRequest } from '../../interfaces/userRequest'
 import { getContractImplementation } from '../../libs/7702/7702'
 import {
@@ -234,6 +230,20 @@ export type OnBroadcastSuccess = (props: OnboardingSuccessProps) => Promise<void
 
 export type OnBroadcastFailed = (accountOp: AccountOp) => void
 
+export type SignAccountOpFeeTokenPreference = StorageProps['signAccountOpFeeTokenPreference']
+
+const DEFAULT_FEE_TOKEN_PREFERENCE: SignAccountOpFeeTokenPreference = {
+  preferGasTank: false,
+  erc20ByChainId: {}
+}
+
+const FEE_TOKEN_PREFERENCE_STORAGE_KEY = 'signAccountOpFeeTokenPreference'
+
+const getDefaultFeeTokenPreference = (): SignAccountOpFeeTokenPreference => ({
+  preferGasTank: DEFAULT_FEE_TOKEN_PREFERENCE.preferGasTank,
+  erc20ByChainId: { ...DEFAULT_FEE_TOKEN_PREFERENCE.erc20ByChainId }
+})
+
 export class SignAccountOpController
   extends HumanizationController
   implements ISignAccountOpController
@@ -247,6 +257,8 @@ export class SignAccountOpController
   #keystore: IKeystoreController
 
   #portfolio: IPortfolioController
+
+  #storage: IStorageController
 
   #externalSignerControllers: ExternalSignerControllers
 
@@ -282,12 +294,18 @@ export class SignAccountOpController
 
   #paidBy: string | null = null
 
+  #hasUserSelectedFeeOption: boolean = false
+
   /**
    * The selected fee token the user is going to broadcast with.
    * This probably exists in selectedOption as well and it could
    * be refactored away someday
    */
   feeTokenResult: TokenResult | null = null
+
+  feeTokenPreference: SignAccountOpFeeTokenPreference = DEFAULT_FEE_TOKEN_PREFERENCE
+
+  #isFeeTokenPreferenceLoaded: boolean = false
 
   selectedFeeSpeed: FeeSpeed | null = FeeSpeed.Fast
 
@@ -403,6 +421,7 @@ export class SignAccountOpController
     networks,
     keystore,
     portfolio,
+    storage,
     externalSignerControllers,
     account,
     network,
@@ -424,6 +443,7 @@ export class SignAccountOpController
     networks: INetworksController
     keystore: IKeystoreController
     portfolio: IPortfolioController
+    storage: IStorageController
     externalSignerControllers: ExternalSignerControllers
     account: Account
     network: Network
@@ -444,6 +464,7 @@ export class SignAccountOpController
     this.#accounts = accounts
     this.#keystore = keystore
     this.#portfolio = portfolio
+    this.#storage = storage
     this.#externalSignerControllers = externalSignerControllers
     this.account = account
     const accountState = accounts.accountStates[account.addr]![network.chainId.toString()]! // ! is safe as otherwise, nothing will work
@@ -750,6 +771,7 @@ export class SignAccountOpController
   }
 
   #load() {
+    void this.#loadFeeTokenPreference()
     this.#setDefaults()
     this.humanize()
     this.learnTokens()
@@ -915,6 +937,76 @@ export class SignAccountOpController
     return this.estimation && this.estimation.isInitialized()
   }
 
+  async #loadFeeTokenPreference() {
+    try {
+      this.feeTokenPreference = await this.#storage.get(
+        FEE_TOKEN_PREFERENCE_STORAGE_KEY,
+        getDefaultFeeTokenPreference()
+      )
+      this.#isFeeTokenPreferenceLoaded = true
+
+      if (!this.#hasUserSelectedFeeOption && this.estimation.status === EstimationStatus.Success) {
+        this.feeTokenResult = null
+        this.#paidBy = null
+        this.update({ hasNewEstimation: true })
+        return
+      }
+
+      this.emitUpdate()
+    } catch (error) {
+      this.emitError({
+        message: 'Error loading SignAccountOp fee token preference',
+        error: error instanceof Error ? error : new Error(String(error)),
+        level: 'silent'
+      })
+    }
+  }
+
+  #isNativeFeeOption(option: FeePaymentOption) {
+    return option.token.address === ZERO_ADDRESS && !option.token.flags.onGasTank
+  }
+
+  #isErc20FeeOption(option: FeePaymentOption) {
+    return option.token.address !== ZERO_ADDRESS && !option.token.flags.onGasTank
+  }
+
+  #getPreferredFeeOption(options: FeePaymentOption[]) {
+    const erc20Preference =
+      this.feeTokenPreference.erc20ByChainId[this.accountOp.chainId.toString()]
+
+    if (erc20Preference) {
+      return options.find(
+        (option) =>
+          this.#isErc20FeeOption(option) &&
+          option.token.address.toLowerCase() === erc20Preference.address.toLowerCase() &&
+          option.token.symbol.toLowerCase() === erc20Preference.symbol.toLowerCase()
+      )
+    }
+
+    if (this.feeTokenPreference.preferGasTank) {
+      return options.find((option) => option.token.flags.onGasTank)
+    }
+
+    return undefined
+  }
+
+  #getDefaultFeeOption(options: FeePaymentOption[]) {
+    const notDisabled = options.filter((option) => !this.#getIsFeeOptionDisabled(option))
+    const selectableOptions = notDisabled.length ? notDisabled : options
+    const preferred = this.#isFeeTokenPreferenceLoaded
+      ? this.#getPreferredFeeOption(selectableOptions)
+      : undefined
+
+    if (preferred) return preferred
+
+    return (
+      selectableOptions.find((option) => this.#isNativeFeeOption(option)) ||
+      selectableOptions.find((option) => option.token.flags.onGasTank) ||
+      selectableOptions.find((option) => this.#isErc20FeeOption(option)) ||
+      selectableOptions[0]
+    )
+  }
+
   #setDefaults() {
     // Set the first signer as the default one.
     // If there are more available signers, the user will be able to select a different signer from the application.
@@ -954,30 +1046,17 @@ export class SignAccountOpController
         // for Safe accounts, always select the first not disabled EOA
         // or the first EOA if all are disabled
         if (!!this.account.safeCreation && payOptionsPaidByEOA.length) {
-          const notDisabled = payOptionsPaidByEOA.find(
-            (option) => !this.#getIsFeeOptionDisabled(option)
-          )
-          const selected = notDisabled ?? payOptionsPaidByEOA[0]!
+          const selected = this.#getDefaultFeeOption(payOptionsPaidByEOA)!
           this.feeTokenResult = selected.token
           this.#paidBy = selected.paidBy
-        } else if (
-          payOptionsPaidByUsOrGasTank.length > 0 &&
-          !this.#getIsFeeOptionDisabled(payOptionsPaidByUsOrGasTank[0]!)
-        ) {
-          this.feeTokenResult = payOptionsPaidByUsOrGasTank[0]!.token
-          this.#paidBy = payOptionsPaidByUsOrGasTank[0]!.paidBy
-        } else if (
-          payOptionsPaidByEOA.length > 0 &&
-          !this.#getIsFeeOptionDisabled(payOptionsPaidByEOA[0]!)
-        ) {
-          this.feeTokenResult = payOptionsPaidByEOA[0]!.token
-          this.#paidBy = payOptionsPaidByEOA[0]!.paidBy
         } else if (payOptionsPaidByUsOrGasTank.length) {
-          this.feeTokenResult = payOptionsPaidByUsOrGasTank[0]!.token
-          this.#paidBy = payOptionsPaidByUsOrGasTank[0]!.paidBy
+          const selected = this.#getDefaultFeeOption(payOptionsPaidByUsOrGasTank)!
+          this.feeTokenResult = selected.token
+          this.#paidBy = selected.paidBy
         } else if (payOptionsPaidByEOA.length) {
-          this.feeTokenResult = payOptionsPaidByEOA[0]!.token
-          this.#paidBy = payOptionsPaidByEOA[0]!.paidBy
+          const selected = this.#getDefaultFeeOption(payOptionsPaidByEOA)!
+          this.feeTokenResult = selected.token
+          this.#paidBy = selected.paidBy
         }
       }
     }
@@ -1385,6 +1464,43 @@ export class SignAccountOpController
     this.#simulateAndEstimateOrSimulateInterval.restart({ runImmediately: true })
   }
 
+  async setFeeTokenPreference(feeToken: TokenResult) {
+    try {
+      const nextPreference: SignAccountOpFeeTokenPreference = {
+        preferGasTank: this.feeTokenPreference.preferGasTank,
+        erc20ByChainId: { ...this.feeTokenPreference.erc20ByChainId }
+      }
+      const chainId = this.accountOp.chainId.toString()
+
+      if (feeToken.flags.onGasTank) {
+        // set the gas tank across chains, remove other tokens chosen
+        nextPreference.preferGasTank = true
+        nextPreference.erc20ByChainId = {}
+      } else if (feeToken.address === ZERO_ADDRESS) {
+        // set native across chains, remove other tokens chosen
+        nextPreference.preferGasTank = false
+        nextPreference.erc20ByChainId = {}
+      } else {
+        // set a chain specific option
+        nextPreference.erc20ByChainId[chainId] = {
+          address: feeToken.address,
+          symbol: feeToken.symbol
+        }
+      }
+
+      this.feeTokenPreference = nextPreference
+      this.#isFeeTokenPreferenceLoaded = true
+      await this.#storage.set(FEE_TOKEN_PREFERENCE_STORAGE_KEY, nextPreference)
+      this.emitUpdate()
+    } catch (error) {
+      this.emitError({
+        message: 'Error saving SignAccountOp fee token preference',
+        error: error instanceof Error ? error : new Error(String(error)),
+        level: 'silent'
+      })
+    }
+  }
+
   update({
     gasPrices,
     customGasPrices,
@@ -1554,6 +1670,7 @@ export class SignAccountOpController
       if (feeToken && paidBy && !isSpeedUpTransaction) {
         this.#paidBy = paidBy
         this.feeTokenResult = feeToken
+        this.#hasUserSelectedFeeOption = true
 
         if (this.accountOp.gasFeePayment && this.accountOp.gasFeePayment.paidBy !== paidBy) {
           // Reset paidByKeyType if the payer has changed
@@ -1854,13 +1971,13 @@ export class SignAccountOpController
     if (aCanCoverFee && !bCanCoverFee) return -1
     if (!aCanCoverFee && bCanCoverFee) return 1
 
-    // gas tank first
+    // native first
+    if (this.#isNativeFeeOption(a) && !this.#isNativeFeeOption(b)) return -1
+    if (!this.#isNativeFeeOption(a) && this.#isNativeFeeOption(b)) return 1
+
+    // gas tank second
     if (a.token.flags.onGasTank && !b.token.flags.onGasTank) return -1
     if (!a.token.flags.onGasTank && b.token.flags.onGasTank) return 1
-
-    // native second
-    if (a.token.address === ZERO_ADDRESS && b.token.address !== ZERO_ADDRESS) return -1
-    if (a.token.address !== ZERO_ADDRESS && b.token.address === ZERO_ADDRESS) return 1
 
     if (!a || !b) return 0
 
@@ -2782,9 +2899,8 @@ export class SignAccountOpController
 
         const { safeTxn, typedData, safeTxnHash, signingRequest } =
           this.#getSafeSigningData(accountState)
-        const signature = (await this.#withHardwareWalletSigningRequest(
-          signingRequest,
-          () => safeSigner.signTypedData(typedData)
+        const signature = (await this.#withHardwareWalletSigningRequest(signingRequest, () =>
+          safeSigner.signTypedData(typedData)
         )) as Hex
         nowSignedSigs.push(signature)
 
@@ -3722,6 +3838,7 @@ export class SignAccountOpController
       accountKeyStoreKeys: this.accountKeyStoreKeys,
       feePayerKeyStoreKeys: this.feePayerKeyStoreKeys,
       feeToken: this.feeToken,
+      feeTokenPreference: this.feeTokenPreference,
       speedOptions: this.speedOptions,
       selectedOption: this.selectedOption,
       account: this.account,

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -233,17 +233,7 @@ export type OnBroadcastFailed = (accountOp: AccountOp) => void
 
 export type SignAccountOpFeeTokenPreference = StorageProps['signAccountOpFeeTokenPreference']
 
-const DEFAULT_FEE_TOKEN_PREFERENCE: SignAccountOpFeeTokenPreference = {
-  preferGasTank: false,
-  erc20ByChainId: {}
-}
-
 const FEE_TOKEN_PREFERENCE_STORAGE_KEY = 'signAccountOpFeeTokenPreference'
-
-const getDefaultFeeTokenPreference = (): SignAccountOpFeeTokenPreference => ({
-  preferGasTank: DEFAULT_FEE_TOKEN_PREFERENCE.preferGasTank,
-  erc20ByChainId: { ...DEFAULT_FEE_TOKEN_PREFERENCE.erc20ByChainId }
-})
 
 export class SignAccountOpController
   extends HumanizationController
@@ -304,7 +294,7 @@ export class SignAccountOpController
    */
   feeTokenResult: TokenResult | null = null
 
-  feeTokenPreference: SignAccountOpFeeTokenPreference = DEFAULT_FEE_TOKEN_PREFERENCE
+  feeTokenPreference: SignAccountOpFeeTokenPreference = {}
 
   pendingFeeTokenPreference: SignAccountOpFeeTokenPreference | null = null
 
@@ -942,10 +932,7 @@ export class SignAccountOpController
 
   async #loadFeeTokenPreference() {
     try {
-      this.feeTokenPreference = await this.#storage.get(
-        FEE_TOKEN_PREFERENCE_STORAGE_KEY,
-        getDefaultFeeTokenPreference()
-      )
+      this.feeTokenPreference = await this.#storage.get(FEE_TOKEN_PREFERENCE_STORAGE_KEY, {})
       this.#isFeeTokenPreferenceLoaded = true
 
       if (!this.#hasUserSelectedFeeOption && this.estimation.status === EstimationStatus.Success) {
@@ -969,25 +956,17 @@ export class SignAccountOpController
     return option.token.address === ZERO_ADDRESS && !option.token.flags.onGasTank
   }
 
-  #isErc20FeeOption(option: FeePaymentOption) {
-    return option.token.address !== ZERO_ADDRESS && !option.token.flags.onGasTank
-  }
-
   #getPreferredFeeOption(options: FeePaymentOption[]) {
-    const erc20Preference =
-      this.feeTokenPreference.erc20ByChainId[this.accountOp.chainId.toString()]
+    const pref = this.feeTokenPreference[this.accountOp.chainId.toString()]
 
-    if (erc20Preference) {
-      return options.find(
-        (option) =>
-          this.#isErc20FeeOption(option) &&
-          option.token.address.toLowerCase() === erc20Preference.address.toLowerCase() &&
-          option.token.symbol.toLowerCase() === erc20Preference.symbol.toLowerCase()
-      )
-    }
+    if (pref) {
+      // find the gas tank
+      if (pref === 'gasTank') {
+        return options.find((option) => option.token.flags.onGasTank)
+      }
 
-    if (this.feeTokenPreference.preferGasTank) {
-      return options.find((option) => option.token.flags.onGasTank)
+      // find the token/native
+      return options.find((option) => option.token.address.toLowerCase() === pref.toLowerCase())
     }
 
     return undefined
@@ -1005,34 +984,17 @@ export class SignAccountOpController
     return (
       selectableOptions.find((option) => this.#isNativeFeeOption(option)) ||
       selectableOptions.find((option) => option.token.flags.onGasTank) ||
-      selectableOptions.find((option) => this.#isErc20FeeOption(option)) ||
       selectableOptions[0]
     )
   }
 
   #getFeeTokenPreference(feeToken: TokenResult) {
     const nextPreference: SignAccountOpFeeTokenPreference = {
-      preferGasTank: this.feeTokenPreference.preferGasTank,
-      erc20ByChainId: { ...this.feeTokenPreference.erc20ByChainId }
+      ...this.feeTokenPreference
     }
-    const chainId = this.accountOp.chainId.toString()
-
-    if (feeToken.flags.onGasTank) {
-      // set the gas tank across chains, remove other tokens chosen
-      nextPreference.preferGasTank = true
-      nextPreference.erc20ByChainId = {}
-    } else if (feeToken.address === ZERO_ADDRESS) {
-      // set native across chains, remove other tokens chosen
-      nextPreference.preferGasTank = false
-      nextPreference.erc20ByChainId = {}
-    } else {
-      // set a chain specific option
-      nextPreference.erc20ByChainId[chainId] = {
-        address: feeToken.address,
-        symbol: feeToken.symbol
-      }
-    }
-
+    nextPreference[this.accountOp.chainId.toString()] = feeToken.flags.onGasTank
+      ? 'gasTank'
+      : feeToken.address
     return nextPreference
   }
 
@@ -1042,21 +1004,13 @@ export class SignAccountOpController
   ) {
     const chainId = this.accountOp.chainId.toString()
 
-    if (feeToken.flags.onGasTank) {
-      return preference.preferGasTank && !preference.erc20ByChainId[chainId]
-    }
+    const chainPreference = preference[chainId]
+    if (!chainPreference) return false
 
-    if (feeToken.address === ZERO_ADDRESS) {
-      return !preference.preferGasTank && !preference.erc20ByChainId[chainId]
-    }
+    const isGasTank = feeToken.flags.onGasTank && chainPreference === 'gasTank'
+    const isSelectedToken = feeToken.address.toLowerCase() === chainPreference.toLowerCase()
 
-    const chainPreference = preference.erc20ByChainId[chainId]
-
-    return (
-      !!chainPreference &&
-      chainPreference.address.toLowerCase() === feeToken.address.toLowerCase() &&
-      chainPreference.symbol.toLowerCase() === feeToken.symbol.toLowerCase()
-    )
+    return isGasTank || isSelectedToken
   }
 
   async #persistPendingFeeTokenPreference() {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -939,7 +939,10 @@ export class SignAccountOpController
       }
 
       // find the token/native
-      return options.find((option) => option.token.address.toLowerCase() === pref.toLowerCase())
+      return options.find(
+        (option) =>
+          !option.token.flags.onGasTank && option.token.address.toLowerCase() === pref.toLowerCase()
+      )
     }
 
     return undefined

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -982,7 +982,8 @@ export class SignAccountOpController
     if (!chainPreference) return false
 
     const isGasTank = feeToken.flags.onGasTank && chainPreference === 'gasTank'
-    const isSelectedToken = feeToken.address.toLowerCase() === chainPreference.toLowerCase()
+    const isSelectedToken =
+      !feeToken.flags.onGasTank && feeToken.address.toLowerCase() === chainPreference.toLowerCase()
 
     return isGasTank || isSelectedToken
   }

--- a/src/controllers/signAccountOp/signAccountOpPreference.ts
+++ b/src/controllers/signAccountOp/signAccountOpPreference.ts
@@ -9,6 +9,8 @@ export const FEE_TOKEN_PREFERENCE_STORAGE_KEY = 'signAccountOpFeeTokenPreference
 export class SignAccountOpPreferenceController extends EventEmitter {
   #storage: IStorageController
 
+  #updateQueue: Promise<void> = Promise.resolve()
+
   feeTokenPreference: SignAccountOpFeeTokenPreference = {}
 
   initialLoadPromise?: Promise<void>
@@ -42,17 +44,22 @@ export class SignAccountOpPreferenceController extends EventEmitter {
   }
 
   async setFeeTokenPreference(feeTokenPreference: SignAccountOpFeeTokenPreference) {
-    this.feeTokenPreference = feeTokenPreference
-    this.emitUpdate()
+    const update = this.#updateQueue.then(async () => {
+      try {
+        await this.#storage.set(FEE_TOKEN_PREFERENCE_STORAGE_KEY, feeTokenPreference)
+        this.feeTokenPreference = feeTokenPreference
+        this.emitUpdate()
+      } catch (error) {
+        this.emitError({
+          message: 'Error saving SignAccountOp fee token preference',
+          error: error instanceof Error ? error : new Error(String(error)),
+          level: 'silent'
+        })
+        throw error
+      }
+    })
 
-    try {
-      await this.#storage.set(FEE_TOKEN_PREFERENCE_STORAGE_KEY, this.feeTokenPreference)
-    } catch (error) {
-      this.emitError({
-        message: 'Error saving SignAccountOp fee token preference',
-        error: error instanceof Error ? error : new Error(String(error)),
-        level: 'silent'
-      })
-    }
+    this.#updateQueue = update.catch(() => {})
+    await update
   }
 }

--- a/src/controllers/signAccountOp/signAccountOpPreference.ts
+++ b/src/controllers/signAccountOp/signAccountOpPreference.ts
@@ -1,0 +1,58 @@
+import { IEventEmitterRegistryController } from '../../interfaces/eventEmitter'
+import { IStorageController, StorageProps } from '../../interfaces/storage'
+import EventEmitter from '../eventEmitter/eventEmitter'
+
+export type SignAccountOpFeeTokenPreference = StorageProps['signAccountOpFeeTokenPreference']
+
+export const FEE_TOKEN_PREFERENCE_STORAGE_KEY = 'signAccountOpFeeTokenPreference'
+
+export class SignAccountOpPreferenceController extends EventEmitter {
+  #storage: IStorageController
+
+  feeTokenPreference: SignAccountOpFeeTokenPreference = {}
+
+  initialLoadPromise?: Promise<void>
+
+  constructor({
+    eventEmitterRegistry,
+    storage
+  }: {
+    eventEmitterRegistry?: IEventEmitterRegistryController
+    storage: IStorageController
+  }) {
+    super(eventEmitterRegistry)
+
+    this.#storage = storage
+    this.initialLoadPromise = this.#load().finally(() => {
+      this.initialLoadPromise = undefined
+    })
+  }
+
+  async #load() {
+    try {
+      this.feeTokenPreference = await this.#storage.get(FEE_TOKEN_PREFERENCE_STORAGE_KEY, {})
+      this.emitUpdate()
+    } catch (error) {
+      this.emitError({
+        message: 'Error loading SignAccountOp fee token preference',
+        error: error instanceof Error ? error : new Error(String(error)),
+        level: 'silent'
+      })
+    }
+  }
+
+  async setFeeTokenPreference(feeTokenPreference: SignAccountOpFeeTokenPreference) {
+    this.feeTokenPreference = feeTokenPreference
+    this.emitUpdate()
+
+    try {
+      await this.#storage.set(FEE_TOKEN_PREFERENCE_STORAGE_KEY, this.feeTokenPreference)
+    } catch (error) {
+      this.emitError({
+        message: 'Error saving SignAccountOp fee token preference',
+        error: error instanceof Error ? error : new Error(String(error)),
+        level: 'silent'
+      })
+    }
+  }
+}

--- a/src/controllers/signAccountOp/signAccountOpTester.ts
+++ b/src/controllers/signAccountOp/signAccountOpTester.ts
@@ -6,6 +6,7 @@ import { INetworksController, Network } from '../../interfaces/network'
 import { IPhishingController } from '../../interfaces/phishing'
 import { IPortfolioController } from '../../interfaces/portfolio'
 import { RPCProvider } from '../../interfaces/provider'
+import { IStorageController } from '../../interfaces/storage'
 import { UserRequest } from '../../interfaces/userRequest'
 import { AccountOp } from '../../libs/accountOp/accountOp'
 import { EstimationController } from '../estimation/estimation'
@@ -21,6 +22,7 @@ export class SignAccountOpTesterController extends SignAccountOpController {
     networks: INetworksController
     keystore: IKeystoreController
     portfolio: IPortfolioController
+    storage: IStorageController
     externalSignerControllers: ExternalSignerControllers
     account: Account
     network: Network

--- a/src/controllers/signAccountOp/signAccountOpTester.ts
+++ b/src/controllers/signAccountOp/signAccountOpTester.ts
@@ -6,23 +6,24 @@ import { INetworksController, Network } from '../../interfaces/network'
 import { IPhishingController } from '../../interfaces/phishing'
 import { IPortfolioController } from '../../interfaces/portfolio'
 import { RPCProvider } from '../../interfaces/provider'
-import { IStorageController } from '../../interfaces/storage'
 import { UserRequest } from '../../interfaces/userRequest'
 import { AccountOp } from '../../libs/accountOp/accountOp'
+import { BindedRelayerCall } from '../../libs/relayerCall/relayerCall'
 import { EstimationController } from '../estimation/estimation'
 import { GasPriceController } from '../gasPrice/gasPrice'
 import { SignAccountOpType } from './helper'
 import { OnBroadcastFailed, OnBroadcastSuccess, SignAccountOpController } from './signAccountOp'
+import { SignAccountOpPreferenceController } from './signAccountOpPreference'
 
 export class SignAccountOpTesterController extends SignAccountOpController {
   constructor(props: {
     type?: SignAccountOpType
-    callRelayer: Function
+    callRelayer: BindedRelayerCall
     accounts: IAccountsController
     networks: INetworksController
     keystore: IKeystoreController
     portfolio: IPortfolioController
-    storage: IStorageController
+    signAccountOpPreference: SignAccountOpPreferenceController
     externalSignerControllers: ExternalSignerControllers
     account: Account
     network: Network

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -309,6 +309,7 @@ requestsCtrl = new RequestsController({
   accounts: accountsCtrl,
   networks: networksCtrl,
   providers: providersCtrl,
+  storage: storageCtrl,
   selectedAccount: selectedAccountCtrl,
   keystore,
   transfer: transferCtrl,

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -30,6 +30,7 @@ import { ProvidersController } from '../providers/providers'
 import { RequestsController } from '../requests/requests'
 import { SafeController } from '../safe/safe'
 import { SelectedAccountController } from '../selectedAccount/selectedAccount'
+import { SignAccountOpPreferenceController } from '../signAccountOp/signAccountOpPreference'
 import { StorageController } from '../storage/storage'
 import { SurveyController } from '../survey/survey'
 import { TransferController } from '../transfer/transfer'
@@ -250,6 +251,7 @@ const PORTFOLIO_TOKENS = [
 ]
 
 let requestsCtrl: IRequestsController | undefined
+const signAccountOpPreference = new SignAccountOpPreferenceController({ storage: storageCtrl })
 const dappsControllerMock = {
   dapps: [],
   isReady: true,
@@ -257,12 +259,13 @@ const dappsControllerMock = {
 } as any
 
 const swapAndBridgeController = new SwapAndBridgeController({
-  callRelayer: () => {},
+  callRelayer: async () => ({}),
   selectedAccount: selectedAccountCtrl,
   networks: networksCtrl,
   accounts: accountsCtrl,
   activity: activityCtrl,
   storage: storageCtrl,
+  signAccountOpPreference,
   swapProvider: socketAPIMock as any,
   keystore,
   portfolio: portfolioCtrl,
@@ -279,8 +282,9 @@ const swapAndBridgeController = new SwapAndBridgeController({
 })
 
 const transferCtrl = new TransferController(
-  () => {},
+  async () => ({}),
   storageCtrl,
+  signAccountOpPreference,
   humanizerInfo as HumanizerMeta,
   selectedAccountCtrl,
   networksCtrl,
@@ -310,6 +314,7 @@ requestsCtrl = new RequestsController({
   networks: networksCtrl,
   providers: providersCtrl,
   storage: storageCtrl,
+  signAccountOpPreference,
   selectedAccount: selectedAccountCtrl,
   keystore,
   transfer: transferCtrl,

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -80,6 +80,7 @@ import {
   OnBroadcastSuccess,
   SignAccountOpController
 } from '../signAccountOp/signAccountOp'
+import { SignAccountOpPreferenceController } from '../signAccountOp/signAccountOpPreference'
 
 type SwapAndBridgeErrorType = {
   id: 'to-token-list-fetch-failed' | 'no-routes' | 'all-routes-failed'
@@ -145,6 +146,8 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
   #activity: IActivityController
 
   #storage: IStorageController
+
+  #signAccountOpPreference: SignAccountOpPreferenceController
 
   #serviceProviderAPI: SwapProvider
 
@@ -295,6 +298,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     networks,
     activity,
     storage,
+    signAccountOpPreference,
     phishing,
     dapps,
     portfolioUpdate,
@@ -318,6 +322,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     networks: INetworksController
     activity: IActivityController
     storage: IStorageController
+    signAccountOpPreference: SignAccountOpPreferenceController
     phishing: IPhishingController
     dapps: IDappsController
     relayerUrl: string
@@ -346,6 +351,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     this.#activity = activity
     this.#serviceProviderAPI = swapProvider
     this.#storage = storage
+    this.#signAccountOpPreference = signAccountOpPreference
     this.#phishing = phishing
     this.#dapps = dapps
     this.#relayerUrl = relayerUrl
@@ -2537,6 +2543,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       }
     }
 
+    await this.#signAccountOpPreference.initialLoadPromise
     this.#signAccountOpController = new SignAccountOpController({
       type: 'one-click-swap-and-bridge',
       callRelayer: this.#callRelayer,
@@ -2544,7 +2551,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       networks: this.#networks,
       keystore: this.#keystore,
       portfolio: this.#portfolio,
-      storage: this.#storage,
+      signAccountOpPreference: this.#signAccountOpPreference,
       externalSignerControllers: this.#externalSignerControllers,
       activity: this.#activity,
       account: this.#selectedAccount.account,

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2544,6 +2544,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       networks: this.#networks,
       keystore: this.#keystore,
       portfolio: this.#portfolio,
+      storage: this.#storage,
       externalSignerControllers: this.#externalSignerControllers,
       activity: this.#activity,
       account: this.#selectedAccount.account,

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -1098,6 +1098,7 @@ export class TransferController extends EventEmitter implements ITransferControl
       networks: this.#networks,
       keystore: this.#keystore,
       portfolio: this.#portfolio,
+      storage: this.#storage,
       externalSignerControllers: this.#externalSignerControllers,
       activity: this.#activity,
       account: this.#selectedAccount.account,

--- a/src/controllers/transfer/transfer.ts
+++ b/src/controllers/transfer/transfer.ts
@@ -52,6 +52,7 @@ import {
 import { generateUuid } from '../../utils/uuid'
 import EventEmitter from '../eventEmitter/eventEmitter'
 import { OnBroadcastSuccess, SignAccountOpController } from '../signAccountOp/signAccountOp'
+import { SignAccountOpPreferenceController } from '../signAccountOp/signAccountOpPreference'
 
 const CONVERSION_PRECISION = 16
 const CONVERSION_PRECISION_POW = BigInt(10 ** CONVERSION_PRECISION)
@@ -91,6 +92,8 @@ export class TransferController extends EventEmitter implements ITransferControl
   #callRelayer: BindedRelayerCall
 
   #storage: IStorageController
+
+  #signAccountOpPreference: SignAccountOpPreferenceController
 
   #networks: INetworksController
 
@@ -193,6 +196,7 @@ export class TransferController extends EventEmitter implements ITransferControl
   constructor(
     callRelayer: BindedRelayerCall,
     storage: IStorageController,
+    signAccountOpPreference: SignAccountOpPreferenceController,
     humanizerInfo: HumanizerMeta,
     selectedAccount: ISelectedAccountController,
     networks: INetworksController,
@@ -214,6 +218,7 @@ export class TransferController extends EventEmitter implements ITransferControl
 
     this.#callRelayer = callRelayer
     this.#storage = storage
+    this.#signAccountOpPreference = signAccountOpPreference
     this.#humanizerInfo = humanizerInfo
     this.#selectedAccount = selectedAccount
     this.#networks = networks
@@ -1091,6 +1096,7 @@ export class TransferController extends EventEmitter implements ITransferControl
     }
 
     await this.#updateRecipientHistoryAndPoisoning()
+    await this.#signAccountOpPreference.initialLoadPromise
     this.signAccountOpController = new SignAccountOpController({
       type: 'one-click-transfer',
       callRelayer: this.#callRelayer,
@@ -1098,7 +1104,7 @@ export class TransferController extends EventEmitter implements ITransferControl
       networks: this.#networks,
       keystore: this.#keystore,
       portfolio: this.#portfolio,
-      storage: this.#storage,
+      signAccountOpPreference: this.#signAccountOpPreference,
       externalSignerControllers: this.#externalSignerControllers,
       activity: this.#activity,
       account: this.#selectedAccount.account,

--- a/src/interfaces/storage.ts
+++ b/src/interfaces/storage.ts
@@ -84,6 +84,15 @@ export type StorageProps = {
   automaticallyResolvedSafeTxns: { nonce: bigint; txnIds: string[] }[]
   rejectedSafeTxns: string[]
   // Other
+  signAccountOpFeeTokenPreference: {
+    preferGasTank: boolean
+    erc20ByChainId: {
+      [chainId: string]: {
+        address: string
+        symbol: string
+      }
+    }
+  }
   networks: { [key: string]: Network }
   accounts: Account[]
   networkPreferences: { [key: string]: Partial<Network> }

--- a/src/interfaces/storage.ts
+++ b/src/interfaces/storage.ts
@@ -85,13 +85,7 @@ export type StorageProps = {
   rejectedSafeTxns: string[]
   // Other
   signAccountOpFeeTokenPreference: {
-    preferGasTank: boolean
-    erc20ByChainId: {
-      [chainId: string]: {
-        address: string
-        symbol: string
-      }
-    }
+    [chainId: string]: string | 'gasTank'
   }
   networks: { [key: string]: Network }
   accounts: Account[]


### PR DESCRIPTION
## Changes

- Added `SignAccountOpPreferenceController`
  - loads `signAccountOpFeeTokenPreference` from storage once
  - keeps the preference in memory
  - persists updates when the user sets a new default fee token
- Injected the shared preference controller into:
  - `RequestsController`
  - `TransferController`
  - `SwapAndBridgeController`
  - `SignAccountOpController`
- Ensured sign account op construction waits for fee token preference initialization
- Removed per-instance fee token preference storage reads from `SignAccountOpController`
- Removed `#hasUserSelectedFeeOption` and `#isFeeTokenPreferenceLoaded`
- Updated affected tests/helpers to use the shared preference controller

## Why

`SignAccountOpController` instances are ephemeral and should not each fetch the same user preference from storage. Loading the preference once at a higher level avoids repeated async storage reads and removes the race where a late storage response could affect fee option selection after the user interacts with the UI.