### PR TITLE
Config / Treat tokens & NFTs that embed domains in their name/symbol as scam and hide them

### DIFF
--- a/src/libs/portfolio/blacklist.test.ts
+++ b/src/libs/portfolio/blacklist.test.ts
@@ -1,4 +1,4 @@
-import { filterStaticBlacklistedAddrs } from './blacklist'
+import { containsDomainLike, filterStaticBlacklistedAddrs, isBlacklistedAsset } from './blacklist'
 
 describe('portfolio blacklist', () => {
   it('filters static blacklisted addresses', () => {
@@ -8,5 +8,84 @@ describe('portfolio blacklist', () => {
     expect(filterStaticBlacklistedAddrs([blacklistedToken, allowedToken], 1n)).toEqual([
       allowedToken
     ])
+  })
+
+  describe('containsDomainLike', () => {
+    it('detects a domain embedded anywhere in the text', () => {
+      expect(containsDomainLike('Visit uniswap.org')).toBe(true)
+      expect(containsDomainLike('claim-x.xyz reward')).toBe(true)
+      expect(containsDomainLike('airdrop at app.uniswap.org')).toBe(true)
+      expect(containsDomainLike('go to t.me/scam')).toBe(true)
+    })
+
+    it('detects a domain regardless of casing or surrounding punctuation', () => {
+      expect(containsDomainLike('UNISWAP.ORG')).toBe(true)
+      expect(containsDomainLike('(uniswap.org)')).toBe(true)
+      expect(containsDomainLike('claim@uniswap.org')).toBe(true)
+    })
+
+    it('does not flag legitimate token names', () => {
+      expect(containsDomainLike('USD Coin')).toBe(false)
+      expect(containsDomainLike('Wrapped Ether')).toBe(false)
+      expect(containsDomainLike('lobsterdao')).toBe(false)
+    })
+
+    it('does not flag non-domain dotted strings', () => {
+      expect(containsDomainLike('ETH 2.0')).toBe(false)
+      expect(containsDomainLike('v2.0')).toBe(false)
+      // suffix is not a real ICANN TLD
+      expect(containsDomainLike('eth.staking')).toBe(false)
+      expect(containsDomainLike('file.tmp')).toBe(false)
+    })
+
+    it('handles empty and address-like input', () => {
+      expect(containsDomainLike('')).toBe(false)
+      expect(containsDomainLike('0xdAC17F958D2ee523a2206206994597C13D831ec7')).toBe(false)
+    })
+  })
+
+  describe('isBlacklistedAsset', () => {
+    it('matches a blacklist pattern in the symbol', () => {
+      expect(
+        isBlacklistedAsset({ symbol: 'www.scam', name: '', lowercasedPatterns: ['www.'] })
+      ).toBe(true)
+    })
+
+    it('matches a blacklist pattern in the name', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'OK',
+          name: 'claim at https://scam',
+          lowercasedPatterns: ['https']
+        })
+      ).toBe(true)
+    })
+
+    it('matches a phishing domain in the name even with no patterns', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'AIRDROP',
+          name: 'Claim your reward at claim-x.xyz',
+          lowercasedPatterns: []
+        })
+      ).toBe(true)
+    })
+
+    it('does not hide a clean asset', () => {
+      expect(
+        isBlacklistedAsset({ symbol: 'USDC', name: 'USD Coin', lowercasedPatterns: ['https', 'www.'] })
+      ).toBe(false)
+    })
+
+    it('never hides custom (user-added) assets, even when they would match', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'www.scam',
+          name: 'Visit uniswap.org',
+          isCustom: true,
+          lowercasedPatterns: ['www.']
+        })
+      ).toBe(false)
+    })
   })
 })

--- a/src/libs/portfolio/blacklist.ts
+++ b/src/libs/portfolio/blacklist.ts
@@ -1,3 +1,5 @@
+import { parse } from 'tldts'
+
 import type { TokenBlacklist } from './interfaces'
 
 /**
@@ -45,4 +47,76 @@ export const filterStaticBlacklistedAddrs = (tokenAddrs: string[], chainId: bigi
   )
 
   return tokenAddrs.filter((addr) => !staticBlacklistedAddrsLower.has(addr.toLowerCase()))
+}
+
+const isDomainChar = (char: string): boolean =>
+  (char >= 'a' && char <= 'z') ||
+  (char >= '0' && char <= '9') ||
+  char === '.' ||
+  char === '-'
+
+/**
+ * Detects a real registrable domain anywhere in the text (e.g. "uniswap.org",
+ * "claim-x.xyz"). Spam assets embed phishing domains in their name/symbol to
+ * impersonate real projects, often without an "https"/"www." prefix.
+ *
+ * We scan the text into domain-charset candidates (no regex, per repo rule) and
+ * validate each against the Public Suffix List via tldts. The `isIcann` check
+ * rejects non-domain dotted strings such as "v2.0" or "eth.staking".
+ */
+export const containsDomainLike = (text: string): boolean => {
+  // A domain needs a dot; skip the scan entirely for the common dot-free case
+  if (!text.includes('.')) return false
+
+  const lower = text.toLowerCase()
+  let candidate = ''
+  let candidateHasDot = false
+
+  // Iterate one past the end so the final candidate is flushed too
+  for (let i = 0; i <= lower.length; i++) {
+    const char = lower[i]
+    if (char && isDomainChar(char)) {
+      candidate += char
+      if (char === '.') candidateHasDot = true
+      continue
+    }
+
+    // Only dotted candidates can be domains, so parse just those
+    if (candidateHasDot && parse(candidate).isIcann === true) return true
+    candidate = ''
+    candidateHasDot = false
+  }
+
+  return false
+}
+
+/**
+ * Decides whether an asset (ERC-20 token or NFT collection) should be hidden as
+ * spam based on its symbol and name. Custom (user-added) assets are never hidden.
+ *
+ * Spam often hides the lure in the name rather than the symbol, so both are
+ * checked, combining two signals:
+ * - substring patterns from the static + dynamic blacklist (e.g. "https", "www.")
+ * - a domain-like detector (see `containsDomainLike`)
+ *
+ * `lowercasedPatterns` must already be lowercased by the caller.
+ */
+export const isBlacklistedAsset = ({
+  symbol,
+  name,
+  isCustom,
+  lowercasedPatterns
+}: {
+  symbol: string
+  name?: string
+  isCustom?: boolean
+  lowercasedPatterns: string[]
+}): boolean => {
+  if (isCustom) return false
+
+  const haystack = `${symbol} ${name || ''}`.toLowerCase()
+
+  if (lowercasedPatterns.some((pattern) => haystack.includes(pattern))) return true
+
+  return containsDomainLike(haystack)
 }

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -10,7 +10,7 @@ import { Network } from '../../interfaces/network'
 import { RPCProvider } from '../../interfaces/provider'
 import { Deployless, fromDescriptor } from '../deployless/deployless'
 import batcher from './batcher'
-import { STATIC_BLACKLIST } from './blacklist'
+import { isBlacklistedAsset, STATIC_BLACKLIST } from './blacklist'
 import { geckoRequestBatcher, geckoResponseIdentifier } from './gecko'
 import { getNFTs, getTokens } from './getOnchainBalances'
 import {
@@ -374,13 +374,18 @@ export class Portfolio {
       .filter((_tokensWithErrResult: [TokenError, TokenResult]) => {
         if (!isValidToken(_tokensWithErrResult[0], _tokensWithErrResult[1])) return false
 
-        // Symbol/name-based blacklist: skip custom tokens so user-added assets are never hidden.
-        // Spam often hides the URL/lure in the name rather than the symbol, so match both.
-        if (allBlacklistedSymbols.length > 0 && !_tokensWithErrResult[1]?.flags?.isCustom) {
-          const token = _tokensWithErrResult[1]
-          const haystack = `${token.symbol} ${token.name || ''}`.toLowerCase()
-          if (allBlacklistedSymbols.some((pattern) => haystack.includes(pattern))) return false
-        }
+        // Spam filter: hide tokens whose symbol/name matches a blacklisted pattern
+        // or embeds a phishing domain. Custom (user-added) tokens are never hidden.
+        const token = _tokensWithErrResult[1]
+        if (
+          isBlacklistedAsset({
+            symbol: token.symbol,
+            name: token.name,
+            isCustom: token.flags?.isCustom,
+            lowercasedPatterns: allBlacklistedSymbols
+          })
+        )
+          return false
 
         // Don't filter by balance/custom/hidden etc. if this param isn't passed
         // The portfolio lib is used outside the controller, in which case we want to
@@ -418,12 +423,18 @@ export class Portfolio {
       (acc, [error, collection]) => {
         if (!isValidToken(error, collection)) return acc
 
-        // Never filter custom collections, even tho we don't support them atm.
-        // Spam often hides the URL/lure in the name rather than the symbol, so match both.
-        if (allBlacklistedSymbols.length > 0 && !collection?.flags?.isCustom) {
-          const haystack = `${collection.symbol} ${collection.name || ''}`.toLowerCase()
-          if (allBlacklistedSymbols.some((pattern) => haystack.includes(pattern))) return acc
-        }
+        // Spam filter: hide collections whose symbol/name matches a blacklisted
+        // pattern or embeds a phishing domain. Custom collections are never hidden
+        // (even tho we don't support them atm).
+        if (
+          isBlacklistedAsset({
+            symbol: collection.symbol,
+            name: collection.name,
+            isCustom: collection.flags?.isCustom,
+            lowercasedPatterns: allBlacklistedSymbols
+          })
+        )
+          return acc
 
         // Important note: Collections with 0 collectibles are allow to pass through the filter.
         if (!toBeLearned.erc721s[collection.address] && collection.collectibles.length > 0) {


### PR DESCRIPTION
The portfolio spam filter previously matched only a small substring list (https, www.) against a token/collection symbol, missing most spam - which embeds a bare domain (e.g. claim-rewards.xyz), often in the name and without an https/www. prefix.

This PR adds a shared `isBlacklistedAsset` helper (used by both the ERC20 and NFT paths, replacing the duplicated inline logic) that matches over both symbol and name, combining the existing substring patterns with a new `containsDomainLike` detector. The detector validates candidates against the Public Suffix List via `tldts`, using `isIcann` to reject non-domains like "v2.0". Custom assets stay exempt; covered by unit + existing integration tests.

Tradeoffs: a legit domain-styled name (e.g. curve.fi) would also be flagged. We should discuss if this is fine.

Resolves https://github.com/AmbireTech/ambire-app/issues/7046