### PR TITLE
Socket v3 implementation

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -104,6 +104,7 @@ import { isNetworkReady } from '@/libs/selectedAccount/selectedAccount'
 import { LiFiAPI } from '@/services/lifi/api'
 import { paymasterFactory } from '@/services/paymaster'
 import { SocketAPI } from '@/services/socket/api'
+import { SocketV3API } from '@/services/socketv3/api'
 import { SquidAPI } from '@/services/squid/api'
 import { SwapProviderParallelExecutor } from '@/services/swapIntegrators/swapProviderParallelExecutor'
 import { UniswapAPI } from '@/services/uniswap/api'
@@ -479,7 +480,8 @@ export class MainController extends EventEmitter implements IMainController {
       eventEmitterRegistry
     })
     const LiFiProvider = new LiFiAPI({ fetch, apiKey: liFiApiKey })
-    const SocketProvider = new SocketAPI({ fetch, apiKey: bungeeApiKey })
+    const SocketLegacyProvider = new SocketAPI({ fetch, apiKey: bungeeApiKey })
+    const SocketProvider = new SocketV3API({ fetch, apiKey: bungeeApiKey })
     const SquidProvider = new SquidAPI({ fetch, integratorId: squidIntegratorId })
     const UniswapProvider = new UniswapAPI({ fetch, apiKey: uniswapApiKey })
     this.swapAndBridge = new SwapAndBridgeController({
@@ -499,7 +501,8 @@ export class MainController extends EventEmitter implements IMainController {
       dapps: this.dapps,
       swapProvider: new SwapProviderParallelExecutor(
         [LiFiProvider, SocketProvider, SquidProvider, UniswapProvider],
-        () => this.networks.networks.map((network) => ({ chainId: Number(network.chainId) }))
+        () => this.networks.networks.map((network) => ({ chainId: Number(network.chainId) })),
+        [SocketLegacyProvider]
       ),
       relayerUrl,
       portfolioUpdate: (chainsToUpdate: Network['chainId'][]) => {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -506,8 +506,7 @@ export class MainController extends EventEmitter implements IMainController {
       dapps: this.dapps,
       swapProvider: new SwapProviderParallelExecutor(
         [LiFiProvider, SocketProvider, SquidProvider, UniswapProvider],
-        () => this.networks.networks.map((network) => ({ chainId: Number(network.chainId) })),
-        [SocketLegacyProvider]
+        () => this.networks.networks.map((network) => ({ chainId: Number(network.chainId) }))
       ),
       relayerUrl,
       portfolioUpdate: (chainsToUpdate: Network['chainId'][]) => {

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2091,6 +2091,15 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
           },
           true
         )
+      } else if (status === 'failed') {
+        this.updateActiveRoute(
+          activeRoute.activeRouteId,
+          {
+            routeStatus: 'failed',
+            error: undefined
+          },
+          true
+        )
       }
     }
 

--- a/src/interfaces/swapAndBridge.ts
+++ b/src/interfaces/swapAndBridge.ts
@@ -450,7 +450,7 @@ export interface BungeeRouteStatus {
   bungeeStatusCode: number
 }
 
-export type SwapAndBridgeRouteStatus = 'ready' | 'completed' | 'refunded' | null
+export type SwapAndBridgeRouteStatus = 'ready' | 'completed' | 'failed' | 'refunded' | null
 
 export type SwapAndBridgeRouteStatusResult = {
   status: SwapAndBridgeRouteStatus

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -719,7 +719,8 @@ export const calculateAmountWarnings = (
 
 const getLink = (route: SwapAndBridgeActiveRoute) => {
   const providerId = route.route ? route.route.providerId : route.serviceProviderId
-  if (providerId === 'socket') return `${SOCKET_EXPLORER_URL}/tx/${route.userTxHash}`
+  if (providerId === 'socket' || providerId === 'socketv3')
+    return `${SOCKET_EXPLORER_URL}/tx/${route.userTxHash}`
   if (providerId === 'squid') return `${SQUID_EXPLORER_URL}/${route.userTxHash}`
 
   return `${LIFI_EXPLORER_URL}/tx/${route.userTxHash}`

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -7,6 +7,14 @@ import {
   parseUnits,
   ZeroAddress
 } from 'ethers'
+import { ethAddress, zeroAddress } from 'viem'
+
+import {
+  AMBIRE_WALLET_TOKEN_ON_ETHEREUM,
+  FEE_PERCENT,
+  JPYC_TOKEN,
+  SOCKET_EXPLORER_URL
+} from '@/services/socketv3/constants'
 
 import ERC20 from '../../../contracts/compiled/IERC20.json'
 import { MAX_UINT256 } from '../../consts/deploy'
@@ -35,14 +43,6 @@ import {
 } from '../../interfaces/swapAndBridge'
 import { CallsUserRequest } from '../../interfaces/userRequest'
 import { LIFI_EXPLORER_URL } from '../../services/lifi/consts'
-import {
-  AMBIRE_WALLET_TOKEN_ON_ETHEREUM,
-  FEE_PERCENT,
-  JPYC_TOKEN,
-  NULL_ADDRESS,
-  SOCKET_EXPLORER_URL,
-  ZERO_ADDRESS
-} from '../../services/socket/constants'
 import { SQUID_EXPLORER_URL } from '../../services/squid/constants'
 import { safeTokenAmountAndNumberMultiplication } from '../../utils/numbers/formatters'
 import { isBasicAccount } from '../account/account'
@@ -731,7 +731,7 @@ const isTxnBridge = (txn: SwapAndBridgeUserTx): boolean => {
 }
 
 const convertNullAddressToZeroAddressIfNeeded = (addr: string) =>
-  addr === NULL_ADDRESS ? ZERO_ADDRESS : addr
+  addr === ethAddress ? zeroAddress : addr
 
 /**
  * Get the swap sponsorship details.

--- a/src/services/socket/constants.ts
+++ b/src/services/socket/constants.ts
@@ -1,5 +1,3 @@
-import { SwapAndBridgeToToken } from '../../interfaces/swapAndBridge'
-
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 // Some services (like Socket) use the null token address to represent the
 // native token as the ZERO_ADDRESS is not standard for it.
@@ -12,33 +10,6 @@ export const ETH_ON_OPTIMISM_LEGACY_ADDRESS = '0xdeaddeaddeaddeaddeaddeaddeaddea
  * Can be up to three decimal places and cannot be more than 5%.
  */
 export const FEE_PERCENT = 0.5
-
-const AMBIRE_WALLET_TOKEN_COMMON_PROPS = {
-  name: 'Ambire Wallet',
-  symbol: 'WALLET',
-  decimals: 18,
-  icon: '' // will fallback to get the icon from the same place as the portfolio
-}
-
-export const AMBIRE_WALLET_TOKEN_ON_ETHEREUM: SwapAndBridgeToToken = {
-  chainId: 1,
-  address: '0x88800092fF476844f74dC2FC427974BBee2794Ae',
-  ...AMBIRE_WALLET_TOKEN_COMMON_PROPS
-}
-
-export const AMBIRE_WALLET_TOKEN_ON_BASE: SwapAndBridgeToToken = {
-  chainId: 8453,
-  address: '0x0BbbEad62f7647AE8323d2cb243A0DB74B7C2b80',
-  ...AMBIRE_WALLET_TOKEN_COMMON_PROPS
-}
-
-export const JPYC_TOKEN = {
-  name: 'JPY Coin',
-  symbol: 'JPYC',
-  decimals: 18,
-  address: '0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29',
-  icon: 'https://assets.coingecko.com/coins/images/70314/standard/JPYC_400x400.jpg'
-}
 
 export const AMBIRE_FEE_TAKER_ADDRESSES: { [chainId: number]: string } = {
   143: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
@@ -62,8 +33,6 @@ export const AMBIRE_FEE_TAKER_ADDRESSES: { [chainId: number]: string } = {
   7777777: '0xDA1c734b7843f18E9B1A25Bb997A45975315C001',
   4326: '0x942f9CE5D9a33a82F88D233AEb3292E680230348'
 }
-
-export const SOCKET_EXPLORER_URL = 'https://www.socketscan.io'
 
 export const PROTOCOLS_WITH_CONTRACT_FEE_IN_NATIVE = [
   'stargate',

--- a/src/services/socketv3/api.test.ts
+++ b/src/services/socketv3/api.test.ts
@@ -1,6 +1,21 @@
 import { SocketV3API } from './api'
 
 describe('SocketV3API', () => {
+  it('clears the response timeout when the fetch rejects first', async () => {
+    jest.useFakeTimers()
+
+    try {
+      const fetch = jest.fn().mockRejectedValue(new Error('network error'))
+      const api = new SocketV3API({ fetch: fetch as any, apiKey: 'test-api-key' })
+
+      await expect(api.getSupportedChains()).rejects.toThrow('network error')
+
+      expect(jest.getTimerCount()).toBe(0)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   it('maps fulfilled bridge status responses to completed', async () => {
     const destinationTxHash = '0xaeb80e8fb7a01c8cf0332a91473a30dfbedbf115214d3f3fb9bda4ed02cd1cbc'
     const fetch = jest.fn().mockResolvedValue({
@@ -19,6 +34,42 @@ describe('SocketV3API', () => {
             status: 'COMPLETED',
             txHash: '0x173e02dc31b2277c60a73d0e644290d28f1a29082ffd0e1ff86b6e025b19ab4b'
           },
+          destination: {
+            chainId: 10,
+            status: 'COMPLETED',
+            txHash: destinationTxHash
+          },
+          refund: null
+        },
+        message: null
+      })
+    })
+    const api = new SocketV3API({ fetch: fetch as any, apiKey: 'test-api-key' })
+
+    await expect(
+      api.getRouteStatus({
+        txHash: '0x173e02dc31b2277c60a73d0e644290d28f1a29082ffd0e1ff86b6e025b19ab4b',
+        routeId: '0xb91d4ddc9649d8cbece4e8976c4e9a38237f1a16ba3a67485ebca244178fc410'
+      })
+    ).resolves.toEqual({
+      status: 'completed',
+      txnId: destinationTxHash
+    })
+  })
+
+  it('maps direct fulfilled statuses to completed', async () => {
+    const destinationTxHash = '0xaeb80e8fb7a01c8cf0332a91473a30dfbedbf115214d3f3fb9bda4ed02cd1cbc'
+    const fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        success: true,
+        statusCode: 200,
+        result: {
+          quoteId: '0xb91d4ddc9649d8cbece4e8976c4e9a38237f1a16ba3a67485ebca244178fc410',
+          userOp: 'tx',
+          status: 'FULFILLED',
+          statusCode: 'FULFILLED',
           destination: {
             chainId: 10,
             status: 'COMPLETED',

--- a/src/services/socketv3/api.test.ts
+++ b/src/services/socketv3/api.test.ts
@@ -1,0 +1,44 @@
+import { SocketV3API } from './api'
+
+describe('SocketV3API', () => {
+  it('maps fulfilled bridge status responses to completed', async () => {
+    const destinationTxHash = '0xaeb80e8fb7a01c8cf0332a91473a30dfbedbf115214d3f3fb9bda4ed02cd1cbc'
+    const fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        success: true,
+        statusCode: 200,
+        result: {
+          quoteId: '0xb91d4ddc9649d8cbece4e8976c4e9a38237f1a16ba3a67485ebca244178fc410',
+          userOp: 'tx',
+          status: 'COMPLETED',
+          statusCode: 'FULFILLED',
+          origin: {
+            chainId: 8453,
+            status: 'COMPLETED',
+            txHash: '0x173e02dc31b2277c60a73d0e644290d28f1a29082ffd0e1ff86b6e025b19ab4b'
+          },
+          destination: {
+            chainId: 10,
+            status: 'COMPLETED',
+            txHash: destinationTxHash
+          },
+          refund: null
+        },
+        message: null
+      })
+    })
+    const api = new SocketV3API({ fetch: fetch as any, apiKey: 'test-api-key' })
+
+    await expect(
+      api.getRouteStatus({
+        txHash: '0x173e02dc31b2277c60a73d0e644290d28f1a29082ffd0e1ff86b6e025b19ab4b',
+        routeId: '0xb91d4ddc9649d8cbece4e8976c4e9a38237f1a16ba3a67485ebca244178fc410'
+      })
+    ).resolves.toEqual({
+      status: 'completed',
+      txnId: destinationTxHash
+    })
+  })
+})

--- a/src/services/socketv3/api.ts
+++ b/src/services/socketv3/api.ts
@@ -1,4 +1,5 @@
 import { getAddress } from 'ethers'
+import { ethAddress, zeroAddress } from 'viem'
 
 import SwapAndBridgeProviderApiError from '../../classes/SwapAndBridgeProviderApiError'
 import { CustomResponse, Fetch, RequestInitWithCustomHeaders } from '../../interfaces/fetch'
@@ -23,9 +24,7 @@ import { CITREA_CHAIN_ID } from '../squid/constants'
 import {
   AMBIRE_FEE_TAKER_ADDRESSES,
   ETH_ON_OPTIMISM_LEGACY_ADDRESS,
-  FEE_PERCENT,
-  NULL_ADDRESS,
-  ZERO_ADDRESS
+  FEE_PERCENT
 } from './constants'
 
 type SocketV3Protocol = {
@@ -130,7 +129,7 @@ type SocketV3StatusResponse = {
 }
 
 const convertZeroAddressToNullAddressIfNeeded = (addr: string) =>
-  addr === ZERO_ADDRESS ? NULL_ADDRESS : addr
+  addr === zeroAddress ? ethAddress : addr
 
 const normalizeIncomingSocketTokenAddress = (address: string) =>
   // incoming token addresses from Socket are all lowercased
@@ -168,7 +167,8 @@ const getRouteProtocol = (route: SocketV3Route): SocketV3Protocol => {
 const getNativeValue = (route: SocketV3Route) => {
   try {
     return BigInt(route.txData?.object.value || '0')
-  } catch {
+  } catch (e) {
+    console.error(e)
     return 0n
   }
 }
@@ -361,7 +361,7 @@ export class SocketV3API implements SwapProvider {
     // One is with the `ZERO_ADDRESS` and one with `NULL_ADDRESS`, both for ETH.
     // Strip out the one with the `ZERO_ADDRESS` to be consistent with the rest.
     if (toChainId === 1)
-      tokens = tokens.filter((token: SocketAPIToken) => token.address !== ZERO_ADDRESS)
+      tokens = tokens.filter((token: SocketAPIToken) => token.address !== zeroAddress)
 
     tokens = tokens.map(normalizeIncomingSocketToken)
 
@@ -453,7 +453,7 @@ export class SocketV3API implements SwapProvider {
       const protocol = getRouteProtocol(route)
       const nativeValue = getNativeValue(route)
       const hasNativeValueFee =
-        nativeValue > 0n && normalizeOutgoingSocketTokenAddress(fromTokenAddress) !== NULL_ADDRESS
+        nativeValue > 0n && normalizeOutgoingSocketTokenAddress(fromTokenAddress) !== ethAddress
       const serviceFee: SwapAndBridgeRoute['serviceFee'] = hasNativeValueFee
         ? {
             amount: nativeValue.toString(),
@@ -506,20 +506,20 @@ export class SocketV3API implements SwapProvider {
         serviceFee,
         userTxs,
         userAddress,
-        isOnlySwapRoute: fromChainId === route.output.token.chainId,
+        isOnlySwapRoute: fromChainId === normalizedToAsset.chainId,
         currentUserTxIndex: 0,
         serviceTime: route.estimatedTime ?? 1,
         fromChainId,
-        toChainId: route.output.token.chainId,
+        toChainId: normalizedToAsset.chainId,
         inputValueInUsd: response.input.valueInUsd,
         toToken: {
-          address: route.output.token.address,
-          chainId: route.output.token.chainId,
+          address: normalizedToAsset.address,
+          chainId: normalizedToAsset.chainId,
           priceUSD: route.output.priceInUsd.toString(),
-          symbol: route.output.token.symbol,
-          decimals: route.output.token.decimals,
-          name: route.output.token.name,
-          logoURI: route.output.token.logoURI
+          symbol: normalizedToAsset.symbol,
+          decimals: normalizedToAsset.decimals,
+          name: normalizedToAsset.name,
+          logoURI: normalizedToAsset.logoURI
         },
         approvalData: route.approval || undefined,
         txData: route.txData
@@ -533,8 +533,8 @@ export class SocketV3API implements SwapProvider {
         rawRoute: route as any,
         withConvenienceFee: shouldIncludeConvenienceFee,
         usedBridgeNames:
-          fromChainId !== route.output.token.chainId ? [protocol.name.toLowerCase()] : [''],
-        usedDexName: fromChainId === route.output.token.chainId ? protocol.displayName : undefined
+          fromChainId !== normalizedToAsset.chainId ? [protocol.name.toLowerCase()] : [''],
+        usedDexName: fromChainId === normalizedToAsset.chainId ? protocol.displayName : undefined
       }
 
       return swapAndBridgeRoute

--- a/src/services/socketv3/api.ts
+++ b/src/services/socketv3/api.ts
@@ -594,7 +594,7 @@ export class SocketV3API implements SwapProvider {
 
     const status = (response.status || response.statusCode || '').toUpperCase()
     const statusCode = (response.statusCode || '').toUpperCase()
-    if (status === 'COMPLETED' || status === 'FULFILLED' || statusCode === 'FULFILLED')
+    if (status === 'COMPLETED' || statusCode === 'FULFILLED')
       return { status: 'completed', txnId: getStatusTxnId(response, txHash) }
     if (status === 'REFUNDED')
       return { status: 'refunded', txnId: getStatusTxnId(response, txHash) }

--- a/src/services/socketv3/api.ts
+++ b/src/services/socketv3/api.ts
@@ -245,10 +245,9 @@ export class SocketV3API implements SwapProvider {
     errorPrefix: string
   }): Promise<T> {
     let response: CustomResponse
+    let timeoutPromise: ReturnType<typeof setTimeout> | undefined
 
     try {
-      let timeoutPromise
-
       response = await Promise.race([
         fetchPromise,
         new Promise<CustomResponse>((_, reject) => {
@@ -261,13 +260,13 @@ export class SocketV3API implements SwapProvider {
           }, this.#requestTimeoutMs)
         })
       ])
-
-      if (timeoutPromise) clearTimeout(timeoutPromise)
     } catch (e: any) {
       const message = e?.message || 'no message'
       const status = e?.status ? `, status: <${e.status}>` : ''
       const error = `${errorPrefix} Upstream error: <${message}>${status}`
       throw new SwapAndBridgeProviderApiError(error)
+    } finally {
+      if (timeoutPromise) clearTimeout(timeoutPromise)
     }
 
     if (response.status === 429) {
@@ -595,7 +594,7 @@ export class SocketV3API implements SwapProvider {
 
     const status = (response.status || response.statusCode || '').toUpperCase()
     const statusCode = (response.statusCode || '').toUpperCase()
-    if (status === 'COMPLETED' || statusCode === 'FULFILLED')
+    if (status === 'COMPLETED' || status === 'FULFILLED' || statusCode === 'FULFILLED')
       return { status: 'completed', txnId: getStatusTxnId(response, txHash) }
     if (status === 'REFUNDED')
       return { status: 'refunded', txnId: getStatusTxnId(response, txHash) }

--- a/src/services/socketv3/api.ts
+++ b/src/services/socketv3/api.ts
@@ -593,8 +593,9 @@ export class SocketV3API implements SwapProvider {
       errorPrefix: 'Unable to get the route status. Please check back later to proceed.'
     })
 
-    const status = (response.statusCode || response.status || '').toUpperCase()
-    if (status === 'COMPLETED')
+    const status = (response.status || response.statusCode || '').toUpperCase()
+    const statusCode = (response.statusCode || '').toUpperCase()
+    if (status === 'COMPLETED' || statusCode === 'FULFILLED')
       return { status: 'completed', txnId: getStatusTxnId(response, txHash) }
     if (status === 'REFUNDED')
       return { status: 'refunded', txnId: getStatusTxnId(response, txHash) }

--- a/src/services/socketv3/api.ts
+++ b/src/services/socketv3/api.ts
@@ -1,0 +1,607 @@
+import { getAddress } from 'ethers'
+
+import SwapAndBridgeProviderApiError from '../../classes/SwapAndBridgeProviderApiError'
+import { CustomResponse, Fetch, RequestInitWithCustomHeaders } from '../../interfaces/fetch'
+import {
+  ProviderQuoteParams,
+  SocketAPISupportedChain,
+  SocketAPIToken,
+  SwapAndBridgeQuote,
+  SwapAndBridgeRoute,
+  SwapAndBridgeRouteStatusResult,
+  SwapAndBridgeSendTxRequest,
+  SwapAndBridgeSupportedChain,
+  SwapAndBridgeToToken,
+  SwapProvider
+} from '../../interfaces/swapAndBridge'
+import {
+  addCustomTokensIfNeeded,
+  convertNullAddressToZeroAddressIfNeeded,
+  isNoFeeToken
+} from '../../libs/swapAndBridge/swapAndBridge'
+import { CITREA_CHAIN_ID } from '../squid/constants'
+import {
+  AMBIRE_FEE_TAKER_ADDRESSES,
+  ETH_ON_OPTIMISM_LEGACY_ADDRESS,
+  FEE_PERCENT,
+  NULL_ADDRESS,
+  ZERO_ADDRESS
+} from './constants'
+
+type SocketV3Protocol = {
+  name: string
+  displayName?: string
+  icon?: string
+}
+
+type SocketV3RouteDetails = {
+  name?: string
+  logoURI?: string
+  dexDetails?: {
+    protocol?: SocketV3Protocol
+    amountIn?: string
+    amountOut?: string
+    minAmountOut?: string
+    slippage?: number
+  } | null
+  bridgeDetails?: {
+    protocol?: SocketV3Protocol
+    amountIn?: string
+    amountOut?: string
+    minAmountOut?: string
+    slippage?: number
+  } | null
+  feeDetails?: {
+    amount?: string
+    feeInUsd?: number
+    token?: SocketAPIToken
+  } | null
+}
+
+type SocketV3Approval = {
+  amount: string
+  tokenAddress: string
+  spenderAddress: string
+  userAddress: string
+}
+
+type SocketV3TxData = {
+  kind: string
+  object: {
+    chainId?: number
+    to: string
+    data: string
+    value?: string
+  }
+}
+
+type SocketV3Route = {
+  userOp: 'tx'
+  quoteId: string
+  expiresAt?: number
+  output: {
+    amount: string
+    minAmountOut: string
+    priceInUsd: number
+    token: SocketAPIToken
+    valueInUsd: number
+  }
+  estimatedTime?: number
+  slippage?: number
+  suggestedSlippage?: number
+  routeTags?: string[]
+  routeDetails?: SocketV3RouteDetails | null
+  approval?: SocketV3Approval | null
+  txData?: SocketV3TxData | null
+  gasFee?: {
+    feeInUsd?: number | string
+  } | null
+}
+
+type SocketV3QuoteResponse = {
+  originChainId: number
+  destinationChainId: number
+  userAddress: string
+  receiverAddress: string
+  input: {
+    token: SocketAPIToken
+    amount: string
+    priceInUsd: number
+    valueInUsd: number
+  }
+  routes: SocketV3Route[]
+}
+
+type SocketV3StatusResponse = {
+  quoteId: string
+  status?: string
+  statusCode?: string
+  origin?: {
+    status?: string
+    txHash?: string | null
+  }
+  destination?: {
+    status?: string
+    txHash?: string | null
+  }
+  refund?: {
+    txHash?: string | null
+  } | null
+}
+
+const convertZeroAddressToNullAddressIfNeeded = (addr: string) =>
+  addr === ZERO_ADDRESS ? NULL_ADDRESS : addr
+
+const normalizeIncomingSocketTokenAddress = (address: string) =>
+  // incoming token addresses from Socket are all lowercased
+  getAddress(
+    // native token addresses come as null address instead of the zero address
+    convertNullAddressToZeroAddressIfNeeded(address)
+  )
+
+export const normalizeIncomingSocketToken = (token: SocketAPIToken) => ({
+  ...token,
+  icon: token.icon || token.logoURI || '',
+  logoURI: token.logoURI || token.icon || '',
+  address: normalizeIncomingSocketTokenAddress(token.address)
+})
+
+const normalizeOutgoingSocketTokenAddress = (address: string) =>
+  // Socket expects to receive null address instead of the zero address for native tokens.
+  convertZeroAddressToNullAddressIfNeeded(
+    // Socket works only with all lowercased token addresses, otherwise, bad request
+    address.toLocaleLowerCase()
+  )
+
+const getRouteProtocol = (route: SocketV3Route): SocketV3Protocol => {
+  const details = route.routeDetails
+  const protocol = details?.bridgeDetails?.protocol || details?.dexDetails?.protocol
+  if (protocol) return protocol
+
+  return {
+    name: details?.name || 'Socket',
+    displayName: details?.name || 'Socket',
+    icon: details?.logoURI || ''
+  }
+}
+
+const getNativeValue = (route: SocketV3Route) => {
+  try {
+    return BigInt(route.txData?.object.value || '0')
+  } catch {
+    return 0n
+  }
+}
+
+const getStatusTxnId = (response: SocketV3StatusResponse, fallbackTxnId: string) =>
+  response.destination?.txHash ||
+  response.refund?.txHash ||
+  response.origin?.txHash ||
+  fallbackTxnId
+
+export class SocketV3API implements SwapProvider {
+  id: string = 'socketv3'
+
+  name = 'Socket'
+
+  #fetch: Fetch
+
+  #requestTimeoutMs = 15000
+
+  #socketApiUrl = 'https://dedicated-backend.socket.tech'
+
+  #headers: RequestInitWithCustomHeaders['headers']
+
+  isHealthy: boolean | null = null
+
+  supportedChains: SwapProvider['supportedChains'] = null
+
+  constructor({ fetch, apiKey }: { fetch: Fetch; apiKey: string }) {
+    this.#fetch = fetch
+
+    this.#headers = {
+      'x-api-key': apiKey,
+      affiliate:
+        '609913096e183b62cecd0dfdc13382f618baedceb5fef75aad43e6cbff367039708902197e0b2b78b1d76cb0837ad0b318baedceb5fef75aad43e6cb',
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  }
+
+  async getHealth() {
+    // deprecated mechanism
+    return true
+  }
+
+  async updateHealth() {
+    this.isHealthy = await this.getHealth()
+  }
+
+  async updateHealthIfNeeded() {
+    // Update health status only if previously unhealthy
+    if (this.isHealthy) return
+
+    await this.updateHealth()
+  }
+
+  resetHealth() {
+    this.isHealthy = null
+  }
+
+  /** disable explicitly citrea for socket */
+  areChainsSupported({ fromChainId, toChainId }: { fromChainId: number; toChainId: number }) {
+    return fromChainId !== CITREA_CHAIN_ID && toChainId !== CITREA_CHAIN_ID
+  }
+
+  /**
+   * Processes Socket API responses and throws custom errors for various
+   * failures, including handling the API's unique response structure.
+   */
+  async #handleResponse<T>({
+    fetchPromise,
+    errorPrefix
+  }: {
+    fetchPromise: Promise<CustomResponse>
+    errorPrefix: string
+  }): Promise<T> {
+    let response: CustomResponse
+
+    try {
+      let timeoutPromise
+
+      response = await Promise.race([
+        fetchPromise,
+        new Promise<CustomResponse>((_, reject) => {
+          timeoutPromise = setTimeout(() => {
+            reject(
+              new SwapAndBridgeProviderApiError(
+                'Our service provider Socket is temporarily unavailable or your internet connection is too slow.'
+              )
+            )
+          }, this.#requestTimeoutMs)
+        })
+      ])
+
+      if (timeoutPromise) clearTimeout(timeoutPromise)
+    } catch (e: any) {
+      const message = e?.message || 'no message'
+      const status = e?.status ? `, status: <${e.status}>` : ''
+      const error = `${errorPrefix} Upstream error: <${message}>${status}`
+      throw new SwapAndBridgeProviderApiError(error)
+    }
+
+    if (response.status === 429) {
+      const error = `Our service provider received too many requests, temporarily preventing your request from being processed. ${errorPrefix}`
+      throw new SwapAndBridgeProviderApiError(error)
+    }
+
+    let responseBody: {
+      result?: T
+      statusCode?: number
+      message?: { error?: string; details?: any } | string | null
+      success?: boolean
+    }
+    try {
+      responseBody = await response.json()
+    } catch (e: any) {
+      const message = e?.message || 'no message'
+      const error = `${errorPrefix} Error details: <Unexpected non-JSON response from our service provider>, message: <${message}>`
+      throw new SwapAndBridgeProviderApiError(error)
+    }
+
+    if (!response.ok || responseBody?.success === false) {
+      const responseMessage = responseBody?.message
+      const genericErrorMessage =
+        typeof responseMessage === 'string'
+          ? responseMessage
+          : responseMessage?.error || 'no message'
+      const specificError =
+        typeof responseMessage === 'string' ? undefined : responseMessage?.details?.error?.message
+      const specificErrorMessage = specificError ? `, details: <${specificError}>` : ''
+      const specificErrorCode =
+        typeof responseMessage === 'string' ? undefined : responseMessage?.details?.error?.code
+      const specificErrorCodeMessage = specificErrorCode ? `, code: <${specificErrorCode}>` : ''
+      const error = `${errorPrefix} Our service provider upstream error: <${genericErrorMessage}>${specificErrorMessage}${specificErrorCodeMessage}`
+      throw new SwapAndBridgeProviderApiError(error)
+    }
+
+    // Always attempt to update health status (if needed) when a response was
+    // successful, in case the API was previously unhealthy (to recover).
+    // Do not wait on purpose, to not block or delay the response
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.updateHealthIfNeeded()
+
+    return responseBody.result !== undefined ? responseBody.result : (responseBody as T)
+  }
+
+  async getSupportedChains(): Promise<SwapAndBridgeSupportedChain[]> {
+    const url = `${this.#socketApiUrl}/v3/swap/supported-chains`
+
+    const response = await this.#handleResponse<SocketAPISupportedChain[]>({
+      fetchPromise: this.#fetch(url, { headers: this.#headers }),
+      errorPrefix:
+        'Unable to retrieve the list of supported Swap & Bridge chains from our service provider.'
+    })
+
+    const chains = response
+      .filter((c) => c.sendingEnabled && c.receivingEnabled && c.chainId !== CITREA_CHAIN_ID)
+      .map(({ chainId }) => ({
+        chainId
+      }))
+
+    this.supportedChains = chains
+
+    return chains
+  }
+
+  async getToTokenList({ toChainId }: { toChainId: number }): Promise<SwapAndBridgeToToken[]> {
+    const params = new URLSearchParams({
+      chainIds: toChainId.toString(),
+      // The long list for some networks is HUGE (e.g. Ethereum has 10,000+ tokens),
+      // which makes serialization and deserialization of this controller computationally expensive.
+      list: 'trending'
+    })
+    const url = `${this.#socketApiUrl}/v3/swap/tokens/list?${params.toString()}`
+
+    const response = await this.#handleResponse<{ [chainId: string]: SocketAPIToken[] }>({
+      fetchPromise: this.#fetch(url, { headers: this.#headers }),
+      errorPrefix:
+        'Unable to retrieve the list of supported receive tokens. Please reload to try again.'
+    })
+
+    let tokens = response[toChainId] || []
+
+    // Exception for Optimism, strip out the legacy ETH address
+    // TODO: Remove when Socket removes the legacy ETH address from their response
+    if (toChainId === 10)
+      tokens = tokens.filter(
+        (token: SocketAPIToken) => token.address !== ETH_ON_OPTIMISM_LEGACY_ADDRESS
+      )
+
+    // Exception for Ethereum, duplicate ETH tokens are incoming from the API.
+    // One is with the `ZERO_ADDRESS` and one with `NULL_ADDRESS`, both for ETH.
+    // Strip out the one with the `ZERO_ADDRESS` to be consistent with the rest.
+    if (toChainId === 1)
+      tokens = tokens.filter((token: SocketAPIToken) => token.address !== ZERO_ADDRESS)
+
+    tokens = tokens.map(normalizeIncomingSocketToken)
+
+    return addCustomTokensIfNeeded({ chainId: toChainId, tokens })
+  }
+
+  async getToken({
+    address,
+    chainId
+  }: {
+    address: string
+    chainId: number
+  }): Promise<SwapAndBridgeToToken | null> {
+    const params = new URLSearchParams({
+      q: address.toString()
+    })
+    const url = `${this.#socketApiUrl}/v3/swap/tokens/search?${params.toString()}`
+
+    const response = await this.#handleResponse<{
+      tokens: { [chainId: string]: SocketAPIToken[] }
+    }>({
+      fetchPromise: this.#fetch(url, { headers: this.#headers }),
+      errorPrefix: 'Unable to retrieve token information by address.'
+    })
+
+    if (!response.tokens || !response.tokens[chainId] || !response.tokens[chainId].length)
+      return null
+
+    return normalizeIncomingSocketToken(response.tokens[chainId][0]!)
+  }
+
+  async quote({
+    fromAsset,
+    toAsset,
+    fromChainId,
+    fromTokenAddress,
+    toChainId,
+    toTokenAddress,
+    fromAmount,
+    userAddress,
+    isWrapOrUnwrap,
+    accountNativeBalance,
+    nativeSymbol
+  }: ProviderQuoteParams): Promise<SwapAndBridgeQuote> {
+    if (!fromAsset || !toAsset)
+      throw new SwapAndBridgeProviderApiError(
+        'Quote requested, but missing required params. Error details: <from token details are missing>'
+      )
+
+    const params = new URLSearchParams({
+      userOps: 'tx',
+      userAddress,
+      originChainId: fromChainId.toString(),
+      destinationChainId: toChainId.toString(),
+      inputToken: normalizeOutgoingSocketTokenAddress(fromTokenAddress),
+      outputToken: normalizeOutgoingSocketTokenAddress(toTokenAddress),
+      inputAmount: fromAmount.toString(),
+      receiverAddress: userAddress
+    })
+    const feeTakerAddress = AMBIRE_FEE_TAKER_ADDRESSES[fromChainId]
+    const shouldIncludeConvenienceFee =
+      !!feeTakerAddress && !isWrapOrUnwrap && !isNoFeeToken(fromChainId, fromTokenAddress)
+    if (shouldIncludeConvenienceFee) {
+      params.append('feeTakerAddress', feeTakerAddress)
+      params.append('feeBps', (FEE_PERCENT * 100).toString())
+    }
+
+    const url = `${this.#socketApiUrl}/v3/swap/quote?${params.toString()}`
+
+    const response = await this.#handleResponse<SocketV3QuoteResponse>({
+      fetchPromise: this.#fetch(url, { headers: this.#headers }),
+      errorPrefix: 'Unable to fetch the quote.'
+    })
+
+    const socketToAsset = response.routes[0]?.output.token || {
+      ...toAsset,
+      icon: toAsset.icon ?? '',
+      logoURI: toAsset.icon ?? ''
+    }
+    const allRoutes = [...response.routes].sort((r1, r2) => {
+      const a = BigInt(r1.output.amount)
+      const b = BigInt(r2.output.amount)
+      if (a === b) return 0
+      if (a > b) return -1
+      return 1
+    })
+
+    const routes = allRoutes.map((route) => {
+      const protocol = getRouteProtocol(route)
+      const nativeValue = getNativeValue(route)
+      const hasNativeValueFee =
+        nativeValue > 0n && normalizeOutgoingSocketTokenAddress(fromTokenAddress) !== NULL_ADDRESS
+      const serviceFee: SwapAndBridgeRoute['serviceFee'] = hasNativeValueFee
+        ? {
+            amount: nativeValue.toString(),
+            amountUSD: route.gasFee?.feeInUsd?.toString() || ''
+          }
+        : undefined
+      const disabled =
+        serviceFee === undefined ? false : accountNativeBalance < BigInt(serviceFee.amount)
+      const disabledReason = disabled
+        ? `Insufficient ${nativeSymbol}. This bridge imposes a fee that must be paid in ${nativeSymbol}.`
+        : undefined
+      const normalizedToAsset = normalizeIncomingSocketToken(route.output.token)
+      const outputValueAfterGasInUsd =
+        route.gasFee?.feeInUsd === undefined
+          ? route.output.valueInUsd
+          : route.output.valueInUsd - Number(route.gasFee.feeInUsd)
+      const steps: SwapAndBridgeRoute['steps'] = [
+        {
+          chainId: fromChainId,
+          fromAmount: response.input.amount,
+          fromAsset: { ...fromAsset, chainId: Number(fromAsset.chainId) },
+          serviceTime: route.estimatedTime ?? 1,
+          minAmountOut: route.output.minAmountOut,
+          protocol: {
+            name: protocol.name,
+            displayName: protocol.displayName || protocol.name,
+            icon: protocol.icon || ''
+          },
+          swapSlippage: route.slippage,
+          toAmount: route.output.amount,
+          toAsset: normalizedToAsset,
+          type: 'swap' as const,
+          userTxIndex: 0
+        }
+      ]
+      const userTxs: SwapAndBridgeRoute['userTxs'] = steps.map((step) => ({
+        ...step,
+        chainId: step.chainId || fromChainId
+      }))
+
+      const swapAndBridgeRoute: SwapAndBridgeRoute = {
+        ...steps[0]!,
+        providerId: this.id,
+        outputValueInUsd: route.output.valueInUsd,
+        outputValueAfterGasInUsd,
+        routeId: route.quoteId,
+        disabled,
+        disabledReason,
+        steps,
+        serviceFee,
+        userTxs,
+        userAddress,
+        isOnlySwapRoute: fromChainId === route.output.token.chainId,
+        currentUserTxIndex: 0,
+        serviceTime: route.estimatedTime ?? 1,
+        fromChainId,
+        toChainId: route.output.token.chainId,
+        inputValueInUsd: response.input.valueInUsd,
+        toToken: {
+          address: route.output.token.address,
+          chainId: route.output.token.chainId,
+          priceUSD: route.output.priceInUsd.toString(),
+          symbol: route.output.token.symbol,
+          decimals: route.output.token.decimals,
+          name: route.output.token.name,
+          logoURI: route.output.token.logoURI
+        },
+        approvalData: route.approval || undefined,
+        txData: route.txData
+          ? {
+              chainId: route.txData.object.chainId || fromChainId,
+              data: route.txData.object.data,
+              to: route.txData.object.to,
+              value: route.txData.object.value || '0'
+            }
+          : undefined,
+        rawRoute: route as any,
+        withConvenienceFee: shouldIncludeConvenienceFee,
+        usedBridgeNames:
+          fromChainId !== route.output.token.chainId ? [protocol.name.toLowerCase()] : [''],
+        usedDexName: fromChainId === route.output.token.chainId ? protocol.displayName : undefined
+      }
+
+      return swapAndBridgeRoute
+    })
+
+    return {
+      fromAsset: normalizeIncomingSocketToken(response.input.token),
+      toAsset: normalizeIncomingSocketToken(socketToAsset),
+      fromChainId,
+      toChainId,
+      selectedRoute: routes[0],
+      selectedRouteSteps: routes[0]?.steps || [],
+      routes
+    }
+  }
+
+  async startRoute(route: SwapAndBridgeRoute): Promise<SwapAndBridgeSendTxRequest> {
+    if (!route) throw new Error('route not set')
+    if (!route.txData) throw new Error('route tx data not set')
+
+    return {
+      activeRouteId: route.routeId,
+      approvalData: route.approvalData
+        ? {
+            allowanceTarget: route.approvalData.spenderAddress,
+            approvalTokenAddress: route.approvalData.tokenAddress,
+            minimumApprovalAmount: route.approvalData.amount,
+            owner: route.approvalData.userAddress
+          }
+        : null,
+      chainId: route.fromChainId,
+      txData: route.txData.data,
+      txTarget: route.txData.to,
+      userTxIndex: route.steps.length ? route.steps[0]!.userTxIndex : 0,
+      value: route.txData.value
+    }
+  }
+
+  async getRouteStatus({
+    txHash,
+    routeId
+  }: {
+    txHash: string
+    routeId?: string
+  }): Promise<SwapAndBridgeRouteStatusResult> {
+    if (!routeId) return { status: null }
+
+    const params = new URLSearchParams({
+      quoteId: routeId
+    })
+    const url = `${this.#socketApiUrl}/v3/swap/status?${params.toString()}`
+
+    const response = await this.#handleResponse<SocketV3StatusResponse>({
+      fetchPromise: this.#fetch(url, { headers: this.#headers }),
+      errorPrefix: 'Unable to get the route status. Please check back later to proceed.'
+    })
+
+    const status = (response.statusCode || response.status || '').toUpperCase()
+    if (status === 'COMPLETED')
+      return { status: 'completed', txnId: getStatusTxnId(response, txHash) }
+    if (status === 'REFUNDED')
+      return { status: 'refunded', txnId: getStatusTxnId(response, txHash) }
+    if (status === 'FAILED' || status === 'EXPIRED') {
+      return { status: 'failed', txnId: getStatusTxnId(response, txHash) }
+    }
+
+    return { status: null }
+  }
+}

--- a/src/services/socketv3/constants.ts
+++ b/src/services/socketv3/constants.ts
@@ -1,10 +1,5 @@
 import { SwapAndBridgeToToken } from '../../interfaces/swapAndBridge'
 
-export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
-// Some services (like Socket) use the null token address to represent the
-// native token as the ZERO_ADDRESS is not standard for it.
-export const NULL_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
-
 export const ETH_ON_OPTIMISM_LEGACY_ADDRESS = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000'
 
 /**
@@ -64,12 +59,3 @@ export const AMBIRE_FEE_TAKER_ADDRESSES: { [chainId: number]: string } = {
 }
 
 export const SOCKET_EXPLORER_URL = 'https://www.socketscan.io'
-
-export const PROTOCOLS_WITH_CONTRACT_FEE_IN_NATIVE = [
-  'stargate',
-  'stargate-v2',
-  'arbitrum-bridge',
-  'zksync-native',
-  'Stargate V2',
-  'Stargate'
-]

--- a/src/services/socketv3/constants.ts
+++ b/src/services/socketv3/constants.ts
@@ -1,0 +1,75 @@
+import { SwapAndBridgeToToken } from '../../interfaces/swapAndBridge'
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+// Some services (like Socket) use the null token address to represent the
+// native token as the ZERO_ADDRESS is not standard for it.
+export const NULL_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+
+export const ETH_ON_OPTIMISM_LEGACY_ADDRESS = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000'
+
+/**
+ * The % of fee to be cut from the source input token amount.
+ * Can be up to three decimal places and cannot be more than 5%.
+ */
+export const FEE_PERCENT = 0.5
+
+const AMBIRE_WALLET_TOKEN_COMMON_PROPS = {
+  name: 'Ambire Wallet',
+  symbol: 'WALLET',
+  decimals: 18,
+  icon: '' // will fallback to get the icon from the same place as the portfolio
+}
+
+export const AMBIRE_WALLET_TOKEN_ON_ETHEREUM: SwapAndBridgeToToken = {
+  chainId: 1,
+  address: '0x88800092fF476844f74dC2FC427974BBee2794Ae',
+  ...AMBIRE_WALLET_TOKEN_COMMON_PROPS
+}
+
+export const AMBIRE_WALLET_TOKEN_ON_BASE: SwapAndBridgeToToken = {
+  chainId: 8453,
+  address: '0x0BbbEad62f7647AE8323d2cb243A0DB74B7C2b80',
+  ...AMBIRE_WALLET_TOKEN_COMMON_PROPS
+}
+
+export const JPYC_TOKEN = {
+  name: 'JPY Coin',
+  symbol: 'JPYC',
+  decimals: 18,
+  address: '0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29',
+  icon: 'https://assets.coingecko.com/coins/images/70314/standard/JPYC_400x400.jpg'
+}
+
+export const AMBIRE_FEE_TAKER_ADDRESSES: { [chainId: number]: string } = {
+  143: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  324: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  480: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  1101: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  5000: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  34443: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  43114: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  59144: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  534352: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  1313161554: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  81457: '0x942f9CE5D9a33a82F88D233AEb3292E680230348',
+  1: '0xDCe4f65Aa650B3FaFEa9892E807C1770d6e9c618',
+  10: '0xDA1c734b7843f18E9B1A25Bb997A45975315C001',
+  137: '0xDA1c734b7843f18E9B1A25Bb997A45975315C001',
+  8453: '0xDA1c734b7843f18E9B1A25Bb997A45975315C001',
+  56: '0xDA1c734b7843f18E9B1A25Bb997A45975315C001',
+  42161: '0xDA1c734b7843f18E9B1A25Bb997A45975315C001',
+  100: '0xDA1c734b7843f18E9B1A25Bb997A45975315C001',
+  7777777: '0xDA1c734b7843f18E9B1A25Bb997A45975315C001',
+  4326: '0x942f9CE5D9a33a82F88D233AEb3292E680230348'
+}
+
+export const SOCKET_EXPLORER_URL = 'https://www.socketscan.io'
+
+export const PROTOCOLS_WITH_CONTRACT_FEE_IN_NATIVE = [
+  'stargate',
+  'stargate-v2',
+  'arbitrum-bridge',
+  'zksync-native',
+  'Stargate V2',
+  'Stargate'
+]

--- a/src/services/swapIntegrators/swapProviderParallelExecutor.ts
+++ b/src/services/swapIntegrators/swapProviderParallelExecutor.ts
@@ -22,6 +22,12 @@ export class SwapProviderParallelExecutor {
 
   #providers: SwapProvider[]
 
+  /**
+   * Used for legacy providers to prevent active routes from bricking
+   * while also disabling these from new quotes
+   */
+  #routeProviders: SwapProvider[]
+
   #getFallbackSupportedChains?: () => SwapAndBridgeSupportedChain[]
 
   // Added for compatibility with the type
@@ -29,9 +35,11 @@ export class SwapProviderParallelExecutor {
 
   constructor(
     providers: SwapProvider[],
-    getFallbackSupportedChains?: () => SwapAndBridgeSupportedChain[]
+    getFallbackSupportedChains?: () => SwapAndBridgeSupportedChain[],
+    routeProviders: SwapProvider[] = []
   ) {
     this.#providers = providers
+    this.#routeProviders = routeProviders
     this.#getFallbackSupportedChains = getFallbackSupportedChains
   }
 
@@ -169,7 +177,7 @@ export class SwapProviderParallelExecutor {
     method: M,
     ...args: any
   ): Promise<T> {
-    const provider = this.#providers.find((p) => p.id === providerId)
+    const provider = [...this.#providers, ...this.#routeProviders].find((p) => p.id === providerId)
     if (!provider) throw new Error('Swap provider misconfiguration')
     return (provider[method] as any)(...args)
   }

--- a/src/services/swapIntegrators/swapProviderParallelExecutor.ts
+++ b/src/services/swapIntegrators/swapProviderParallelExecutor.ts
@@ -22,12 +22,6 @@ export class SwapProviderParallelExecutor {
 
   #providers: SwapProvider[]
 
-  /**
-   * Used for legacy providers to prevent active routes from bricking
-   * while also disabling these from new quotes
-   */
-  #routeProviders: SwapProvider[]
-
   #getFallbackSupportedChains?: () => SwapAndBridgeSupportedChain[]
 
   // Added for compatibility with the type
@@ -35,11 +29,9 @@ export class SwapProviderParallelExecutor {
 
   constructor(
     providers: SwapProvider[],
-    getFallbackSupportedChains?: () => SwapAndBridgeSupportedChain[],
-    routeProviders: SwapProvider[] = []
+    getFallbackSupportedChains?: () => SwapAndBridgeSupportedChain[]
   ) {
     this.#providers = providers
-    this.#routeProviders = routeProviders
     this.#getFallbackSupportedChains = getFallbackSupportedChains
   }
 
@@ -177,7 +169,7 @@ export class SwapProviderParallelExecutor {
     method: M,
     ...args: any
   ): Promise<T> {
-    const provider = [...this.#providers, ...this.#routeProviders].find((p) => p.id === providerId)
+    const provider = this.#providers.find((p) => p.id === providerId)
     if (!provider) throw new Error('Swap provider misconfiguration')
     return (provider[method] as any)(...args)
   }


### PR DESCRIPTION
## Summary

Migrates the Socket/Bungee swap provider integration to Socket Swap V3 for new quotes, while keeping the legacy Bungee API available for existing active routes.

## Changes

- Added a new `socketv3` service based on the existing `socket` provider structure.
- Uses Socket Swap V3 endpoints for new quote flows:
  - `/v3/swap/quote?userOps=tx`
  - `/v3/swap/status?quoteId=...`
  - `/v3/swap/supported-chains`
  - `/v3/swap/tokens/list`
  - `/v3/swap/tokens/search`
- Keeps the old `socket`/Bungee provider route-only so users with pending legacy routes can still resolve them.
- Wires new Socket quotes through `providerId: socketv3`.
- Updates route UI/provider handling so Socket v3 routes render as Socket/Bungee instead of falling back to Li.Fi branding.
- Fixes Socket v3 bridge status parsing:
  - prefers `status` over `statusCode`
  - treats `statusCode: FULFILLED` as completed
  - uses the destination tx hash when available