### PR TITLE
Config / Exclude tokens without a USD price from the Swap & Bridge "From" list

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1046,7 +1046,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
           // added to the "Receive" token list as additional tokens from portfolio,
           // BUT 3) They will appear in the "Receive" if they are present in service
           // provider's to token list. This is the desired behavior.
-          getIsTokenEligibleForSwapAndBridge(token) && !token.flags.isHidden
+          getIsTokenEligibleForSwapAndBridge(token, true, true) && !token.flags.isHidden
       )
       .map((token) => ({
         ...token,

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -47,6 +47,7 @@ import { getAmbirePaymasterService } from '../../libs/erc7677/erc7677'
 import { randomId } from '../../libs/humanizer/utils'
 import { TokenResult } from '../../libs/portfolio'
 import { getTokenAmount } from '../../libs/portfolio/helpers'
+import { PORTFOLIO_LIB_ERROR_NAMES } from '../../libs/portfolio/portfolio'
 import {
   addCustomTokensIfNeeded,
   convertNullAddressToZeroAddressIfNeeded,
@@ -1038,6 +1039,20 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     // until the user manually selects a new token
     const isSelectedTokenFalsyBeforeListUpdate = !this.fromSelectedToken && !!this.toSelectedToken
     const { preselectedToken, preselectedToToken, fromAmount } = params || {}
+
+    // When the price endpoint is down, tokens come back without a USD price. We must
+    // not exclude them as "priceless" in that case, otherwise switching to an account
+    // with such tokens would wrongly hide them. Skip the price requirement for chains
+    // that currently have a price fetch error.
+    const chainIdsWithPriceError = new Set<string>()
+    const priceError = this.#selectedAccount.balanceAffectingErrors.find(
+      (error) => error.id === PORTFOLIO_LIB_ERROR_NAMES.PriceFetchError
+    )
+    priceError?.networkNames.forEach((networkName) => {
+      const network = this.#networks.networks.find((n) => n.name === networkName)
+      if (network) chainIdsWithPriceError.add(network.chainId.toString())
+    })
+
     const tokens = nextPortfolioTokenList
       .filter(
         (token) =>
@@ -1046,7 +1061,11 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
           // added to the "Receive" token list as additional tokens from portfolio,
           // BUT 3) They will appear in the "Receive" if they are present in service
           // provider's to token list. This is the desired behavior.
-          getIsTokenEligibleForSwapAndBridge(token, true, true) && !token.flags.isHidden
+          getIsTokenEligibleForSwapAndBridge(
+            token,
+            true,
+            !chainIdsWithPriceError.has(token.chainId.toString())
+          ) && !token.flags.isHidden
       )
       .map((token) => ({
         ...token,

--- a/src/libs/portfolio/helpers.ts
+++ b/src/libs/portfolio/helpers.ts
@@ -486,12 +486,14 @@ export const getTokenAmount = (token: TokenResult, beforeSimulation?: boolean): 
   return typeof token.amountPostSimulation === 'bigint' ? token.amountPostSimulation : token.amount
 }
 
+export const getTokenUsdPrice = (token: TokenResult) =>
+  token.priceIn.find(({ baseCurrency }) => baseCurrency === 'usd')?.price || 0
+
 export const getTokenBalanceInUSD = (token: TokenResult) => {
   const amount = getTokenAmount(token)
-  const { decimals, priceIn } = token
+  const { decimals } = token
   const balance = parseFloat(formatUnits(amount, decimals))
-  const price =
-    priceIn.find(({ baseCurrency }: { baseCurrency: string }) => baseCurrency === 'usd')?.price || 0
+  const price = getTokenUsdPrice(token)
 
   return balance * price
 }

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -44,7 +44,7 @@ import { Call } from '../accountOp/types'
 import { AssetType } from '../defiPositions/types'
 import { PaymasterService } from '../erc7677/types'
 import { TokenResult } from '../portfolio'
-import { getTokenBalanceInUSD } from '../portfolio/helpers'
+import { getTokenBalanceInUSD, getTokenUsdPrice } from '../portfolio/helpers'
 import { getSanitizedAmount } from '../transfer/amount'
 
 /**
@@ -234,7 +234,8 @@ export const sortPortfolioTokenList = (accountPortfolioTokenList: TokenResult[])
  */
 export const getIsTokenEligibleForSwapAndBridge = (
   token: TokenResult,
-  requirePositiveBalance: boolean = true
+  requirePositiveBalance: boolean = true,
+  requirePrice: boolean = false
 ) => {
   const flagsRequirement =
     // The same token can be in the Gas Tank (or as a Reward) and in the portfolio.
@@ -245,6 +246,12 @@ export const getIsTokenEligibleForSwapAndBridge = (
     // Borrow tokens (e.g. variableDebt tokens) are protocol accounting assets
     // and are not transferable/swappable by design.
     token.flags.defiTokenType !== AssetType.Borrow
+
+  // Tokens without a known USD price most prob can't be quoted reliably, so exclude them
+  // from the list when the caller opts in (e.g. the Swap & Bridge "form" tokens).
+  if (requirePrice && getTokenUsdPrice(token) <= 0) {
+    return false
+  }
 
   if (!requirePositiveBalance) {
     return flagsRequirement


### PR DESCRIPTION
Tokens without a known USD price most prob can't be quoted reliably, so they're now filtered out of the Swap & Bridge "From" list.