### PR TITLE
Feature: token discovery optimization

### DIFF
--- a/src/controllers/signAccountOp/discoverTxnTokens.ts
+++ b/src/controllers/signAccountOp/discoverTxnTokens.ts
@@ -1,0 +1,103 @@
+import { Account, AccountOnchainState } from '../../interfaces/account'
+import { Network } from '../../interfaces/network'
+import { BaseAccount } from '../../libs/account/BaseAccount'
+import { AccountOp } from '../../libs/accountOp/accountOp'
+import { createAccessListCall, getShouldUseAccessListCall } from '../../libs/tracer/accessListCall'
+import { debugTraceCall, getStateOverride } from '../../libs/tracer/debugTraceCall'
+import { ethSimulateV1 } from '../../libs/tracer/ethSimulatev1'
+
+type DiscoveryMethod = 'eth_createAccessList' | 'debug_traceCall' | 'eth_simulateV1'
+
+type DiscoverTxnTokensProps = {
+  account: Account
+  accountOp: AccountOp
+  accountState?: AccountOnchainState
+  baseAccount: BaseAccount
+  network: Network
+  isCurrent: () => boolean
+}
+
+type DiscoveredAssets = { tokens: string[]; nfts: [string, bigint[]][] }
+
+const discoveryMethodCache = new Map<string, DiscoveryMethod>()
+
+/**
+ * A helper function to use in the tests only
+ */
+export const clearDiscoverTxnTokensCache = () => discoveryMethodCache.clear()
+
+/**
+ * Goal: discover tokens that are interacting with the account during a txn
+ * To do this, we use 3 methods:
+ * - eth_createAccessList
+ * - debug_traceCall
+ * - eth_simulateV1
+ * The end product of each method is the same. However, different methods
+ * are supported on different chains depending on the chain configs and RPC.
+ * Also, some accounts require state overrides which may not be supported
+ * on the specific chain. That's why we have 3 methods and rely on 1
+ * having the exact support we need. Each method is called one by one until
+ * we hit a success or all methods have failed.
+ * We also have a memory cache. It's simple: record the method that succeeded
+ * for chain-account. The next time discoverTxnTokens is called, it will start
+ * from the method that was successful.
+ */
+export async function discoverTxnTokens({
+  account,
+  accountOp,
+  accountState,
+  baseAccount,
+  network,
+  isCurrent
+}: DiscoverTxnTokensProps): Promise<DiscoveredAssets | null> {
+  // we cannot perform a token discovery if there's no accountState
+  if (!accountState) return null
+
+  const stateOverride = getStateOverride(account, accountOp, accountState)
+  const shouldUseAccessList = getShouldUseAccessListCall(account, !!stateOverride)
+  const methodCalls: Record<DiscoveryMethod, () => Promise<DiscoveredAssets>> = {
+    eth_createAccessList: async () => {
+      const addresses = await createAccessListCall(baseAccount, accountOp, network, accountState)
+
+      return { tokens: addresses, nfts: addresses.map((address) => [address, []]) }
+    },
+    debug_traceCall: () =>
+      debugTraceCall(baseAccount, accountOp, network, accountState, stateOverride),
+    eth_simulateV1: () => ethSimulateV1(baseAccount, accountOp, network, accountState)
+  }
+  const availableMethods: DiscoveryMethod[] = [
+    ...(shouldUseAccessList ? (['eth_createAccessList'] as const) : []),
+    'debug_traceCall',
+    'eth_simulateV1'
+  ]
+  const cacheKey = `${network.chainId}-${account.addr}`
+  const cachedMethod = discoveryMethodCache.get(cacheKey)
+  const orderedMethods =
+    cachedMethod && availableMethods.includes(cachedMethod)
+      ? [cachedMethod, ...availableMethods.filter((method) => method !== cachedMethod)]
+      : availableMethods
+
+  let discoveredAssets: DiscoveredAssets | null = null
+  let lastError: unknown
+
+  for (const method of orderedMethods) {
+    console.log(`Debug: using ${method} for asset discovery`)
+
+    try {
+      discoveredAssets = await methodCalls[method]()
+      discoveryMethodCache.set(cacheKey, method)
+      break
+    } catch (error) {
+      lastError = error
+      // do not emit an error here as there is a retry mechanism
+      console.log(`${method} failed`, error)
+    }
+
+    // If this discovery run has been superseded, do not continue with its fallbacks.
+    if (!isCurrent()) return null
+  }
+
+  if (!discoveredAssets) throw lastError
+  if (!isCurrent()) return null
+  return discoveredAssets
+}

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -84,6 +84,7 @@ import { SelectedAccountController } from '../selectedAccount/selectedAccount'
 import { StorageController } from '../storage/storage'
 import { SurveyController } from '../survey/survey'
 import { UiController } from '../ui/ui'
+import { clearDiscoverTxnTokensCache } from './discoverTxnTokens'
 import { getFeeSpeedIdentifier, SignAccountOpType } from './helper'
 import { FeeSpeed, SigningStatus } from './signAccountOp'
 import { SignAccountOpPreferenceController } from './signAccountOpPreference'
@@ -3017,6 +3018,7 @@ describe('traceCall asset discovery', () => {
 
     await wait(100)
     controller.traceCallDiscoveryStatus = TraceCallDiscoveryStatus.NotStarted
+    clearDiscoverTxnTokensCache()
     jest.clearAllMocks()
 
     return controller
@@ -3121,6 +3123,43 @@ describe('traceCall asset discovery', () => {
     // errors, since eth_simulateV1 (the last fallback) succeeds.
     expect(emitErrorSpy).not.toHaveBeenCalled()
     expect(controller.traceCallDiscoveryStatus).toBe(TraceCallDiscoveryStatus.Done)
+  })
+
+  test('tries the last successful method first on the next discovery', async () => {
+    const controller = await initTraceCall()
+
+    createAccessListCallSpy.mockRejectedValueOnce(new Error('access list failed'))
+
+    await (controller as any).traceCall()
+
+    controller.traceCallDiscoveryStatus = TraceCallDiscoveryStatus.NotStarted
+    jest.clearAllMocks()
+
+    await (controller as any).traceCall()
+
+    expect(debugTraceCallSpy).toHaveBeenCalledTimes(1)
+    expect(createAccessListCallSpy).not.toHaveBeenCalled()
+    expect(ethSimulateV1Spy).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the other methods when the cached method fails', async () => {
+    const controller = await initTraceCall()
+
+    createAccessListCallSpy.mockRejectedValueOnce(new Error('access list failed'))
+
+    await (controller as any).traceCall()
+
+    controller.traceCallDiscoveryStatus = TraceCallDiscoveryStatus.NotStarted
+    jest.clearAllMocks()
+    debugTraceCallSpy.mockRejectedValueOnce(new Error('trace failed'))
+
+    await (controller as any).traceCall()
+
+    expect(debugTraceCallSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      createAccessListCallSpy.mock.invocationCallOrder[0]!
+    )
+    expect(createAccessListCallSpy).toHaveBeenCalledTimes(1)
+    expect(ethSimulateV1Spy).not.toHaveBeenCalled()
   })
 
   test('sets Failed and emits a silent error when discovery throws', async () => {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -12,7 +12,6 @@ import {
 
 import { isNative } from '@/libs/portfolio/helpers'
 import { BindedRelayerCall } from '@/libs/relayerCall/relayerCall'
-import { debugTraceCall, getStateOverride } from '@/libs/tracer/debugTraceCall'
 
 import ERC20 from '../../../contracts/compiled/IERC20.json'
 import EmittableError from '../../classes/EmittableError'
@@ -131,8 +130,6 @@ import {
 } from '../../libs/signMessage/signMessage'
 import { isPermit2Interaction } from '../../libs/simulation/detectPermit2Interaction'
 import { getGasUsed } from '../../libs/singleton/singleton'
-import { createAccessListCall, getShouldUseAccessListCall } from '../../libs/tracer/accessListCall'
-import { ethSimulateV1 } from '../../libs/tracer/ethSimulatev1'
 import { UserOperation } from '../../libs/userOperation/types'
 import {
   getActivatorCall,
@@ -151,6 +148,7 @@ import { EstimationController } from '../estimation/estimation'
 import { EstimationStatus } from '../estimation/types'
 import { GasPriceController } from '../gasPrice/gasPrice'
 import HumanizationController from '../humanization/humanization'
+import { discoverTxnTokens } from './discoverTxnTokens'
 import {
   getFeeSpeedIdentifier,
   getFeeTokenPriceUnavailableWarning,
@@ -2102,97 +2100,34 @@ export class SignAccountOpController
     this.traceCallTimeoutId = timeoutId
 
     try {
-      const state =
-        this.#accounts.accountStates[this.account.addr]?.[this.#network.chainId.toString()]
-      // TODO: how to handle this case?
-      if (!state) return
-      let erc20s: string[] = []
-      let erc721s: [string, bigint[]][] = []
+      const discoveredAssets = await discoverTxnTokens({
+        account: this.account,
+        accountOp: this.accountOp,
+        accountState:
+          this.#accounts.accountStates[this.account.addr]?.[this.#network.chainId.toString()],
+        baseAccount: this.baseAccount,
+        network: this.#network,
+        isCurrent: () => this.traceCallTimeoutId === timeoutId
+      })
+      if (!discoveredAssets) return
 
-      const stateOverride = getStateOverride(this.account, this.accountOp, state)
-      const shouldUseAccessList = getShouldUseAccessListCall(this.account, !!stateOverride)
-      let accessListFailed = false
-      let debugTraceCallFailed = false
-
-      if (shouldUseAccessList) {
-        console.log('Debug: using eth_createAccessList for asset discovery')
-        const addresses = await createAccessListCall(
-          this.baseAccount,
-          this.accountOp,
-          this.#network,
-          state
-        ).catch((e) => {
-          // do not emit an error here as there is a retry mechanism
-          console.log('eth_createAccessList failed', e)
-          accessListFailed = true
-          return null
-        })
-        if (addresses) {
-          erc20s = addresses
-          erc721s = addresses.map((address) => [address, []])
-        }
-      }
-
-      if (this.traceCallTimeoutId !== timeoutId) {
-        // If the timeout ID doesn't match, it means that another traceCall has been initiated,
-        // and we should not proceed with this one
-        return
-      }
-
-      if (!shouldUseAccessList || accessListFailed) {
-        console.log('Debug: using debug_traceCall for asset discovery')
-        try {
-          const { tokens, nfts } = await debugTraceCall(
-            this.baseAccount,
-            this.accountOp,
-            this.#network,
-            state,
-            stateOverride
-          )
-          erc20s = tokens
-          erc721s = nfts
-        } catch (e: any) {
-          // do not emit an error here as there is a retry mechanism
-          console.log('debug_traceCall failed', e)
-          debugTraceCallFailed = true
-        }
-      }
-
-      if (this.traceCallTimeoutId !== timeoutId) {
-        // If the timeout ID doesn't match, it means that another traceCall has been initiated,
-        // and we should not proceed with this one
-        return
-      }
-
-      if ((!shouldUseAccessList || accessListFailed) && debugTraceCallFailed) {
-        console.log('Debug: using eth_simulateV1 for asset discovery')
-        const { tokens, nfts } = await ethSimulateV1(
-          this.baseAccount,
-          this.accountOp,
-          this.#network,
-          state
-        )
-        erc20s = tokens
-        erc721s = nfts
-      }
-
-      if (this.traceCallTimeoutId !== timeoutId) {
-        // If the timeout ID doesn't match, it means that another traceCall has been initiated,
-        // and we should not proceed with this one
-        return
-      }
-
-      const learnedNewTokens = this.#portfolio.addTokensToBeLearned(erc20s, this.#network.chainId)
+      const learnedNewTokens = this.#portfolio.addTokensToBeLearned(
+        discoveredAssets.tokens,
+        this.#network.chainId
+      )
       const learnedNewNfts = this.#portfolio.addErc721sToBeLearned(
-        erc721s,
+        discoveredAssets.nfts,
         this.account.addr,
         this.#network.chainId
       )
 
-      if (this.canUpdate() && (learnedNewTokens || learnedNewNfts)) {
-        !!this.#onUpdateAfterTraceCallSuccess && (await this.#onUpdateAfterTraceCallSuccess())
+      if (
+        this.canUpdate() &&
+        (learnedNewTokens || learnedNewNfts) &&
+        this.#onUpdateAfterTraceCallSuccess
+      ) {
+        await this.#onUpdateAfterTraceCallSuccess()
       }
-
       this.setDiscoveryStatus(TraceCallDiscoveryStatus.Done)
     } catch (e: any) {
       this.setDiscoveryStatus(TraceCallDiscoveryStatus.Failed)


### PR DESCRIPTION
Add: move the 3 methods for token discovery (eth_createAccessList, debug_traceCall, eth_simulateV1) to their own lib and prioritize the successful one

Basically, the comment here covers all the changes:
```
/**
 * Goal: discover tokens that are interacting with the account during a txn
 * To do this, we use 3 methods:
 * - eth_createAccessList
 * - debug_traceCall
 * - eth_simulateV1
 * The end product of each method is the same. However, different methods
 * are supported on different chains depending on the chain configs and RPC.
 * Also, some accounts require state overrides which may not be supported
 * on the specific chain. That's why we have 3 methods and rely on 1
 * having the exact support we need. Each method is called one by one until
 * we hit a success or all methods have failed.
 * We also have a memory cache. It's simple: record the method that succeeded
 * for chain-account. The next time discoverTxnTokens is called, it will start
 * from the method that was successful.
 */
export async function discoverTxnTokens
```