### PR TITLE
Fix safe/ signature ordering

### DIFF
--- a/src/libs/safe/safe.ts
+++ b/src/libs/safe/safe.ts
@@ -332,13 +332,17 @@ export function toCallsUserRequest(
           value: call.value,
           data: call.data
         }))
-      } catch (e) {
+      } catch {
         // this just means it's not a batch
         calls = [{ to: txn.to, value: BigInt(txn.value), data: txn.data || '0x' }]
       }
 
-      const signature = txn.confirmations
-        ? (concat(txn.confirmations?.map((c) => c.signature)) as Hex)
+      let signature = txn.confirmations
+        ? sortSigs(
+            txn.confirmations.map((c) => c.signature as Hex),
+            txn.safeTxHash,
+            txn.confirmations
+          )
         : null
       if (!signature) return
       userRequests.push({


### PR DESCRIPTION
When pressing 'Execute' i get toast with error `GS026` execution error and tx reverted. This comes from the estimation

## How to reproduce
- On safe account with 2 signers - signer A and signer B, where BigInt(signer A address) > BigInt(Signer B address)
- Initiate a transaction in the Safe UI using signer A (the bigger one)
- Then go to the ambire extension, switch to the safe account
- Click the `Open` on the banner and in the sign account op screen begin signing with the second account B (smaller)
- Press the sign later option instead of `Execute` and restart the extension
- After opening it again you should not be able to execute this account op from ambire

## Why this broke
When pressing execute, we run an estimation, which takes the field `signature` which had the unsorted concatenated signatures.
It was handled in other places in the codebase, but one place was missed

The reason this was not hit by anyone so far is combination of 1) if you have the signers you are not gonna sign everything and exit before execution and 2) you have to sign first with the bigger address and then the smaller