### PR TITLE
Config / Filter spam tokens & NFTs by name (in addition to symbol)

### DIFF
--- a/src/libs/portfolio/portfolio.test.ts
+++ b/src/libs/portfolio/portfolio.test.ts
@@ -801,23 +801,49 @@ describe('Portfolio', () => {
       expect(blacklistedTokenFound).toBe(false)
     })
 
-    test('should filter a held token by symbol pattern (case-insensitive, substring match)', async () => {
-      const filtered = await portfolio.get('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', {
+    test('should filter a held token by symbol or name pattern (case-insensitive, substring match)', async () => {
+      const baseline = await portfolio.get('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', {
         additionalErc20Hints: [ETHEREUM_TOKEN_ADDRESS],
         blacklist: {
           blacklistAddrs: {},
-          blacklistBySymbols: ['usdt'],
+          blacklistBySymbols: [],
           updatedAt: Date.now()
         }
       })
 
-      const blacklistedTokenFound = filtered.tokens.some(
+      const token = baseline.tokens.find(
         (t) => t.address.toLowerCase() === ETHEREUM_TOKEN_ADDRESS.toLowerCase()
       )
-      expect(blacklistedTokenFound).toBe(false)
+
+      if (!token) throw new Error('Expected token to be present in baseline')
+
+      const isFilteredBy = async (pattern: string) => {
+        const filtered = await portfolio.get('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', {
+          additionalErc20Hints: [ETHEREUM_TOKEN_ADDRESS],
+          blacklist: {
+            blacklistAddrs: {},
+            blacklistBySymbols: [pattern],
+            updatedAt: Date.now()
+          }
+        })
+
+        return !filtered.tokens.some(
+          (t) => t.address.toLowerCase() === ETHEREUM_TOKEN_ADDRESS.toLowerCase()
+        )
+      }
+
+      // Symbol match
+      expect(await isFilteredBy(token.symbol.toLowerCase())).toBe(true)
+
+      // Name match: the pattern lives in the name only, so the previous
+      // symbol-only filter would not have caught it.
+      const namePattern = token.name.toLowerCase()
+      expect(token.name).not.toBe('')
+      expect(token.symbol.toLowerCase().includes(namePattern)).toBe(false)
+      expect(await isFilteredBy(namePattern)).toBe(true)
     })
 
-    test('should filter a held collection by symbol pattern', async () => {
+    test('should filter a held collection by symbol or name pattern', async () => {
       const baseline = await portfolio.get('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', {
         additionalErc721Hints: {
           [ETHEREUM_COLLECTION_ADDRESS]: []
@@ -837,25 +863,36 @@ describe('Portfolio', () => {
         throw new Error('Expected collection to be present in baseline')
       }
 
-      const pattern = collection.symbol
+      const isFilteredBy = async (pattern: string) => {
+        const filtered = await portfolio.get('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', {
+          additionalErc721Hints: {
+            [ETHEREUM_COLLECTION_ADDRESS]: []
+          },
+          blacklist: {
+            blacklistAddrs: {},
+            blacklistBySymbols: [pattern],
+            updatedAt: Date.now()
+          }
+        })
+
+        return !filtered.collections.some(
+          (c) => c.address.toLowerCase() === ETHEREUM_COLLECTION_ADDRESS.toLowerCase()
+        )
+      }
+
+      // Symbol match
+      const symbolPattern = collection.symbol
         .slice(0, Math.min(4, collection.symbol.length))
         .toLowerCase()
+      expect(await isFilteredBy(symbolPattern)).toBe(true)
 
-      const filtered = await portfolio.get('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8', {
-        additionalErc721Hints: {
-          [ETHEREUM_COLLECTION_ADDRESS]: []
-        },
-        blacklist: {
-          blacklistAddrs: {},
-          blacklistBySymbols: [pattern],
-          updatedAt: Date.now()
-        }
-      })
-
-      const blacklistedCollectionFound = filtered.collections.some(
-        (c) => c.address.toLowerCase() === ETHEREUM_COLLECTION_ADDRESS.toLowerCase()
-      )
-      expect(blacklistedCollectionFound).toBe(false)
+      // Name match: the pattern lives in the name only, so the previous
+      // symbol-only filter would not have caught it. This is the common spam
+      // NFT shape, where the URL/lure sits in the name and not the symbol.
+      const namePattern = collection.name.toLowerCase()
+      expect(collection.name).not.toBe('')
+      expect(collection.symbol.toLowerCase().includes(namePattern)).toBe(false)
+      expect(await isFilteredBy(namePattern)).toBe(true)
     })
 
     test('should never filter custom tokens even if blacklisted', async () => {

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -1,5 +1,4 @@
 import { ZeroAddress } from 'ethers'
-
 import { getAddress } from 'viem'
 
 import BalanceGetter from '../../../contracts/compiled/BalanceGetter.json'
@@ -375,10 +374,12 @@ export class Portfolio {
       .filter((_tokensWithErrResult: [TokenError, TokenResult]) => {
         if (!isValidToken(_tokensWithErrResult[0], _tokensWithErrResult[1])) return false
 
-        // Symbol-based blacklist: skip custom tokens so user-added assets are never hidden
+        // Symbol/name-based blacklist: skip custom tokens so user-added assets are never hidden.
+        // Spam often hides the URL/lure in the name rather than the symbol, so match both.
         if (allBlacklistedSymbols.length > 0 && !_tokensWithErrResult[1]?.flags?.isCustom) {
-          const symbolLower = _tokensWithErrResult[1].symbol.toLowerCase()
-          if (allBlacklistedSymbols.some((pattern) => symbolLower.includes(pattern))) return false
+          const token = _tokensWithErrResult[1]
+          const haystack = `${token.symbol} ${token.name || ''}`.toLowerCase()
+          if (allBlacklistedSymbols.some((pattern) => haystack.includes(pattern))) return false
         }
 
         // Don't filter by balance/custom/hidden etc. if this param isn't passed

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -417,10 +417,11 @@ export class Portfolio {
       (acc, [error, collection]) => {
         if (!isValidToken(error, collection)) return acc
 
-        // Never filter custom collections, even tho we don't support them atm
+        // Never filter custom collections, even tho we don't support them atm.
+        // Spam often hides the URL/lure in the name rather than the symbol, so match both.
         if (allBlacklistedSymbols.length > 0 && !collection?.flags?.isCustom) {
-          const symbolLower = collection.symbol.toLowerCase()
-          if (allBlacklistedSymbols.some((pattern) => symbolLower.includes(pattern))) return acc
+          const haystack = `${collection.symbol} ${collection.name || ''}`.toLowerCase()
+          if (allBlacklistedSymbols.some((pattern) => haystack.includes(pattern))) return acc
         }
 
         // Important note: Collections with 0 collectibles are allow to pass through the filter.


### PR DESCRIPTION
The symbol-based portfolio blacklist (`blacklistBySymbols`, e.g. "https", "www.") previously matched only against a token/collection symbol.

Some spam - especially NFTs - hides the URL/lure in the name field while keeping the symbol empty or innocent, so it slipped through.

This change matches the patterns against both symbol and name for ERC20 tokens and NFT collections. The `isCustom` escape-hatch is preserved on both paths, so user-added assets are never hidden.

Also, existing blacklist tests were extended to cover the name-only path (with a precondition asserting the pattern lives only in name, making them genuine regression guards).

Part of https://github.com/AmbireTech/ambire-app/issues/7046