### PR TITLE
Fix / SignMessage - dapp verification banner propagate update

### DIFF
--- a/src/controllers/dapps/dapps.test.ts
+++ b/src/controllers/dapps/dapps.test.ts
@@ -301,6 +301,40 @@ describe('DappsController', () => {
       }
     })
 
+    test('should return loading banner while the initial storage load is still pending', async () => {
+      const updateDomainsSpy = mockDappVerificationStatuses({ 'aave.com': 'FAILED_TO_GET' })
+
+      try {
+        const { controller } = await prepareTest(async (storageCtrl) => {
+          await storageCtrl.set('dappsV2', predefinedDapps)
+          await storageCtrl.set('lastDappsUpdateVersion', 'test-version')
+        })
+        await controller.fetchAndUpdatePromise
+
+        const aave = controller.getDapp('aave.com')!
+
+        // Simulate a banner request arriving before the initial storage load has finished
+        // (e.g. right after a service worker restart) - the statuses are not known yet,
+        // so the banner must report the verification as in progress, not failed/unknown
+        controller.initialLoadPromise = new Promise<void>(() => {})
+        expect(controller.getDappVerificationBanner([aave.url])).toEqual({
+          id: DAPP_VERIFICATION_BANNER_IDS.LOADING,
+          type: 'warning',
+          text: "We're still verifying the app. Please wait, or make sure you trust it before signing requests: AAVE"
+        })
+
+        // Once the load completes, the actual (failed) status should be reported again
+        controller.initialLoadPromise = undefined
+        expect(controller.getDappVerificationBanner([aave.url])).toEqual({
+          id: DAPP_VERIFICATION_BANNER_IDS.FAILED_TO_GET_OR_UNKNOWN,
+          type: 'warning',
+          text: "We couldn't verify the app. Make sure you trust it before signing requests: AAVE"
+        })
+      } finally {
+        updateDomainsSpy.mockRestore()
+      }
+    })
+
     test('should return failed banner for dapps with failed verification', async () => {
       const updateDomainsSpy = mockDappVerificationStatuses({ 'aave.com': 'FAILED_TO_GET' })
 

--- a/src/controllers/dapps/dapps.ts
+++ b/src/controllers/dapps/dapps.ts
@@ -1147,7 +1147,10 @@ export class DappsController extends EventEmitter implements IDappsController {
 
       return {
         id,
-        status: dapp?.blacklisted,
+        // While the initial storage load is still pending, #dapps is empty, so a missing
+        // record/status here doesn't mean verification failed - report LOADING instead
+        // (e.g. a sign request can arrive right after the service worker wakes up).
+        status: this.initialLoadPromise ? ('LOADING' as const) : dapp?.blacklisted,
         name: dapp?.name || new URL(url).hostname
       }
     })

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -760,5 +760,55 @@ describe('SignMessageController', () => {
 
       expect(signMessageController.banners).toEqual([])
     })
+
+    test('shows the loading banner while the dapps controller is still loading and clears it once resolved', async () => {
+      const signMessageCtrl = new SignMessageController(
+        keystoreCtrl,
+        providersCtrl,
+        networksCtrl,
+        accountsCtrl,
+        {},
+        inviteCtrl,
+        undefined,
+        dappsCtrl
+      )
+
+      // Until the dapps controller finishes its initial storage load (e.g. right after a service
+      // worker restart), verification is unknown and must be reported as in progress, never as
+      // failed. A never-resolving promise holds it in that pending state.
+      dappsCtrl.initialLoadPromise = new Promise<void>(() => {})
+
+      try {
+        await signMessageCtrl.init({ messageToSign, dapp: getDappRequestData(verifiedDapp) })
+        // Flush the background humanization so its emit can't be mistaken for the one we assert on
+        await new Promise((resolve) => {
+          setTimeout(resolve, 0)
+        })
+        expect(signMessageCtrl.banners).toEqual([
+          {
+            id: DAPP_VERIFICATION_BANNER_IDS.LOADING,
+            type: 'warning',
+            text: "We're still verifying the app. Please wait, or make sure you trust it before signing requests."
+          }
+        ])
+
+        let emitsCount = 0
+        const unsubscribe = signMessageCtrl.onUpdate(() => {
+          emitsCount++
+        })
+
+        // The load completes and the dapps controller emits; the controller must re-emit so the
+        // loading banner is replaced by the resolved state (verified dapp in catalog → no banner).
+        dappsCtrl.initialLoadPromise = undefined
+        await dappsCtrl.forceEmitUpdate()
+
+        expect(emitsCount).toBeGreaterThan(0)
+        expect(signMessageCtrl.banners).toEqual([])
+
+        unsubscribe()
+      } finally {
+        dappsCtrl.initialLoadPromise = undefined
+      }
+    })
   })
 })

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -145,6 +145,15 @@ export class SignMessageController
     this.#dapps = dapps
     this.#callRelayer = callRelayer
     this.status = SignMessageStatus.Initial
+
+    // `banners` is derived from DappsController state (the dapp verification status), so its
+    // updates must be propagated - otherwise a banner computed before the status resolves
+    // (e.g. right after a service worker restart) would stay stale in the UI until this
+    // controller happens to emit for another reason.
+    // NOTE: No unsubscribe needed - both controllers are singletons living for the app lifetime.
+    this.#dapps?.onUpdate((forceEmit) => {
+      if (this.dapp?.url) this.propagateUpdate(forceEmit)
+    }, 'sign-message-dapps-verification')
   }
 
   async init({


### PR DESCRIPTION
Tomek reported that from time to time he sees the FAILED_TO_GET dapp verification banner for heyAura staging when signing.

My theory is that we don't propagate dapp controller updates to signMessage, so the initial banner value FAILED_TO_GET gets cached - simply because it was the very first value, set while the storage hadn't loaded yet in the dapps controller.

With this PR, I'm introducing 2 changes:
1. First, while the dapp controller is loading, the banner resolves to the LOADING state.
2. Second, propagate dapp controller updates to the signMessage controller, so it receives the correct banner state.

https://goodmorning-dev.slack.com/archives/C0644227TAP/p1781007768349939