### PR TITLE
Update/ Switch to kimi nitro to improve reliability

### DIFF
--- a/.github/workflows/general-review.yml
+++ b/.github/workflows/general-review.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/pr-agent.yml
     with:
-      model: openrouter/moonshotai/kimi-k2.6
+      model: openrouter/moonshotai/kimi-k2.6:nitro
       fallback_models: '["openrouter/anthropic/claude-sonnet-4.6"]'
       extra_instructions: |
         You are reviewing changes in `ambire-common`, the environment-agnostic core


### PR DESCRIPTION
Done to avoid shitty providers like this one (caps output to 16k tokens)
<img width="2108" height="582" alt="image" src="https://github.com/user-attachments/assets/930c3ef6-2193-40ca-837a-edb181b0a246" />

Also should make reviews faster


https://openrouter.ai/docs/guides/routing/model-variants/nitro