### PR TITLE
Update/ PR review: Bump models to sonnet 5, opus 4.8 and GLM 5.2 instead of Kimi K2.6

### DIFF
--- a/.github/workflows/general-review.yml
+++ b/.github/workflows/general-review.yml
@@ -27,12 +27,12 @@ jobs:
       # and without them typing out the whole model name. Done so we can test with both models
       model: >-
         ${{ contains(github.event.comment.body, '--sonnet')
-            && 'openrouter/anthropic/claude-sonnet-4.6'
-            || 'openrouter/moonshotai/kimi-k2.6:nitro' }}
+            && 'openrouter/anthropic/claude-sonnet-5'
+            || 'openrouter/z-ai/glm-5.2:nitro' }}
       fallback_models: >-
         ${{ contains(github.event.comment.body, '--sonnet')
-            && '["openrouter/moonshotai/kimi-k2.6:nitro"]'
-            || '["openrouter/anthropic/claude-sonnet-4.6"]' }}
+            && '["openrouter/z-ai/glm-5.2:nitro"]'
+            || '["openrouter/anthropic/claude-sonnet-5"]' }}
       extra_instructions: |
         You are reviewing changes in `ambire-common`, the environment-agnostic core
         business-logic package of a security-sensitive Web3 wallet. It is imported by

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -22,8 +22,8 @@ jobs:
       contents: read
     uses: ./.github/workflows/pr-agent.yml
     with:
-      model: openrouter/anthropic/claude-opus-4.7
-      fallback_models: '["openrouter/openai/gpt-5.5"]'
+      model: openrouter/anthropic/claude-opus-4.8
+      fallback_models: '["openrouter/openai/gpt-5.6"]'
       require_todo_scan: 'false'
       require_estimate_effort_to_review: 'false'
       extra_instructions: |


### PR DESCRIPTION
Self-explanatory for Anthropic and OpenAI models and GLM 5.2 performs much better than Kimi