### PR TITLE
Feature/ Retry mechanism to `signAccountOp.traceCall`

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -34,6 +34,7 @@ import { Account } from '../../interfaces/account'
 import { Dapp, DAPP_VERIFICATION_BANNER_IDS, IDappsController } from '../../interfaces/dapp'
 import { Hex } from '../../interfaces/hex'
 import { IProvidersController } from '../../interfaces/provider'
+import { TraceCallDiscoveryStatus } from '../../interfaces/signAccountOp'
 import { Storage } from '../../interfaces/storage'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { AccountOp, accountOpSignableHash } from '../../libs/accountOp/accountOp'
@@ -50,6 +51,8 @@ import {
   getTypedData
 } from '../../libs/signMessage/signMessage'
 import { PERMIT2_ADDRESS_LOWERCASED } from '../../libs/simulation/detectPermit2Interaction'
+import * as accessListCallLib from '../../libs/tracer/accessListCall'
+import * as debugTraceCallLib from '../../libs/tracer/debugTraceCall'
 import { BundlerSwitcher } from '../../services/bundlers/bundlerSwitcher'
 import { GasSpeeds } from '../../services/bundlers/types'
 import { paymasterFactory } from '../../services/paymaster'
@@ -396,6 +399,7 @@ const init = async (
     dapps?: Dapp[]
     callRelayer?: BindedRelayerCall
     initialSetStorage?: (storageCtrl: StorageController) => Promise<void>
+    onUpdateAfterTraceCallSuccess?: () => Promise<void>
   }
 ) => {
   const storage: Storage = produceMemoryStore()
@@ -658,8 +662,8 @@ const init = async (
     fromRequestId: 1,
     accountOp: op,
     shouldSimulate: false,
-    // @ts-expect-error
-    onBroadcastSuccess: () => {},
+    onUpdateAfterTraceCallSuccess: options?.onUpdateAfterTraceCallSuccess,
+    onBroadcastSuccess: async () => {},
     estimateController: estimationController,
     gasPriceController
   })
@@ -1076,7 +1080,7 @@ describe('SignAccountOp Controller ', () => {
       new Promise((resolve) => {
         const unsub = controller.estimation.onUpdate(() => {
           if (controller.estimation.status !== EstimationStatus.Loading) {
-            // @ts-expect-error
+            // @ts-expect-error - we want to check the internal state
             expect(controller.estimation.lastAccountOpId).toBe(latestAccountOpId)
             resolve(true)
             unsub()
@@ -2782,5 +2786,230 @@ describe('dapp verification banners', () => {
         text: 'App is not on the default Ambire App Catalog. Make sure you trust it before signing requests: Custom Dapp'
       }
     ])
+  })
+})
+
+describe('traceCall asset discovery', () => {
+  suppressConsoleBeforeEach(true)
+
+  const traceCallGasPrices = {
+    slow: { maxFeePerGas: toBeHex(200n) as Hex, maxPriorityFeePerGas: toBeHex(100n) as Hex },
+    medium: { maxFeePerGas: toBeHex(400n) as Hex, maxPriorityFeePerGas: toBeHex(200n) as Hex },
+    fast: { maxFeePerGas: toBeHex(600n) as Hex, maxPriorityFeePerGas: toBeHex(300n) as Hex },
+    ape: { maxFeePerGas: toBeHex(800n) as Hex, maxPriorityFeePerGas: toBeHex(400n) as Hex }
+  }
+
+  let getShouldUseAccessListCallSpy: jest.SpiedFunction<
+    typeof accessListCallLib.getShouldUseAccessListCall
+  >
+  let createAccessListCallSpy: jest.SpiedFunction<typeof accessListCallLib.createAccessListCall>
+  let debugTraceCallSpy: jest.SpiedFunction<typeof debugTraceCallLib.debugTraceCall>
+  let addTokensToBeLearnedSpy: jest.SpiedFunction<
+    typeof PortfolioController.prototype.addTokensToBeLearned
+  >
+  let addErc721sToBeLearnedSpy: jest.SpiedFunction<
+    typeof PortfolioController.prototype.addErc721sToBeLearned
+  >
+
+  beforeEach(() => {
+    // Defaults: the access list branch resolves with no discovered assets and
+    // nothing new learned. Individual tests override these to drive a path.
+    jest.spyOn(debugTraceCallLib, 'getStateOverride').mockReturnValue(undefined as any)
+    getShouldUseAccessListCallSpy = jest
+      .spyOn(accessListCallLib, 'getShouldUseAccessListCall')
+      .mockReturnValue(true)
+    createAccessListCallSpy = jest
+      .spyOn(accessListCallLib, 'createAccessListCall')
+      .mockResolvedValue([])
+    debugTraceCallSpy = jest
+      .spyOn(debugTraceCallLib, 'debugTraceCall')
+      .mockResolvedValue({ tokens: [], nfts: [] })
+    addTokensToBeLearnedSpy = jest
+      .spyOn(PortfolioController.prototype, 'addTokensToBeLearned')
+      .mockReturnValue(false)
+    addErc721sToBeLearnedSpy = jest
+      .spyOn(PortfolioController.prototype, 'addErc721sToBeLearned')
+      .mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.useRealTimers()
+  })
+
+  // Builds a controller and neutralizes the discovery run that the estimate
+  // interval fires on init, so every test starts from a clean NotStarted state
+  // with empty mock history.
+  const initTraceCall = async (onUpdateAfterTraceCallSuccess?: () => Promise<void>) => {
+    const feePaymentOptions = [
+      {
+        paidBy: smartAccount.addr,
+        availableAmount: 1000000000000000000n,
+        gasUsed: 25000n,
+        addedNative: 0n,
+        token: nativeFeeToken
+      }
+    ]
+    const { controller } = await init(
+      smartAccount,
+      createAccountOp(smartAccount, 1n),
+      eoaSigner,
+      {
+        providerEstimation: { gasUsed: 25000n, feePaymentOptions },
+        ambireEstimation: {
+          deploymentGas: 0n,
+          gasUsed: 25000n,
+          feePaymentOptions,
+          ambireAccountNonce: 0,
+          flags: {}
+        },
+        flags: {},
+        updatedAt: Date.now()
+      },
+      traceCallGasPrices,
+      false,
+      { onUpdateAfterTraceCallSuccess }
+    )
+
+    await wait(100)
+    controller.traceCallDiscoveryStatus = TraceCallDiscoveryStatus.NotStarted
+    jest.clearAllMocks()
+
+    return controller
+  }
+
+  test('runs the full discovery lifecycle and learns the discovered assets', async () => {
+    const onUpdateAfterTraceCallSuccess = jest.fn(async () => {})
+    const controller = await initTraceCall(onUpdateAfterTraceCallSuccess)
+
+    const discovered = ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48']
+    const createAccessListDeferred = createDeferred<string[]>()
+    createAccessListCallSpy.mockReturnValue(createAccessListDeferred.promise)
+    addTokensToBeLearnedSpy.mockReturnValue(true)
+
+    jest.useFakeTimers()
+
+    // Discovery is kicked off and immediately flips to InProgress.
+    const traceCallPromise = (controller as any).traceCall()
+    expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.InProgress)
+
+    // A second request while one is in progress is a no-op (reentrancy guard).
+    await (controller as any).traceCall()
+    expect(createAccessListCallSpy).toHaveBeenCalledTimes(1)
+
+    // After 2s without a response the status reflects the slow pending state.
+    jest.advanceTimersByTime(2000)
+    expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.SlowPendingResponse)
+
+    // Resolving discovery learns the assets, fires the success callback and
+    // settles on Done.
+    createAccessListDeferred.resolve(discovered)
+    await traceCallPromise
+
+    expect(addTokensToBeLearnedSpy).toHaveBeenCalledWith(discovered, 1n)
+    expect(addErc721sToBeLearnedSpy).toHaveBeenCalledWith(
+      discovered.map((address) => [address, []]),
+      smartAccount.addr,
+      1n
+    )
+    expect(onUpdateAfterTraceCallSuccess).toHaveBeenCalledTimes(1)
+    expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.Done)
+  })
+
+  test('falls back to debug_traceCall when the access list fails and skips the callback when nothing is learned', async () => {
+    const onUpdateAfterTraceCallSuccess = jest.fn(async () => {})
+    const controller = await initTraceCall(onUpdateAfterTraceCallSuccess)
+
+    const emitErrorSpy = jest.fn()
+    ;(controller as any).emitError = emitErrorSpy
+
+    getShouldUseAccessListCallSpy.mockReturnValue(true)
+    createAccessListCallSpy.mockRejectedValueOnce(new Error('access list failed'))
+    debugTraceCallSpy.mockResolvedValueOnce({
+      tokens: ['0xdAC17F958D2ee523a2206206994597C13D831ec7'],
+      nfts: []
+    })
+
+    await (controller as any).traceCall()
+
+    // The access list failure is reported silently, then discovery falls back
+    // to debug_traceCall.
+    expect(emitErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'silent', message: 'Error in signAccountOp.traceCall' })
+    )
+    expect(debugTraceCallSpy).toHaveBeenCalledTimes(1)
+    expect(addTokensToBeLearnedSpy).toHaveBeenCalledWith(
+      ['0xdAC17F958D2ee523a2206206994597C13D831ec7'],
+      1n
+    )
+    // Nothing new learned (both learn spies default to false) -> no callback.
+    expect(onUpdateAfterTraceCallSuccess).not.toHaveBeenCalled()
+    expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.Done)
+  })
+
+  test('sets Failed and emits a silent error when discovery throws', async () => {
+    const onUpdateAfterTraceCallSuccess = jest.fn(async () => {})
+    const controller = await initTraceCall(onUpdateAfterTraceCallSuccess)
+
+    const emitErrorSpy = jest.fn()
+    ;(controller as any).emitError = emitErrorSpy
+
+    getShouldUseAccessListCallSpy.mockReturnValue(false)
+    debugTraceCallSpy.mockRejectedValueOnce(new Error('trace failed'))
+
+    await (controller as any).traceCall()
+
+    expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.Failed)
+    expect(emitErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'silent', message: 'Error in signAccountOp.traceCall' })
+    )
+    expect(onUpdateAfterTraceCallSuccess).not.toHaveBeenCalled()
+  })
+
+  // A cool way to not write two test cases for both branches
+  describe.each([
+    { branch: 'access-list', useAccessList: true },
+    { branch: 'debug', useAccessList: false }
+  ])('discards stale runs', ({ useAccessList }) => {
+    test('the stale run does not overwrite the latest results', async () => {
+      const controller = await initTraceCall()
+
+      getShouldUseAccessListCallSpy.mockReturnValue(useAccessList)
+
+      const deferredA = createDeferred<any>()
+      const deferredB = createDeferred<any>()
+      const armNextCall = (deferred: { promise: Promise<any> }) =>
+        useAccessList
+          ? createAccessListCallSpy.mockReturnValueOnce(deferred.promise)
+          : debugTraceCallSpy.mockReturnValueOnce(deferred.promise)
+      const resultWith = (token: string) =>
+        useAccessList ? [token] : { tokens: [token], nfts: [] }
+
+      armNextCall(deferredA)
+      const runA = (controller as any).traceCall()
+
+      // Supersede the in-flight run A with a newer run B.
+      controller.traceCallDiscoveryStatus = TraceCallDiscoveryStatus.NotStarted
+      armNextCall(deferredB)
+      const runB = (controller as any).traceCall()
+
+      // B finishes first and commits its discovered token.
+      const tokenB = '0xB0B86991c6218b36C1d19D4A2e9Eb0CE3606eB48'
+      deferredB.resolve(resultWith(tokenB))
+      await runB
+
+      expect(addTokensToBeLearnedSpy).toHaveBeenCalledWith([tokenB], 1n)
+      expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.Done)
+
+      addTokensToBeLearnedSpy.mockClear()
+
+      // A resolves late but is detected as stale and must not learn or mutate state.
+      const tokenA = '0xA0a86991C6218b36c1D19D4a2E9eB0cE3606eb48'
+      deferredA.resolve(resultWith(tokenA))
+      await runA
+
+      expect(addTokensToBeLearnedSpy).not.toHaveBeenCalled()
+      expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.Done)
+    })
   })
 })

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/brace-style */
-
 import {
   AbiCoder,
   formatEther,
@@ -403,7 +401,7 @@ export class SignAccountOpController
 
   signAndBroadcastPromise: Promise<void> | undefined
 
-  #traceCallTimeoutId: ReturnType<typeof setTimeout> | null = null
+  private traceCallTimeoutId: ReturnType<typeof setTimeout> | null = null
 
   #gasPriceInterval: IRecurringTimeout
 
@@ -774,8 +772,23 @@ export class SignAccountOpController
     this.humanize()
     this.learnTokens()
 
+    let lastEstimationStatus: EstimationStatus | null = null
+
     this.estimation.onUpdate(() => {
       this.update({ hasNewEstimation: true })
+      // Retry asset discovery if the estimation managed to recover after failure
+      // An example is doing an approval and a transaction immediately after - the second
+      // transaction will fail before the approval txn is confirmed.
+      if (
+        lastEstimationStatus === EstimationStatus.Error &&
+        this.estimation.status === EstimationStatus.Success &&
+        this.traceCallDiscoveryStatus === TraceCallDiscoveryStatus.Failed
+      ) {
+        this.traceCallDiscoveryStatus = TraceCallDiscoveryStatus.NotStarted
+        this.traceCall()
+      }
+
+      lastEstimationStatus = this.estimation.status
     })
 
     this.gasPrice.onUpdate(() => {
@@ -1373,7 +1386,7 @@ export class SignAccountOpController
     // no simulation / estimation if we're in a signing state
     if (!this.canUpdate()) return
 
-    if (shouldTraceCall) this.#traceCall()
+    if (shouldTraceCall) this.traceCall()
 
     await Promise.all([
       this.#portfolio.simulateAccountOp(this.accountOp),
@@ -1482,6 +1495,7 @@ export class SignAccountOpController
     this.gasFeeChangedConfirmationRequired = true
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async retry(method: 'simulate' | 'estimate') {
     this.bundlerSwitcher.cleanUp()
     this.#simulateAndEstimateOrSimulateInterval.restart({ runImmediately: true })
@@ -2061,11 +2075,16 @@ export class SignAccountOpController
     return BigInt(toBigInt)
   }
 
-  async #traceCall() {
+  private async traceCall() {
+    if (this.traceCallDiscoveryStatus !== TraceCallDiscoveryStatus.NotStarted) {
+      console.warn('Trace call already in progress')
+      return
+    }
+
     // `traceCall` should not be invoked too frequently. However, if there is a pending timeout,
     // it should be cleared to prevent the previous interval from changing the status
     // to `SlowPendingResponse` for the newer `traceCall` invocation.
-    if (this.#traceCallTimeoutId) clearTimeout(this.#traceCallTimeoutId)
+    if (this.traceCallTimeoutId) clearTimeout(this.traceCallTimeoutId)
 
     // Here, we also check the status because, in the case of re-estimation,
     // `traceCallDiscoveryStatus` is already set, and we don’t want to reset it to "InProgress".
@@ -2079,7 +2098,7 @@ export class SignAccountOpController
       this.calculateWarnings()
     }, 2000)
 
-    this.#traceCallTimeoutId = timeoutId
+    this.traceCallTimeoutId = timeoutId
 
     try {
       const state =
@@ -2114,6 +2133,13 @@ export class SignAccountOpController
           erc721s = addresses.map((address) => [address, []])
         }
       }
+
+      if (this.traceCallTimeoutId !== timeoutId) {
+        // If the timeout ID doesn't match, it means that another traceCall has been initiated,
+        // and we should not proceed with this one
+        return
+      }
+
       if (!shouldUseAccessList || accessListFailed) {
         console.log('Debug: using debug_traceCall for asset discovery')
         const { tokens, nfts } = await debugTraceCall(
@@ -2125,6 +2151,12 @@ export class SignAccountOpController
         )
         erc20s = tokens
         erc721s = nfts
+      }
+
+      if (this.traceCallTimeoutId !== timeoutId) {
+        // If the timeout ID doesn't match, it means that another traceCall has been initiated,
+        // and we should not proceed with this one
+        return
       }
 
       const learnedNewTokens = this.#portfolio.addTokensToBeLearned(erc20s, this.#network.chainId)
@@ -2150,7 +2182,7 @@ export class SignAccountOpController
     }
 
     this.calculateWarnings()
-    this.#traceCallTimeoutId = null
+    this.traceCallTimeoutId = null
     clearTimeout(timeoutId)
   }
 
@@ -2536,6 +2568,7 @@ export class SignAccountOpController
   #emitSigningErrorAndResetToReadyToSign({
     message,
     sendCrashReport,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     accountState
   }: {
     message: string

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -782,7 +782,11 @@ export class SignAccountOpController
       if (
         lastEstimationStatus === EstimationStatus.Error &&
         this.estimation.status === EstimationStatus.Success &&
-        this.traceCallDiscoveryStatus === TraceCallDiscoveryStatus.Failed
+        // Retry unless discovery already completed (Done) - not only when it Failed.
+        // Any discovery that was still pending while the estimation was failing is
+        // unreliable too: it may have queried the RPC before the underlying issue
+        // cleared, so its result can't be trusted. Only a Done discovery is safe to keep.
+        this.traceCallDiscoveryStatus !== TraceCallDiscoveryStatus.Done
       ) {
         this.traceCallDiscoveryStatus = TraceCallDiscoveryStatus.NotStarted
         this.traceCall()

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -781,14 +781,9 @@ export class SignAccountOpController
       // transaction will fail before the approval txn is confirmed.
       if (
         lastEstimationStatus === EstimationStatus.Error &&
-        this.estimation.status === EstimationStatus.Success &&
-        // Retry unless discovery already completed (Done) - not only when it Failed.
-        // Any discovery that was still pending while the estimation was failing is
-        // unreliable too: it may have queried the RPC before the underlying issue
-        // cleared, so its result can't be trusted. Only a Done discovery is safe to keep.
-        this.traceCallDiscoveryStatus !== TraceCallDiscoveryStatus.Done
+        this.estimation.status === EstimationStatus.Success
       ) {
-        this.traceCallDiscoveryStatus = TraceCallDiscoveryStatus.NotStarted
+        this.setDiscoveryStatus(TraceCallDiscoveryStatus.NotStarted)
         this.traceCall()
       }
 
@@ -2102,6 +2097,13 @@ export class SignAccountOpController
 
     // Flag the discovery logic as `SlowPendingResponse` if the call does not resolve within 2 seconds.
     const timeoutId = setTimeout(() => {
+      // Prevent race conditions between multiple `traceCall` invocations
+      if (
+        this.traceCallDiscoveryStatus !== TraceCallDiscoveryStatus.InProgress ||
+        this.traceCallTimeoutId !== timeoutId
+      )
+        return
+
       this.setDiscoveryStatus(TraceCallDiscoveryStatus.SlowPendingResponse)
       this.calculateWarnings()
     }, 2000)

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -792,7 +792,11 @@ export class SignAccountOpController
         this.traceCall()
       }
 
-      lastEstimationStatus = this.estimation.status
+      // Ignore the transient Loading status. estimate() emits Loading at its start,
+      // so recording it here would overwrite a remembered Error before the following
+      // Success is seen, and the Error -> Success recovery above would never be detected.
+      if (this.estimation.status !== EstimationStatus.Loading)
+        lastEstimationStatus = this.estimation.status
     })
 
     this.gasPrice.onUpdate(() => {

--- a/src/controllers/signAccountOp/signAccountOpTester.ts
+++ b/src/controllers/signAccountOp/signAccountOpTester.ts
@@ -34,6 +34,7 @@ export class SignAccountOpTesterController extends SignAccountOpController {
     accountOp: AccountOp
     shouldSimulate: boolean
     traceCall?: Function
+    onUpdateAfterTraceCallSuccess?: () => Promise<void>
     onBroadcastSuccess: OnBroadcastSuccess
     onBroadcastFailed?: OnBroadcastFailed
     estimateController: EstimationController


### PR DESCRIPTION
## How it may fail

1. App requests approval
2. Approval pending; app sends a transaction that depends on it
3. Transaction is being estimation; traceCall is ran for the txn
4. Estimation+traceCall fail; Estimation keeps retrying
5. Approval is confirmed; estimation retries, trace call doesn't