### PR TITLE
Make the user hold to sign when there's an approval, increase allowance or permit approval / increaseApproval in a multicall

### DIFF
--- a/src/controllers/signAccountOp/nestedTokenApproval.test.ts
+++ b/src/controllers/signAccountOp/nestedTokenApproval.test.ts
@@ -1,0 +1,132 @@
+import { Interface, ZeroHash } from 'ethers'
+
+import { expect, test } from '@jest/globals'
+
+import { getMulticallBanners } from './nestedTokenApproval'
+
+const token = '0x0bF0164D17469241B6E086dA4016DCc54FEAA334'
+const owner = '0x3E1B8F98Ed69C6A97A8540E1D7AeD33FdF4509aA'
+const spender = '0x0012b7C5D4310915bB2d58C0b14C72546D320C05'
+const multicallInterface = new Interface(['function multicall(bytes[] data)'])
+
+const asMulticall = (nestedCalls: string[]) => ({
+  data: multicallInterface.encodeFunctionData('multicall', [nestedCalls])
+})
+
+const approvalCalls = [
+  {
+    name: 'ERC-20 approve',
+    call: new Interface(['function approve(address spender, uint256 value)']).encodeFunctionData(
+      'approve',
+      [spender, 1n]
+    )
+  },
+  {
+    name: 'Permit2 approve',
+    call: new Interface([
+      'function approve(address token, address spender, uint160 amount, uint48 expiration)'
+    ]).encodeFunctionData('approve', [token, spender, 1n, 1n])
+  },
+  {
+    name: 'ERC-20 increaseAllowance',
+    call: new Interface([
+      'function increaseAllowance(address spender, uint256 addedValue)'
+    ]).encodeFunctionData('increaseAllowance', [spender, 1n])
+  },
+  {
+    name: 'legacy ERC-20 increaseApproval',
+    call: new Interface([
+      'function increaseApproval(address spender, uint256 addedValue)'
+    ]).encodeFunctionData('increaseApproval', [spender, 1n])
+  },
+  {
+    name: 'ERC-2612 permit',
+    call: new Interface([
+      'function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)'
+    ]).encodeFunctionData('permit', [owner, spender, 1n, 1n, 27, ZeroHash, ZeroHash])
+  },
+  {
+    name: 'DAI-style permit',
+    call: new Interface([
+      'function permit(address holder, address spender, uint256 nonce, uint256 expiry, bool allowed, uint8 v, bytes32 r, bytes32 s)'
+    ]).encodeFunctionData('permit', [owner, spender, 0n, 1n, true, 27, ZeroHash, ZeroHash])
+  }
+]
+
+test.each(approvalCalls)('detects $name nested in multicall(bytes[])', ({ call }) => {
+  expect(getMulticallBanners([asMulticall([call])])).toEqual([
+    expect.objectContaining({ id: 'nested-token-approval-warning-banner' })
+  ])
+})
+
+test('returns the nested token approval banner entry', () => {
+  const transfer = new Interface([
+    'function transfer(address recipient, uint256 value)'
+  ]).encodeFunctionData('transfer', [spender, 1n])
+
+  expect(getMulticallBanners([asMulticall([approvalCalls[0]!.call, transfer])])).toEqual([
+    {
+      id: 'nested-token-approval-warning-banner',
+      type: 'warning',
+      text: 'This multicall includes a token approval. Make sure you trust the spender and the amount before signing.'
+    }
+  ])
+})
+
+test('does not detect direct approvals or Safe MultiSend calls', () => {
+  expect(getMulticallBanners([{ data: approvalCalls[0]!.call }])).toEqual([])
+  expect(getMulticallBanners([{ data: '0x8d80ff0a' }])).toEqual([])
+})
+
+test('ignores revocations, no-op increases, and unrelated calls', () => {
+  const approveInterface = new Interface(['function approve(address spender, uint256 value)'])
+  const increaseAllowanceInterface = new Interface([
+    'function increaseAllowance(address spender, uint256 addedValue)'
+  ])
+  const daiPermitInterface = new Interface([
+    'function permit(address holder, address spender, uint256 nonce, uint256 expiry, bool allowed, uint8 v, bytes32 r, bytes32 s)'
+  ])
+  const transferInterface = new Interface(['function transfer(address recipient, uint256 value)'])
+
+  expect(
+    getMulticallBanners([
+      asMulticall([
+        approveInterface.encodeFunctionData('approve', [spender, 0n]),
+        increaseAllowanceInterface.encodeFunctionData('increaseAllowance', [spender, 0n]),
+        daiPermitInterface.encodeFunctionData('permit', [
+          owner,
+          spender,
+          0n,
+          1n,
+          false,
+          27,
+          ZeroHash,
+          ZeroHash
+        ]),
+        transferInterface.encodeFunctionData('transfer', [spender, 1n])
+      ])
+    ])
+  ).toEqual([])
+  expect(getMulticallBanners([asMulticall([])])).toEqual([])
+})
+
+test('returns a separate warning for malformed multicall arguments', () => {
+  const malformedMulticall = { data: '0xac9650d8' }
+
+  expect(getMulticallBanners([malformedMulticall])).toEqual([
+    {
+      id: 'malformed-multicall-warning-banner',
+      type: 'warning',
+      text: "We couldn't inspect the actions inside this multicall. Proceed only if you trust the app."
+    }
+  ])
+})
+
+test('returns both banners for separate approval and malformed multicalls', () => {
+  expect(
+    getMulticallBanners([asMulticall([approvalCalls[0]!.call]), { data: '0xac9650d8' }])
+  ).toEqual([
+    expect.objectContaining({ id: 'nested-token-approval-warning-banner' }),
+    expect.objectContaining({ id: 'malformed-multicall-warning-banner' })
+  ])
+})

--- a/src/controllers/signAccountOp/nestedTokenApproval.ts
+++ b/src/controllers/signAccountOp/nestedTokenApproval.ts
@@ -1,0 +1,127 @@
+import { Interface } from 'ethers'
+
+import { SignAccountOpBanner } from '../../interfaces/signAccountOp'
+import { Call } from '../../libs/accountOp/types'
+
+const multicallInterface = new Interface(['function multicall(bytes[] data)'])
+const erc20ApproveInterface = new Interface(['function approve(address spender, uint256 value)'])
+const permit2ApproveInterface = new Interface([
+  'function approve(address token, address spender, uint160 amount, uint48 expiration)'
+])
+const increaseAllowanceInterface = new Interface([
+  'function increaseAllowance(address spender, uint256 addedValue)'
+])
+const increaseApprovalInterface = new Interface([
+  'function increaseApproval(address spender, uint256 addedValue)'
+])
+const erc2612PermitInterface = new Interface([
+  'function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)'
+])
+const daiPermitInterface = new Interface([
+  'function permit(address holder, address spender, uint256 nonce, uint256 expiry, bool allowed, uint8 v, bytes32 r, bytes32 s)'
+])
+
+const MULTICALL_SELECTOR = multicallInterface.getFunction('multicall')!.selector
+const ERC20_APPROVE_SELECTOR = erc20ApproveInterface.getFunction('approve')!.selector
+const PERMIT2_APPROVE_SELECTOR = permit2ApproveInterface.getFunction('approve')!.selector
+const INCREASE_ALLOWANCE_SELECTOR =
+  increaseAllowanceInterface.getFunction('increaseAllowance')!.selector
+const INCREASE_APPROVAL_SELECTOR =
+  increaseApprovalInterface.getFunction('increaseApproval')!.selector
+const ERC2612_PERMIT_SELECTOR = erc2612PermitInterface.getFunction('permit')!.selector
+const DAI_PERMIT_SELECTOR = daiPermitInterface.getFunction('permit')!.selector
+
+type MulticallInspection =
+  | { type: 'not-multicall' | 'malformed' }
+  | { type: 'decoded'; nestedCalls: readonly string[] }
+
+const inspectMulticall = (call: Pick<Call, 'data'>): MulticallInspection => {
+  if (!call.data || call.data.slice(0, 10).toLowerCase() !== MULTICALL_SELECTOR)
+    return { type: 'not-multicall' }
+
+  try {
+    const [nestedCalls] = multicallInterface.decodeFunctionData('multicall', call.data)
+
+    return { type: 'decoded', nestedCalls }
+  } catch {
+    return { type: 'malformed' }
+  }
+}
+
+const grantsTokenApproval = (data: string): boolean => {
+  const selector = data.slice(0, 10).toLowerCase()
+
+  try {
+    if (selector === ERC20_APPROVE_SELECTOR) {
+      const [, value] = erc20ApproveInterface.decodeFunctionData('approve', data)
+      return value > 0n
+    }
+
+    if (selector === PERMIT2_APPROVE_SELECTOR) {
+      const [, , amount] = permit2ApproveInterface.decodeFunctionData('approve', data)
+      return amount > 0n
+    }
+
+    if (selector === INCREASE_ALLOWANCE_SELECTOR) {
+      const [, addedValue] = increaseAllowanceInterface.decodeFunctionData(
+        'increaseAllowance',
+        data
+      )
+      return addedValue > 0n
+    }
+
+    if (selector === INCREASE_APPROVAL_SELECTOR) {
+      const [, addedValue] = increaseApprovalInterface.decodeFunctionData('increaseApproval', data)
+      return addedValue > 0n
+    }
+
+    if (selector === ERC2612_PERMIT_SELECTOR) {
+      const [, , value] = erc2612PermitInterface.decodeFunctionData('permit', data)
+      return value > 0n
+    }
+
+    if (selector === DAI_PERMIT_SELECTOR) {
+      const [, , , , allowed] = daiPermitInterface.decodeFunctionData('permit', data)
+      return allowed
+    }
+  } catch {
+    return false
+  }
+
+  return false
+}
+
+export const getMulticallBanners = (calls: Pick<Call, 'data'>[]): SignAccountOpBanner[] => {
+  let hasNestedTokenApproval = false
+  let hasMalformedMulticall = false
+
+  for (const call of calls) {
+    const inspection = inspectMulticall(call)
+    if (inspection.type === 'malformed') hasMalformedMulticall = true
+    if (inspection.type === 'decoded' && inspection.nestedCalls.some(grantsTokenApproval)) {
+      hasNestedTokenApproval = true
+    }
+
+    if (hasNestedTokenApproval && hasMalformedMulticall) break
+  }
+
+  const banners: SignAccountOpBanner[] = []
+
+  if (hasNestedTokenApproval) {
+    banners.push({
+      id: 'nested-token-approval-warning-banner',
+      type: 'warning',
+      text: 'This multicall includes a token approval. Make sure you trust the spender and the amount before signing.'
+    })
+  }
+
+  if (hasMalformedMulticall) {
+    banners.push({
+      id: 'malformed-multicall-warning-banner',
+      type: 'warning',
+      text: "We couldn't inspect the actions inside this multicall. Proceed only if you trust the app."
+    })
+  }
+
+  return banners
+}

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -160,6 +160,7 @@ import {
   isUnderpriced,
   SignAccountOpType
 } from './helper'
+import { getMulticallBanners } from './nestedTokenApproval'
 import {
   SignAccountOpFeeTokenPreference,
   SignAccountOpPreferenceController
@@ -3904,6 +3905,8 @@ export class SignAccountOpController
         })
       }
     }
+
+    banners.push(...getMulticallBanners(this.accountOp.calls))
 
     const dappVerificationBanner = this.#getDappVerificationBanner()
     if (dappVerificationBanner) banners.push(dappVerificationBanner)


### PR DESCRIPTION
We switch signAccountOp to a warning state when there's an approval / allowance call as part of a multicall

<img width="728" height="760" alt="Screenshot 2026-07-27 at 14 24 26" src="https://github.com/user-attachments/assets/2fc26ad6-500f-4614-8532-2232702d30d8" />
