### PR TITLE
Call this.#hwCleanup() on cancelSignReq() in signAccountOp

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -3878,6 +3878,7 @@ export class SignAccountOpController
     this.broadcastPromise = undefined
     this.signAndBroadcastPromise = undefined
     this.status = { type: SigningStatus.ReadyToSign }
+    this.#hwCleanup()
     this.emitUpdate()
   }
 


### PR DESCRIPTION
Part of the efforts to try to resolve this bug:

<img width="1829" height="571" alt="image" src="https://github.com/user-attachments/assets/ffa0b75b-3224-448a-939e-994e1e87e728" />

This bug has happened because of the new security related code released in main.ts:
```
    // Security: a dapp can append calls before signing starts. The accountOp id
    // changes on every calls change, so a mismatch with the reviewed id means the
    // live op differs from the screen - abort so the user re-reviews.
    if (
      isDappCallsRequest &&
      reviewedAccountOpId &&
      signAccountOp.accountOp.id !== reviewedAccountOpId
    ) {
      return this.emitError({
        level: 'major',
        message:
          'The transaction changed after you reviewed it. Please review the updated transaction and try again.',
        error: new Error(
          'handleSignAndBroadcastAccountOp: reviewed accountOp id does not match the live accountOp id; aborting to prevent signing unreviewed calls'
        )
      })
    }
```