### PR TITLE
Fix / block AmbireOperation typed-data bypass after account switch 

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -688,14 +688,15 @@ describe('RequestsController ', () => {
 
     const buildSignTypedDataRequest = (
       controller: Awaited<ReturnType<typeof prepareTest>>['controller'],
-      typedData: object
+      typedData: object,
+      signerAddress: string = FROM
     ) =>
       controller.build({
         type: 'dappRequest',
         params: {
           request: {
             method: 'eth_signTypedData_v4',
-            params: [FROM, JSON.stringify(typedData)],
+            params: [signerAddress, JSON.stringify(typedData)],
             session: MOCK_SESSION
           },
           dappPromise: {
@@ -778,6 +779,66 @@ describe('RequestsController ', () => {
       const req = controller.userRequests[0]! as any
       expect(req.kind).toBe('typedMessage')
       expect(req.meta.params.domain.chainId).toBe(1n)
+    })
+
+    const SELECTED_ACCOUNT = FROM
+    const OTHER_ACCOUNT = '0xa07D75aacEFd11b425AF7181958F0F85c312f143'
+
+    const AMBIRE_OPERATION_TYPED_DATA = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+          { name: 'salt', type: 'bytes32' }
+        ],
+        AmbireOperation: [
+          { name: 'account', type: 'address' },
+          { name: 'hash', type: 'bytes32' }
+        ]
+      },
+      primaryType: 'AmbireOperation',
+      domain: {
+        name: 'Ambire',
+        version: '1',
+        chainId: 1,
+        verifyingContract: SELECTED_ACCOUNT,
+        salt: '0x0000000000000000000000000000000000000000000000000000000000000000'
+      },
+      message: {
+        account: SELECTED_ACCOUNT,
+        hash: '0x1111111111111111111111111111111111111111111111111111111111111111'
+      }
+    }
+
+    test('rejects AmbireOperation typed data for the selected account', async () => {
+      const { controller } = await prepareTest(true)
+      await expect(
+        buildSignTypedDataRequest(controller, AMBIRE_OPERATION_TYPED_DATA, SELECTED_ACCOUNT)
+      ).rejects.toThrow('Signing an AmbireOperation is not allowed')
+      expect(controller.userRequests.length).toBe(0)
+    })
+
+    test('rejects AmbireOperation typed data for a non-selected account', async () => {
+      const { controller } = await prepareTest(true)
+      const otherAccountTypedData = {
+        ...AMBIRE_OPERATION_TYPED_DATA,
+        domain: {
+          ...AMBIRE_OPERATION_TYPED_DATA.domain,
+          verifyingContract: OTHER_ACCOUNT
+        },
+        message: {
+          account: OTHER_ACCOUNT,
+          hash: '0x1111111111111111111111111111111111111111111111111111111111111111'
+        }
+      }
+
+      await expect(
+        buildSignTypedDataRequest(controller, otherAccountTypedData, OTHER_ACCOUNT)
+      ).rejects.toThrow('Signing an AmbireOperation is not allowed')
+      expect(controller.userRequests.length).toBe(0)
+      expect(controller.userRequestsWaitingAccountSwitch.length).toBe(0)
     })
   })
 })

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -67,6 +67,10 @@ import {
   messageOnNewRequest
 } from '../../libs/requests/requests'
 import { parse } from '../../libs/richJson/richJson'
+import {
+  AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE,
+  isAmbireOperationTypedData
+} from '../../libs/signMessage/signMessage'
 import { getSwapAndBridgeRequestParams } from '../../libs/swapAndBridge/swapAndBridge'
 import {
   getClaimWalletRequestParams,
@@ -395,6 +399,14 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
     for (const req of reqs) {
       const { kind, meta, dappPromises } = req
+
+      if (
+        kind === 'typedMessage' &&
+        isAmbireOperationTypedData((meta as TypedMessageUserRequest['meta']).params)
+      ) {
+        this.#rejectAmbireOperationTypedDataRequest(req as TypedMessageUserRequest)
+        continue
+      }
 
       if (allowAccountSwitch && isSignRequest(kind)) {
         if ((meta as SignUserRequest['meta']).accountAddr !== this.#selectedAccount.account?.addr) {
@@ -913,6 +925,15 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
         requestsToAddOrRemove.forEach((r) => {
           this.userRequestsWaitingAccountSwitch.splice(this.userRequests.indexOf(r), 1)
+
+          if (
+            r.kind === 'typedMessage' &&
+            isAmbireOperationTypedData((r as TypedMessageUserRequest).meta.params)
+          ) {
+            this.#rejectAmbireOperationTypedDataRequest(r as TypedMessageUserRequest)
+            return
+          }
+
           userRequestsToAdd.push(r)
         })
       }
@@ -1303,11 +1324,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         throw ethErrors.rpc.invalidParams('The message contents did not match the provided types.')
       }
 
-      if (
-        msgAddress === this.#selectedAccount.account.addr &&
-        (typedData.primaryType === 'AmbireOperation' || !!typedData.types.AmbireOperation)
-      ) {
-        throw ethErrors.rpc.methodNotSupported('Signing an AmbireOperation is not allowed')
+      if (isAmbireOperationTypedData(typedData)) {
+        throw ethErrors.rpc.methodNotSupported(AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE)
       }
 
       userRequest = {
@@ -1716,7 +1734,18 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     if (userRequest) await this.addUserRequests([userRequest])
   }
 
+  #rejectAmbireOperationTypedDataRequest(req: TypedMessageUserRequest) {
+    req.dappPromises.forEach((p) => {
+      p.reject(ethErrors.rpc.methodNotSupported(AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE))
+    })
+  }
+
   async #addSwitchAccountUserRequest(req: SignUserRequest) {
+    if (req.kind === 'typedMessage' && isAmbireOperationTypedData(req.meta.params)) {
+      this.#rejectAmbireOperationTypedDataRequest(req)
+      return
+    }
+
     this.userRequestsWaitingAccountSwitch.push(req)
     await this.addUserRequests(
       [

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -3189,7 +3189,10 @@ export class SignAccountOpController
                 this.account,
                 accountState,
                 signer,
-                this.#network
+                this.#network,
+                false,
+                undefined,
+                true
               )
           )
           if (!this.accountOp.meta) {

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -40,13 +40,15 @@ import {
   getSigningRequestDisplayData
 } from '../../libs/signingRequest/signingRequest'
 import {
+  AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE,
   getAppFormatted,
   getEIP712Hash,
   getEIP712Signature,
   getPlainTextSignature,
   getSafeMessageTypedData,
   getVerifyMessageSignature,
-  verifyMessage
+  verifyMessage,
+  isAmbireOperationTypedData
 } from '../../libs/signMessage/signMessage'
 import hexStringToUint8Array from '../../utils/hexStringToUint8Array'
 import { SignedMessage } from '../activity/types'
@@ -560,6 +562,10 @@ export class SignMessageController
         }
 
         if (this.messageToSign.content.kind === 'typedMessage') {
+          if (isAmbireOperationTypedData(this.messageToSign.content)) {
+            throw new Error(AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE)
+          }
+
           if (this.#account.creation && this.messageToSign.content.primaryType === 'Permit') {
             throw new Error(
               'It looks like that this app doesn\'t detect Smart Account wallets, and requested incompatible approval type. Please, go back to the app and change the approval type to "Transaction", which is supported by Smart Account wallets.'

--- a/src/libs/signMessage/signMessage.test.ts
+++ b/src/libs/signMessage/signMessage.test.ts
@@ -359,6 +359,8 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       accountState,
       signer,
       polygonNetwork,
+      true,
+      undefined,
       true
     )
 
@@ -658,7 +660,10 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       smartAccount,
       accountState,
       signer,
-      polygonNetwork
+      polygonNetwork,
+      false,
+      undefined,
+      true
     )
     // the key should be dedicatedToOneSA, so we expect the signature to end in 00
     expect(eip712Sig.signature.slice(-2)).toEqual('00')
@@ -697,7 +702,10 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       v1Account,
       accountState,
       signer,
-      ethereumNetwork
+      ethereumNetwork,
+      false,
+      undefined,
+      true
     )
     // the key is for a v1 acc so it should be 00
     expect(eip712Sig.signature.slice(-2)).toEqual('00')
@@ -752,7 +760,10 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       v1Account,
       accountState,
       signer,
-      ethereumNetwork
+      ethereumNetwork,
+      false,
+      undefined,
+      true
     )
     // the key is for a v1 acc so it should be 00
     expect(eip712Sig.signature.slice(-2)).toEqual('00')
@@ -777,7 +788,16 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       hashMessage('test')
     )
     try {
-      await getEIP712Signature(typedData, v1Account, accountState, signer, polygonNetwork)
+      await getEIP712Signature(
+        typedData,
+        v1Account,
+        accountState,
+        signer,
+        polygonNetwork,
+        false,
+        undefined,
+        true
+      )
       console.log('No error was thrown for [V1 SA]: eip-712, but it should have')
       expect(true).toEqual(false)
     } catch (e: any) {
@@ -855,7 +875,10 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       smartAccount,
       v2AccountState,
       signer,
-      polygonNetwork
+      polygonNetwork,
+      false,
+      undefined,
+      true
     )
     expect(eip712Sig.signature.slice(-2)).toEqual('00')
 
@@ -1056,7 +1079,16 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: false', () => {
       hashMessage('test')
     )
     try {
-      await getEIP712Signature(typedData, smartAccount, accountState, signer, polygonNetwork)
+      await getEIP712Signature(
+        typedData,
+        smartAccount,
+        accountState,
+        signer,
+        polygonNetwork,
+        false,
+        undefined,
+        true
+      )
       console.log('No error was thrown for [Not dedicated to one SA]: eip-712, but it should have')
       expect(true).toEqual(false)
     } catch (e: any) {
@@ -1064,6 +1096,21 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: false', () => {
         `Signer with address ${signer.key.addr} does not have privileges to execute this operation. Please choose a different signer and try again`
       )
     }
+  })
+  test('Signing [V2 SA]: rejects AmbireOperation typed data from untrusted sources by default', async () => {
+    const accountStates = await getAccountsInfo([smartAccount])
+    const accountState = accountStates[smartAccount.addr]![polygonNetwork.chainId.toString()]!
+    const signer = await keystore.getSigner(eoaSigner.keyPublicAddress, 'internal')
+
+    const typedData = getTypedData(
+      polygonNetwork.chainId,
+      accountState.accountAddr,
+      hashMessage('test')
+    )
+
+    await expect(
+      getEIP712Signature(typedData, smartAccount, accountState, signer, polygonNetwork)
+    ).rejects.toThrow('Signing an AmbireOperation is not allowed')
   })
 })
 

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -50,18 +50,17 @@ import type { HardwareWalletSigningRequest } from '../../interfaces/signAccountO
 // as 0x92 is not a valid value for v.
 const magicBytes = '6492649264926492649264926492649264926492649264926492649264926492'
 
-export const EIP_1271_NOT_SUPPORTED_BY = [
-  'opensea.io',
-  'paraswap.xyz',
-  'blur.io',
-  'aevo.xyz',
-  'socialscan.io',
-  'tally.xyz',
-  'questn.com',
-  'taskon.xyz',
-  'hyperliquid.xyz',
-  'bitrefill.com'
-]
+export const AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE =
+  'Signing an AmbireOperation is not allowed'
+
+export const isAmbireOperationTypedData = (typedData: {
+  primaryType: string
+  types: Record<string, unknown>
+}) => {
+  if ('AmbireReadableOperation' in typedData.types) return false
+
+  return typedData.primaryType === 'AmbireOperation' || 'AmbireOperation' in typedData.types
+}
 
 /**
  * For Unprotected signatures, we need to append 00 at the end
@@ -607,7 +606,8 @@ export async function getEIP712Signature(
   signer: KeystoreSignerInterface,
   network: Network,
   isOG = false,
-  withHardwareWalletSigningRequest?: WithHardwareWalletSigningRequest
+  withHardwareWalletSigningRequest?: WithHardwareWalletSigningRequest,
+  allowAmbireOperation = false
 ): Promise<{ signature: Hex; hash?: Hex }> {
   if (!message.types.EIP712Domain) {
     throw new Error(
@@ -641,6 +641,10 @@ export async function getEIP712Signature(
         withHardwareWalletSigningRequest
       )) as Hex
     }
+
+  if (isAmbireOperationTypedData(message) && !allowAmbireOperation) {
+    throw new Error(AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE)
+  }
 
   if (!accountState.isV2) {
     if (

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -50,6 +50,19 @@ import type { HardwareWalletSigningRequest } from '../../interfaces/signAccountO
 // as 0x92 is not a valid value for v.
 const magicBytes = '6492649264926492649264926492649264926492649264926492649264926492'
 
+export const EIP_1271_NOT_SUPPORTED_BY = [
+  'opensea.io',
+  'paraswap.xyz',
+  'blur.io',
+  'aevo.xyz',
+  'socialscan.io',
+  'tally.xyz',
+  'questn.com',
+  'taskon.xyz',
+  'hyperliquid.xyz',
+  'bitrefill.com'
+]
+
 export const AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE =
   'Signing an AmbireOperation is not allowed'
 


### PR DESCRIPTION
closes https://github.com/AmbireTech/ambire-app/issues/7492

## Summary

- Fix a high-severity bypass where dApps could request `eth_signTypedData_v4` with `AmbireOperation` for a non-selected smart account, evade the wallet rejection, and obtain a signature usable for `AmbireAccount.execute()` after flipping the signature mode suffix (`00` → `01`).
- Reject `AmbireOperation` typed data for any requested signer address at request intake, not only when it matches the currently selected account.
- Add defense-in-depth checks when replaying queued sign requests after account switch and immediately before EIP-712 signing.
- Block untrusted `AmbireOperation` signing in `getEIP712Signature` by default, while preserving internal wallet flows (`signAccountOp`, entry-point authorization, `AmbireReadableOperation`) via `allowAmbireOperation`.

## Root cause

The safety check in `RequestsController` only ran when `msgAddress === selectedAccount`. Requests for another account were queued behind a switch-account prompt and replayed without re-running the `AmbireOperation` validation. A v2 smart account could then sign the digest in Unprotected mode, and an attacker could change the suffix to Standard mode so on-chain verification matched the signed `AmbireOperation` digest.

## Test plan

- [x] `requests.test.ts` — rejects `AmbireOperation` for the selected account
- [x] `requests.test.ts` — rejects `AmbireOperation` for a non-selected account (original bypass path)
- [x] `signMessage.test.ts` — rejects untrusted `AmbireOperation` in `getEIP712Signature` by default
- [ ] Manual: with account A selected and account B connected to a dApp, `eth_signTypedData_v4` for B with `AmbireOperation` is rejected immediately (no switch prompt, no signing screen)
- [ ] Regression: normal EIP-712 signing (Permit, SIWE, etc.) still works
- [ ] Regression: normal smart-account transaction signing still works