### PR TITLE
Bug / Enhance asset blacklist checks by ensuring separate matching for symbol and name to prevent false positives (+ add tests)

### DIFF
--- a/src/libs/portfolio/blacklist.test.ts
+++ b/src/libs/portfolio/blacklist.test.ts
@@ -94,6 +94,38 @@ describe('portfolio blacklist', () => {
       ).toBe(true)
     })
 
+    it('matches a space-padded lure word inside a phrase', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'OK',
+          name: 'claim your reward now',
+          lowercasedPatterns: ['claim ', ' airdrop']
+        })
+      ).toBe(true)
+    })
+
+    it('does not hide a token whose symbol equals a lure word (no artificial space from joining)', () => {
+      // Regression: joining symbol + " " + name produced "win " and tripped the
+      // space-padded "win " pattern. Symbol and name must be matched separately.
+      expect(
+        isBlacklistedAsset({
+          symbol: 'WIN',
+          name: '',
+          lowercasedPatterns: [' win', 'win ']
+        })
+      ).toBe(false)
+    })
+
+    it('does not hide a token whose name embeds a lure word without a boundary', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'WINNER',
+          name: 'Winner',
+          lowercasedPatterns: [' win', 'win ']
+        })
+      ).toBe(false)
+    })
+
     it('does not hide a clean asset', () => {
       expect(
         isBlacklistedAsset({ symbol: 'USDC', name: 'USD Coin', lowercasedPatterns: ['https', 'www.'] })

--- a/src/libs/portfolio/blacklist.ts
+++ b/src/libs/portfolio/blacklist.ts
@@ -93,8 +93,15 @@ export const containsDomainLike = (text: string): boolean => {
  *
  * Spam often hides the lure in the name rather than the symbol, so both are
  * checked, combining two signals:
- * - substring patterns from the static + dynamic blacklist (e.g. "https", "www.")
+ * - substring patterns from the static + dynamic blacklist (e.g. "https", "www.",
+ *   or space-padded lure words like "claim " / " airdrop")
  * - a domain-like detector (see `containsDomainLike`)
+ *
+ * The symbol and name are matched SEPARATELY and never joined into one string.
+ * Many patterns are space-padded to match on word boundaries (e.g. "win " catches
+ * "win the prize" but not "winner"). Joining symbol + " " + name would insert an
+ * artificial space and wrongly trip those patterns — e.g. a token with symbol
+ * "WIN" would become "win " and match the "win " pattern.
  *
  * `lowercasedPatterns` must already be lowercased by the caller.
  */
@@ -113,11 +120,15 @@ export const isBlacklistedAsset = ({
 }): boolean => {
   if (isCustom) return false
 
-  const haystack = `${symbol} ${name || ''}`.toLowerCase()
+  const haystacks = [symbol.toLowerCase(), ...(name ? [name.toLowerCase()] : [])]
 
-  if (lowercasedPatterns.some((pattern) => haystack.includes(pattern))) return true
+  const matchesBlacklistedPattern = haystacks.some((haystack) =>
+    lowercasedPatterns.some((pattern) => haystack.includes(pattern))
+  )
+  if (matchesBlacklistedPattern) return true
 
   if (!checkForEmbeddedDomain) return false
 
-  return containsDomainLike(haystack)
+  const embedsPhishingDomain = haystacks.some((haystack) => containsDomainLike(haystack))
+  return embedsPhishingDomain
 }


### PR DESCRIPTION
The symbol and name are now matched SEPARATELY and never joined into one string. We agreed to make almost all patterns space-padded to match on word boundaries (e.g. "win " catches "win the prize" but not "winner").

Joining symbol + " " + name was bad idea at the first place - because it was inserting an artificial space and wrongly trip those patterns - e.g. a token with symbol "WIN" would become "win " and match the "win " pattern.