### PR TITLE
Feature / Safe accounts on mobile

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -210,6 +210,8 @@ export class MainController extends EventEmitter implements IMainController {
 
   #continuousUpdates: ContinuousUpdatesController | undefined
 
+  #fetchSafeTxnsPromise: Promise<void> | undefined
+
   safe: ISafeController
 
   get continuousUpdates() {
@@ -715,12 +717,16 @@ export class MainController extends EventEmitter implements IMainController {
             await this.keystore.updateKeystoreKeys()
           }
         )
-        this.fetchSafeTxns().catch((e) => e) // we catch the error inside
       }
     })
 
     this.ui.uiEvent.on('addView', async (view: View) => {
       if (view.type === 'popup') await this.onPopupOpen(view.id)
+    })
+
+    this.ui.uiEvent.on('viewFocus', () => {
+      console.log('in')
+      this.fetchSafeTxns([]).catch((e) => e) // we catch the error inside
     })
   }
 
@@ -764,8 +770,6 @@ export class MainController extends EventEmitter implements IMainController {
       if (!this.accounts.areAccountStatesLoading) {
         this.accounts.updateAccountState(selectedAccountAddr)
       }
-
-      this.fetchSafeTxns().catch((e) => e) // we catch the error inside
     }
 
     this.ui.updateView(viewId, { isReady: true })
@@ -1633,6 +1637,16 @@ export class MainController extends EventEmitter implements IMainController {
    * if the selected account is a safe
    */
   async fetchSafeTxns(chainIds: bigint[] = [], forceRefetch = false) {
+    if (this.#fetchSafeTxnsPromise) return this.#fetchSafeTxnsPromise
+
+    this.#fetchSafeTxnsPromise = this.#fetchSafeTxns(chainIds, forceRefetch).finally(() => {
+      this.#fetchSafeTxnsPromise = undefined
+    })
+
+    return this.#fetchSafeTxnsPromise
+  }
+
+  async #fetchSafeTxns(chainIds: bigint[] = [], forceRefetch = false) {
     if (!this.selectedAccount?.account?.safeCreation) return
     // cache the addr here to prevent race conditions
     const safeAddr = this.selectedAccount?.account?.addr as Hex

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -724,7 +724,6 @@ export class MainController extends EventEmitter implements IMainController {
     })
 
     this.ui.uiEvent.on('viewFocus', () => {
-      console.log('in')
       this.fetchSafeTxns([]).catch((e) => e) // we catch the error inside
     })
   }

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1453,7 +1453,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     message,
     messageHash,
     created,
-    signatures
+    signatures,
+    dappName,
+    dappUrl
   }: {
     chainId: bigint
     signed: string[]
@@ -1461,6 +1463,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     messageHash: Hex
     created: number
     signatures: Hex[]
+    dappName?: string
+    dappUrl?: string
   }) {
     await this.initialLoadPromise
     if (!this.#selectedAccount.account) return
@@ -1479,7 +1483,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           signed,
           hash: messageHash,
           created,
-          signatures
+          signatures,
+          dappName,
+          dappUrl
         }
       }
       await this.addUserRequests([req], { position: 'last', executionType: 'queue' })
@@ -1510,7 +1516,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         signed,
         hash: messageHash,
         created,
-        signatures
+        signatures,
+        dappName,
+        dappUrl
       }
     }
     await this.addUserRequests([req], { position: 'last', executionType: 'queue' })

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -28,10 +28,10 @@ import {
 } from '../../interfaces/signMessage'
 import { AuthorizationUserRequest, Message } from '../../interfaces/userRequest'
 import { fetchErc7730DescriptorForMessage, humanizeMessage } from '../../libs/humanizer'
+import { buildSafeMessageOrigin } from '../../libs/safe/helpers'
 import {
   addMessage,
   addMessageSignature,
-  buildSafeMessageOrigin,
   getImportedSignersThatHaveNotSigned,
   sortSigs
 } from '../../libs/safe/safe'

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -31,6 +31,7 @@ import { fetchErc7730DescriptorForMessage, humanizeMessage } from '../../libs/hu
 import {
   addMessage,
   addMessageSignature,
+  buildSafeMessageOrigin,
   getImportedSignersThatHaveNotSigned,
   sortSigs
 } from '../../libs/safe/safe'
@@ -449,10 +450,16 @@ export class SignMessageController
   async addMsgToSafeGlobal(sig: string, message: string | EIP712TypedData) {
     if (!this.network || !this.#account) return
 
+    // Attach the requesting dapp's name and url so the other owners can see the
+    // request context when co-signing on a different device (see buildSafeMessageOrigin)
+    const origin = buildSafeMessageOrigin(this.dapp)
+
     // send only to Safe Global if it doesn't already exists and if the threshold is not met
-    await addMessage(this.network.chainId, this.#account.addr as Hex, message, sig).catch((e) => {
-      console.log('failed to send message to Safe Global: ', e)
-    })
+    await addMessage(this.network.chainId, this.#account.addr as Hex, message, sig, origin).catch(
+      (e) => {
+        console.log('failed to send message to Safe Global: ', e)
+      }
+    )
   }
 
   async addSigToSafeGlobal(sig: string, hash: string) {

--- a/src/controllers/ui/ui.ts
+++ b/src/controllers/ui/ui.ts
@@ -74,6 +74,13 @@ export class UiController extends EventEmitter implements IUiController {
     this.emitUpdate()
   }
 
+  emitViewFocus(viewId: string) {
+    const view = this.views.find((v) => v.id === viewId)
+    if (!view) return
+
+    this.uiEvent.emit('viewFocus', view)
+  }
+
   removeView(viewId: string) {
     const view = this.views.find((v) => v.id === viewId)
 

--- a/src/interfaces/requests.ts
+++ b/src/interfaces/requests.ts
@@ -84,5 +84,7 @@ export type BuildRequest =
         messageHash: Hex
         created: number
         signatures: Hex[]
+        dappName?: string
+        dappUrl?: string
       }
     }

--- a/src/interfaces/userRequest.ts
+++ b/src/interfaces/userRequest.ts
@@ -80,6 +80,10 @@ export interface PlainTextMessageUserRequest extends UserRequestBase<[] | [DappP
     hash?: Hex
     created?: number
     signatures?: Hex[]
+    // set for Safe messages co-signed from another device, where there is no live
+    // dapp session; recovered from the Safe message's `origin` field
+    dappName?: string
+    dappUrl?: string
   }
 }
 
@@ -119,6 +123,10 @@ export interface TypedMessageUserRequest extends UserRequestBase<[] | [DappPromi
     hash?: Hex
     created?: number
     signatures?: Hex[]
+    // set for Safe messages co-signed from another device, where there is no live
+    // dapp session; recovered from the Safe message's `origin` field
+    dappName?: string
+    dappUrl?: string
   }
 }
 

--- a/src/libs/safe/helpers.ts
+++ b/src/libs/safe/helpers.ts
@@ -153,6 +153,42 @@ export function decodeMultiSend(transactionsHex: string) {
 }
 
 /**
+ * The requesting dapp is only known on the device that originates the message.
+ * We stamp its name and url into Safe's `origin` field so other owners co-signing
+ * on a different device can see the request context (they fetch the message from
+ * the Safe Transaction Service, which carries no dapp identity of its own).
+ * `origin` is capped at 200 chars; if it doesn't fit we skip it rather than risk
+ * the message proposal failing validation (missing metadata is recoverable).
+ */
+export function buildSafeMessageOrigin(
+  dapp: { name?: string; url?: string } | null
+): string | undefined {
+  const name = dapp?.name || ''
+  const url = dapp?.url || ''
+  if (!name && !url) return undefined
+
+  const origin = JSON.stringify({ name, url })
+  if (origin.length > 200) return undefined
+  return origin
+}
+
+export function parseSafeMessageOrigin(origin?: string): { name?: string; url?: string } {
+  if (!origin) return {}
+  try {
+    const parsed = JSON.parse(origin)
+    if (parsed && typeof parsed === 'object') {
+      const name = typeof parsed.name === 'string' ? parsed.name : undefined
+      const url = typeof parsed.url === 'string' ? parsed.url : undefined
+      return { name, url }
+    }
+  } catch {
+    // origin may be a plain, non-JSON string set by another wallet; treat it as the name
+    return { name: origin }
+  }
+  return {}
+}
+
+/**
  * Safe requests may have multiple "call" ones with the same nonce
  */
 export function getSameNonceRequests(requests: CallsUserRequest[]) {

--- a/src/libs/safe/safe.test.ts
+++ b/src/libs/safe/safe.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from '@jest/globals'
 
 import type { EIP712TypedData } from '@safe-global/types-kit'
 
-import { normalizeSafeGlobalMessage } from './safe'
+import { buildSafeMessageOrigin, normalizeSafeGlobalMessage, parseSafeMessageOrigin } from './safe'
 
 describe('normalizeSafeGlobalMessage', () => {
   test('converts a typed message domain chainId bigint to a decimal string', () => {
@@ -42,5 +42,60 @@ describe('normalizeSafeGlobalMessage', () => {
 
     expect(normalizeSafeGlobalMessage('plain message')).toBe('plain message')
     expect(normalizeSafeGlobalMessage(typedMessage)).toBe(typedMessage)
+  })
+})
+
+describe('buildSafeMessageOrigin', () => {
+  test('serializes the dapp name and url', () => {
+    expect(buildSafeMessageOrigin({ name: 'Uniswap', url: 'https://app.uniswap.org' })).toBe(
+      '{"name":"Uniswap","url":"https://app.uniswap.org"}'
+    )
+  })
+
+  test('keeps whichever field is present', () => {
+    expect(buildSafeMessageOrigin({ name: 'Uniswap' })).toBe('{"name":"Uniswap","url":""}')
+    expect(buildSafeMessageOrigin({ url: 'https://app.uniswap.org' })).toBe(
+      '{"name":"","url":"https://app.uniswap.org"}'
+    )
+  })
+
+  test('returns undefined when there is no dapp metadata', () => {
+    expect(buildSafeMessageOrigin(null)).toBeUndefined()
+    expect(buildSafeMessageOrigin({})).toBeUndefined()
+    expect(buildSafeMessageOrigin({ name: '', url: '' })).toBeUndefined()
+  })
+
+  test('skips the field rather than exceed the 200 char Safe limit', () => {
+    const longUrl = `https://${'a'.repeat(250)}.com`
+    expect(buildSafeMessageOrigin({ name: 'Uniswap', url: longUrl })).toBeUndefined()
+  })
+})
+
+describe('parseSafeMessageOrigin', () => {
+  test('parses name and url out of the JSON origin', () => {
+    expect(
+      parseSafeMessageOrigin('{"name":"Uniswap","url":"https://app.uniswap.org"}')
+    ).toEqual({ name: 'Uniswap', url: 'https://app.uniswap.org' })
+  })
+
+  test('round-trips with buildSafeMessageOrigin', () => {
+    const dapp = { name: 'Uniswap', url: 'https://app.uniswap.org' }
+    expect(parseSafeMessageOrigin(buildSafeMessageOrigin(dapp))).toEqual(dapp)
+  })
+
+  test('returns empty object when origin is missing', () => {
+    expect(parseSafeMessageOrigin()).toEqual({})
+    expect(parseSafeMessageOrigin('')).toEqual({})
+  })
+
+  test('treats a non-JSON origin as the name (e.g. set by another wallet)', () => {
+    expect(parseSafeMessageOrigin('My Custom Safe App')).toEqual({ name: 'My Custom Safe App' })
+  })
+
+  test('ignores non-string name/url fields', () => {
+    expect(parseSafeMessageOrigin('{"name":123,"url":true}')).toEqual({
+      name: undefined,
+      url: undefined
+    })
   })
 })

--- a/src/libs/safe/safe.test.ts
+++ b/src/libs/safe/safe.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from '@jest/globals'
 
 import type { EIP712TypedData } from '@safe-global/types-kit'
 
-import { buildSafeMessageOrigin, normalizeSafeGlobalMessage, parseSafeMessageOrigin } from './safe'
+import { buildSafeMessageOrigin, parseSafeMessageOrigin } from './helpers'
+import { normalizeSafeGlobalMessage } from './safe'
 
 describe('normalizeSafeGlobalMessage', () => {
   test('converts a typed message domain chainId bigint to a decimal string', () => {

--- a/src/libs/safe/safe.ts
+++ b/src/libs/safe/safe.ts
@@ -26,6 +26,7 @@ import { adaptTypedMessageForMetaMaskSigUtil } from '../signMessage/signMessage'
 import { decodeMultiSend, multiCallAbi } from './helpers'
 
 import type {
+  AddMessageOptions,
   ProposeTransactionProps,
   SafeCreationInfoResponse,
   SafeMessage,
@@ -165,13 +166,55 @@ export async function addMessage(
   chainId: bigint,
   safeAddress: Hex,
   message: string | EIP712TypedData,
-  signature: string
+  signature: string,
+  origin?: string
 ) {
   const apiKit = getApiKit(chainId)
-  return apiKit.addMessage(safeAddress, {
+  // `origin` is a free-form field the Safe Transaction Service persists and returns
+  // on the message. api-kit doesn't type it, but it forwards the options as the POST
+  // body verbatim, so we widen the payload to carry it through.
+  const options: AddMessageOptions & { origin?: string } = {
     message: normalizeSafeGlobalMessage(message),
     signature
-  })
+  }
+  if (origin) options.origin = origin
+  return apiKit.addMessage(safeAddress, options)
+}
+
+/**
+ * The requesting dapp is only known on the device that originates the message.
+ * We stamp its name and url into Safe's `origin` field so other owners co-signing
+ * on a different device can see the request context (they fetch the message from
+ * the Safe Transaction Service, which carries no dapp identity of its own).
+ * `origin` is capped at 200 chars; if it doesn't fit we skip it rather than risk
+ * the message proposal failing validation (missing metadata is recoverable).
+ */
+export function buildSafeMessageOrigin(
+  dapp: { name?: string; url?: string } | null
+): string | undefined {
+  const name = dapp?.name || ''
+  const url = dapp?.url || ''
+  if (!name && !url) return undefined
+
+  const origin = JSON.stringify({ name, url })
+  if (origin.length > 200) return undefined
+  return origin
+}
+
+export function parseSafeMessageOrigin(origin?: string): { name?: string; url?: string } {
+  if (!origin) return {}
+  try {
+    const parsed = JSON.parse(origin)
+    if (parsed && typeof parsed === 'object') {
+      const name = typeof parsed.name === 'string' ? parsed.name : undefined
+      const url = typeof parsed.url === 'string' ? parsed.url : undefined
+      return { name, url }
+    }
+  } catch {
+    // origin may be a plain, non-JSON string set by another wallet; treat it as the name
+    return { name: origin }
+  }
+  return {}
 }
 
 export function normalizeSafeGlobalMessage(message: string | EIP712TypedData) {
@@ -369,6 +412,8 @@ export function toSigMessageUserRequests(response: SafeResults): {
     signature: Hex
     created: number
     signatures: Hex[]
+    dappName?: string
+    dappUrl?: string
   }
   isConfirmed: boolean
 }[] {
@@ -382,6 +427,8 @@ export function toSigMessageUserRequests(response: SafeResults): {
       signature: Hex
       created: number
       signatures: Hex[]
+      dappName?: string
+      dappUrl?: string
     }
     isConfirmed: boolean
   }[] = []
@@ -393,6 +440,8 @@ export function toSigMessageUserRequests(response: SafeResults): {
         ? (concat(message.confirmations.map((c) => c.signature)) as Hex)
         : null
       if (!signature) return
+
+      const { name: dappName, url: dappUrl } = parseSafeMessageOrigin(message.origin)
 
       userRequests.push({
         type: 'safeSignMessageRequest',
@@ -410,7 +459,9 @@ export function toSigMessageUserRequests(response: SafeResults): {
             message.confirmations
           ),
           created: new Date(message.created).getTime(),
-          signatures: message.confirmations.map((c) => c.signature) as Hex[]
+          signatures: message.confirmations.map((c) => c.signature) as Hex[],
+          dappName,
+          dappUrl
         },
         isConfirmed: !!message.isConfirmed
       })

--- a/src/libs/safe/safe.ts
+++ b/src/libs/safe/safe.ts
@@ -23,7 +23,7 @@ import { SafeTx } from '../../interfaces/safe'
 import { CallsUserRequest, TypedMessageUserRequest } from '../../interfaces/userRequest'
 import wait from '../../utils/wait'
 import { adaptTypedMessageForMetaMaskSigUtil } from '../signMessage/signMessage'
-import { decodeMultiSend, multiCallAbi } from './helpers'
+import { decodeMultiSend, multiCallAbi, parseSafeMessageOrigin } from './helpers'
 
 import type {
   AddMessageOptions,
@@ -179,42 +179,6 @@ export async function addMessage(
   }
   if (origin) options.origin = origin
   return apiKit.addMessage(safeAddress, options)
-}
-
-/**
- * The requesting dapp is only known on the device that originates the message.
- * We stamp its name and url into Safe's `origin` field so other owners co-signing
- * on a different device can see the request context (they fetch the message from
- * the Safe Transaction Service, which carries no dapp identity of its own).
- * `origin` is capped at 200 chars; if it doesn't fit we skip it rather than risk
- * the message proposal failing validation (missing metadata is recoverable).
- */
-export function buildSafeMessageOrigin(
-  dapp: { name?: string; url?: string } | null
-): string | undefined {
-  const name = dapp?.name || ''
-  const url = dapp?.url || ''
-  if (!name && !url) return undefined
-
-  const origin = JSON.stringify({ name, url })
-  if (origin.length > 200) return undefined
-  return origin
-}
-
-export function parseSafeMessageOrigin(origin?: string): { name?: string; url?: string } {
-  if (!origin) return {}
-  try {
-    const parsed = JSON.parse(origin)
-    if (parsed && typeof parsed === 'object') {
-      const name = typeof parsed.name === 'string' ? parsed.name : undefined
-      const url = typeof parsed.url === 'string' ? parsed.url : undefined
-      return { name, url }
-    }
-  } catch {
-    // origin may be a plain, non-JSON string set by another wallet; treat it as the name
-    return { name: origin }
-  }
-  return {}
 }
 
 export function normalizeSafeGlobalMessage(message: string | EIP712TypedData) {


### PR DESCRIPTION
## Summary
Cross-device support for Safe (multisig) message co-signing: propagates the requesting dapp's identity to other owners, and refreshes pending Safe requests when the view regains focus.

## Changes
- **Dapp metadata across devices** — when the first owner signs a Safe message, the requesting dapp's `{name, url}` is stamped into the Safe Transaction Service `origin` field. On the co-signing device the message is rebuilt with that metadata (`dappName`/`dappUrl` on the request meta), so the signer sees which dapp requested the signature instead of an empty screen.
- **Pending requests refresh** — added a generic `viewFocus` UI event (`SET_VIEW_FOCUS`) so the UI only reports focus and the controllers decide when to refresh Safe pending requests.

## Notes
- `origin` is capped at 200 chars, so only name + url are carried; if it doesn't fit, origin is skipped so the message proposal never fails (the icon is resolved app-side from the dapp catalog).
- Reading is defensive — a non-JSON `origin` set by another wallet is treated as the name.
- Added unit tests for the origin build/parse helpers.