### PR TITLE
Humanizer hotfix: DAI modules

### DIFF
--- a/src/libs/humanizer/humanizeMessages.test.ts
+++ b/src/libs/humanizer/humanizeMessages.test.ts
@@ -1,4 +1,4 @@
-import { parseEther } from 'ethers'
+import { MaxUint256, parseEther } from 'ethers'
 
 import { beforeEach, describe, expect } from '@jest/globals'
 
@@ -13,6 +13,7 @@ const address1 = '0x6942069420694206942069420694206942069420'
 const address2 = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 const NFT_ADDRESS = '0x026224A2940bFE258D0dbE947919B62fE321F042'
+const DAI_ADDRESS = '0x6b175474e89094c44da98b954eedeac495271d0f'
 const typedMessages = {
   erc20: [
     {
@@ -24,6 +25,32 @@ const typedMessages = {
     }
   ],
 
+  daiPermit: [
+    // grant with expiry
+    {
+      holder: address1,
+      spender: address2,
+      nonce: 1n,
+      expiry: 968187600n,
+      allowed: true
+    },
+    // grant without expiry (0 means the permit never expires)
+    {
+      holder: address1,
+      spender: address2,
+      nonce: 1n,
+      expiry: 0n,
+      allowed: true
+    },
+    // revoke
+    {
+      holder: address1,
+      spender: address2,
+      nonce: 1n,
+      expiry: 968187600n,
+      allowed: false
+    }
+  ],
   erc721: [
     {
       spender: address2,
@@ -125,6 +152,57 @@ describe('typed message tests', () => {
     ]
 
     messageTemplate.content.message = typedMessages.erc20[0]!
+    const { fullVisualization } = erc20Module(messageTemplate)
+    expect(fullVisualization).toBeTruthy()
+    compareVisualizations(fullVisualization!, expectedVisualization)
+  })
+  test('erc20 module with DAI-style permit (grant)', () => {
+    const expectedVisualization = [
+      getAction('Grant approval'),
+      getLabel('for'),
+      getToken(DAI_ADDRESS, MaxUint256),
+      getLabel('to'),
+      getAddressVisualization(address2),
+      getDeadline(968187600n)
+    ]
+
+    messageTemplate.content.message = typedMessages.daiPermit[0]!
+    ;(
+      messageTemplate.content as TypedMessageUserRequest['meta']['params']
+    ).domain.verifyingContract = DAI_ADDRESS
+    const { fullVisualization } = erc20Module(messageTemplate)
+    expect(fullVisualization).toBeTruthy()
+    compareVisualizations(fullVisualization!, expectedVisualization)
+  })
+  test('erc20 module with DAI-style permit (grant, no expiry)', () => {
+    const expectedVisualization = [
+      getAction('Grant approval'),
+      getLabel('for'),
+      getToken(DAI_ADDRESS, MaxUint256),
+      getLabel('to'),
+      getAddressVisualization(address2)
+    ]
+
+    messageTemplate.content.message = typedMessages.daiPermit[1]!
+    ;(
+      messageTemplate.content as TypedMessageUserRequest['meta']['params']
+    ).domain.verifyingContract = DAI_ADDRESS
+    const { fullVisualization } = erc20Module(messageTemplate)
+    expect(fullVisualization).toBeTruthy()
+    compareVisualizations(fullVisualization!, expectedVisualization)
+  })
+  test('erc20 module with DAI-style permit (revoke)', () => {
+    const expectedVisualization = [
+      getAction('Revoke approval'),
+      getToken(DAI_ADDRESS, 0n),
+      getLabel('for'),
+      getAddressVisualization(address2)
+    ]
+
+    messageTemplate.content.message = typedMessages.daiPermit[2]!
+    ;(
+      messageTemplate.content as TypedMessageUserRequest['meta']['params']
+    ).domain.verifyingContract = DAI_ADDRESS
     const { fullVisualization } = erc20Module(messageTemplate)
     expect(fullVisualization).toBeTruthy()
     compareVisualizations(fullVisualization!, expectedVisualization)

--- a/src/libs/humanizer/index.ts
+++ b/src/libs/humanizer/index.ts
@@ -31,6 +31,7 @@ import AllowanceModule from './modules/Allowance'
 import asciiModule from './modules/AsciiModule'
 import Bundler3Module from './modules/Bundler3'
 import curveModule from './modules/Curve'
+import daiPermitModule from './modules/DaiPermit'
 import { deploymentModule } from './modules/Deployment'
 import { embeddedAmbireOperationHumanizer } from './modules/embeddedAmbireOperationHumanizer'
 import { ensModule } from './modules/ENS'
@@ -66,6 +67,7 @@ export const humanizerCallModules: HumanizerCallModule[] = [
   deploymentModule,
   genericErc721Humanizer,
   genericErc20Humanizer,
+  daiPermitModule,
   TrustlessManifestoModule,
   LidoModule,
   gasTankModule,

--- a/src/libs/humanizer/messageModules/erc20Module.ts
+++ b/src/libs/humanizer/messageModules/erc20Module.ts
@@ -1,17 +1,22 @@
+import { MaxUint256 } from 'ethers'
+
 import { Message } from '../../../interfaces/userRequest'
-import { HumanizerTypedMessageModule, HumanizerVisualization } from '../interfaces'
+import { HumanizerTypedMessageModule } from '../interfaces'
 import { getAction, getAddressVisualization, getDeadline, getLabel, getToken } from '../utils'
 
 export const erc20Module: HumanizerTypedMessageModule = (message: Message) => {
   if (message.content.kind !== 'typedMessage') return { fullVisualization: [] }
   const tm = message.content
   if (
-    tm.types.Permit &&
-    tm.primaryType === 'Permit' &&
-    tm.message &&
-    ['owner', 'spender', 'value', 'nonce', 'deadline'].every((i) => i in tm.message) &&
-    tm.domain.verifyingContract
-  ) {
+    tm.primaryType !== 'Permit' ||
+    !tm.types.Permit ||
+    !tm.message ||
+    !tm.domain.verifyingContract
+  )
+    return { fullVisualization: [] }
+
+  // EIP-2612 permit
+  if (['owner', 'spender', 'value', 'nonce', 'deadline'].every((i) => i in tm.message)) {
     return {
       fullVisualization: [
         getAction('Grant approval'),
@@ -19,9 +24,36 @@ export const erc20Module: HumanizerTypedMessageModule = (message: Message) => {
         getToken(tm.domain.verifyingContract!, tm.message.value),
         getLabel('to'),
         getAddressVisualization(tm.message.spender),
-        tm.message.deadline ? getDeadline(tm.message.deadline) : null
-      ].filter((x) => x) as HumanizerVisualization[]
+        ...(tm.message.deadline ? [getDeadline(tm.message.deadline)] : [])
+      ]
     }
   }
+
+  // DAI-style permit (pre EIP-2612): no `value`, only a boolean `allowed` that
+  // grants an unlimited allowance when true and revokes it when false.
+  // `expiry` of 0 means the permit never expires
+  if (['holder', 'spender', 'nonce', 'expiry', 'allowed'].every((i) => i in tm.message)) {
+    const isGranting = Boolean(tm.message.allowed)
+    if (!isGranting)
+      return {
+        fullVisualization: [
+          getAction('Revoke approval'),
+          getToken(tm.domain.verifyingContract!, 0n),
+          getLabel('for'),
+          getAddressVisualization(tm.message.spender)
+        ]
+      }
+    return {
+      fullVisualization: [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken(tm.domain.verifyingContract!, MaxUint256),
+        getLabel('to'),
+        getAddressVisualization(tm.message.spender),
+        ...(tm.message.expiry ? [getDeadline(tm.message.expiry)] : [])
+      ]
+    }
+  }
+
   return { fullVisualization: [] }
 }

--- a/src/libs/humanizer/modules/DaiPermit/daiPermit.test.ts
+++ b/src/libs/humanizer/modules/DaiPermit/daiPermit.test.ts
@@ -1,0 +1,108 @@
+import { Interface, MaxUint256 } from 'ethers'
+
+import { describe, expect, test } from '@jest/globals'
+
+import daiPermitModule from '.'
+import { AccountOp } from '../../../accountOp/accountOp'
+import { IrCall } from '../../interfaces'
+import { compareHumanizerVisualizations } from '../../testHelpers'
+import { getAction, getAddressVisualization, getDeadline, getLabel, getToken } from '../../utils'
+
+const accountOp: AccountOp = {
+  id: '1',
+  accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',
+  chainId: 1n,
+  // this may not be defined, in case the user has not picked a key yet
+  signingKeyAddr: null,
+  signingKeyType: null,
+  // this may not be set in case we haven't set it yet
+  nonce: null,
+  calls: [],
+  gasLimit: null,
+  signature: null,
+  gasFeePayment: null
+}
+
+const DAI = '0x6b175474e89094c44da98b954eedeac495271d0f'
+const spender = '0x46705dfff24256421a05d056c29e81bdc09723b8'
+const otherHolder = '0xc4ce03b36f057591b2a360d773edb9896255051e'
+const expiry = 968187600n
+const emptySig = { v: 27, r: `0x${'0'.repeat(64)}`, s: `0x${'0'.repeat(64)}` }
+
+const daiIface = new Interface([
+  'function permit(address holder, address spender, uint256 nonce, uint256 expiry, bool allowed, uint8 v, bytes32 r, bytes32 s)'
+])
+
+const getPermitCall = (holder: string, permitExpiry: bigint, allowed: boolean): IrCall => ({
+  to: DAI,
+  value: 0n,
+  data: daiIface.encodeFunctionData('permit', [
+    holder,
+    spender,
+    1n,
+    permitExpiry,
+    allowed,
+    emptySig.v,
+    emptySig.r,
+    emptySig.s
+  ])
+})
+
+describe('dai permit module', () => {
+  test('grant with expiry', () => {
+    const calls = daiPermitModule(accountOp, [getPermitCall(accountOp.accountAddr, expiry, true)])
+    compareHumanizerVisualizations(calls, [
+      [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken(DAI, MaxUint256),
+        getLabel('to'),
+        getAddressVisualization(spender),
+        getDeadline(expiry)
+      ]
+    ])
+  })
+  test('grant without expiry (0 means the permit never expires)', () => {
+    const calls = daiPermitModule(accountOp, [getPermitCall(accountOp.accountAddr, 0n, true)])
+    compareHumanizerVisualizations(calls, [
+      [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken(DAI, MaxUint256),
+        getLabel('to'),
+        getAddressVisualization(spender)
+      ]
+    ])
+  })
+  test('revoke', () => {
+    const calls = daiPermitModule(accountOp, [getPermitCall(accountOp.accountAddr, expiry, false)])
+    compareHumanizerVisualizations(calls, [
+      [
+        getAction('Revoke approval'),
+        getToken(DAI, 0n),
+        getLabel('for'),
+        getAddressVisualization(spender)
+      ]
+    ])
+  })
+  test('grant on behalf of another holder', () => {
+    const calls = daiPermitModule(accountOp, [getPermitCall(otherHolder, expiry, true)])
+    compareHumanizerVisualizations(calls, [
+      [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken(DAI, MaxUint256),
+        getLabel('to'),
+        getAddressVisualization(spender),
+        getDeadline(expiry),
+        getLabel('on behalf of'),
+        getAddressVisualization(otherHolder)
+      ]
+    ])
+  })
+  test('does not touch unrelated calls', () => {
+    const unrelatedCall: IrCall = { to: DAI, value: 0n, data: '0x' }
+    const calls = daiPermitModule(accountOp, [unrelatedCall])
+    expect(calls[0]!.fullVisualization).toBeUndefined()
+  })
+})

--- a/src/libs/humanizer/modules/DaiPermit/index.ts
+++ b/src/libs/humanizer/modules/DaiPermit/index.ts
@@ -1,0 +1,57 @@
+import { MaxUint256 } from 'ethers'
+import { decodeFunctionData, parseAbi, toFunctionSelector } from 'viem'
+
+import { AccountOp } from '../../../accountOp/accountOp'
+import { HumanizerCallModule, IrCall } from '../../interfaces'
+import {
+  getAction,
+  getAddressVisualization,
+  getDeadline,
+  getLabel,
+  getOnBehalfOf,
+  getToken,
+  isHexCall
+} from '../../utils'
+
+// DAI predates EIP-2612, so its permit has no `value` param - only a boolean
+// `allowed` that grants an unlimited allowance when true and revokes it when false
+const daiPermitAbi = parseAbi([
+  'function permit(address holder, address spender, uint256 nonce, uint256 expiry, bool allowed, uint8 v, bytes32 r, bytes32 s)'
+])
+
+const daiPermitModule: HumanizerCallModule = (accOp: AccountOp, calls: IrCall[]): IrCall[] =>
+  calls.map((call) => {
+    if (call.fullVisualization || !isHexCall(call) || !call.to) return call
+    if (call.data.slice(0, 10) !== toFunctionSelector(daiPermitAbi[0])) return call
+
+    const { args } = decodeFunctionData({ abi: daiPermitAbi, data: call.data })
+    const [holder, spender, , expiry, allowed] = args
+
+    if (!allowed)
+      return {
+        ...call,
+        fullVisualization: [
+          getAction('Revoke approval'),
+          getToken(call.to, 0n),
+          getLabel('for'),
+          getAddressVisualization(spender),
+          ...getOnBehalfOf(holder, accOp.accountAddr)
+        ]
+      }
+
+    return {
+      ...call,
+      fullVisualization: [
+        getAction('Grant approval'),
+        getLabel('for'),
+        getToken(call.to, MaxUint256),
+        getLabel('to'),
+        getAddressVisualization(spender),
+        // an expiry of 0 means the permit never expires
+        ...(expiry ? [getDeadline(expiry)] : []),
+        ...getOnBehalfOf(holder, accOp.accountAddr)
+      ]
+    }
+  })
+
+export default daiPermitModule


### PR DESCRIPTION
DAI has different formats for the `permit` function and permit EIP-712 message


This PR is testable with this code, just replace the spender, owner etc.
```
// ============================================================
// DAI permit() — sign + SEND the on-chain permit transaction
//
// Standard EIP-2612 permit function:
//   permit(owner, spender, value, deadline, v, r, s)
//
// DAI's LEGACY permit function is different:
//   permit(holder, spender, nonce, expiry, allowed, v, r, s)
//
// Differences:
//   - "value" (amount) is replaced by "nonce" (the holder's current permit nonce)
//   - "deadline" is replaced by "expiry" (0 = never expires)
//   - there's an extra "allowed" bool: true = grant max allowance, false = revoke
//   - first param is named "holder" instead of "owner" (same role)
//
// This script signs the DAI-style typed data, then sends a REAL
// on-chain tx calling DAI.permit(...) with the resulting v,r,s.
// ============================================================

(async () => {
  // ---- CONFIG: edit these ----------------------------------
  const DAI     = "0x6B175474E89094C44Da98b954EedeAC495271d0F"; // mainnet DAI
  const spender = "0x6B175474E89094C44Da98b954EedeAC495271d0F"; // who you're approving
  const allowed = true;                     // true = grant max allowance, false = revoke
  const expiry  = Math.floor(Date.now() / 1000) + 3600; // 0 = never expires
  // ----------------------------------------------------------

  if (!window.ethereum) throw new Error("No injected wallet (window.ethereum) found.");
  if (!/^0x[a-fA-F0-9]{40}$/.test(spender)) {
    throw new Error("`spender` is not a valid 42-char hex address — set it before running.");
  }

  const [holder] = await ethereum.request({ method: "eth_requestAccounts" });

  const chainId = parseInt(await ethereum.request({ method: "eth_chainId" }), 16);
  if (chainId !== 1) {
    console.warn(`You're on chainId ${chainId}. This domain (name/version/address) is for mainnet DAI.`);
  }

  // ---- Step 1: get current permit nonce -> nonces(address), selector 0x7ecebe00
  const nonceHex = await ethereum.request({
    method: "eth_call",
    params: [{ to: DAI, data: "0x7ecebe00" + holder.slice(2).padStart(64, "0") }, "latest"],
  });
  const nonce = BigInt(nonceHex).toString();

  // ---- Step 2: sign the DAI-style typed data (holder/spender/nonce/expiry/allowed)
  const typedData = {
    types: {
      EIP712Domain: [
        { name: "name",              type: "string"  },
        { name: "version",           type: "string"  },
        { name: "chainId",           type: "uint256" },
        { name: "verifyingContract", type: "address" },
      ],
      Permit: [
        { name: "holder",  type: "address" },
        { name: "spender", type: "address" },
        { name: "nonce",   type: "uint256" },
        { name: "expiry",  type: "uint256" },
        { name: "allowed", type: "bool"    },
      ],
    },
    primaryType: "Permit",
    domain: {
      name: "Dai Stablecoin",
      version: "1",
      chainId: chainId.toString(),
      verifyingContract: DAI,
    },
    message: {
      holder,
      spender,
      nonce: Number(nonce),
      expiry,
      allowed,
    },
  };

  let signature;
  try {
    signature = await ethereum.request({
      method: "eth_signTypedData_v4",
      params: [holder, JSON.stringify(typedData)],
    });
  } catch (err) {
    console.warn("Stringified params failed, retrying with raw object:", err);
    signature = await ethereum.request({
      method: "eth_signTypedData_v4",
      params: [holder, typedData],
    });
  }

  const r = signature.slice(0, 66);
  const s = "0x" + signature.slice(66, 130);
  const v = parseInt(signature.slice(130, 132), 16);

  console.log("Signed. v,r,s:", { v, r, s });

  // ---- Step 3: encode DAI's legacy permit(holder,spender,nonce,expiry,allowed,v,r,s)
  // selector = first 4 bytes of keccak256("permit(address,address,uint256,uint256,bool,uint8,bytes32,bytes32)")
  const selector = "0x8fcbaf0c";

  const encodeAddress = (addr) => addr.slice(2).toLowerCase().padStart(64, "0");
  const encodeUint    = (n) => BigInt(n).toString(16).padStart(64, "0");
  const encodeBool    = (b) => (b ? "1" : "0").padStart(64, "0");
  const encodeUint8   = (n) => BigInt(n).toString(16).padStart(64, "0");
  const encodeBytes32 = (hex) => hex.slice(2).padStart(64, "0");

  const data =
    selector +
    encodeAddress(holder) +
    encodeAddress(spender) +
    encodeUint(nonce) +
    encodeUint(expiry) +
    encodeBool(allowed) +
    encodeUint8(v) +
    encodeBytes32(r) +
    encodeBytes32(s);

  console.log("Sending permit tx:", { holder, spender, nonce, expiry, allowed, v, r, s });

  // ---- Step 4: send the on-chain permit transaction
  const txHash = await ethereum.request({
    method: "eth_sendTransaction",
    params: [{ from: holder, to: DAI, data }],
  });

  console.log("Permit tx sent. Hash:", txHash);
  return txHash;
})();
```