### PR TITLE
Fix: safe accounts status bridges were always in a pending state

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -55,6 +55,54 @@ const accounts = [
   }
 ]
 
+const getSubmittedAccountOp = (
+  txnId: string,
+  activeRouteId: string,
+  status = 'broadcasted-but-not-confirmed'
+) =>
+  ({
+    accountAddr: accounts[0]!.addr,
+    signingKeyAddr: '0x5Be214147EA1AE3653f289E17fE7Dc17A73AD175',
+    gasLimit: null,
+    gasFeePayment: {
+      isGasTank: false,
+      paidBy: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
+      inToken: '0x0000000000000000000000000000000000000000',
+      amount: 1n,
+      simulatedGasLimit: 1n,
+      gasPrice: 1n
+    },
+    chainId: 10n,
+    nonce: 225n,
+    signature: '0x0000000000000000000000005be214147ea1ae3653f289e17fe7dc17a73ad17503',
+    calls: [
+      {
+        id: 'safe-request-call-id',
+        to: '0x18Ce9CF7156584CDffad05003410C3633EFD1ad0',
+        value: BigInt(0),
+        data: '0x'
+      }
+    ],
+    txnId,
+    status,
+    timestamp: Date.now(),
+    identifiedBy: {
+      type: 'Transaction',
+      identifier: txnId
+    },
+    meta: {
+      swapTxn: {
+        activeRouteId,
+        approvalData: null,
+        chainId: 10,
+        txData: '0x',
+        txTarget: '0x0000000000000000000000000000000000000000',
+        userTxIndex: 0,
+        value: '0'
+      }
+    }
+  }) as any
+
 // Notice
 // The status of swapAndBridge.ts is a bit more difficult to test
 // as we now have this code:
@@ -611,6 +659,56 @@ describe('SwapAndBridge Controller', () => {
     expect(swapAndBridgeController.activeRoutes[0]!.routeStatus).toEqual('ready')
     expect(swapAndBridgeController.quote).toBeDefined()
     expect(swapAndBridgeController.banners).toHaveLength(0)
+  })
+  test('should update an existing activeRoute when adding the same route again', async () => {
+    const activeRouteId = swapAndBridgeController.activeRoutes[0]!.activeRouteId
+
+    swapAndBridgeController.addActiveRoute({
+      userTxIndex: swapAndBridgeController.activeRoutes[0]!.userTxIndex,
+      routeStatus: 'in-progress'
+    })
+    swapAndBridgeController.updateActiveRoute(activeRouteId, {
+      userTxHash: 'test'
+    })
+
+    expect(swapAndBridgeController.activeRoutes).toHaveLength(1)
+    expect(swapAndBridgeController.activeRoutes[0]!.routeStatus).toEqual('in-progress')
+    expect(swapAndBridgeController.activeRoutes[0]!.userTxHash).toEqual('test')
+    expect(swapAndBridgeController.activeRoutesInProgress).toHaveLength(1)
+  })
+  test('should update an activeRoute userTxHash from submitted account op swapTxn meta', async () => {
+    const activeRouteId = swapAndBridgeController.activeRoutes[0]!.activeRouteId
+    const submittedAccountOp = getSubmittedAccountOp('test', activeRouteId)
+
+    swapAndBridgeController.updateActiveRoute(activeRouteId, {
+      routeStatus: 'in-progress',
+      userTxHash: null,
+      identifiedBy: null
+    })
+    swapAndBridgeController.handleUpdateActiveRouteOnSubmittedAccountOpStatusUpdate(
+      submittedAccountOp
+    )
+
+    expect(swapAndBridgeController.activeRoutes[0]!.userTxHash).toEqual('test')
+    expect(swapAndBridgeController.activeRoutesInProgress).toHaveLength(1)
+  })
+  test('should fail an activeRoute from submitted account op swapTxn meta', async () => {
+    const activeRouteId = swapAndBridgeController.activeRoutes[0]!.activeRouteId
+    const submittedAccountOp = getSubmittedAccountOp('test', activeRouteId, 'failure')
+
+    swapAndBridgeController.updateActiveRoute(activeRouteId, {
+      routeStatus: 'in-progress',
+      userTxHash: 'test'
+    })
+    swapAndBridgeController.handleUpdateActiveRouteOnSubmittedAccountOpStatusUpdate(
+      submittedAccountOp
+    )
+
+    expect(swapAndBridgeController.activeRoutes[0]!.routeStatus).toEqual('failed')
+    expect(swapAndBridgeController.activeRoutes[0]!.error).toEqual(
+      'The transaction failed onchain'
+    )
+    expect(swapAndBridgeController.activeRoutesInProgress).toHaveLength(0)
   })
   test('should update an activeRoute', async () => {
     const activeRouteId = swapAndBridgeController.activeRoutes[0]!.activeRouteId

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2143,7 +2143,7 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
     try {
       const route = finalQuote.selectedRoute
-      this.activeRoutes.push({
+      const activeRoute: SwapAndBridgeActiveRoute = {
         serviceProviderId: finalQuote.selectedRoute.providerId,
         activeRouteId: route.routeId.toString(),
         userTxIndex,
@@ -2169,7 +2169,16 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
           routeStatus,
           transactionData: null
         }
-      })
+      }
+
+      const activeRouteIndex = this.activeRoutes.findIndex(
+        (r) => r.activeRouteId === activeRoute.activeRouteId
+      )
+
+      this.activeRoutes =
+        activeRouteIndex === -1
+          ? [...this.activeRoutes, activeRoute]
+          : this.activeRoutes.map((r, i) => (i === activeRouteIndex ? activeRoute : r))
 
       this.emitUpdate()
     } catch (error: any) {
@@ -2299,6 +2308,8 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
   // update active route if needed on SubmittedAccountOp update
   handleUpdateActiveRouteOnSubmittedAccountOpStatusUpdate(op: SubmittedAccountOp) {
+    this.#handleUpdateActiveRouteFromSwapTxnMeta(op)
+
     op.calls.forEach((call) => {
       this.#handleActiveRouteBroadcastedTransaction(call.id, op.status)
       this.#handleActiveRouteBroadcastedApproval(call.id, op.status)
@@ -2306,6 +2317,35 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       this.#handleUpdateActiveRoutesUserTxData(call.id, op)
       this.#handleActiveRoutesCompleted(call.id, op.status)
     })
+  }
+
+  #handleUpdateActiveRouteFromSwapTxnMeta(submittedAccountOp: SubmittedAccountOp) {
+    const swapTxn = submittedAccountOp.meta?.swapTxn
+    if (!swapTxn) return
+
+    const activeRoute = this.activeRoutes.find((r) => r.activeRouteId === swapTxn.activeRouteId)
+    if (!activeRoute) return
+
+    if (!activeRoute.userTxHash && submittedAccountOp.txnId) {
+      this.updateActiveRoute(activeRoute.activeRouteId, {
+        userTxHash: submittedAccountOp.txnId,
+        identifiedBy: submittedAccountOp.identifiedBy
+      })
+    }
+
+    if (
+      submittedAccountOp.status === AccountOpStatus.Failure ||
+      submittedAccountOp.status === AccountOpStatus.Rejected
+    ) {
+      const errorMessage =
+        submittedAccountOp.status === AccountOpStatus.Rejected
+          ? 'The transaction was rejected'
+          : 'The transaction failed onchain'
+      this.updateActiveRoute(activeRoute.activeRouteId, {
+        routeStatus: 'failed',
+        error: errorMessage
+      })
+    }
   }
 
   #handleActiveRouteBroadcastedTransaction(


### PR DESCRIPTION
This was because, with safe accounts, we don't have a "one click broadcast" in the swap & bridge mode