### PR TITLE
Config / Exception for custom tokens without a USD price from the Swap & Bridge "From" list

### DIFF
--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -249,7 +249,8 @@ export const getIsTokenEligibleForSwapAndBridge = (
 
   // Tokens without a known USD price most prob can't be quoted reliably, so exclude them
   // from the list when the caller opts in (e.g. the Swap & Bridge "form" tokens).
-  // Custom tokens are exempt - the user explicitly imported them and likely wants to swap them.
+  // Custom tokens are exempt - the user explicitly imported them and likely wants
+  // to use them for something (maybe swap or bridge).
   if (requirePrice && !token.flags.isCustom && getTokenUsdPrice(token) <= 0) {
     return false
   }

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -249,7 +249,8 @@ export const getIsTokenEligibleForSwapAndBridge = (
 
   // Tokens without a known USD price most prob can't be quoted reliably, so exclude them
   // from the list when the caller opts in (e.g. the Swap & Bridge "form" tokens).
-  if (requirePrice && getTokenUsdPrice(token) <= 0) {
+  // Custom tokens are exempt - the user explicitly imported them and likely wants to swap them.
+  if (requirePrice && !token.flags.isCustom && getTokenUsdPrice(token) <= 0) {
     return false
   }
 


### PR DESCRIPTION
Exception after https://github.com/AmbireTech/ambire-common/pull/2460 for the custom tokens without a price, since the user imported them deliberately and likely wants to use them for something (maybe Swap & Bridge).