### PR TITLE
Fix: safe eip-712 messages through safe global

### DIFF
--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -22,7 +22,6 @@ import {
 } from '../../interfaces/keystore'
 import { INetworksController, Network } from '../../interfaces/network'
 import { IProvidersController } from '../../interfaces/provider'
-import type { HardwareWalletSigningRequest } from '../../interfaces/signAccountOp'
 import {
   ISignMessageController,
   SignMessageStatus,
@@ -53,6 +52,7 @@ import hexStringToUint8Array from '../../utils/hexStringToUint8Array'
 import { SignedMessage } from '../activity/types'
 import HumanizationController from '../humanization/humanization'
 
+import type { HardwareWalletSigningRequest } from '../../interfaces/signAccountOp'
 import type { IrMessage } from '../../libs/humanizer/interfaces'
 const STATUS_WRAPPED_METHODS = {
   sign: 'INITIAL'
@@ -558,7 +558,7 @@ export class SignMessageController
               if (this.signed.length === 1) {
                 await this.addMsgToSafeGlobal(
                   signed.signature,
-                  this.messageToSign.content.message as EIP712TypedData
+                  this.messageToSign.content as EIP712TypedData
                 )
               } else {
                 await this.addSigToSafeGlobal(signed.signature, signed.hash)

--- a/src/libs/safe/safe.test.ts
+++ b/src/libs/safe/safe.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from '@jest/globals'
+
+import type { EIP712TypedData } from '@safe-global/types-kit'
+
+import { normalizeSafeGlobalMessage } from './safe'
+
+describe('normalizeSafeGlobalMessage', () => {
+  test('converts a typed message domain chainId bigint to a decimal string', () => {
+    const message = {
+      types: {
+        EIP712Domain: [{ name: 'chainId', type: 'uint256' }],
+        Permit: [{ name: 'value', type: 'uint256' }]
+      },
+      domain: {
+        chainId: 1n
+      },
+      message: {
+        value: '133700'
+      },
+      primaryType: 'Permit'
+    }
+
+    const normalizedMessage = normalizeSafeGlobalMessage(message as unknown as EIP712TypedData)
+
+    expect((normalizedMessage as EIP712TypedData).domain.chainId).toBe('1')
+  })
+
+  test('does not copy messages without a bigint domain chainId', () => {
+    const typedMessage = {
+      types: {
+        EIP712Domain: [{ name: 'chainId', type: 'uint256' }],
+        Permit: [{ name: 'value', type: 'uint256' }]
+      },
+      domain: {
+        chainId: 1
+      },
+      message: {
+        value: '133700'
+      },
+      primaryType: 'Permit'
+    }
+
+    expect(normalizeSafeGlobalMessage('plain message')).toBe('plain message')
+    expect(normalizeSafeGlobalMessage(typedMessage)).toBe(typedMessage)
+  })
+})

--- a/src/libs/safe/safe.ts
+++ b/src/libs/safe/safe.ts
@@ -280,9 +280,23 @@ export async function addMessage(
     apiKey: process.env.SAFE_API_KEY
   })
   return apiKit.addMessage(safeAddress, {
-    message,
+    message: normalizeSafeGlobalMessage(message),
     signature
   })
+}
+
+export function normalizeSafeGlobalMessage(message: string | EIP712TypedData) {
+  if (typeof message === 'string') return message
+  const chainId = (message.domain as { chainId?: unknown }).chainId
+  if (typeof chainId !== 'bigint') return message
+
+  return {
+    ...message,
+    domain: {
+      ...message.domain,
+      chainId: chainId.toString()
+    }
+  } as unknown as EIP712TypedData
 }
 
 export async function getMessage({


### PR DESCRIPTION
Some Safe eip-712 messages were not relayed to safe global because:
* bigint serialization
* only the eip-712 message were being passed instead of the whole content