### PR TITLE
Feature/ Behaviour logging implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ambire-common",
-  "version": "2.99.0",
+  "version": "2.101.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ambire-common",
-      "version": "2.99.0",
+      "version": "2.101.2",
       "dependencies": {
         "@ambire/signature-validator": "^1.5.0",
         "@lifi/types": "^17.7.1",

--- a/src/controllers/AGENTS.md
+++ b/src/controllers/AGENTS.md
@@ -98,6 +98,7 @@ The networks controller that reads the network list from storage (which is async
 - If a controller depends on the state of the UI (e.g., which screen it is on), it should subscribe to `this.ui.uiEvent.on`
 - When retrying failed background fetches, use a retry counter with a maximum number of attempts (reset on success) and an increasing delay. For periodic polling with retry, use `RecurringTimeout` with adaptive intervals (shorter on failure, longer on success). See `PortfolioController.updateExchangeList()`, `DappsController.#retryFetchAndUpdateInterval`, and `ContractNamesController`'s `retryAfter` timestamps for examples.
 - ALWAYS guard async operations that update state with appropriate stale-data checks, such as debounce, unique ID/version checks, or cancellation with `AbortController`, to prevent state corruption from out-of-order or concurrent operations. Examples of these patterns can be found in `SwapAndBridgeController` and `AccountPickerController`.
+- ALWAYS Write to storage AFTER updating the in-memory state and emitting updates so the UI updates asap, NEVER before.
 
 ## Controller list
 ALWAYS update this list when creating a new controller, and provide a one-sentence description of its responsibilities. 
@@ -114,6 +115,7 @@ ALWAYS update this list when creating a new controller, and provide a one-senten
 - **ContinuousUpdatesController** – Orchestrates periodic background updates for multiple controllers (e.g., portfolio and activity)
 - **ContractNamesController** – Resolves human-readable names for smart-contract addresses via the relayer.
 - **DappsController** – Manages dApp connections, sessions, verification status, and the dApp catalog.
+- **DebugController** – Toggles per-controller debug logging at runtime (developer tool); persists toggles and hydrates the `debugLogger` module.
 - **DomainsController** – Resolves and caches ENS and Namoshi names (and avatars) for addresses.
 - **EmailVaultController** – Handles email-based recovery, magic-link flows, and vault secret management.
 - **FeatureFlagsController** – Toggles application features at runtime for roll-outs and A/B testing.

--- a/src/controllers/debug/debug.ts
+++ b/src/controllers/debug/debug.ts
@@ -1,0 +1,64 @@
+import { IEventEmitterRegistryController } from '../../interfaces/eventEmitter'
+import { IStorageController } from '../../interfaces/storage'
+import { debugLoggerRegistry } from '../../libs/debugLogger/debugLogger'
+import EventEmitter from '../eventEmitter/eventEmitter'
+
+/**
+ * Enables/disables per-controller debug logging at runtime. Logging settings
+ * are persisted in storage and reloaded at startup.
+ */
+export class DebugController extends EventEmitter {
+  #storage: IStorageController
+
+  #unsubscribeFromRegistry: () => void
+
+  initialLoadPromise?: Promise<void>
+
+  constructor(storage: IStorageController, eventEmitterRegistry?: IEventEmitterRegistryController) {
+    super(eventEmitterRegistry)
+
+    this.#storage = storage
+
+    // Re-emit when a new namespace registers, so dynamically-constructed controllers
+    // (e.g. SignAccountOpController) appear in the UI the moment they're created
+    this.#unsubscribeFromRegistry = debugLoggerRegistry.subscribe(() => this.emitUpdate())
+
+    this.initialLoadPromise = this.#load().finally(() => {
+      this.initialLoadPromise = undefined
+    })
+  }
+
+  async #load(): Promise<void> {
+    const stored = await this.#storage.get('debugLogNamespaces', {})
+    debugLoggerRegistry.hydrate(stored)
+    this.emitUpdate()
+  }
+
+  /**
+   * Full catalog of toggleable controllers with their on/off state (for the UI)
+   */
+  get namespaces(): { name: string; enabled: boolean }[] {
+    return debugLoggerRegistry
+      .catalog()
+      .map((name) => ({ name, enabled: debugLoggerRegistry.isEnabled(name) }))
+  }
+
+  async setNamespaceEnabled(namespace: string, value: boolean): Promise<void> {
+    debugLoggerRegistry.setEnabled(namespace, value)
+    this.emitUpdate()
+    await this.#storage.set('debugLogNamespaces', debugLoggerRegistry.snapshot())
+  }
+
+  destroy() {
+    this.#unsubscribeFromRegistry()
+    super.destroy()
+  }
+
+  toJSON() {
+    return {
+      ...this,
+      ...super.toJSON(),
+      namespaces: this.namespaces
+    }
+  }
+}

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -1,11 +1,17 @@
 import { v4 as uuidv4 } from 'uuid'
 
 import { ErrorRef, IEventEmitterRegistryController, Statuses } from '../../interfaces/eventEmitter'
+import {
+  debugLog as moduleDebugLog,
+  debugLoggerRegistry,
+  DebugLogOptions
+} from '../../libs/debugLogger/debugLogger'
 import wait from '../../utils/wait'
 
 const LIMIT_ON_THE_NUMBER_OF_ERRORS = 100
 
-export default class EventEmitter {
+// Can be overwritten by controllers to narrow the flow tags for better console filtering and type safety.
+export default class EventEmitter<DebugFlow extends string = string> {
   id: string
 
   #registry: IEventEmitterRegistryController | null = null
@@ -38,6 +44,9 @@ export default class EventEmitter {
    */
   constructor(registry?: IEventEmitterRegistryController, registerImmediately: boolean = true) {
     this.id = uuidv4()
+
+    // Register the controller on construction
+    debugLoggerRegistry.registerNamespace(this.name)
 
     if (registry) {
       this.#registry = registry
@@ -124,6 +133,22 @@ export default class EventEmitter {
     for (const i of this.#callbacksWithId) i.cb(forceEmit)
 
     for (const cb of this.#callbacks) cb(forceEmit)
+  }
+
+  /** True when this controller's debug logging is toggled on. */
+  get isDebugLogEnabled(): boolean {
+    return debugLoggerRegistry.isEnabled(this.name)
+  }
+
+  /** Per-controller gated debug log. No-op unless this controller's namespace is
+   *  toggled on via DebugController. */
+  protected debugLog(
+    flow: DebugFlow,
+    message: string,
+    payload?: unknown | (() => unknown),
+    options?: DebugLogOptions
+  ): void {
+    moduleDebugLog(this.name, flow, message, payload, options)
   }
 
   protected emitError(error: ErrorRef) {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -21,6 +21,7 @@ import { ContinuousUpdatesController } from '@/controllers/continuousUpdates/con
 import { ContractInfoController } from '@/controllers/contractInfo/contractInfo'
 import { ContractNamesController } from '@/controllers/contractNames/contractNames'
 import { DappsController } from '@/controllers/dapps/dapps'
+import { DebugController } from '@/controllers/debug/debug'
 import { DomainsController } from '@/controllers/domains/domains'
 import { EmailVaultController } from '@/controllers/emailVault/emailVault'
 import { EstimationStatus } from '@/controllers/estimation/types'
@@ -55,6 +56,7 @@ import { Banner, IBannerController } from '@/interfaces/banner'
 import { IContractInfoController } from '@/interfaces/contractInfo'
 import { IContractNamesController } from '@/interfaces/contractNames'
 import { IDappsController } from '@/interfaces/dapp'
+import { IDebugController } from '@/interfaces/debug'
 import { IDomainsController } from '@/interfaces/domains'
 import { IEmailVaultController } from '@/interfaces/emailVault'
 import { ErrorRef, IEventEmitterRegistryController, Statuses } from '@/interfaces/eventEmitter'
@@ -138,6 +140,8 @@ export class MainController extends EventEmitter implements IMainController {
   signAccountOpPreference: SignAccountOpPreferenceController
 
   featureFlags: IFeatureFlagsController
+
+  debug: IDebugController
 
   invite: IInviteController
 
@@ -247,6 +251,8 @@ export class MainController extends EventEmitter implements IMainController {
     this.#appVersion = appVersion
     this.fetch = fetch
     this.storage = new StorageController(this.#storageAPI, eventEmitterRegistry)
+    // Constructed early so debug-log toggles are hydrated before other controllers start logging
+    this.debug = new DebugController(this.storage, eventEmitterRegistry)
     this.signAccountOpPreference = new SignAccountOpPreferenceController({
       eventEmitterRegistry,
       storage: this.storage

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -48,6 +48,7 @@ import { getAccountKeysCount } from '../../libs/keys/keys'
 import { Portfolio } from '../../libs/portfolio'
 import batcher from '../../libs/portfolio/batcher'
 import { CustomToken, TokenPreference } from '../../libs/portfolio/customToken'
+import { PortfolioDebugFlow } from '../../libs/portfolio/debug'
 import getAccountNetworksWithAssets from '../../libs/portfolio/getNetworksWithAssets'
 import {
   convertApiTokenDataToTokenDataCache,
@@ -137,7 +138,10 @@ const TOKEN_PRICE_CACHE_TTL = 5 * 60 * 1000
  * - Velcro, existing defi positions, learned assets, toBeLearnedAssets, custom tokens
  * - On manual updates, learned tokens of other accounts are also used to discover new assets
  */
-export class PortfolioController extends EventEmitter implements IPortfolioController {
+export class PortfolioController
+  extends EventEmitter<PortfolioDebugFlow>
+  implements IPortfolioController
+{
   #state: PortfolioControllerState
 
   // A queue to prevent race conditions when calling `updateSelectedAccount`.
@@ -687,6 +691,13 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
    */
   async overrideSimulationResults(accountOp: AccountOp) {
     const { accountAddr, chainId } = accountOp
+    this.debugLog(
+      'simulation',
+      `${chainId.toString()}: Overriding simulation results for ${accountAddr}`,
+      () => ({
+        accountOpId: accountOp.id
+      })
+    )
 
     const updatePromise = async () => {
       if (!this.#state[accountAddr] || !this.#state[accountAddr][chainId.toString()]) return
@@ -814,8 +825,22 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
         networkAlreadyScheduledForAccount.bypassServerSideCache || bypassServerSideCache
       // Debounce: start the 60s window from the most recent transaction, not the first
       networkAlreadyScheduledForAccount.scheduledAt = Date.now()
+
+      this.debugLog(
+        'simulation',
+        `${chainId.toString()} Debounced scheduled update for ${accountId}`,
+        () => ({
+          bypassServerSideCache: networkAlreadyScheduledForAccount.bypassServerSideCache,
+          scheduledAt: networkAlreadyScheduledForAccount.scheduledAt
+        })
+      )
       return
     }
+
+    this.debugLog('simulation', `${chainId.toString()} Scheduled update for ${accountId}`, () => ({
+      bypassServerSideCache,
+      scheduledAt: Date.now()
+    }))
 
     this.#scheduledUpdates[accountId] = [
       ...(this.#scheduledUpdates[accountId] || []),
@@ -870,6 +895,10 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     })
 
     if (!accountAddrToUpdate || networksToUpdate.length === 0) return
+    this.debugLog('simulation', `Discarding simulation for ${accountAddrToUpdate}`, () => ({
+      discardedOpIds: accountOps.map((op) => op.id),
+      chainIds: networksToUpdate.map((n) => n.chainId.toString())
+    }))
     await this.updateSelectedAccount(accountAddrToUpdate, networksToUpdate, {
       accountOps: accountOpsAfterUpdate
     })
@@ -1259,8 +1288,19 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       !bypassServerSideCache &&
       getCanSkipUpdate(defiState, hasNonceChangedSinceLastUpdate, defiMaxDataAgeMs)
 
+    // Request can be skipped altogether
     if (canSkipExternalApiHintsUpdate && canSkipDefiUpdate) {
-      // Request can be skipped altogether
+      this.debugLog(
+        'discovery',
+        `${chainId.toString()}: Skipping portfolio discovery for ${account.addr}`,
+        () => ({
+          lastUpdate: externalApiHintsResponse?.lastUpdate,
+          hasHints: externalApiHintsResponse?.hasHints,
+          isManualUpdate,
+          bypassServerSideCache,
+          hasNonceChangedSinceLastUpdate
+        })
+      )
       return null
     }
 
@@ -1402,7 +1442,19 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       maxDataAgeMs
     )
 
-    if (canSkipUpdate) return [true, null]
+    if (canSkipUpdate) {
+      this.debugLog(
+        'update',
+        `${network.chainId.toString()} update skipped for ${account.addr}`,
+        () => ({
+          lastSuccessfulUpdate: accountState[network.chainId.toString()]?.lastSuccessfulUpdate,
+          maxDataAgeMs,
+          isManualUpdate,
+          isLoading: accountState[network.chainId.toString()]?.isLoading
+        })
+      )
+      return [true, null]
+    }
 
     this.#setNetworkLoading(account.addr, network.chainId.toString(), true)
     const state = accountState[network.chainId.toString()]!
@@ -1583,7 +1635,14 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       !portfolioProps.bypassServerSideCache &&
       PortfolioController.#getCanSkipUpdate(accountState['defiApps'], defiMaxDataAgeMs)
 
-    if (canSkipUpdate) return
+    if (canSkipUpdate) {
+      this.debugLog('defi', 'Skipping DeFi apps update for account', () => ({
+        account: account.addr,
+        lastSuccessfulUpdate: accountState['defiApps']?.lastSuccessfulUpdate,
+        defiMaxDataAgeMs
+      }))
+      return
+    }
 
     const updateStarted = Date.now()
 
@@ -1758,6 +1817,17 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
     learnedTokensHints.push(...defiHints)
 
+    this.debugLog(
+      'hints',
+      `${chainId.toString()}: hints for ${accountId} (${!isManualUpdate ? 'not ' : ''}enhanced with those of other accounts)`,
+      () => ({
+        specialErc20Hints,
+        specialErc721Hints,
+        learnedTokensHints,
+        learnedNftsHints
+      })
+    )
+
     return {
       specialErc20Hints,
       specialErc721Hints,
@@ -1865,6 +1935,11 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
     const accountState = this.#state[accountId]
 
     const networksToUpdate = networks || this.#networks.networks
+    this.debugLog('update', `Update queued for ${accountId}`, () => ({
+      chainIds: networksToUpdate.map((n) => n.chainId.toString()),
+      hasSimulation: !!simulation,
+      opts
+    }))
     await Promise.all([
       this.#getAdditionalPortfolio(accountId, paramsMaxDataAgeMs),
       ...networksToUpdate.map(async (network) => {
@@ -1928,6 +2003,24 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
               disableAutoDiscovery: true,
               hasKeys: this.#keystore.getAccountKeys(selectedAccount).length > 0
             }
+          )
+
+          if (accountOpsToSimulate?.length)
+            this.debugLog(
+              'simulation',
+              `${network.chainId.toString()}: Simulated ${accountOpsToSimulate.length} account op(s)`,
+              () => ({
+                accountOpIds: accountOpsToSimulate.map((op) => op.id),
+                isSuccessful
+              })
+            )
+
+          this.debugLog(
+            'update',
+            `${network.chainId.toString()}: Portfolio updated on ${network.name}`,
+            () => ({
+              isSuccessful
+            })
           )
 
           // Learn tokens and nfts from the portfolio lib
@@ -2142,6 +2235,12 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
 
     networkToBeLearnedTokens = [...tokensToLearn, ...networkToBeLearnedTokens]
 
+    this.debugLog(
+      'learning',
+      `${chainId.toString()}: Added ERC-20 tokens to be learned`,
+      tokensToLearn
+    )
+
     this.#toBeLearnedAssets.erc20s[chainIdString] = networkToBeLearnedTokens
     return true
   }
@@ -2228,6 +2327,12 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
           }
 
           if (tokenId) toBeLearnedAssets[collectionAddress].push(tokenId)
+
+          this.debugLog('learning', `${chainId.toString()}: Added ERC-721 to be learned`, () => ({
+            collectionAddress,
+            tokenId: tokenId.toString(),
+            accountAddr
+          }))
         })
       })
 
@@ -2318,11 +2423,26 @@ export class PortfolioController extends EventEmitter implements IPortfolioContr
       .sort(([, timestampA], [, timestampB]) => timestampB - timestampA)
       .map(([address]) => address)
 
+    this.debugLog('learning', `${chainId.toString()}: Tokens learned for ${key}`, () => ({
+      learned: tokensWithBalance.filter((addr) => addr !== ZeroAddress),
+      currentlyTracked: Object.keys(learnedTokens).length
+    }))
+
     // Remove the oldest no longer owned tokens
     if (noLongerOwnedTokens.length > LEARNED_UNOWNED_LIMITS.erc20s) {
-      noLongerOwnedTokens.slice(LEARNED_UNOWNED_LIMITS.erc20s).forEach((address) => {
+      const discarded = noLongerOwnedTokens.slice(LEARNED_UNOWNED_LIMITS.erc20s)
+      discarded.forEach((address) => {
         delete learnedTokens[address]
       })
+      this.debugLog(
+        'learning',
+        `${chainId.toString()}: Discarded learned tokens for ${key}`,
+        () => ({
+          discarded,
+          limit: LEARNED_UNOWNED_LIMITS.erc20s,
+          noLongerOwned: noLongerOwnedTokens.length
+        })
+      )
     }
 
     await this.#storage.set('learnedAssets', this.#learnedAssets)

--- a/src/interfaces/debug.ts
+++ b/src/interfaces/debug.ts
@@ -1,0 +1,5 @@
+import { ControllerInterface } from './controller'
+
+export type IDebugController = ControllerInterface<
+  InstanceType<typeof import('../controllers/debug/debug').DebugController>
+>

--- a/src/interfaces/storage.ts
+++ b/src/interfaces/storage.ts
@@ -107,6 +107,8 @@ export type StorageProps = {
   isBatchingEnabled: boolean
   surveysRespondedTo: string[]
   functionSelectors: Selectors
+  // Per-controller debug logging toggles. Only enabled ones are stored
+  debugLogNamespaces: Record<string, boolean>
 }
 
 export interface Storage {

--- a/src/libs/debugLogger/debugLogger.test.ts
+++ b/src/libs/debugLogger/debugLogger.test.ts
@@ -1,0 +1,293 @@
+import {
+  createScopedDebugLogger,
+  debugLog,
+  debugLoggerRegistry,
+  SEED_NAMESPACES
+} from './debugLogger'
+
+const USDC = {
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  symbol: 'USDC',
+  chainId: '1'
+}
+const WETH = {
+  address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  symbol: 'WETH',
+  chainId: '1'
+}
+
+describe('debugLogger', () => {
+  let logSpy: jest.SpyInstance
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    // The registry is a module-level singleton, so reset the toggles and buffers
+    // between tests. hydrate({}) clears the enabled set; clear() empties the buffers.
+    debugLoggerRegistry.hydrate({})
+    debugLoggerRegistry.clear()
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    warnSpy.mockRestore()
+  })
+
+  describe('toggle gating', () => {
+    it('stays completely silent for a controller that is switched off', () => {
+      debugLog('PortfolioController', 'simulation', 'simulating account op', { accountOps: 2 })
+
+      expect(logSpy).not.toHaveBeenCalled()
+      expect(debugLoggerRegistry.read('PortfolioController')).toHaveLength(0)
+    })
+
+    it('does not evaluate the lazy payload function while disabled', () => {
+      const buildExpensivePayload = jest.fn(() => ({ tokens: 5000 }))
+
+      debugLog('PortfolioController', 'fetch', 'portfolio fetched', buildExpensivePayload)
+
+      expect(buildExpensivePayload).not.toHaveBeenCalled()
+    })
+
+    it('starts logging the moment the controller is enabled and goes quiet again when disabled', () => {
+      debugLoggerRegistry.setEnabled('AccountsController', true)
+      debugLog('AccountsController', 'update', 'accounts reloaded', { count: 3 })
+      expect(logSpy).toHaveBeenCalledTimes(1)
+
+      debugLoggerRegistry.setEnabled('AccountsController', false)
+      debugLog('AccountsController', 'update', 'accounts reloaded again', { count: 4 })
+      expect(logSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('log line format and buffering', () => {
+    beforeEach(() => debugLoggerRegistry.setEnabled('PortfolioController', true))
+
+    it('tags the line as [Controller:flow] and appends the serialized payload', () => {
+      debugLog('PortfolioController', 'blacklist', 'filtered token', USDC)
+
+      const expected =
+        '[PortfolioController:blacklist] filtered token ' +
+        '{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","symbol":"USDC","chainId":"1"}'
+      expect(logSpy).toHaveBeenCalledWith(expected)
+      expect(debugLoggerRegistry.read('PortfolioController')).toEqual([expected])
+    })
+
+    it('omits the payload section when there is nothing to serialize', () => {
+      debugLog('PortfolioController', 'update', 'update queued')
+
+      expect(logSpy).toHaveBeenCalledWith('[PortfolioController:update] update queued')
+    })
+
+    it('resolves a thunk payload so callers can defer building it until logging is on', () => {
+      const buildPayload = jest.fn(() => ({ symbol: 'DAI', chainId: '1' }))
+
+      debugLog('PortfolioController', 'learnedTokens', 'token learned', buildPayload)
+
+      expect(buildPayload).toHaveBeenCalledTimes(1)
+      expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
+        '[PortfolioController:learnedTokens] token learned {"symbol":"DAI","chainId":"1"}'
+      )
+    })
+
+    it('prefixes a traceId when given, to correlate one flow across controllers', () => {
+      debugLoggerRegistry.setEnabled('SignAccountOpController', true)
+
+      debugLog(
+        'SignAccountOpController',
+        'broadcast',
+        'user op submitted',
+        { hash: '0xfeed' },
+        { traceId: 'op-7f3a' }
+      )
+
+      expect(debugLoggerRegistry.read('SignAccountOpController')[0]).toBe(
+        '[op-7f3a][SignAccountOpController:broadcast] user op submitted {"hash":"0xfeed"}'
+      )
+    })
+
+    it('routes warn-level lines to console.warn instead of console.log', () => {
+      debugLoggerRegistry.setEnabled('GasPriceController', true)
+
+      debugLog('GasPriceController', 'fetch', 'rpc gas estimate slow', undefined, { level: 'warn' })
+
+      expect(warnSpy).toHaveBeenCalledWith('[GasPriceController:fetch] rpc gas estimate slow')
+      expect(logSpy).not.toHaveBeenCalled()
+    })
+
+    it('stores the serialized string in the buffer, not the live object reference', () => {
+      const mutablePayload = { symbol: 'USDC', chainId: '1' }
+      debugLog('PortfolioController', 'fetch', 'fetched', mutablePayload)
+      mutablePayload.symbol = 'MUTATED'
+
+      expect(debugLoggerRegistry.read('PortfolioController')[0]).toContain('"symbol":"USDC"')
+      expect(debugLoggerRegistry.read('PortfolioController')[0]).not.toContain('MUTATED')
+    })
+  })
+
+  describe('payload serialization', () => {
+    beforeEach(() => debugLoggerRegistry.setEnabled('PortfolioController', true))
+
+    it('serializes a bigint amount  without throwing', () => {
+      debugLog('PortfolioController', 'fetch', 'native balance', { wei: 1500000000000000000n })
+
+      expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
+        '[PortfolioController:fetch] native balance {"wei":{"$bigint":"1500000000000000000"}}'
+      )
+    })
+
+    it('falls back to a placeholder when a payload cannot be serialized', () => {
+      const payloadThatThrowsOnRead = {
+        get balance() {
+          throw new Error('getter blew up')
+        }
+      }
+
+      debugLog('PortfolioController', 'fetch', 'reading balance', payloadThatThrowsOnRead)
+
+      expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
+        '[PortfolioController:fetch] reading balance [unserializable payload]'
+      )
+    })
+
+    it('preserves nested objects and arrays — the token list a portfolio "fetch" log is meant to show', () => {
+      debugLog('PortfolioController', 'fetch', 'portfolio fetched', {
+        chainId: '1',
+        tokens: [USDC, WETH],
+        totalMs: 42
+      })
+
+      expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
+        '[PortfolioController:fetch] portfolio fetched ' +
+          '{"chainId":"1","tokens":[' +
+          '{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","symbol":"USDC","chainId":"1"},' +
+          '{"address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","symbol":"WETH","chainId":"1"}' +
+          '],"totalMs":42}'
+      )
+    })
+  })
+
+  describe('per-namespace ring buffer', () => {
+    it('caps a namespace at 200 lines, evicting the oldest first', () => {
+      debugLoggerRegistry.setEnabled('ActivityController', true)
+      for (let i = 0; i < 220; i++) {
+        debugLog('ActivityController', 'submitted', `tx #${i} broadcast`)
+      }
+
+      const buffer = debugLoggerRegistry.read('ActivityController')
+      expect(buffer).toHaveLength(200)
+      expect(buffer[0]).toContain('tx #20 broadcast') // 0..19 evicted
+      expect(buffer[buffer.length - 1]).toContain('tx #219 broadcast')
+    })
+
+    it('keeps a separate buffer per controller', () => {
+      debugLoggerRegistry.setEnabled('PortfolioController', true)
+      debugLoggerRegistry.setEnabled('ActivityController', true)
+
+      debugLog('PortfolioController', 'fetch', 'portfolio fetched')
+      debugLog('ActivityController', 'submitted', 'tx broadcast')
+
+      expect(debugLoggerRegistry.read('PortfolioController')).toHaveLength(1)
+      expect(debugLoggerRegistry.read('ActivityController')).toHaveLength(1)
+    })
+
+    it('clears one namespace without disturbing the others, and clears everything when called bare', () => {
+      debugLoggerRegistry.setEnabled('PortfolioController', true)
+      debugLoggerRegistry.setEnabled('ActivityController', true)
+      debugLog('PortfolioController', 'fetch', 'portfolio fetched')
+      debugLog('ActivityController', 'submitted', 'tx broadcast')
+
+      debugLoggerRegistry.clear('PortfolioController')
+      expect(debugLoggerRegistry.read('PortfolioController')).toHaveLength(0)
+      expect(debugLoggerRegistry.read('ActivityController')).toHaveLength(1)
+
+      debugLoggerRegistry.clear()
+      expect(debugLoggerRegistry.read('ActivityController')).toHaveLength(0)
+    })
+  })
+
+  describe('catalog and UI subscriptions', () => {
+    it('seeds the on-demand controllers so they can be toggled before they are ever constructed', () => {
+      expect(SEED_NAMESPACES).toContain('SignAccountOpController')
+      SEED_NAMESPACES.forEach((namespace) =>
+        expect(debugLoggerRegistry.catalog()).toContain(namespace)
+      )
+    })
+
+    it('lists a library namespace as soon as its scoped logger is created', () => {
+      const swapAndBridgeLog = createScopedDebugLogger('SwapAndBridgeController')
+      debugLoggerRegistry.setEnabled('SwapAndBridgeController', true)
+
+      swapAndBridgeLog('quote', 'fetched route', { provider: 'socket' })
+
+      expect(debugLoggerRegistry.catalog()).toContain('SwapAndBridgeController')
+      expect(debugLoggerRegistry.read('SwapAndBridgeController')[0]).toBe(
+        '[SwapAndBridgeController:quote] fetched route {"provider":"socket"}'
+      )
+    })
+
+    it('notifies subscribers once for a brand-new controller and dedupes repeated registrations', () => {
+      const onCatalogChange = jest.fn()
+      const unsubscribe = debugLoggerRegistry.subscribe(onCatalogChange)
+
+      // NetworksController has not been registered by any earlier test.
+      debugLoggerRegistry.registerNamespace('NetworksController') // new -> notifies
+      debugLoggerRegistry.registerNamespace('NetworksController') // already known -> silent
+      debugLoggerRegistry.registerNamespace('NetworksController')
+
+      expect(onCatalogChange).toHaveBeenCalledTimes(1)
+      expect(debugLoggerRegistry.catalog()).toContain('NetworksController')
+      unsubscribe()
+    })
+
+    it('stops notifying a subscriber after it unsubscribes', () => {
+      const onCatalogChange = jest.fn()
+      const unsubscribe = debugLoggerRegistry.subscribe(onCatalogChange)
+      unsubscribe()
+
+      debugLoggerRegistry.registerNamespace('DappsController')
+
+      expect(onCatalogChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('persistence (snapshot / hydrate)', () => {
+    it('snapshots only the enabled controllers, which is what gets stored', () => {
+      debugLoggerRegistry.setEnabled('PortfolioController', true)
+      debugLoggerRegistry.setEnabled('ActivityController', true)
+
+      expect(debugLoggerRegistry.snapshot()).toEqual({
+        PortfolioController: true,
+        ActivityController: true
+      })
+    })
+
+    it('hydrates enabled controllers from storage and keeps a persisted dynamic one visible cold', () => {
+      // SignAccountOpController was enabled last session but is not constructed yet this session.
+      debugLoggerRegistry.hydrate({ SignAccountOpController: true })
+
+      expect(debugLoggerRegistry.isEnabled('SignAccountOpController')).toBe(true)
+      expect(debugLoggerRegistry.catalog()).toContain('SignAccountOpController')
+    })
+
+    it('hydrate replaces the previous enabled set rather than merging into it', () => {
+      debugLoggerRegistry.setEnabled('PortfolioController', true)
+
+      debugLoggerRegistry.hydrate({ KeystoreController: true })
+
+      expect(debugLoggerRegistry.isEnabled('PortfolioController')).toBe(false)
+      expect(debugLoggerRegistry.isEnabled('KeystoreController')).toBe(true)
+    })
+
+    it('hydrate notifies subscribers so the UI re-renders the toggles', () => {
+      const onChange = jest.fn()
+      const unsubscribe = debugLoggerRegistry.subscribe(onChange)
+
+      debugLoggerRegistry.hydrate({ PortfolioController: true })
+
+      expect(onChange).toHaveBeenCalled()
+      unsubscribe()
+    })
+  })
+})

--- a/src/libs/debugLogger/debugLogger.test.ts
+++ b/src/libs/debugLogger/debugLogger.test.ts
@@ -16,6 +16,9 @@ const WETH = {
   chainId: '1'
 }
 
+// Each log line embeds Date.now(), so pin it to keep exact-match assertions stable.
+const NOW = 1700000000000
+
 describe('debugLogger', () => {
   let logSpy: jest.SpyInstance
   let warnSpy: jest.SpyInstance
@@ -27,11 +30,11 @@ describe('debugLogger', () => {
     debugLoggerRegistry.clear()
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(Date, 'now').mockReturnValue(NOW)
   })
 
   afterEach(() => {
-    logSpy.mockRestore()
-    warnSpy.mockRestore()
+    jest.restoreAllMocks()
   })
 
   describe('toggle gating', () => {
@@ -64,11 +67,11 @@ describe('debugLogger', () => {
   describe('log line format and buffering', () => {
     beforeEach(() => debugLoggerRegistry.setEnabled('PortfolioController', true))
 
-    it('tags the line as [Controller:flow] and appends the serialized payload', () => {
+    it('tags the line with the Controller:flow scope and appends the serialized payload', () => {
       debugLog('PortfolioController', 'blacklist', 'filtered token', USDC)
 
       const expected =
-        '[PortfolioController:blacklist] filtered token ' +
+        `Debug: PortfolioController:blacklist (at ${NOW}) filtered token ` +
         '{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","symbol":"USDC","chainId":"1"}'
       expect(logSpy).toHaveBeenCalledWith(expected)
       expect(debugLoggerRegistry.read('PortfolioController')).toEqual([expected])
@@ -77,7 +80,9 @@ describe('debugLogger', () => {
     it('omits the payload section when there is nothing to serialize', () => {
       debugLog('PortfolioController', 'update', 'update queued')
 
-      expect(logSpy).toHaveBeenCalledWith('[PortfolioController:update] update queued')
+      expect(logSpy).toHaveBeenCalledWith(
+        `Debug: PortfolioController:update (at ${NOW}) update queued`
+      )
     })
 
     it('resolves a thunk payload so callers can defer building it until logging is on', () => {
@@ -87,7 +92,7 @@ describe('debugLogger', () => {
 
       expect(buildPayload).toHaveBeenCalledTimes(1)
       expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
-        '[PortfolioController:learnedTokens] token learned {"symbol":"DAI","chainId":"1"}'
+        `Debug: PortfolioController:learnedTokens (at ${NOW}) token learned {"symbol":"DAI","chainId":"1"}`
       )
     })
 
@@ -103,7 +108,7 @@ describe('debugLogger', () => {
       )
 
       expect(debugLoggerRegistry.read('SignAccountOpController')[0]).toBe(
-        '[op-7f3a][SignAccountOpController:broadcast] user op submitted {"hash":"0xfeed"}'
+        `Debug: op-7f3a:SignAccountOpController:broadcast (at ${NOW}) user op submitted {"hash":"0xfeed"}`
       )
     })
 
@@ -112,7 +117,9 @@ describe('debugLogger', () => {
 
       debugLog('GasPriceController', 'fetch', 'rpc gas estimate slow', undefined, { level: 'warn' })
 
-      expect(warnSpy).toHaveBeenCalledWith('[GasPriceController:fetch] rpc gas estimate slow')
+      expect(warnSpy).toHaveBeenCalledWith(
+        `Debug: GasPriceController:fetch (at ${NOW}) rpc gas estimate slow`
+      )
       expect(logSpy).not.toHaveBeenCalled()
     })
 
@@ -129,11 +136,11 @@ describe('debugLogger', () => {
   describe('payload serialization', () => {
     beforeEach(() => debugLoggerRegistry.setEnabled('PortfolioController', true))
 
-    it('serializes a bigint amount  without throwing', () => {
+    it('serializes a bigint amount without throwing', () => {
       debugLog('PortfolioController', 'fetch', 'native balance', { wei: 1500000000000000000n })
 
       expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
-        '[PortfolioController:fetch] native balance {"wei":{"$bigint":"1500000000000000000"}}'
+        `Debug: PortfolioController:fetch (at ${NOW}) native balance {"wei":{"$bigint":"1500000000000000000"}}`
       )
     })
 
@@ -147,7 +154,7 @@ describe('debugLogger', () => {
       debugLog('PortfolioController', 'fetch', 'reading balance', payloadThatThrowsOnRead)
 
       expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
-        '[PortfolioController:fetch] reading balance [unserializable payload]'
+        `Debug: PortfolioController:fetch (at ${NOW}) reading balance [unserializable payload]`
       )
     })
 
@@ -159,7 +166,7 @@ describe('debugLogger', () => {
       })
 
       expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
-        '[PortfolioController:fetch] portfolio fetched ' +
+        `Debug: PortfolioController:fetch (at ${NOW}) portfolio fetched ` +
           '{"chainId":"1","tokens":[' +
           '{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","symbol":"USDC","chainId":"1"},' +
           '{"address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","symbol":"WETH","chainId":"1"}' +
@@ -223,7 +230,7 @@ describe('debugLogger', () => {
 
       expect(debugLoggerRegistry.catalog()).toContain('SwapAndBridgeController')
       expect(debugLoggerRegistry.read('SwapAndBridgeController')[0]).toBe(
-        '[SwapAndBridgeController:quote] fetched route {"provider":"socket"}'
+        `Debug: SwapAndBridgeController:quote (at ${NOW}) fetched route {"provider":"socket"}`
       )
     })
 

--- a/src/libs/debugLogger/debugLogger.test.ts
+++ b/src/libs/debugLogger/debugLogger.test.ts
@@ -22,6 +22,7 @@ const NOW = 1700000000000
 describe('debugLogger', () => {
   let logSpy: jest.SpyInstance
   let warnSpy: jest.SpyInstance
+  let errorSpy: jest.SpyInstance
 
   beforeEach(() => {
     // The registry is a module-level singleton, so reset the toggles and buffers
@@ -30,6 +31,7 @@ describe('debugLogger', () => {
     debugLoggerRegistry.clear()
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     jest.spyOn(Date, 'now').mockReturnValue(NOW)
   })
 
@@ -77,11 +79,11 @@ describe('debugLogger', () => {
       expect(debugLoggerRegistry.read('PortfolioController')).toEqual([expected])
     })
 
-    it('omits the payload section when there is nothing to serialize', () => {
+    it('marks the line as having no payload when none is given', () => {
       debugLog('PortfolioController', 'update', 'update queued')
 
       expect(logSpy).toHaveBeenCalledWith(
-        `Debug: PortfolioController:update (at ${NOW}) update queued`
+        `Debug: PortfolioController:update (at ${NOW}) update queued No payload (perhaps an error?)`
       )
     })
 
@@ -118,7 +120,7 @@ describe('debugLogger', () => {
       debugLog('GasPriceController', 'fetch', 'rpc gas estimate slow', undefined, { level: 'warn' })
 
       expect(warnSpy).toHaveBeenCalledWith(
-        `Debug: GasPriceController:fetch (at ${NOW}) rpc gas estimate slow`
+        `Debug: GasPriceController:fetch (at ${NOW}) rpc gas estimate slow No payload (perhaps an error?)`
       )
       expect(logSpy).not.toHaveBeenCalled()
     })
@@ -144,6 +146,24 @@ describe('debugLogger', () => {
       )
     })
 
+    it('catches a payload thunk that throws - logs the error and still records the line without a payload', () => {
+      const explodingThunk = jest.fn(() => {
+        throw new Error('balance fetch failed')
+      })
+
+      expect(() =>
+        debugLog('PortfolioController', 'fetch', 'reading balances', explodingThunk)
+      ).not.toThrow()
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Debug: PortfolioController:fetch payload function threw',
+        expect.any(Error)
+      )
+      expect(debugLoggerRegistry.read('PortfolioController')[0]).toBe(
+        `Debug: PortfolioController:fetch (at ${NOW}) reading balances No payload (perhaps an error?)`
+      )
+    })
+
     it('falls back to a placeholder when a payload cannot be serialized', () => {
       const payloadThatThrowsOnRead = {
         get balance() {
@@ -158,7 +178,7 @@ describe('debugLogger', () => {
       )
     })
 
-    it('preserves nested objects and arrays — the token list a portfolio "fetch" log is meant to show', () => {
+    it('preserves nested objects and arrays - the token list a portfolio "fetch" log is meant to show', () => {
       debugLog('PortfolioController', 'fetch', 'portfolio fetched', {
         chainId: '1',
         tokens: [USDC, WETH],

--- a/src/libs/debugLogger/debugLogger.ts
+++ b/src/libs/debugLogger/debugLogger.ts
@@ -98,7 +98,7 @@ export function debugLog(
   const data = typeof payload === 'function' ? (payload as () => unknown)() : payload
   const scope = `${namespace}:${flow}`
   const prefix = options?.traceId ? `${options.traceId}:${scope}` : `${scope}`
-  const line = `Debug: ${prefix} ${message}${serialize(data)}`
+  const line = `Debug: ${prefix} (at ${Date.now()}) ${message}${serialize(data)}`
 
   const buffer = buffers.get(namespace) ?? []
   buffer.push(line)

--- a/src/libs/debugLogger/debugLogger.ts
+++ b/src/libs/debugLogger/debugLogger.ts
@@ -95,10 +95,16 @@ export function debugLog(
 ): void {
   if (!enabled.has(namespace)) return
 
-  const data = typeof payload === 'function' ? (payload as () => unknown)() : payload
+  let data = undefined
+
+  try {
+    data = (typeof payload === 'function' ? (payload as () => unknown)() : payload) as unknown
+  } catch (err) {
+    console.error(`Debug: ${namespace}:${flow} payload function threw`, err)
+  }
   const scope = `${namespace}:${flow}`
   const prefix = options?.traceId ? `${options.traceId}:${scope}` : `${scope}`
-  const line = `Debug: ${prefix} (at ${Date.now()}) ${message}${serialize(data)}`
+  const line = `Debug: ${prefix} (at ${Date.now()}) ${message}${data ? serialize(data) : ' No payload (perhaps an error?)'}`
 
   const buffer = buffers.get(namespace) ?? []
   buffer.push(line)

--- a/src/libs/debugLogger/debugLogger.ts
+++ b/src/libs/debugLogger/debugLogger.ts
@@ -1,0 +1,123 @@
+// Module-level debug logging shared by EventEmitter (controllers) and pure libs
+// (which have no `this`). Logging is per-controller (namespace) on/off, toggled
+// and persisted by DebugController. `flow` is only an embedded tag for console
+// filtering (e.g. "[PortfolioController:simulation]").
+//
+// Output goes to the console AND to a capped in-memory ring buffer of *serialized
+// strings* per namespace. Strings (not live objects) are stored so DevTools cannot
+// retain unbounded expandable object graphs, and the cap frees memory deterministically.
+
+import { stringify } from '@/libs/richJson/richJson'
+
+const LIMIT_PER_NAMESPACE = 200
+
+// Controllers NOT constructed by MainController at startup (they're created on
+// demand inside other controllers), so they'd be missing from the UI catalog
+// until their flow first runs. Seed them so their toggles are available cold,
+// letting a dev pre-enable logging before triggering the flow.
+export const SEED_NAMESPACES = [
+  'SignAccountOpController',
+  'EstimationController',
+  'GasPriceController'
+]
+
+const enabled = new Set<string>()
+const known = new Set<string>(SEED_NAMESPACES)
+const buffers = new Map<string, string[]>()
+const subscribers = new Set<() => void>()
+
+// richJson.stringify preserves nested objects/arrays (plain JSON) and additionally
+// supports BigInt and Error values, which the wallet's debug payloads commonly carry.
+function serialize(payload: unknown): string {
+  if (payload === undefined) return ''
+  try {
+    return ` ${stringify(payload)}`
+  } catch {
+    return ' [unserializable payload]'
+  }
+}
+
+export type DebugLogOptions = {
+  /**
+   * Can be used to correlate related log lines across flows and controllers. E.g.,
+   * every log inside of a portfolio update has the same traceId, so one can filter for that ID in the console.
+   * Although nice, this is a lot more cumbersome for complex flows so we don't require it and it's opt-in per log line rather than per logger.
+   */
+  traceId?: string
+  level?: 'log' | 'warn'
+}
+
+export const debugLoggerRegistry = {
+  isEnabled: (namespace: string) => enabled.has(namespace),
+  // Every EventEmitter registers its name on construction, so this is the full,
+  // self-maintaining catalog of toggleable controllers for the UI.
+  registerNamespace: (namespace: string) => {
+    if (known.has(namespace)) return
+    known.add(namespace)
+    subscribers.forEach((cb) => cb())
+  },
+  catalog: () => [...known].sort(),
+  setEnabled: (namespace: string, value: boolean) => {
+    if (value) enabled.add(namespace)
+    else enabled.delete(namespace)
+    subscribers.forEach((cb) => cb())
+  },
+  hydrate: (state: Record<string, boolean>) => {
+    enabled.clear()
+    Object.entries(state).forEach(([namespace, on]) => {
+      if (!on) return
+      enabled.add(namespace)
+      // A persisted-enabled controller stays visible in the UI on boot even before
+      // it has been (re)constructed - so a dynamic one can be seen and turned off.
+      known.add(namespace)
+    })
+    subscribers.forEach((cb) => cb())
+  },
+  snapshot: (): Record<string, boolean> =>
+    Object.fromEntries([...enabled].map((namespace) => [namespace, true])),
+  // Recent serialized lines for a namespace, for an on-demand dump from the console.
+  read: (namespace: string) => buffers.get(namespace) ?? [],
+  clear: (namespace?: string) => (namespace ? buffers.delete(namespace) : buffers.clear()),
+  subscribe: (cb: () => void) => {
+    subscribers.add(cb)
+    return () => {
+      subscribers.delete(cb)
+    }
+  }
+}
+
+export function debugLog(
+  namespace: string,
+  flow: string,
+  message: string,
+  payload?: unknown | (() => unknown),
+  options?: DebugLogOptions
+): void {
+  if (!enabled.has(namespace)) return
+
+  const data = typeof payload === 'function' ? (payload as () => unknown)() : payload
+  const scope = `${namespace}:${flow}`
+  const prefix = options?.traceId ? `${options.traceId}:${scope}` : `${scope}`
+  const line = `Debug: ${prefix} ${message}${serialize(data)}`
+
+  const buffer = buffers.get(namespace) ?? []
+  buffer.push(line)
+  if (buffer.length > LIMIT_PER_NAMESPACE) buffer.shift()
+  buffers.set(namespace, buffer)
+  ;(options?.level === 'warn' ? console.warn : console.log)(line)
+}
+
+/**
+ * Used by libraries to create a logger function pre-bound to their namespace, so they
+ * don't have to pass the namespace on every call. Example: Used by the portfolio lib to
+ * log under the PortfolioController namespace
+ */
+export function createScopedDebugLogger<Flow extends string = string>(namespace: string) {
+  debugLoggerRegistry.registerNamespace(namespace)
+  return (
+    flow: Flow,
+    message: string,
+    payload?: unknown | (() => unknown),
+    options?: DebugLogOptions
+  ) => debugLog(namespace, flow, message, payload, options)
+}

--- a/src/libs/portfolio/debug.ts
+++ b/src/libs/portfolio/debug.ts
@@ -1,0 +1,14 @@
+import { createScopedDebugLogger } from '../debugLogger/debugLogger'
+
+// Flow tags used by both the lib and the controller
+export type PortfolioDebugFlow =
+  | 'update'
+  | 'discovery'
+  | 'simulation'
+  | 'defi'
+  | 'learning'
+  | 'hints'
+  | 'blacklist'
+
+// Used only in the lib
+export const portfolioDebugLog = createScopedDebugLogger<PortfolioDebugFlow>('PortfolioController')

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -11,6 +11,7 @@ import { RPCProvider } from '../../interfaces/provider'
 import { Deployless, fromDescriptor } from '../deployless/deployless'
 import batcher from './batcher'
 import { isBlacklistedAsset, prepareBlacklistPatterns, STATIC_BLACKLIST } from './blacklist'
+import { portfolioDebugLog } from './debug'
 import { geckoRequestBatcher, geckoResponseIdentifier } from './gecko'
 import { getNFTs, getTokens } from './getOnchainBalances'
 import {
@@ -385,8 +386,18 @@ export class Portfolio {
             isCustom: token.flags?.isCustom,
             patterns: blacklistPatterns
           })
-        )
+        ) {
+          portfolioDebugLog(
+            'blacklist',
+            `${this.network.chainId.toString()}: Filtered token ${token.symbol}`,
+            {
+              address: token.address,
+              symbol: token.symbol,
+              name: token.name
+            }
+          )
           return false
+        }
 
         // Don't filter by balance/custom/hidden etc. if this param isn't passed
         // The portfolio lib is used outside the controller, in which case we want to
@@ -435,8 +446,19 @@ export class Portfolio {
             patterns: blacklistPatterns,
             checkForEmbeddedDomain: true
           })
-        )
+        ) {
+          portfolioDebugLog(
+            'blacklist',
+            `${this.network.chainId.toString()}: Filtered collection ${collection.name}`,
+            {
+              address: collection.address,
+              symbol: collection.symbol,
+              name: collection.name
+            }
+          )
+
           return acc
+        }
 
         // Important note: Collections with 0 collectibles are allow to pass through the filter.
         if (!toBeLearned.erc721s[collection.address] && collection.collectibles.length > 0) {


### PR DESCRIPTION
Implements a logging solution that we can use to log controller and library behaviour. Logs are divided by controller and are currently directly logged as strings. We also save them in memory separately, which can be used to download log dumps in the future.

## Features:
- Toggleable via a new `Debug` controller. This will allow us to debug controllers without restarting the extension and reloading the background process, and even in production
- Easily accessible to controllers - using `this.debugLog`
- Accessible to libraries - libraries can also utilize this logger so a flow that starts in a controller can continue in a library
- Easy to filter - there are many flows in big controllers like the portfolio - hints, defi, updates, blacklisting etc. Logs are structured in a way that makes it very easy to debug controllers: Search for `Debug: Portfolio` and you will see all portfolio logs. Search for `Debug: PortfolioController:learning` and you will see the logs related to token learning

<img width="1255" height="210" alt="image" src="https://github.com/user-attachments/assets/4a868259-6849-4bf3-8dd1-cf4e42d81623" />
