### PR TITLE
Fix: increaseApproval / decreaseApproval humanizer

### DIFF
--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -353,6 +353,122 @@ describe('Humanizer main function', () => {
     compareHumanizerVisualizations(irCalls, expectedVisualizations)
   })
 
+  test('humanizes ERC20 increaseApproval with dirty address padding', async () => {
+    const chainlinkToken = '0x514910771AF9Ca656af840dff83E8264EcF986CA'
+    const spender = '0xbb684c22aa0eb71d10339e5e045cac452c0546d7'
+
+    accountOp.calls = [
+      {
+        to: chainlinkToken,
+        value: 0n,
+        data: '0xd73dd623000010000000000000000000bb684c22aa0eb71d10339e5e045cac452c0546d70000000000000000000000000000000000000000000000000000000000000001'
+      }
+    ]
+
+    const irCalls = humanizeAccountOp(accountOp)
+
+    expect(irCalls[0]?.isFallback).not.toBe(true)
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('IncreaseApproval'),
+        getLabel('with'),
+        getToken(chainlinkToken, 1n),
+        getLabel('to'),
+        getAddressVisualization(spender)
+      ]
+    ])
+  })
+
+  test('humanizes ERC20 decreaseApproval with dirty address padding', async () => {
+    const chainlinkToken = '0x514910771AF9Ca656af840dff83E8264EcF986CA'
+    const spender = '0xbb684c22aa0eb71d10339e5e045cac452c0546d7'
+
+    accountOp.calls = [
+      {
+        to: chainlinkToken,
+        value: 0n,
+        data: '0x66188463000010000000000000000000bb684c22aa0eb71d10339e5e045cac452c0546d70000000000000000000000000000000000000000000000000000000000000001'
+      }
+    ]
+
+    const irCalls = humanizeAccountOp(accountOp)
+
+    expect(irCalls[0]?.isFallback).not.toBe(true)
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('DecreaseApproval'),
+        getLabel('with'),
+        getToken(chainlinkToken, 1n),
+        getLabel('to'),
+        getAddressVisualization(spender)
+      ]
+    ])
+  })
+
+  test('humanizes truncated ERC20 increaseApproval as an approval-shaped call', async () => {
+    const chainlinkToken = '0x514910771AF9Ca656af840dff83E8264EcF986CA'
+    const shiftedSpender = '0x00cd4e0fb96ce878ee69282bc856a3849457c500'
+
+    accountOp.calls = [
+      {
+        to: chainlinkToken,
+        value: 0n,
+        data: '0xd73dd6230000010000000000000000db00cd4e0fb96ce878ee69282bc856a3849457c50000000000000000000000000000000000000000000000000000000000000001'
+      }
+    ]
+
+    const irCalls = humanizeAccountOp(accountOp)
+
+    expect(irCalls[0]?.isFallback).not.toBe(true)
+    expect(irCalls[0]?.warnings).toEqual([
+      getWarning(
+        'Transaction data seems invalid. Please review it carefully',
+        'TRANSACTION_DATA_INVALID'
+      )
+    ])
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('IncreaseApproval'),
+        getLabel('with'),
+        getToken(chainlinkToken, 256n),
+        getLabel('to'),
+        getAddressVisualization(shiftedSpender)
+      ]
+    ])
+  })
+
+  test('humanizes truncated ERC20 decreaseApproval as an approval-shaped call', async () => {
+    const chainlinkToken = '0x514910771AF9Ca656af840dff83E8264EcF986CA'
+    const shiftedSpender = '0x00cd4e0fb96ce878ee69282bc856a3849457c500'
+
+    accountOp.calls = [
+      {
+        to: chainlinkToken,
+        value: 0n,
+        data: '0x661884630000010000000000000000db00cd4e0fb96ce878ee69282bc856a3849457c50000000000000000000000000000000000000000000000000000000000000001'
+      }
+    ]
+
+    const irCalls = humanizeAccountOp(accountOp)
+
+    expect(irCalls[0]?.isFallback).not.toBe(true)
+    expect(irCalls[0]?.warnings).toEqual([
+      getWarning(
+        'Transaction data seems invalid. Please review it carefully',
+        'TRANSACTION_DATA_INVALID'
+      )
+    ])
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('DecreaseApproval'),
+        getLabel('with'),
+        getToken(chainlinkToken, 256n),
+        getLabel('to'),
+        getAddressVisualization(shiftedSpender)
+      ]
+    ])
+  })
+
   test('aave not to be parsed by uniswap', async () => {
     // const ir: Ir = []
     const expectedVisualizations = [

--- a/src/libs/humanizer/modules/Tokens/tokens.ts
+++ b/src/libs/humanizer/modules/Tokens/tokens.ts
@@ -1,13 +1,14 @@
-import { parseAbi, decodeFunctionData, toFunctionSelector, zeroAddress } from 'viem'
+import { decodeFunctionData, getAddress, parseAbi, toFunctionSelector, zeroAddress } from 'viem'
 
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerCallModule, IrCall } from '../../interfaces'
 import {
-  HexIrCall,
   getAction,
   getAddressVisualization,
   getLabel,
   getToken,
+  getWarning,
+  HexIrCall,
   isHexCall
 } from '../../utils'
 
@@ -33,9 +34,40 @@ const erc20TransferFromAbi = parseAbi([
 const erc20IncreaseAllowanceAbi = parseAbi([
   'function increaseAllowance(address spender, uint256 addedValue) returns (bool)'
 ])
+const erc20IncreaseApprovalAbi = parseAbi([
+  'function increaseApproval(address spender, uint256 addedValue) returns (bool)'
+])
 const erc20DecreaseAllowanceAbi = parseAbi([
   'function decreaseAllowance(address spender, uint256 subtractedValue) returns (bool)'
 ])
+const erc20DecreaseApprovalAbi = parseAbi([
+  'function decreaseApproval(address spender, uint256 subtractedValue) returns (bool)'
+])
+
+const WORD_HEX_LENGTH = 64
+const SELECTOR_HEX_LENGTH = 10
+const ADDRESS_AMOUNT_ARGS_HEX_LENGTH = WORD_HEX_LENGTH * 2
+const INVALID_TRANSACTION_DATA_WARNING = getWarning(
+  'Transaction data seems invalid. Please review it carefully',
+  'TRANSACTION_DATA_INVALID'
+)
+
+const getStaticCallWord = (data: HexIrCall['data'], index: number): string => {
+  const start = SELECTOR_HEX_LENGTH + index * WORD_HEX_LENGTH
+  const end = start + WORD_HEX_LENGTH
+
+  return data.slice(start, end).padEnd(WORD_HEX_LENGTH, '0')
+}
+
+const getAddressAndAmountArgs = (data: HexIrCall['data']): [string, bigint] => {
+  const addressWord = getStaticCallWord(data, 0)
+  const amountWord = getStaticCallWord(data, 1)
+
+  return [getAddress(`0x${addressWord.slice(-40)}`), BigInt(`0x${amountWord}`)]
+}
+
+const isAddressAndAmountArgsTruncated = (data: HexIrCall['data']): boolean =>
+  data.length < SELECTOR_HEX_LENGTH + ADDRESS_AMOUNT_ARGS_HEX_LENGTH
 
 export const genericErc721Humanizer: HumanizerCallModule = (
   accountOp: AccountOp,
@@ -119,8 +151,7 @@ export const genericErc20Humanizer = (
   const matcher: Record<string, (call: HexIrCall) => any> = {
     [toFunctionSelector(erc20ApproveAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const { args } = decodeFunctionData({ abi: erc20ApproveAbi, data: call.data })
-      const [spender, value] = args
+      const [spender, value] = getAddressAndAmountArgs(call.data)
       return value !== 0n
         ? [
             getAction('Grant approval'),
@@ -138,11 +169,7 @@ export const genericErc20Humanizer = (
     },
     [toFunctionSelector(erc20IncreaseAllowanceAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const { args } = decodeFunctionData({
-        abi: erc20IncreaseAllowanceAbi,
-        data: call.data
-      })
-      const [spender, addedValue] = args
+      const [spender, addedValue] = getAddressAndAmountArgs(call.data)
       return [
         getAction('Increase allowance'),
         getLabel('of'),
@@ -151,19 +178,37 @@ export const genericErc20Humanizer = (
         getToken(call.to, addedValue)
       ]
     },
+    [toFunctionSelector(erc20IncreaseApprovalAbi[0])]: (call) => {
+      if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
+      const [spender, addedValue] = getAddressAndAmountArgs(call.data)
+      return [
+        getAction('IncreaseApproval'),
+        getLabel('with'),
+        getToken(call.to, addedValue),
+        getLabel('to'),
+        getAddressVisualization(spender)
+      ]
+    },
     [toFunctionSelector(erc20DecreaseAllowanceAbi[0])]: (call) => {
       if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
-      const { args } = decodeFunctionData({
-        abi: erc20DecreaseAllowanceAbi,
-        data: call.data
-      })
-      const [spender, subtractedValue] = args
+      const [spender, subtractedValue] = getAddressAndAmountArgs(call.data)
       return [
         getAction('Decrease allowance'),
         getLabel('of'),
         getAddressVisualization(spender),
         getLabel('with'),
         getToken(call.to, subtractedValue)
+      ]
+    },
+    [toFunctionSelector(erc20DecreaseApprovalAbi[0])]: (call) => {
+      if (!call.to) throw Error('Humanizer: should not be in tokens module if !call.to')
+      const [spender, subtractedValue] = getAddressAndAmountArgs(call.data)
+      return [
+        getAction('DecreaseApproval'),
+        getLabel('with'),
+        getToken(call.to, subtractedValue),
+        getLabel('to'),
+        getAddressVisualization(spender)
       ]
     },
     [toFunctionSelector(erc20TransferAbi[0])]: (call) => {
@@ -210,6 +255,13 @@ export const genericErc20Humanizer = (
     if (!call.to) return call
     if (!isHexCall(call)) return call
     const sigHash = call.data.substring(0, 10)
-    return matcher[sigHash] ? { ...call, fullVisualization: matcher[sigHash](call) } : call
+    if (!matcher[sigHash]) return call
+
+    const fullVisualization = matcher[sigHash](call)
+    const warnings = isAddressAndAmountArgsTruncated(call.data)
+      ? [...(call.warnings || []), INVALID_TRANSACTION_DATA_WARNING]
+      : call.warnings
+
+    return { ...call, fullVisualization, warnings }
   })
 }


### PR DESCRIPTION
Add support for old erc-20 tokens's increase/decrease approvals in the humanizer; Add warnings in case of truncated data

Humanization with dirty padding:
<img width="712" height="695" alt="Screenshot 2026-06-30 at 10 49 59" src="https://github.com/user-attachments/assets/deb40560-325d-4b24-901e-6a4295ed7008" />

Humanization with truncated padding:
<img width="716" height="712" alt="Screenshot 2026-06-30 at 10 49 47" src="https://github.com/user-attachments/assets/d76c9a15-16a9-4335-af3a-27c4c476d076" />
