### PR TITLE
Fix: lido humanization was showing eth units in wei

### DIFF
--- a/src/libs/humanizer/erc7730/humanize.ts
+++ b/src/libs/humanizer/erc7730/humanize.ts
@@ -293,6 +293,15 @@ const valueToText = (value: unknown): string => {
   }
 }
 
+const interpolatedValueToText = (path: string, value: unknown): string => {
+  const amount = toBigIntOrNull(value)
+  if ((path === '@.value' || path === '#.@.value') && amount !== null) {
+    return formatUnits(amount, 18)
+  }
+
+  return valueToText(value)
+}
+
 const normalizeDecodedParam = (value: unknown, param: ParamType): unknown => {
   if (param.baseType === 'array' && param.arrayChildren) {
     return Array.from(value as ArrayLike<unknown>).map((item) =>
@@ -895,11 +904,11 @@ const interpolateIntent = (
 
     interpolated += template.slice(currentIndex, openingBraceIndex)
 
-    const path = template.slice(openingBraceIndex + 1, closingBraceIndex)
-    const value = resolvePath(path.trim(), context, base)
+    const path = template.slice(openingBraceIndex + 1, closingBraceIndex).trim()
+    const value = resolvePath(path, context, base)
     if (value === undefined) return null
 
-    interpolated += valueToText(value)
+    interpolated += interpolatedValueToText(path, value)
     currentIndex = closingBraceIndex + 1
   }
 

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -874,6 +874,55 @@ describe('ERC-7730 descriptors', () => {
       ]
     ])
   })
+  test('formats the native transaction value in ERC-7730 interpolated intents', () => {
+    accountOp.calls = [
+      {
+        to: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
+        value: ethers.parseEther('0.001'),
+        data: '0xa1903eab00000000000000000000000011d00000000000000000000000000000000011d0'
+      }
+    ]
+
+    const descriptor = {
+      display: {
+        formats: {
+          'submit(address _referral)': {
+            intent: 'Stake ETH',
+            interpolatedIntent: 'Stake {@.value} ETH',
+            fields: [
+              {
+                label: 'Amount',
+                format: 'amount',
+                path: '@.value'
+              },
+              {
+                label: 'Referral',
+                path: '#._referral',
+                visible: 'never'
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    const irCalls = humanizeAccountOp(accountOp, {
+      erc7730Descriptors: {
+        0: { descriptor }
+      }
+    })
+
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getErc7730Visualization('Stake 0.001 ETH', [
+          {
+            label: 'Amount',
+            value: [getToken(ZeroAddress, 1000000000000000n, 1n)]
+          }
+        ])
+      ]
+    ])
+  })
   test('humanizes nested calldata in execute with permit descriptors', async () => {
     const router = '0x111111125421cA6dc452d289314280a0f8842A65'
     const aave = '0x76fb31fb4af56892a25e32cfc43de717950c9278'


### PR DESCRIPTION
Basically, this is what we had:

<img width="688" height="215" alt="Screenshot 2026-06-10 at 6 57 32" src="https://github.com/user-attachments/assets/c5ff53af-4343-4e90-98fa-c07110dc1ecd" />

And it's now fixed: 

<img width="696" height="233" alt="Screenshot 2026-06-10 at 6 57 57" src="https://github.com/user-attachments/assets/1b9a0c22-da6c-4d21-aadd-7ba7c7356c6b" />
