### PR TITLE
ContractNames test/ remove falsy check or ZeroAddress

### DIFF
--- a/src/controllers/contractNames/contractNames.test.ts
+++ b/src/controllers/contractNames/contractNames.test.ts
@@ -62,7 +62,6 @@ describe('Contract Names', () => {
     expect(contractNamesController.contractNames[randomAddress]).toBeTruthy()
     expect(contractNamesController.contractNames[randomAddress]!.name).toBeFalsy()
     expect(contractNamesController.contractNames[ZeroAddress]).toBeTruthy()
-    expect(contractNamesController.contractNames[ZeroAddress]!.name).toBeFalsy()
     expect(contractNamesController.contractNames[contracts.ambireAtETHSofia]!.name).toBe(
       'EthSofiaNft'
     )


### PR DESCRIPTION
There is not problem for the Zero Address to have a label