### PR TITLE
Add childrenPath to ParsedQrAccount for BC-UR keypath metadata

### DIFF
--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -250,6 +250,8 @@ export type ParsedQrAccount = {
   deviceModel?: string
   deviceId?: string
   hdPath?: string // For wallets that don't provide the hdPath on each account, but only a general one for the whole export (like Keystone)
+  // BC-UR crypto-hdkey children keypath pattern (e.g. "*/*" for BIP44, "*" for Ledger Legacy).
+  childrenPath?: string
   accounts: ParsedQrImportedAccount[]
 }
 


### PR DESCRIPTION
paired with: https://github.com/AmbireTech/ambire-app/pull/7509

## Summary

Adds an optional `childrenPath` field to `ParsedQrAccount` so QR wallet import can carry BC-UR `crypto-hdkey` children keypath metadata from the scanned payload.

When importing from Keycard Shell via QR, the UR payload encodes derivation in two parts:
- **origin** — parent xpub path (e.g. `m/44'/60'/0'`)
- **children** — address discovery pattern (e.g. `*/*` for BIP44 standard, `*` for Ledger Legacy)

Standard Ethereum and Ledger Legacy share the same origin path (`m/44'/60'/0'`) but use different children patterns. Without exposing `childrenPath`, consumers cannot tell them apart and may derive the wrong address.

This is a type-only change in ambire-common. The parsing and derivation logic lives in ambire-app (companion PR on branch `qr-code-based-wallets-derivation-paths`).

## Changes

- Add optional `childrenPath?: string` to `ParsedQrAccount` in `src/interfaces/keystore.ts`

## Test plan

- [ ] Type-check passes (`npm run type:check`)
- [ ] ambire-app PR consuming this field builds and passes unit tests
- [ ] Keycard Shell Ledger Legacy QR import resolves to `m/44'/60'/0'/0` (not `m/44'/60'/0'/0/0`)