### PR TITLE
Config / Update traceCall asset discovery tests to reflect the recent changes

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -3076,11 +3076,10 @@ describe('traceCall asset discovery', () => {
 
     await (controller as any).traceCall()
 
-    // The access list failure is reported silently, then discovery falls back
-    // to debug_traceCall.
-    expect(emitErrorSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ level: 'silent', message: 'Error in signAccountOp.traceCall' })
-    )
+    // The access list failure is not emitted as an error (it would be reported to
+    // Sentry) because there is a retry/fallback mechanism; discovery falls back to
+    // debug_traceCall and no error is emitted once a fallback succeeds.
+    expect(emitErrorSpy).not.toHaveBeenCalled()
     expect(debugTraceCallSpy).toHaveBeenCalledTimes(1)
     expect(addTokensToBeLearnedSpy).toHaveBeenCalledWith(
       ['0xdAC17F958D2ee523a2206206994597C13D831ec7'],
@@ -3118,7 +3117,9 @@ describe('traceCall asset discovery', () => {
       smartAccount.addr,
       1n
     )
-    expect(emitErrorSpy).toHaveBeenCalledTimes(2)
+    // Neither the access list nor the debug_traceCall failures are emitted as
+    // errors, since eth_simulateV1 (the last fallback) succeeds.
+    expect(emitErrorSpy).not.toHaveBeenCalled()
     expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.Done)
   })
 


### PR DESCRIPTION
Updated the traceCall discovery tests to stop expecting a silent emitError on access-list / debug_traceCall failures, since PR #2548 made those failures console.log and only emit if the whole fallback chain (incl. eth_simulateV1) fails.