### PR TITLE
Improvements / Networks update

### DIFF
--- a/src/controllers/networks/networks.test.ts
+++ b/src/controllers/networks/networks.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, test } from '@jest/globals'
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 
+import { relayerUrl } from '../../../test/config'
+import { produceMemoryStore } from '../../../test/helpers'
 import { makeMainController } from '../../../test/helpers/mainController'
 import { networks as predefinedNetworks } from '../../consts/networks'
-import { INetworksController } from '../../interfaces/network'
+import { INetworksController, Network } from '../../interfaces/network'
+import wait from '../../utils/wait'
+import { StorageController } from '../storage/storage'
+import { NetworksController } from './networks'
 
 describe('Networks Controller', () => {
   let networksController: INetworksController
@@ -171,4 +176,145 @@ describe('Networks Controller', () => {
   //     rpcUrls: ['https://fantom-pokt.nodies.app']
   //   })
   // })
+})
+
+describe('Networks Controller - background relayer refresh', () => {
+  let controller: NetworksController
+  // Spy on the relayer merge so the background refresh is deterministic and never
+  // hits the network. Its return value drives whether a network "changed".
+  let mergeRelayerNetworks: jest.SpiedFunction<NetworksController['mergeRelayerNetworks']>
+  // Stands in for MainController's real callback (setProvider + reloadSelectedAccount).
+  let onAddOrUpdateNetworks: jest.Mock<(networks: Network[]) => Promise<void>>
+
+  const noChange = (current: { [key: string]: Network }) => ({
+    mergedNetworks: current,
+    updatedNetworkChainIds: [] as bigint[]
+  })
+
+  // Polls until the (not-awaited) background sync kicked off from `#load` settles,
+  // so each test starts from a clean `areNetworksFetchingFromRelayer === false`.
+  const settleBackgroundSync = async () => {
+    for (let i = 0; i < 100 && controller.areNetworksFetchingFromRelayer; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await wait(0)
+    }
+  }
+
+  const buildController = (defaultNetworksMode: 'mainnet' | 'testnet' = 'mainnet') => {
+    onAddOrUpdateNetworks = jest.fn<(networks: Network[]) => Promise<void>>(async () => {})
+    const ctrl = new NetworksController({
+      defaultNetworksMode,
+      storage: new StorageController(produceMemoryStore()),
+      // Never invoked: `mergeRelayerNetworks` (the only relayer caller) is spied.
+      fetch: jest.fn() as any,
+      relayerUrl,
+      // No-op: it never calls back, so no RPC/network-info work runs on load.
+      useTempProvider: async () => {},
+      onAddOrUpdateNetworks,
+      onReady: async () => {}
+    })
+    // Spied synchronously right after construction — before `#load`'s awaited
+    // microtasks reach `synchronizeNetworks`, so the background refresh is mocked.
+    mergeRelayerNetworks = jest
+      .spyOn(ctrl, 'mergeRelayerNetworks')
+      .mockImplementation(async (current) => noChange(current))
+    return ctrl
+  }
+
+  beforeEach(() => {
+    controller = buildController()
+  })
+
+  test('resolves initialLoadPromise with stored networks without awaiting the relayer refresh', async () => {
+    // Hold the relayer merge pending so we can prove the initial load does not wait on it.
+    let releaseMerge: () => void = () => {}
+    mergeRelayerNetworks.mockImplementation(
+      (current) =>
+        new Promise((resolve) => {
+          releaseMerge = () => resolve(noChange(current))
+        })
+    )
+
+    await controller.initialLoadPromise
+
+    // Networks are available immediately (seeded from predefined on a fresh install)
+    // even though the relayer merge is still pending in the background.
+    expect(controller.isInitialized).toBe(true)
+    expect(controller.networks.length).toBeGreaterThan(0)
+    expect(mergeRelayerNetworks).toHaveBeenCalledTimes(1)
+    expect(controller.areNetworksFetchingFromRelayer).toBe(true)
+
+    releaseMerge()
+    await settleBackgroundSync()
+    expect(controller.areNetworksFetchingFromRelayer).toBe(false)
+  })
+
+  test('flags areNetworksFetchingFromRelayer while a refresh is in flight and clears it after', async () => {
+    await controller.initialLoadPromise
+    await settleBackgroundSync()
+    expect(controller.areNetworksFetchingFromRelayer).toBe(false)
+
+    const syncPromise = controller.synchronizeNetworks()
+    // Set synchronously before the first await inside synchronizeNetworks.
+    expect(controller.areNetworksFetchingFromRelayer).toBe(true)
+
+    await syncPromise
+    expect(controller.areNetworksFetchingFromRelayer).toBe(false)
+  })
+
+  test('keeps the flag true until the portfolio reload finishes when an RPC changed (flash gate)', async () => {
+    await controller.initialLoadPromise
+    await settleBackgroundSync()
+
+    mergeRelayerNetworks.mockImplementation(async (current) => ({
+      mergedNetworks: current,
+      updatedNetworkChainIds: [1n]
+    }))
+
+    let flagWhenReloadStarted: boolean | undefined
+    let flagWhenReloadEnded: boolean | undefined
+    onAddOrUpdateNetworks.mockImplementation(async () => {
+      flagWhenReloadStarted = controller.areNetworksFetchingFromRelayer
+      // Simulate the portfolio reload taking a tick to re-enter its loading state.
+      await wait(0)
+      flagWhenReloadEnded = controller.areNetworksFetchingFromRelayer
+    })
+
+    await controller.synchronizeNetworks()
+
+    // The reload ran, and the flag stayed true for its full duration — so the UI
+    // never flips out of the skeleton before the fresh (new-RPC) portfolio lands.
+    expect(onAddOrUpdateNetworks).toHaveBeenCalledTimes(1)
+    expect(flagWhenReloadStarted).toBe(true)
+    expect(flagWhenReloadEnded).toBe(true)
+    // Cleared only after the reload completed.
+    expect(controller.areNetworksFetchingFromRelayer).toBe(false)
+  })
+
+  test('does not trigger a portfolio reload when nothing changed, but still clears the flag', async () => {
+    await controller.initialLoadPromise
+    await settleBackgroundSync()
+
+    onAddOrUpdateNetworks.mockClear()
+    mergeRelayerNetworks.mockImplementation(async (current) => noChange(current))
+
+    await controller.synchronizeNetworks()
+
+    expect(onAddOrUpdateNetworks).not.toHaveBeenCalled()
+    expect(controller.areNetworksFetchingFromRelayer).toBe(false)
+  })
+
+  test('does not refresh from the relayer in testnet mode and keeps the flag false', async () => {
+    controller = buildController('testnet')
+
+    await controller.initialLoadPromise
+    expect(controller.areNetworksFetchingFromRelayer).toBe(false)
+    // `#load` skips the background refresh in testnet mode.
+    expect(mergeRelayerNetworks).not.toHaveBeenCalled()
+
+    // An explicit call early-returns before touching the relayer.
+    await controller.synchronizeNetworks()
+    expect(mergeRelayerNetworks).not.toHaveBeenCalled()
+    expect(controller.areNetworksFetchingFromRelayer).toBe(false)
+  })
 })

--- a/src/controllers/networks/networks.test.ts
+++ b/src/controllers/networks/networks.test.ts
@@ -195,7 +195,6 @@ describe('Networks Controller - background relayer refresh', () => {
   // so each test starts from a clean `areNetworksFetchingFromRelayer === false`.
   const settleBackgroundSync = async () => {
     for (let i = 0; i < 100 && controller.areNetworksFetchingFromRelayer; i++) {
-      // eslint-disable-next-line no-await-in-loop
       await wait(0)
     }
   }
@@ -225,6 +224,7 @@ describe('Networks Controller - background relayer refresh', () => {
   }
 
   beforeEach(() => {
+    jest.restoreAllMocks()
     controller = buildController()
   })
 

--- a/src/controllers/networks/networks.test.ts
+++ b/src/controllers/networks/networks.test.ts
@@ -200,7 +200,14 @@ describe('Networks Controller - background relayer refresh', () => {
     }
   }
 
-  const buildController = (defaultNetworksMode: 'mainnet' | 'testnet' = 'mainnet') => {
+  // The relayer-merge implementation is applied synchronously right after `new`,
+  // so the background `synchronizeNetworks` kicked off from `#load` already uses
+  // it (its first await yields before reaching `synchronizeNetworks`). This avoids
+  // a race where the construction-time refresh would run with a stale mock.
+  const buildController = (
+    defaultNetworksMode: 'mainnet' | 'testnet' = 'mainnet',
+    mergeImpl: NetworksController['mergeRelayerNetworks'] = async (current) => noChange(current)
+  ) => {
     onAddOrUpdateNetworks = jest.fn<(networks: Network[]) => Promise<void>>(async () => {})
     const ctrl = new NetworksController({
       defaultNetworksMode,
@@ -213,11 +220,7 @@ describe('Networks Controller - background relayer refresh', () => {
       onAddOrUpdateNetworks,
       onReady: async () => {}
     })
-    // Spied synchronously right after construction — before `#load`'s awaited
-    // microtasks reach `synchronizeNetworks`, so the background refresh is mocked.
-    mergeRelayerNetworks = jest
-      .spyOn(ctrl, 'mergeRelayerNetworks')
-      .mockImplementation(async (current) => noChange(current))
+    mergeRelayerNetworks = jest.spyOn(ctrl, 'mergeRelayerNetworks').mockImplementation(mergeImpl)
     return ctrl
   }
 
@@ -226,9 +229,11 @@ describe('Networks Controller - background relayer refresh', () => {
   })
 
   test('resolves initialLoadPromise with stored networks without awaiting the relayer refresh', async () => {
-    // Hold the relayer merge pending so we can prove the initial load does not wait on it.
+    // Build with a relayer merge that stays pending, so the background refresh is
+    // already in flight (with this impl) by the time the initial load resolves.
     let releaseMerge: () => void = () => {}
-    mergeRelayerNetworks.mockImplementation(
+    controller = buildController(
+      'mainnet',
       (current) =>
         new Promise((resolve) => {
           releaseMerge = () => resolve(noChange(current))

--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -60,6 +60,8 @@ export class NetworksController extends EventEmitter implements INetworksControl
     info?: NetworkInfoLoading<NetworkInfo>
   } | null = null
 
+  areNetworksFetchingFromRelayer: boolean = false
+
   #useTempProvider: (
     props: {
       rpcUrl: string
@@ -69,7 +71,7 @@ export class NetworksController extends EventEmitter implements INetworksControl
   ) => Promise<void>
 
   /** Callback that gets called when adding or updating network */
-  #onAddOrUpdateNetworks: (networks: Network[]) => void
+  #onAddOrUpdateNetworks: (networks: Network[]) => void | Promise<void>
 
   #onReady: () => Promise<void>
 
@@ -100,7 +102,7 @@ export class NetworksController extends EventEmitter implements INetworksControl
       },
       callback: (provider: RPCProvider) => Promise<void>
     ) => Promise<void>
-    onAddOrUpdateNetworks: (networks: Network[]) => void
+    onAddOrUpdateNetworks: (networks: Network[]) => void | Promise<void>
     onReady: () => Promise<void>
   }) {
     super(eventEmitterRegistry)
@@ -182,62 +184,69 @@ export class NetworksController extends EventEmitter implements INetworksControl
   }
 
   /**
-   * Loads and synchronizes network configurations from storage and the relayer.
+   * Loads the network configurations for the initial load.
    *
    * This method performs the following steps:
    * 1. Retrieves the latest network configurations from storage.
-   * 2. If no networks are found in storage, sets predefined networks and emits an update.
-   * 3. Merges the networks from the Relayer with the stored networks.
-   * 4. Ensures predefined networks are marked correctly and handles special cases (e.g., Odyssey network).
-   * 5. Sorts networks with predefined ones first, followed by custom networks, ordered by chainId.
-   * 6. Updates the networks in storage.
-   * 7. Asynchronously updates network features if needed.
+   * 2. Seeds the networks from storage, or from the predefined networks on a fresh
+   *    install (instantiating the RPC providers via `#onReady` in that case).
+   * 3. Persists the seeded networks and updates network features asynchronously.
+   * 4. Triggers `synchronizeNetworks` in the BACKGROUND (not awaited) to merge the
+   *    latest configuration from the Relayer.
    *
-   * This method ensures that the application has the most up-to-date network configurations,
-   * handles migration of legacy data, and maintains consistency between stored and relayer-provided networks.
+   * The relayer merge is intentionally not awaited so that `initialLoadPromise`
+   * resolves with the stored networks immediately — keeping the relayer fetch off
+   * the critical path of controllers that gate the mobile splash hide. The merge,
+   * provider swap and portfolio reload for any changed networks all happen in
+   * `synchronizeNetworks`.
    */
   async #load() {
     // Step 1. Get latest storage (networksInStorage) and validate/normalize
     const networksInStorage = await this.getNetworksInStorage()
 
-    let finalNetworks: { [key: string]: Network } = {}
-
-    // If networksInStorage is empty, set predefinedNetworks and emit update
+    // Step 2. Seed the networks from storage (or predefined on a fresh install).
+    // The relayer refresh is intentionally NOT awaited here (see Step 4) so that
+    // the initial load resolves immediately with the stored networks. This keeps
+    // the relayer fetch (/v2/config/networks, up to a 5s timeout) off the critical
+    // path of controllers that await `initialLoadPromise` (accounts →
+    // selectedAccount), which on mobile gate the splash hide.
     if (!Object.keys(networksInStorage).length) {
       const defaultNetworks =
         this.defaultNetworksMode === 'mainnet' ? predefinedNetworks : predefinedTestnetNetworks
-      finalNetworks = defaultNetworks.reduce(
+      this.#networks = defaultNetworks.reduce(
         (acc, network) => {
           acc[network.chainId.toString()] = network
           return acc
         },
         {} as { [key: string]: Network }
       )
-      this.#networks = finalNetworks
-
+      // Instantiate the RPC providers from the seeded networks before resolving.
       await this.#onReady()
-      this.emitUpdate()
+    } else {
+      this.#networks = Object.fromEntries(
+        Object.values(networksInStorage).map((network) => [network.chainId.toString(), network])
+      )
     }
 
-    finalNetworks = Object.fromEntries(
-      Object.values(networksInStorage).map((network) => [network.chainId.toString(), network])
-    )
-
-    if (this.defaultNetworksMode === 'mainnet') {
-      // Step 4: Merge the networks from the Relayer
-      // Note: there is no need to call #onAddOrUpdateNetworks here
-      // as this code runs in the initial load promise, thus the RPC providers
-      // will be instantiated from the final networks list
-      finalNetworks = (await this.mergeRelayerNetworks(finalNetworks)).mergedNetworks
-    }
-
-    this.#networks = finalNetworks
     this.emitUpdate()
-
     await this.#storage.set('networks', this.#networks)
 
-    // Step 8: Update networks features asynchronously
-    this.#updateNetworkFeatures(finalNetworks)
+    // Step 3: Update networks features asynchronously
+    this.#updateNetworkFeatures(this.#networks)
+
+    // Step 4: Refresh from the Relayer in the background (RPC URLs may have
+    // changed). `synchronizeNetworks` merges the relayer config, swaps providers
+    // and reloads the portfolio for any changed networks, and toggles
+    // `areNetworksFetchingFromRelayer` so the dashboard can hold the balance in a
+    // loading state until the fresh data lands. Not awaited so `initialLoadPromise`
+    // resolves now. (Skipped in testnet mode by `synchronizeNetworks` itself.)
+    this.synchronizeNetworks().catch((error) =>
+      this.emitError({
+        level: 'silent',
+        message: 'Failed to refresh the networks configuration from the Relayer.',
+        error
+      })
+    )
   }
 
   /**
@@ -247,23 +256,37 @@ export class NetworksController extends EventEmitter implements INetworksControl
   async synchronizeNetworks() {
     if (this.defaultNetworksMode === 'testnet') return
 
-    // Process updates (merge Relayer data and apply rules)
-    const { mergedNetworks, updatedNetworkChainIds } = await this.mergeRelayerNetworks(
-      this.#networks
-    )
-
-    // Finalize updates
-    this.#networks = mergedNetworks
+    this.areNetworksFetchingFromRelayer = true
     this.emitUpdate()
-    await this.#storage.set('networks', this.#networks)
 
-    // We must call this after merging the local networks with the ones from the Relayer
-    // to ensure that RPC providers of newly enabled networks are instantiated
-    this.#onAddOrUpdateNetworks(
-      this.allNetworks.filter((n) => updatedNetworkChainIds.includes(n.chainId))
-    )
-    // Asynchronously update network features
-    this.#updateNetworkFeatures(mergedNetworks)
+    try {
+      // Process updates (merge Relayer data and apply rules)
+      const { mergedNetworks, updatedNetworkChainIds } = await this.mergeRelayerNetworks(
+        this.#networks
+      )
+
+      // Finalize updates
+      this.#networks = mergedNetworks
+      this.emitUpdate()
+      await this.#storage.set('networks', this.#networks)
+
+      // We must call this after merging the local networks with the ones from the Relayer
+      // to ensure that RPC providers of newly enabled networks are instantiated.
+      // Awaited so `areNetworksFetchingFromRelayer` stays true until the portfolio
+      // reload triggered by the updated RPCs has finished — otherwise the flag would
+      // flip to false before the reload re-enters its loading state, briefly exposing
+      // a balance (and warnings) computed from the old RPCs that were potentially being replaced.
+      if (updatedNetworkChainIds.length) {
+        await this.#onAddOrUpdateNetworks(
+          this.allNetworks.filter((n) => updatedNetworkChainIds.includes(n.chainId))
+        )
+      }
+      // Asynchronously update network features
+      this.#updateNetworkFeatures(mergedNetworks)
+    } finally {
+      this.areNetworksFetchingFromRelayer = false
+      this.emitUpdate()
+    }
   }
 
   /**
@@ -434,7 +457,7 @@ export class NetworksController extends EventEmitter implements INetworksControl
       has7702: false
     }
 
-    this.#onAddOrUpdateNetworks([this.#networks[network.chainId.toString()]!])
+    void this.#onAddOrUpdateNetworks([this.#networks[network.chainId.toString()]!])
 
     await this.#storage.set('networks', this.#networks)
     this.networkToAddOrUpdate = null
@@ -466,7 +489,7 @@ export class NetworksController extends EventEmitter implements INetworksControl
       ...changedNetwork
     }
 
-    if (!skipUpdate) this.#onAddOrUpdateNetworks([this.#networks[chainId.toString()]!])
+    if (!skipUpdate) void this.#onAddOrUpdateNetworks([this.#networks[chainId.toString()]!])
     await this.#storage.set('networks', this.#networks)
 
     const checkRPC = async (
@@ -550,7 +573,7 @@ export class NetworksController extends EventEmitter implements INetworksControl
 
   async #updateNetworks(network: Partial<Network>, chainIds: ChainId[]) {
     await Promise.all(chainIds.map((chainId) => this.#updateNetwork(network, chainId, true)))
-    this.#onAddOrUpdateNetworks(this.allNetworks.filter((n) => chainIds.includes(n.chainId)))
+    void this.#onAddOrUpdateNetworks(this.allNetworks.filter((n) => chainIds.includes(n.chainId)))
     this.emitUpdate()
   }
 


### PR DESCRIPTION
**Defer the networks relayer refresh off the initial load**

NetworksController.#load awaited mergeRelayerNetworks (/v2/config/networks, up to a 5s timeout) before resolving initialLoadPromise. Since accounts → selectedAccount await that promise, the relayer fetch sat on the critical path of the consumers that gate the mobile splash. This moves the refresh to the background.

**Changes**
- #load now seeds networks from storage (or predefined on a fresh install) and resolves immediately, then kicks off synchronizeNetworks() in the background (not awaited).
- Add areNetworksFetchingFromRelayer flag so the UI can hold the balance in a loading state while the refresh is in flight.
- synchronizeNetworks sets the flag, and when an RPC actually changed it awaits onAddOrUpdateNetworks (provider swap + portfolio reload) before clearing the flag — so the consumer never flips out of loading before fresh data lands.

**Impact**
- Initial load no longer blocks on the relayer; the periodic 8h sync behaves the same, just with the new flag.