### PR TITLE
Update AGENTS.md and lint the project

### DIFF
--- a/src/controllers/AGENTS.md
+++ b/src/controllers/AGENTS.md
@@ -76,6 +76,16 @@ There are two patterns:
 - Do not wrap internal helper methods; wrap the public entry-point only.
 - Do not wrap background-interval handlers or fire-and-forget side effects.
 
+## initialLoadPromise
+Most controllers have `initialLoadPromise` that resolves when the controller finishes its initial loading (e.g., fetching data, initializing state, reading from storage). 
+
+### When to use it
+- In the `initialLoadPromise` of another controller that depends on the state of the first controller. 
+- In methods a controller that depends on the `initialLoadPromise` of that controller.
+
+### Example:
+The networks controller that reads the network list from storage (which is async) exposes an `initialLoadPromise` that resolves when the networks are loaded. Then, the providers controller awaits the networks controller's `initialLoadPromise` in its own `initialLoadPromise` before initializing the providers, ensuring it has the network data available. The networks controller also awaits its own `initialLoadPromise` in its methods that read the network list, to ensure the data is loaded before accessing it.
+
 ## Other rules:
 - Never use raw `setInterval`. Always use `RecurringTimeout` from `@common/utils/RecurringTimeout`.
 - Long-running background intervals must be declared in `ContinuousUpdatesController`, which orchestrates their lifecycle based on app state and controller events. If you need a new background loop, add it there and wire its start/stop/restart logic through the existing event subscriptions.
@@ -85,7 +95,6 @@ There are two patterns:
 - NEVER write expensive calculations inside getters.
 - NEVER emit updates in getters. Getters should be pure and side-effect free.
 - Getter values are not automatically propagated to the UI. To update a getter value, you need to call `this.emitUpdate()`. Be VERY careful with this - you should NEVER write a getter that depends on data from another controller without subscribing to that controller's updates and calling `this.propagateUpdate(...)` in the subscription callback, otherwise the UI will not update when the underlying data changes.
-- Most controllers have `initialLoadPromise` that resolves when the controller finishes its initial loading (e.g., fetching data, initializing state). If you need to ensure that the controller is fully loaded before performing an action, await this promise first. Example: `await this.someController.initialLoadPromise`
 - If a controller depends on the state of the UI (e.g., which screen it is on), it should subscribe to `this.ui.uiEvent.on`
 - When retrying failed background fetches, use a retry counter with a maximum number of attempts (reset on success) and an increasing delay. For periodic polling with retry, use `RecurringTimeout` with adaptive intervals (shorter on failure, longer on success). See `PortfolioController.updateExchangeList()`, `DappsController.#retryFetchAndUpdateInterval`, and `ContractNamesController`'s `retryAfter` timestamps for examples.
 - ALWAYS guard async operations that update state with appropriate stale-data checks, such as debounce, unique ID/version checks, or cancellation with `AbortController`, to prevent state corruption from out-of-order or concurrent operations. Examples of these patterns can be found in `SwapAndBridgeController` and `AccountPickerController`.

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -915,7 +915,6 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
     const newKeys: StoredKey[] = (
       await Promise.all(
         uniqueKeysToAdd.map(async ({ addr, type, label, privateKey, dedicatedToOneSA, meta }) => {
-          // eslint-disable-next-line no-param-reassign
           privateKey = privateKey.substring(0, 2) === '0x' ? privateKey.substring(2) : privateKey
 
           // Set up the cipher

--- a/src/libs/humanizer/modules/Aave/aaveV3.ts
+++ b/src/libs/humanizer/modules/Aave/aaveV3.ts
@@ -273,8 +273,7 @@ export const aaveV3Pool = (): {
         return [getAction('Withdraw'), getLabel('from'), getAddressVisualization(call.to)]
 
       const token = tokensByIndex[tokenIndex]
-      if (!token)
-        return [getAction('Withdraw'), getLabel('from'), getAddressVisualization(call.to)]
+      if (!token) return [getAction('Withdraw'), getLabel('from'), getAddressVisualization(call.to)]
 
       // stores amount inn uint128 instead of uint256, but max value is treated as max value
       const amount = amountAsString === 'f'.repeat(32) ? maxUint256 : BigInt(`0x${amountAsString}`)

--- a/src/libs/humanizer/modules/Bundler3/index.ts
+++ b/src/libs/humanizer/modules/Bundler3/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { decodeFunctionData, toFunctionSelector } from 'viem'
 
 import { AccountOp } from '../../../accountOp/accountOp'

--- a/src/libs/humanizer/modules/Curve/index.ts
+++ b/src/libs/humanizer/modules/Curve/index.ts
@@ -13,7 +13,6 @@ const curveModule: HumanizerCallModule = (_: AccountOp, calls: IrCall[]) => {
     address.toLowerCase() === '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' ? zeroAddress : address
 
   const handleBasicSwap = (curveRoute: readonly string[], amountIn: bigint, amountOut: bigint) => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const route = curveRoute.filter((a: string) => a !== zeroAddress)
     const [inToken, outToken] = [route[0], route[route.length - 1]]
     return [

--- a/src/libs/humanizer/modules/Uniswap/utils.ts
+++ b/src/libs/humanizer/modules/Uniswap/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import { zeroAddress } from 'viem'
 
 import { networks } from '../../../../consts/networks'

--- a/src/libs/humanizer/modules/WALLET/index.ts
+++ b/src/libs/humanizer/modules/WALLET/index.ts
@@ -22,7 +22,6 @@ const stkWrapAbi = parseAbi(['function wrap(uint256 shareAmount)'])
 const stkUnwrapAbi = parseAbi(['function unwrap(uint256 shareAmount)'])
 const stkEnterAbi = parseAbi(['function enter(uint256 amount)'])
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const WALLETModule: HumanizerCallModule = (_: AccountOp, irCalls: IrCall[]) => {
   const matcher = {
     supplyController: WALLET_SUPPLY_CONTROLLER_MAPPING,

--- a/src/libs/keystore/keystore.test.ts
+++ b/src/libs/keystore/keystore.test.ts
@@ -206,7 +206,10 @@ describe('Keystore lib', () => {
       const encrypted = await encryptWithKey(key, getBytes(TEST_PRIVATE_KEY))
       // The 128-bit auth tag is appended to the ciphertext, so the last byte is part of the tag.
       const lastByteIndex = getBytes(encrypted.ciphertext).length - 1
-      const tampered = { ...encrypted, ciphertext: tamperHexByte(encrypted.ciphertext, lastByteIndex) }
+      const tampered = {
+        ...encrypted,
+        ciphertext: tamperHexByte(encrypted.ciphertext, lastByteIndex)
+      }
 
       await expect(decryptWithKey(key, tampered)).rejects.toThrow()
     })

--- a/src/libs/portfolio/testData.ts
+++ b/src/libs/portfolio/testData.ts
@@ -18,6 +18,7 @@ const GAS_TANK_STATE: NetworkState<PortfolioGasTankResult> = {
         availableAmount: 5n * 10n ** 6n,
         decimals: 6,
         chainId: 1n,
+        marketDataIn: [],
         priceIn: [{ baseCurrency: 'usd', price: 1 }],
         flags: { onGasTank: true, rewardsType: null, isFeeToken: true, canTopUpGasTank: false }
       }
@@ -34,6 +35,7 @@ const PORTFOLIO_STATE: AccountState = {
     lastSuccessfulUpdate: 1753192920665,
     accountOps: [
       {
+        id: '0x',
         accountAddr: '0x',
         chainId: 1n,
         signingKeyAddr: '0x',
@@ -50,7 +52,8 @@ const PORTFOLIO_STATE: AccountState = {
         hasHints: true,
         lastUpdate: 1753192918712
       },
-      priceCache: new Map(),
+      tokenDataCache: new Map(),
+      collectionErrors: [],
       toBeLearned: {
         erc20s: [],
         erc721s: {}
@@ -74,6 +77,7 @@ const PORTFOLIO_STATE: AccountState = {
             isFeeToken: true,
             isCustom: false
           },
+          marketDataIn: [],
           priceIn: [{ baseCurrency: 'usd', price: 3000 }]
         },
         {
@@ -90,6 +94,7 @@ const PORTFOLIO_STATE: AccountState = {
             isCustom: false,
             canTopUpGasTank: false
           },
+          marketDataIn: [],
           priceIn: [{ baseCurrency: 'usd', price: 4.5 }]
         },
         {
@@ -106,6 +111,7 @@ const PORTFOLIO_STATE: AccountState = {
             isFeeToken: true,
             isCustom: false
           },
+          marketDataIn: [],
           priceIn: [{ baseCurrency: 'usd', price: 1 }]
         },
         // Defi tokens
@@ -125,6 +131,7 @@ const PORTFOLIO_STATE: AccountState = {
             defiTokenType: AssetType.Collateral,
             defiPositionId: '51ee679b-3fc4-4736-9a30-661175777122'
           },
+          marketDataIn: [],
           priceIn: [{ baseCurrency: 'usd', price: 310 }]
         },
         {
@@ -143,6 +150,7 @@ const PORTFOLIO_STATE: AccountState = {
             defiTokenType: AssetType.Collateral,
             defiPositionId: '50901a6f-5c4b-4447-98d8-1eed1b7db67a'
           },
+          marketDataIn: [],
           priceIn: [{ baseCurrency: 'usd', price: 100 }]
         },
         // Removed on purpose so it can be added when enhancing with defi positions
@@ -162,7 +170,8 @@ const PORTFOLIO_STATE: AccountState = {
         //     defiTokenType: AssetType.Collateral,
         //     defiPositionId: '50901a6f-5c4b-4447-98d8-1eed1b7db67a'
         //   },
-        //   priceIn: [{ baseCurrency: 'usd', price: 100 }]
+        //
+        // marketDataIn: [],   priceIn: [{ baseCurrency: 'usd', price: 100 }]
         // },
         {
           address: '0x38e59ADE183BbEb94583d44213c8f3297e9933e9',
@@ -180,6 +189,7 @@ const PORTFOLIO_STATE: AccountState = {
             defiTokenType: AssetType.Borrow,
             defiPositionId: '50901a6f-5c4b-4447-98d8-1eed1b7db67a'
           },
+          marketDataIn: [],
           priceIn: []
         },
         {
@@ -198,6 +208,7 @@ const PORTFOLIO_STATE: AccountState = {
             defiTokenType: AssetType.Borrow,
             defiPositionId: '50901a6f-5c4b-4447-98d8-1eed1b7db67a'
           },
+          marketDataIn: [],
           priceIn: []
         }
       ],
@@ -214,12 +225,12 @@ const PORTFOLIO_STATE: AccountState = {
           decimals: 1,
           collectibles: [],
           address: '0x35bAc15f98Fa2F496FCb84e269d8d0a408442272',
+          marketDataIn: [],
           priceIn: []
         }
       ],
       defiPositions: {
         providerErrors: [],
-        isLoading: false,
         positionsByProvider: [
           {
             providerName: 'LIDO',
@@ -409,8 +420,7 @@ const PORTFOLIO_STATE: AccountState = {
             positionInUSD: 18985.66497510702
           }
         ],
-        nonceId: 'nonce-1',
-        updatedAt: 1753258959994
+        nonceId: 'nonce-1'
       },
       total: { usd: 260 }
     }
@@ -428,7 +438,6 @@ const PORTFOLIO_STATE: AccountState = {
       updateStarted: 1753192918299,
       discoveryTime: 415,
       oracleCallTime: 364,
-      priceCache: new Map(),
       toBeLearned: {
         erc20s: [],
         erc721s: {}
@@ -449,19 +458,20 @@ const PORTFOLIO_STATE: AccountState = {
             isFeeToken: true,
             isCustom: false
           },
+          marketDataIn: [],
           priceIn: [{ baseCurrency: 'usd', price: 10 }]
         }
       ],
+      tokenDataCache: new Map(),
       feeTokens: [],
       blockNumber: 22975182,
       tokenErrors: [],
       collections: [],
+      collectionErrors: [],
       total: { usd: 10 },
       defiPositions: {
         providerErrors: [],
-        isLoading: false,
-        positionsByProvider: [],
-        updatedAt: 1753258959994
+        positionsByProvider: []
       }
     }
   },

--- a/src/libs/tracer/debugTraceCall.ts
+++ b/src/libs/tracer/debugTraceCall.ts
@@ -235,7 +235,6 @@ export async function debugTraceCall(
       }
     ])
     .catch((e) => {
-      // eslint-disable-next-line no-underscore-dangle
       throw new ProviderError({ originalError: e, providerUrl: provider._getConnection()?.url })
     })
 

--- a/src/services/swapIntegrators/swapProviderParallelExecutor.test.ts
+++ b/src/services/swapIntegrators/swapProviderParallelExecutor.test.ts
@@ -26,7 +26,7 @@ describe('Swap Provider Parallel execution', () => {
       startRoute: jest.fn(),
       quote: jest.fn(),
       getRouteStatus: jest.fn()
-    } as unknown as SwapProvider)
+    }) as unknown as SwapProvider
 
   it('Fetch chains successfully and make sure there are no duplicates', async () => {
     const chainIds = await swapProviderParallelExecutor.getSupportedChains()

--- a/src/services/uniswap/api.ts
+++ b/src/services/uniswap/api.ts
@@ -259,7 +259,6 @@ export class UniswapAPI implements SwapProvider {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   async getHealth() {
     return true
   }


### PR DESCRIPTION
1. Provides a bit more information about `initialLoadPromise`. Opus 4.8 created a #load method and initialLoadPromise properly, but didn't await it in methods that rely on the data
2. Fixes eslint issues so agents can run `lint:fix`
3. Fixes some ts errors