### PR TITLE
Default Swap & Bridge receive network on dashboard open

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -385,6 +385,58 @@ describe('SwapAndBridge Controller', () => {
       '0x0000000000000000000000000000000000000000' // the one with highest balance
     )
     expect(swapAndBridgeController.fromChainId).toEqual(10)
+    expect(swapAndBridgeController.toChainId).toEqual(10)
+  })
+  test('should sync toChainId when from token network changes and no to token is selected', async () => {
+    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
+    const tokenOnBase = PORTFOLIO_TOKENS.find((t) => t.chainId === 8453n)!
+
+    await swapAndBridgeController.updateForm({ fromSelectedToken: tokenOnBase })
+
+    expect(swapAndBridgeController.fromChainId).toEqual(8453)
+    expect(swapAndBridgeController.toChainId).toEqual(8453)
+  })
+  test('should clear incompatible to token and sync toChainId when from network changes', async () => {
+    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
+    const tokenOnBase = PORTFOLIO_TOKENS.find((t) => t.chainId === 8453n)!
+
+    await swapAndBridgeController.updateForm({ toChainId: 1 })
+    swapAndBridgeController.toSelectedToken = {
+      address: '0x1',
+      chainId: 1,
+      symbol: 'ETH',
+      name: 'Ether',
+      decimals: 18,
+      icon: undefined
+    }
+
+    await swapAndBridgeController.updateForm({ fromSelectedToken: tokenOnBase })
+
+    expect(swapAndBridgeController.toSelectedToken).toBeNull()
+    expect(swapAndBridgeController.toChainId).toEqual(8453)
+  })
+  test('should sync toChainId when fromChainId is out of sync with the selected from token', async () => {
+    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
+    const selectedFromToken = swapAndBridgeController.fromSelectedToken!
+
+    swapAndBridgeController.fromChainId = 1
+    swapAndBridgeController.toChainId = 1
+
+    await swapAndBridgeController.updateForm({ fromSelectedToken: selectedFromToken })
+
+    expect(swapAndBridgeController.fromChainId).toEqual(Number(selectedFromToken.chainId))
+    expect(swapAndBridgeController.toChainId).toEqual(Number(selectedFromToken.chainId))
+  })
+  test('should keep a manually selected bridge receive network when changing the from token on the same network', async () => {
+    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
+    const selectedFromToken = swapAndBridgeController.fromSelectedToken!
+
+    await swapAndBridgeController.updateForm({ toChainId: 8453 })
+
+    await swapAndBridgeController.updateForm({ fromSelectedToken: selectedFromToken })
+
+    expect(swapAndBridgeController.fromChainId).toEqual(Number(selectedFromToken.chainId))
+    expect(swapAndBridgeController.toChainId).toEqual(8453)
   })
   test('should sync toChainId to the preselected from token chain when no to token is provided', async () => {
     const preselectedToken = PORTFOLIO_TOKENS[1]!

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -387,57 +387,6 @@ describe('SwapAndBridge Controller', () => {
     expect(swapAndBridgeController.fromChainId).toEqual(10)
     expect(swapAndBridgeController.toChainId).toEqual(10)
   })
-  test('should sync toChainId when from token network changes and no to token is selected', async () => {
-    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
-    const tokenOnBase = PORTFOLIO_TOKENS.find((t) => t.chainId === 8453n)!
-
-    await swapAndBridgeController.updateForm({ fromSelectedToken: tokenOnBase })
-
-    expect(swapAndBridgeController.fromChainId).toEqual(8453)
-    expect(swapAndBridgeController.toChainId).toEqual(8453)
-  })
-  test('should clear incompatible to token and sync toChainId when from network changes', async () => {
-    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
-    const tokenOnBase = PORTFOLIO_TOKENS.find((t) => t.chainId === 8453n)!
-
-    await swapAndBridgeController.updateForm({ toChainId: 1 })
-    swapAndBridgeController.toSelectedToken = {
-      address: '0x1',
-      chainId: 1,
-      symbol: 'ETH',
-      name: 'Ether',
-      decimals: 18,
-      icon: undefined
-    }
-
-    await swapAndBridgeController.updateForm({ fromSelectedToken: tokenOnBase })
-
-    expect(swapAndBridgeController.toSelectedToken).toBeNull()
-    expect(swapAndBridgeController.toChainId).toEqual(8453)
-  })
-  test('should sync toChainId when fromChainId is out of sync with the selected from token', async () => {
-    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
-    const selectedFromToken = swapAndBridgeController.fromSelectedToken!
-
-    swapAndBridgeController.fromChainId = 1
-    swapAndBridgeController.toChainId = 1
-
-    await swapAndBridgeController.updateForm({ fromSelectedToken: selectedFromToken })
-
-    expect(swapAndBridgeController.fromChainId).toEqual(Number(selectedFromToken.chainId))
-    expect(swapAndBridgeController.toChainId).toEqual(Number(selectedFromToken.chainId))
-  })
-  test('should keep a manually selected bridge receive network when changing the from token on the same network', async () => {
-    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
-    const selectedFromToken = swapAndBridgeController.fromSelectedToken!
-
-    await swapAndBridgeController.updateForm({ toChainId: 8453 })
-
-    await swapAndBridgeController.updateForm({ fromSelectedToken: selectedFromToken })
-
-    expect(swapAndBridgeController.fromChainId).toEqual(Number(selectedFromToken.chainId))
-    expect(swapAndBridgeController.toChainId).toEqual(8453)
-  })
   test('should sync toChainId to the preselected from token chain when no to token is provided', async () => {
     const preselectedToken = PORTFOLIO_TOKENS[1]!
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -94,7 +94,6 @@ type SwapAndBridgeErrorType = {
 }
 
 const HARD_CODED_CURRENCY = 'usd'
-const DEFAULT_FORM_CHAIN_ID = 1
 
 const isSwapAndBridge = (route: string | undefined) => route === 'swap-and-bridge'
 
@@ -903,59 +902,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     return this.#serviceProviderAPI.isHealthy
   }
 
-  #shouldSyncReceiveNetworkToFrom(
-    fromTokenChainId: number,
-    {
-      isFromNetworkChanged,
-      wasFromChainIdOutOfSync
-    }: { isFromNetworkChanged: boolean; wasFromChainIdOutOfSync: boolean }
-  ) {
-    if (this.toSelectedToken || this.toChainId === fromTokenChainId) return false
-
-    if (isFromNetworkChanged || wasFromChainIdOutOfSync) return true
-
-    // Receive network is still on the initial default after a non-Ethereum from token was selected
-    return this.toChainId === DEFAULT_FORM_CHAIN_ID && fromTokenChainId !== DEFAULT_FORM_CHAIN_ID
-  }
-
-  #syncChainIdsWithFromSelectedToken(
-    fromSelectedToken: TokenResult,
-    isFromNetworkChanged: boolean
-  ): boolean {
-    const network = this.#networks.networks.find((n) => n.chainId === fromSelectedToken.chainId)
-    if (!network) return false
-
-    const fromTokenChainId = Number(network.chainId)
-    let shouldUpdateToTokenList = false
-    const wasFromChainIdOutOfSync = this.fromChainId !== fromTokenChainId
-
-    if (wasFromChainIdOutOfSync) {
-      this.fromChainId = fromTokenChainId
-      shouldUpdateToTokenList = true
-    }
-
-    if (
-      isFromNetworkChanged &&
-      this.toSelectedToken &&
-      Number(this.toSelectedToken.chainId) !== fromTokenChainId
-    ) {
-      this.toSelectedToken = null
-      shouldUpdateToTokenList = true
-    }
-
-    if (
-      this.#shouldSyncReceiveNetworkToFrom(fromTokenChainId, {
-        isFromNetworkChanged,
-        wasFromChainIdOutOfSync
-      })
-    ) {
-      this.toChainId = fromTokenChainId
-      shouldUpdateToTokenList = true
-    }
-
-    return shouldUpdateToTokenList
-  }
-
   #fetchSupportedChainsIfNeeded = async (forceUpdate?: boolean) => {
     const shouldNotReFetchSupportedChains =
       this.#cachedSupportedChains.data.length &&
@@ -966,26 +912,6 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       const supportedChains = await this.#serviceProviderAPI.getSupportedChains()
 
       this.#cachedSupportedChains = { lastFetched: Date.now(), data: supportedChains }
-
-      if (this.sessionIds.length) {
-        if (this.fromSelectedToken && !this.toSelectedToken) {
-          const fromTokenChainId = Number(this.fromSelectedToken.chainId)
-
-          if (
-            this.#shouldSyncReceiveNetworkToFrom(fromTokenChainId, {
-              isFromNetworkChanged: false,
-              wasFromChainIdOutOfSync: false
-            })
-          ) {
-            await this.updateForm({ toChainId: fromTokenChainId }, { emitUpdate: false })
-          }
-        } else if (!this.fromSelectedToken) {
-          await this.updatePortfolioTokenList(
-            structuredClone(this.#selectedAccount.portfolio.tokens)
-          )
-        }
-      }
-
       this.#emitUpdateIfNeeded(forceUpdate)
     } catch (error: any) {
       // Fail silently, as this is not a critical feature, Swap & Bridge is still usable
@@ -1131,10 +1057,12 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     if (typeof fromSelectedToken !== 'undefined') {
       const isFromNetworkChanged = this.fromSelectedToken?.chainId !== fromSelectedToken?.chainId
 
-      if (fromSelectedToken) {
-        shouldUpdateToTokenList =
-          this.#syncChainIdsWithFromSelectedToken(fromSelectedToken, isFromNetworkChanged) ||
-          shouldUpdateToTokenList
+      if (fromSelectedToken && isFromNetworkChanged) {
+        const network = this.#networks.networks.find((n) => n.chainId === fromSelectedToken.chainId)
+        if (network) {
+          this.fromChainId = Number(network.chainId)
+          shouldUpdateToTokenList = true
+        }
       }
 
       const shouldResetFromTokenAmount =
@@ -1220,9 +1148,9 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       this.#toTokenList[toTokenListKey].tokens = []
     }
 
-    this.fromChainId = DEFAULT_FORM_CHAIN_ID
+    this.fromChainId = 1
     this.fromSelectedToken = null
-    this.toChainId = DEFAULT_FORM_CHAIN_ID
+    this.toChainId = 1
     this.errors = []
     this.updateQuoteInterval.stop()
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -94,6 +94,7 @@ type SwapAndBridgeErrorType = {
 }
 
 const HARD_CODED_CURRENCY = 'usd'
+const DEFAULT_FORM_CHAIN_ID = 1
 
 const isSwapAndBridge = (route: string | undefined) => route === 'swap-and-bridge'
 
@@ -902,6 +903,59 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     return this.#serviceProviderAPI.isHealthy
   }
 
+  #shouldSyncReceiveNetworkToFrom(
+    fromTokenChainId: number,
+    {
+      isFromNetworkChanged,
+      wasFromChainIdOutOfSync
+    }: { isFromNetworkChanged: boolean; wasFromChainIdOutOfSync: boolean }
+  ) {
+    if (this.toSelectedToken || this.toChainId === fromTokenChainId) return false
+
+    if (isFromNetworkChanged || wasFromChainIdOutOfSync) return true
+
+    // Receive network is still on the initial default after a non-Ethereum from token was selected
+    return this.toChainId === DEFAULT_FORM_CHAIN_ID && fromTokenChainId !== DEFAULT_FORM_CHAIN_ID
+  }
+
+  #syncChainIdsWithFromSelectedToken(
+    fromSelectedToken: TokenResult,
+    isFromNetworkChanged: boolean
+  ): boolean {
+    const network = this.#networks.networks.find((n) => n.chainId === fromSelectedToken.chainId)
+    if (!network) return false
+
+    const fromTokenChainId = Number(network.chainId)
+    let shouldUpdateToTokenList = false
+    const wasFromChainIdOutOfSync = this.fromChainId !== fromTokenChainId
+
+    if (wasFromChainIdOutOfSync) {
+      this.fromChainId = fromTokenChainId
+      shouldUpdateToTokenList = true
+    }
+
+    if (
+      isFromNetworkChanged &&
+      this.toSelectedToken &&
+      Number(this.toSelectedToken.chainId) !== fromTokenChainId
+    ) {
+      this.toSelectedToken = null
+      shouldUpdateToTokenList = true
+    }
+
+    if (
+      this.#shouldSyncReceiveNetworkToFrom(fromTokenChainId, {
+        isFromNetworkChanged,
+        wasFromChainIdOutOfSync
+      })
+    ) {
+      this.toChainId = fromTokenChainId
+      shouldUpdateToTokenList = true
+    }
+
+    return shouldUpdateToTokenList
+  }
+
   #fetchSupportedChainsIfNeeded = async (forceUpdate?: boolean) => {
     const shouldNotReFetchSupportedChains =
       this.#cachedSupportedChains.data.length &&
@@ -912,6 +966,26 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       const supportedChains = await this.#serviceProviderAPI.getSupportedChains()
 
       this.#cachedSupportedChains = { lastFetched: Date.now(), data: supportedChains }
+
+      if (this.sessionIds.length) {
+        if (this.fromSelectedToken && !this.toSelectedToken) {
+          const fromTokenChainId = Number(this.fromSelectedToken.chainId)
+
+          if (
+            this.#shouldSyncReceiveNetworkToFrom(fromTokenChainId, {
+              isFromNetworkChanged: false,
+              wasFromChainIdOutOfSync: false
+            })
+          ) {
+            await this.updateForm({ toChainId: fromTokenChainId }, { emitUpdate: false })
+          }
+        } else if (!this.fromSelectedToken) {
+          await this.updatePortfolioTokenList(
+            structuredClone(this.#selectedAccount.portfolio.tokens)
+          )
+        }
+      }
+
       this.#emitUpdateIfNeeded(forceUpdate)
     } catch (error: any) {
       // Fail silently, as this is not a critical feature, Swap & Bridge is still usable
@@ -1057,12 +1131,10 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     if (typeof fromSelectedToken !== 'undefined') {
       const isFromNetworkChanged = this.fromSelectedToken?.chainId !== fromSelectedToken?.chainId
 
-      if (fromSelectedToken && isFromNetworkChanged) {
-        const network = this.#networks.networks.find((n) => n.chainId === fromSelectedToken.chainId)
-        if (network) {
-          this.fromChainId = Number(network.chainId)
-          shouldUpdateToTokenList = true
-        }
+      if (fromSelectedToken) {
+        shouldUpdateToTokenList =
+          this.#syncChainIdsWithFromSelectedToken(fromSelectedToken, isFromNetworkChanged) ||
+          shouldUpdateToTokenList
       }
 
       const shouldResetFromTokenAmount =
@@ -1148,9 +1220,9 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       this.#toTokenList[toTokenListKey].tokens = []
     }
 
-    this.fromChainId = 1
+    this.fromChainId = DEFAULT_FORM_CHAIN_ID
     this.fromSelectedToken = null
-    this.toChainId = 1
+    this.toChainId = DEFAULT_FORM_CHAIN_ID
     this.errors = []
     this.updateQuoteInterval.stop()
 
@@ -1256,7 +1328,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
           toSelectedTokenAddr: preselectedToToken?.address,
           toChainId:
             preselectedToToken?.chainId ??
-            (preselectedToken ? nextFromSelectedToken?.chainId : undefined),
+            (!this.toSelectedToken ? nextFromSelectedToken?.chainId : undefined),
           fromAmount
         },
         {


### PR DESCRIPTION
## Summary

paired with: https://github.com/AmbireTech/ambire-app/pull/7365

When opening Swap & Bridge from the Dashboard button (without a preselected from token), the receive network now defaults to the same network as the auto-selected from token.
Previously this only worked when navigating from a token's bottom sheet, because `toChainId` was only set when `preselectedToken` was passed to `updatePortfolioTokenList`.
## Changes
- In `updatePortfolioTokenList`, set `toChainId` from the auto-selected from token whenever no receive token is selected — not only when a token is preselected
- Ad
