### PR TITLE
Clean up the hanging requests after denying an account switch

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -193,6 +193,7 @@ const prepareTest = async (seedTestDapp = false) => {
 
   return {
     selectedAccountCtrl: mainCtrl.selectedAccount,
+    portfolioCtrl: mainCtrl.portfolio,
     controller: mainCtrl.requests,
     getSignAccountOp,
     getCallsRequest,
@@ -369,6 +370,40 @@ describe('RequestsController ', () => {
     expect(controller.visibleUserRequests.length).toBe(0)
     expect(rejectMock).toHaveBeenCalled()
     expect(resolveMock).not.toHaveBeenCalled()
+  })
+  test('rejecting an account switch removes the pending request and its simulation', async () => {
+    const { controller, getCallsRequest, portfolioCtrl, selectedAccountCtrl } = await prepareTest()
+    const req = await getCallsRequest({
+      addr: accounts[0]!.addr,
+      chainId: 1n
+    })
+    const rejectMock = jest.fn()
+    req.dappPromises = [
+      {
+        id: 'account-switch-request',
+        resolve: jest.fn(),
+        reject: rejectMock,
+        session: MOCK_SESSION,
+        meta: {}
+      }
+    ]
+    const destroySpy = jest.spyOn(req.signAccountOp, 'destroy')
+    const overrideSimulationResultsSpy = jest.spyOn(portfolioCtrl, 'overrideSimulationResults')
+
+    await controller.addUserRequests([req], { allowAccountSwitch: true })
+
+    const switchAccountRequest = controller.userRequests[0]!
+    expect(switchAccountRequest.kind).toBe('switchAccount')
+    expect(controller.userRequestsWaitingAccountSwitch).toStrictEqual([req])
+
+    await controller.rejectUserRequests('User rejected', [switchAccountRequest.id])
+    await selectedAccountCtrl.setAccount(accounts[0]!)
+
+    expect(rejectMock).toHaveBeenCalledTimes(1)
+    expect(overrideSimulationResultsSpy).toHaveBeenCalledWith(req.signAccountOp.accountOp)
+    expect(destroySpy).toHaveBeenCalledTimes(1)
+    expect(controller.userRequestsWaitingAccountSwitch).toHaveLength(0)
+    expect(controller.userRequests).toHaveLength(0)
   })
   test('add multiple user requests', async () => {
     const { controller, getCallsRequest } = await prepareTest()

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -924,7 +924,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         )
 
         requestsToAddOrRemove.forEach((r) => {
-          this.userRequestsWaitingAccountSwitch.splice(this.userRequests.indexOf(r), 1)
+          this.userRequestsWaitingAccountSwitch.splice(
+            this.userRequestsWaitingAccountSwitch.indexOf(r),
+            1
+          )
 
           if (
             r.kind === 'typedMessage' &&
@@ -1001,16 +1004,35 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       shouldOpenNextRequest?: boolean
     }
   ) {
-    this.userRequests
-      .filter((r) => requestIds.includes(r.id))
-      .forEach(async (r) => {
-        r.dappPromises.forEach((p) => p.reject(ethErrors.provider.userRejectedRequest<any>(err)))
+    const userRequestsToReject = this.userRequests.filter((r) => requestIds.includes(r.id))
+    const rejectedSwitchAccountRequestIds = userRequestsToReject
+      .filter((r) => r.kind === 'switchAccount')
+      .map((r) => r.id)
+    const waitingUserRequestsToReject = this.userRequestsWaitingAccountSwitch.filter((r) =>
+      rejectedSwitchAccountRequestIds.includes(r.meta.switchAccountRequestId)
+    )
 
-        // Done here because remove handles approved requests too. We want this logic only on reject
-        if (r.kind === 'calls') {
-          await this.#portfolio.overrideSimulationResults(r.signAccountOp.accountOp)
-        }
-      })
+    userRequestsToReject.forEach((r) => {
+      r.dappPromises.forEach((p) => p.reject(ethErrors.provider.userRejectedRequest<any>(err)))
+    })
+
+    const callsUserRequestsToReject = [
+      ...userRequestsToReject,
+      ...waitingUserRequestsToReject
+    ].filter((r) => r.kind === 'calls') as CallsUserRequest[]
+
+    await Promise.all(
+      callsUserRequestsToReject.map((r) =>
+        this.#portfolio.overrideSimulationResults(r.signAccountOp.accountOp)
+      )
+    )
+
+    waitingUserRequestsToReject.forEach((r) => {
+      if (r.kind === 'calls') r.signAccountOp.destroy()
+    })
+    this.userRequestsWaitingAccountSwitch = this.userRequestsWaitingAccountSwitch.filter(
+      (r) => !waitingUserRequestsToReject.includes(r)
+    )
 
     await this.removeUserRequests(requestIds, options)
   }
@@ -1746,20 +1768,17 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       return
     }
 
+    const switchAccountUserRequest = buildSwitchAccountUserRequest({
+      nextUserRequest: req,
+      selectedAccountAddr: req.meta.accountAddr,
+      dappPromises: req.dappPromises
+    })
+    req.meta.switchAccountRequestId = switchAccountUserRequest.id
     this.userRequestsWaitingAccountSwitch.push(req)
-    await this.addUserRequests(
-      [
-        buildSwitchAccountUserRequest({
-          nextUserRequest: req,
-          selectedAccountAddr: req.meta.accountAddr,
-          dappPromises: req.dappPromises
-        })
-      ],
-      {
-        position: 'last',
-        executionType: 'open-request-window'
-      }
-    )
+    await this.addUserRequests([switchAccountUserRequest], {
+      position: 'last',
+      executionType: 'open-request-window'
+    })
   }
 
   // ! IMPORTANT !


### PR DESCRIPTION
We have this nasty bug:
1. The currently selected account is not the one connected to the dapp
2. We try to do a dapp request
3. An account change request comes
4. We deny it
5. When we do that and we after select the account connected to the dapp in the extension, a simulation persists for the request we were about to make

Video of the bug:

https://github.com/user-attachments/assets/927a6f42-a272-40b9-a25e-9b3b66a28c99

Fixing it by cleaning up after denying the account switch request