### PR TITLE
Config / Do NOT run the embedded-domain check for ERC-20 tokens

### DIFF
--- a/src/libs/portfolio/blacklist.test.ts
+++ b/src/libs/portfolio/blacklist.test.ts
@@ -61,12 +61,35 @@ describe('portfolio blacklist', () => {
       ).toBe(true)
     })
 
-    it('matches a phishing domain in the name even with no patterns', () => {
+    it('matches a phishing domain in the name only when checkForEmbeddedDomain is set (NFT collections)', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'AIRDROP',
+          name: 'Claim your reward at claim-x.xyz',
+          lowercasedPatterns: [],
+          checkForEmbeddedDomain: true
+        })
+      ).toBe(true)
+    })
+
+    it('does not run the embedded-domain check for tokens (checkForEmbeddedDomain off)', () => {
+      // A token name that embeds a domain is NOT hidden, because token
+      // names/symbols legitimately contain dotted strings (false positives).
       expect(
         isBlacklistedAsset({
           symbol: 'AIRDROP',
           name: 'Claim your reward at claim-x.xyz',
           lowercasedPatterns: []
+        })
+      ).toBe(false)
+    })
+
+    it('still matches blacklist patterns for tokens even with the domain check off', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'OK',
+          name: 'claim at https://scam',
+          lowercasedPatterns: ['https']
         })
       ).toBe(true)
     })
@@ -83,7 +106,8 @@ describe('portfolio blacklist', () => {
           symbol: 'www.scam',
           name: 'Visit uniswap.org',
           isCustom: true,
-          lowercasedPatterns: ['www.']
+          lowercasedPatterns: ['www.'],
+          checkForEmbeddedDomain: true
         })
       ).toBe(false)
     })

--- a/src/libs/portfolio/blacklist.ts
+++ b/src/libs/portfolio/blacklist.ts
@@ -50,10 +50,7 @@ export const filterStaticBlacklistedAddrs = (tokenAddrs: string[], chainId: bigi
 }
 
 const isDomainChar = (char: string): boolean =>
-  (char >= 'a' && char <= 'z') ||
-  (char >= '0' && char <= '9') ||
-  char === '.' ||
-  char === '-'
+  (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char === '.' || char === '-'
 
 /**
  * Detects a real registrable domain anywhere in the text (e.g. "uniswap.org",
@@ -105,18 +102,22 @@ export const isBlacklistedAsset = ({
   symbol,
   name,
   isCustom,
-  lowercasedPatterns
+  lowercasedPatterns,
+  checkForEmbeddedDomain
 }: {
   symbol: string
   name?: string
   isCustom?: boolean
   lowercasedPatterns: string[]
+  checkForEmbeddedDomain?: boolean
 }): boolean => {
   if (isCustom) return false
 
   const haystack = `${symbol} ${name || ''}`.toLowerCase()
 
   if (lowercasedPatterns.some((pattern) => haystack.includes(pattern))) return true
+
+  if (!checkForEmbeddedDomain) return false
 
   return containsDomainLike(haystack)
 }

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -374,8 +374,9 @@ export class Portfolio {
       .filter((_tokensWithErrResult: [TokenError, TokenResult]) => {
         if (!isValidToken(_tokensWithErrResult[0], _tokensWithErrResult[1])) return false
 
-        // Spam filter: hide tokens whose symbol/name matches a blacklisted pattern
-        // or embeds a phishing domain. Custom (user-added) tokens are never hidden.
+        // Spam filter: hide tokens whose symbol/name matches a blacklisted
+        // pattern. Custom (user-added) tokens are never hidden. We don't run the
+        // embedded-domain check here because token names/symbols legitimately contain domains.
         const token = _tokensWithErrResult[1]
         if (
           isBlacklistedAsset({
@@ -431,7 +432,8 @@ export class Portfolio {
             symbol: collection.symbol,
             name: collection.name,
             isCustom: collection.flags?.isCustom,
-            lowercasedPatterns: allBlacklistedSymbols
+            lowercasedPatterns: allBlacklistedSymbols,
+            checkForEmbeddedDomain: true
           })
         )
           return acc


### PR DESCRIPTION
It turned out https://github.com/AmbireTech/ambire-common/pull/2458 is too strict for ERC-20 tokens and some legitime ones result in false-positives.

Worse yet, while for NFTs the consensus we had is false-positives are no biggie (vs false-negatives), for ERC-20s false-positives turned out to be a lot worse when having into considerations simulation might miss them.