### PR TITLE
Fix/ Returns the exact registrar expiry + 90-day grace for .eth name (test)

### DIFF
--- a/src/services/ensDomains/ensDomains.test.ts
+++ b/src/services/ensDomains/ensDomains.test.ts
@@ -156,10 +156,10 @@ describe('getEnsExpiry', () => {
     const result = await getEnsExpiry(ethereumProvider, { name: 'vitalik.eth' })
 
     expect(result).not.toBeNull()
-    // Dec 28, 2047 15:25:30 GMT+2
-    expect(result!.expiresAt).toBe(new Date('2047-12-28T15:25:30+02:00').getTime())
-    // Mar 27, 2048 15:25:30 GMT+2 (registration expiry + the 90-day registrar grace period)
-    expect(result!.gracePeriodEndsAt).toBe(new Date('2048-03-27T15:25:30+02:00').getTime())
+    // Jan 27, 2048 00:56:52 GMT+2
+    expect(result!.expiresAt).toBe(new Date('2048-01-27T00:56:52+02:00').getTime())
+    // Apr 26, 2048 01:56:52 GMT+3 (registration expiry + the 90-day registrar grace period)
+    expect(result!.gracePeriodEndsAt).toBe(new Date('2048-04-26T01:56:52+03:00').getTime())
     expectFreshTimestamp(result!.updatedAt)
   })
 
@@ -340,7 +340,7 @@ describe('resolveENSDomain', () => {
 
     expect(result.address).toBe('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
     expect(result.expiry).not.toBeNull()
-    expect(result.expiry!.expiresAt).toBe(new Date('2047-12-28T15:25:30+02:00').getTime())
-    expect(result.expiry!.gracePeriodEndsAt).toBe(new Date('2048-03-27T15:25:30+02:00').getTime())
+    expect(result.expiry!.expiresAt).toBe(new Date('2048-01-27T00:56:52+02:00').getTime())
+    expect(result.expiry!.gracePeriodEndsAt).toBe(new Date('2048-04-26T01:56:52+03:00').getTime())
   })
 })


### PR DESCRIPTION
Fixes the unit test