### PR TITLE
Config / Improve asset blacklisting to avoid false positives

### DIFF
--- a/src/libs/portfolio/blacklist.test.ts
+++ b/src/libs/portfolio/blacklist.test.ts
@@ -1,4 +1,9 @@
-import { containsDomainLike, filterStaticBlacklistedAddrs, isBlacklistedAsset } from './blacklist'
+import {
+  containsDomainLike,
+  filterStaticBlacklistedAddrs,
+  isBlacklistedAsset,
+  prepareBlacklistPatterns
+} from './blacklist'
 
 describe('portfolio blacklist', () => {
   it('filters static blacklisted addresses', () => {
@@ -44,19 +49,46 @@ describe('portfolio blacklist', () => {
     })
   })
 
+  describe('prepareBlacklistPatterns', () => {
+    it('treats space-padded patterns as lure words and dedupes their variants', () => {
+      const prepared = prepareBlacklistPatterns([' Mint', 'mint ', ' MINT ', ' airdrop '])
+
+      expect([...prepared.wordPatterns].sort()).toEqual(['airdrop', 'mint'])
+      expect(prepared.substringPatterns).toEqual([])
+    })
+
+    it('treats bare patterns as substring signals (preserves the existing contract)', () => {
+      const prepared = prepareBlacklistPatterns(['www.', 'https', 'weth'])
+
+      expect([...prepared.substringPatterns].sort()).toEqual(['https', 'weth', 'www.'])
+      expect(prepared.wordPatterns).toEqual([])
+    })
+
+    it('drops empty and whitespace-only patterns', () => {
+      const prepared = prepareBlacklistPatterns(['', '   ', ' mint '])
+
+      expect(prepared.wordPatterns).toEqual(['mint'])
+      expect(prepared.substringPatterns).toEqual([])
+    })
+  })
+
   describe('isBlacklistedAsset', () => {
-    it('matches a blacklist pattern in the symbol', () => {
+    it('matches a substring pattern in the symbol', () => {
       expect(
-        isBlacklistedAsset({ symbol: 'www.scam', name: '', lowercasedPatterns: ['www.'] })
+        isBlacklistedAsset({
+          symbol: 'www.scam',
+          name: '',
+          patterns: prepareBlacklistPatterns(['www.'])
+        })
       ).toBe(true)
     })
 
-    it('matches a blacklist pattern in the name', () => {
+    it('matches a URL marker in the name', () => {
       expect(
         isBlacklistedAsset({
           symbol: 'OK',
           name: 'claim at https://scam',
-          lowercasedPatterns: ['https']
+          patterns: prepareBlacklistPatterns(['https'])
         })
       ).toBe(true)
     })
@@ -66,7 +98,7 @@ describe('portfolio blacklist', () => {
         isBlacklistedAsset({
           symbol: 'AIRDROP',
           name: 'Claim your reward at claim-x.xyz',
-          lowercasedPatterns: [],
+          patterns: prepareBlacklistPatterns([]),
           checkForEmbeddedDomain: true
         })
       ).toBe(true)
@@ -79,7 +111,7 @@ describe('portfolio blacklist', () => {
         isBlacklistedAsset({
           symbol: 'AIRDROP',
           name: 'Claim your reward at claim-x.xyz',
-          lowercasedPatterns: []
+          patterns: prepareBlacklistPatterns([])
         })
       ).toBe(false)
     })
@@ -89,31 +121,119 @@ describe('portfolio blacklist', () => {
         isBlacklistedAsset({
           symbol: 'OK',
           name: 'claim at https://scam',
-          lowercasedPatterns: ['https']
+          patterns: prepareBlacklistPatterns(['https'])
         })
       ).toBe(true)
     })
 
-    it('matches a space-padded lure word inside a phrase', () => {
+    it('matches a lure word on word boundaries inside a phrase', () => {
       expect(
         isBlacklistedAsset({
           symbol: 'OK',
           name: 'claim your reward now',
-          lowercasedPatterns: ['claim ', ' airdrop']
+          patterns: prepareBlacklistPatterns(['claim ', ' airdrop'])
         })
       ).toBe(true)
     })
 
-    it('does not hide a token whose symbol equals a lure word (no artificial space from joining)', () => {
-      // Regression: joining symbol + " " + name produced "win " and tripped the
-      // space-padded "win " pattern. Symbol and name must be matched separately.
+    it('matches a lure word bounded by punctuation, not just spaces', () => {
+      // Old space-padding missed "AIRDROP:" because no space sits next to the word.
+      expect(
+        isBlacklistedAsset({
+          symbol: 'OK',
+          name: 'AIRDROP: claim your tokens',
+          patterns: prepareBlacklistPatterns([' airdrop'])
+        })
+      ).toBe(true)
+    })
+
+    it('hides the real-world spam examples (multi-word lure)', () => {
+      const patterns = prepareBlacklistPatterns([' airdrop '])
+
+      expect(
+        isBlacklistedAsset({ symbol: '', name: 'Collection weETH airdrop by AaveFi', patterns })
+      ).toBe(true)
+      expect(isBlacklistedAsset({ symbol: '', name: 'ARBITRUM AIRDROP', patterns })).toBe(true)
+      expect(isBlacklistedAsset({ symbol: '', name: '$PENDLE AIRDROP', patterns })).toBe(true)
+      expect(isBlacklistedAsset({ symbol: '', name: 'SUI AIRDROP', patterns })).toBe(true)
+      // not real world, but still worth checking
+      expect(isBlacklistedAsset({ symbol: '', name: 'AIRDROP! SUI', patterns })).toBe(true)
+      expect(isBlacklistedAsset({ symbol: '', name: 'AIRDROP: SUI', patterns })).toBe(true)
+    })
+
+    it('hides an NFT collection that embeds a phishing domain', () => {
+      // e.g. "$SHIB Reward: t.me/s/shibpool" / "...t.me/s/claimspepe"
+      expect(
+        isBlacklistedAsset({
+          symbol: '',
+          name: '$SHIB Reward: t.me/s/shibpool',
+          patterns: prepareBlacklistPatterns([]),
+          checkForEmbeddedDomain: true
+        })
+      ).toBe(true)
+    })
+
+    it('does NOT hide a legitimate project whose name embeds a lure word as a suffix', () => {
+      // Regression: "mint " used to match inside "papermint ", hiding a real token.
+      expect(
+        isBlacklistedAsset({
+          symbol: 'PMINT',
+          name: 'papermint protocol',
+          patterns: prepareBlacklistPatterns([' mint', 'mint '])
+        })
+      ).toBe(false)
+    })
+
+    it('does not hide a token whose symbol equals a lure word', () => {
+      // A standalone lure word is left visible: a project literally named/symboled
+      // "WIN" is not spam; the word only counts inside a multi-word lure.
       expect(
         isBlacklistedAsset({
           symbol: 'WIN',
           name: '',
-          lowercasedPatterns: [' win', 'win ']
+          patterns: prepareBlacklistPatterns([' win', 'win '])
         })
       ).toBe(false)
+    })
+
+    it('does not hide a token whose name is exactly a lure word', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'X',
+          name: 'Mint',
+          patterns: prepareBlacklistPatterns([' mint', 'mint '])
+        })
+      ).toBe(false)
+    })
+
+    it('does not hide a single-token symbol that embeds a lure across punctuation', () => {
+      // Symbols are tickers: with no space, "WIN-AIRDROP" reads as one token and
+      // stays visible, even though "airdrop" is a whole word across the hyphen.
+      expect(
+        isBlacklistedAsset({
+          symbol: 'WIN-AIRDROP',
+          name: '',
+          patterns: prepareBlacklistPatterns([' airdrop '])
+        })
+      ).toBe(false)
+    })
+
+    it('hides a symbol that contains a lure word among spaces', () => {
+      expect(
+        isBlacklistedAsset({
+          symbol: 'CLAIM AIRDROP',
+          name: '',
+          patterns: prepareBlacklistPatterns([' airdrop '])
+        })
+      ).toBe(true)
+    })
+
+    it('matches a lure word as the first, middle or last word of a name', () => {
+      const patterns = prepareBlacklistPatterns([' airdrop '])
+
+      expect(isBlacklistedAsset({ symbol: 'X', name: 'Airdrop for holders', patterns })).toBe(true)
+      expect(isBlacklistedAsset({ symbol: 'X', name: 'Free airdrop now', patterns })).toBe(true)
+      expect(isBlacklistedAsset({ symbol: 'X', name: 'Holders airdrop', patterns })).toBe(true)
     })
 
     it('does not hide a token whose name embeds a lure word without a boundary', () => {
@@ -121,14 +241,18 @@ describe('portfolio blacklist', () => {
         isBlacklistedAsset({
           symbol: 'WINNER',
           name: 'Winner',
-          lowercasedPatterns: [' win', 'win ']
+          patterns: prepareBlacklistPatterns([' win', 'win '])
         })
       ).toBe(false)
     })
 
     it('does not hide a clean asset', () => {
       expect(
-        isBlacklistedAsset({ symbol: 'USDC', name: 'USD Coin', lowercasedPatterns: ['https', 'www.'] })
+        isBlacklistedAsset({
+          symbol: 'USDC',
+          name: 'USD Coin',
+          patterns: prepareBlacklistPatterns(['https', 'www.'])
+        })
       ).toBe(false)
     })
 
@@ -138,7 +262,7 @@ describe('portfolio blacklist', () => {
           symbol: 'www.scam',
           name: 'Visit uniswap.org',
           isCustom: true,
-          lowercasedPatterns: ['www.'],
+          patterns: prepareBlacklistPatterns(['www.']),
           checkForEmbeddedDomain: true
         })
       ).toBe(false)

--- a/src/libs/portfolio/blacklist.ts
+++ b/src/libs/portfolio/blacklist.ts
@@ -87,45 +87,130 @@ export const containsDomainLike = (text: string): boolean => {
   return false
 }
 
+const isWordChar = (char: string | undefined): boolean =>
+  !!char && ((char >= 'a' && char <= 'z') || (char >= '0' && char <= '9'))
+
+/**
+ * Splits text into its word tokens — maximal runs of [a-z0-9] — so a lure word
+ * can be matched as a WHOLE word rather than a substring. No regex, per repo
+ * rule, mirroring the char scan in `containsDomainLike`.
+ *
+ * "free mint!" → ["free", "mint"], so the lure "mint" matches "free mint" but
+ * never the legitimate "papermint". Text is assumed lowercased by the caller.
+ */
+const toWords = (text: string): string[] => {
+  const words: string[] = []
+  let current = ''
+  for (const char of text) {
+    if (isWordChar(char)) {
+      current += char
+    } else if (current) {
+      words.push(current)
+      current = ''
+    }
+  }
+  if (current) words.push(current)
+
+  return words
+}
+
+// A space (incl. non-breaking) marks a word break; punctuation does not, so a
+// single-token symbol like "WIN", "WETH" or "WIN-AIRDROP" is not multi-word.
+const isMultiWord = (text: string): boolean => text.includes(' ') || text.includes('\u00a0')
+
+export interface PreparedBlacklistPatterns {
+  // Lure words (e.g. "airdrop", "mint"), matched on word boundaries.
+  wordPatterns: string[]
+  // Raw substring signals (e.g. "https", "www.", a full symbol/name), matched anywhere.
+  substringPatterns: string[]
+}
+
+/**
+ * Normalizes raw blacklist patterns once, so per-asset matching stays cheap.
+ *
+ * Classification keys off the surrounding whitespace the backend already uses:
+ * - a SPACE-PADDED single word (" mint", "mint ", " mint ") is a lure word. The
+ *   padding was a one-sided word-boundary hack that misfired on words like
+ *   "papermint", so we strip it and match it as a whole word instead (see
+ *   `toWords`). Padded duplicates collapse to one entry, so the backend can also
+ *   send a single padded variant per word.
+ * - everything else — a BARE pattern ("https", "www.", a full symbol/name) or a
+ *   padded multi-word phrase — keeps the case-insensitive SUBSTRING contract and
+ *   matches anywhere.
+ */
+export const prepareBlacklistPatterns = (rawPatterns: string[]): PreparedBlacklistPatterns => {
+  const wordPatterns = new Set<string>()
+  const substringPatterns = new Set<string>()
+
+  for (const raw of rawPatterns) {
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    const pattern = trimmed.toLowerCase()
+    // Surrounding whitespace marks a lure word; a bare pattern (or a padded
+    // multi-word phrase, which has no single whole-word token) stays a substring.
+    const isPaddedLureWord = trimmed !== raw && !pattern.includes(' ')
+    if (isPaddedLureWord) wordPatterns.add(pattern)
+    else substringPatterns.add(pattern)
+  }
+
+  return {
+    wordPatterns: [...wordPatterns],
+    substringPatterns: [...substringPatterns]
+  }
+}
+
 /**
  * Decides whether an asset (ERC-20 token or NFT collection) should be hidden as
  * spam based on its symbol and name. Custom (user-added) assets are never hidden.
  *
  * Spam often hides the lure in the name rather than the symbol, so both are
- * checked, combining two signals:
- * - substring patterns from the static + dynamic blacklist (e.g. "https", "www.",
- *   or space-padded lure words like "claim " / " airdrop")
- * - a domain-like detector (see `containsDomainLike`)
+ * checked, combining the prepared blacklist patterns (see
+ * `prepareBlacklistPatterns`) with a domain-like detector (see
+ * `containsDomainLike`):
+ * - word patterns ("airdrop", "claim") match only on word boundaries, so
+ *   "free mint" is hidden but "papermint protocol" is not
+ * - substring patterns ("www.", "t.me") match anywhere
  *
- * The symbol and name are matched SEPARATELY and never joined into one string.
- * Many patterns are space-padded to match on word boundaries (e.g. "win " catches
- * "win the prize" but not "winner"). Joining symbol + " " + name would insert an
- * artificial space and wrongly trip those patterns — e.g. a token with symbol
- * "WIN" would become "win " and match the "win " pattern.
+ * The symbol and name are matched SEPARATELY and never joined into one string,
+ * so a token with symbol "WIN" plus a name does not gain an artificial boundary.
  *
- * `lowercasedPatterns` must already be lowercased by the caller.
+ * Word patterns only fire inside MULTI-WORD text. A single-token symbol or name
+ * — "WIN", "WETH", even "WIN-AIRDROP" — is left visible, because a legitimate
+ * ticker often collides with a lure word; the spam we target reads as a phrase
+ * ("claim your airdrop now"), where the lure sits among other words. Substring
+ * patterns ("www.", "https") ignore this gate and still match a single token.
  */
 export const isBlacklistedAsset = ({
   symbol,
   name,
   isCustom,
-  lowercasedPatterns,
+  patterns,
   checkForEmbeddedDomain
 }: {
   symbol: string
   name?: string
   isCustom?: boolean
-  lowercasedPatterns: string[]
+  patterns: PreparedBlacklistPatterns
   checkForEmbeddedDomain?: boolean
 }): boolean => {
   if (isCustom) return false
 
   const haystacks = [symbol.toLowerCase(), ...(name ? [name.toLowerCase()] : [])]
 
-  const matchesBlacklistedPattern = haystacks.some((haystack) =>
-    lowercasedPatterns.some((pattern) => haystack.includes(pattern))
+  const matchesSubstringPattern = haystacks.some((haystack) =>
+    patterns.substringPatterns.some((pattern) => haystack.includes(pattern))
   )
-  if (matchesBlacklistedPattern) return true
+  if (matchesSubstringPattern) return true
+
+  const matchesWordPattern = haystacks.some((haystack) => {
+    const trimmed = haystack.trim()
+    // Lure words count only in multi-word text, so a single-token symbol/name
+    // (e.g. "WIN") stays visible even when it embeds a lure across punctuation.
+    if (!isMultiWord(trimmed)) return false
+    const words = new Set(toWords(trimmed))
+    return patterns.wordPatterns.some((pattern) => words.has(pattern))
+  })
+  if (matchesWordPattern) return true
 
   if (!checkForEmbeddedDomain) return false
 

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -10,7 +10,7 @@ import { Network } from '../../interfaces/network'
 import { RPCProvider } from '../../interfaces/provider'
 import { Deployless, fromDescriptor } from '../deployless/deployless'
 import batcher from './batcher'
-import { isBlacklistedAsset, STATIC_BLACKLIST } from './blacklist'
+import { isBlacklistedAsset, prepareBlacklistPatterns, STATIC_BLACKLIST } from './blacklist'
 import { geckoRequestBatcher, geckoResponseIdentifier } from './gecko'
 import { getNFTs, getTokens } from './getOnchainBalances'
 import {
@@ -365,10 +365,10 @@ export class Portfolio {
     const isValidToken = (error: TokenError, token: TokenResult): boolean =>
       error === '0x' && !!token.symbol
 
-    const allBlacklistedSymbols = [
+    const blacklistPatterns = prepareBlacklistPatterns([
       ...STATIC_BLACKLIST.blacklistBySymbols,
       ...(blacklist?.blacklistBySymbols || [])
-    ].map((p) => p.toLowerCase())
+    ])
 
     const tokensWithoutPrices = tokensWithErrResult
       .filter((_tokensWithErrResult: [TokenError, TokenResult]) => {
@@ -383,7 +383,7 @@ export class Portfolio {
             symbol: token.symbol,
             name: token.name,
             isCustom: token.flags?.isCustom,
-            lowercasedPatterns: allBlacklistedSymbols
+            patterns: blacklistPatterns
           })
         )
           return false
@@ -432,7 +432,7 @@ export class Portfolio {
             symbol: collection.symbol,
             name: collection.name,
             isCustom: collection.flags?.isCustom,
-            lowercasedPatterns: allBlacklistedSymbols,
+            patterns: blacklistPatterns,
             checkForEmbeddedDomain: true
           })
         )


### PR DESCRIPTION
Blacklist patterns for token/NFT symbols and names were matched as space-padded substrings (e.g. "mint "), which only checks one boundary and wrongly hid legitimate assets like "papermint protocol".

This reworks the matching:

- `prepareBlacklistPatterns` normalizes the static + dynamic lists once. Space-padded entries are treated as lure words and de-duplicated (" mint", "mint ", " mint " all collapse to "mint"); bare entries ("https", "www.", a full symbol/name) keep the existing substring contract.
- Lure words are matched as whole words and only inside multi-word text, so a single-token symbol/name (WIN, WETH, WIN-AIRDROP) stays visible while "claim your airdrop now" is hidden.
- Matching tokenizes the text once and does a set lookup (no regex).

Confirmed spam from the logs (e.g. "ARBITRUM AIRDROP", "$PENDLE AIRDROP", domain-bearing NFT names) is still hidden. Added unit tests for the new behavior and the papermint-style regression.