### PR TITLE
Fix: move the simulation discard to updateSelectedAccount to prevent it from overriding legit simulations

### DIFF
--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -1064,13 +1064,13 @@ describe('Portfolio Controller ', () => {
         states: accountStates[account.addr]!
       })
 
-      const updateSelectedAccountSpy = jest.spyOn(controller, 'updateSelectedAccount')
+      const updatePortfolioStateSpy = jest.spyOn(controller as any, 'updatePortfolioState')
       const nonMatchingAccountOp = structuredClone(accountOp['1']![0]!)
       nonMatchingAccountOp.accountAddr = account2.addr
 
       await controller.discardSimulation([nonMatchingAccountOp])
 
-      expect(updateSelectedAccountSpy).not.toHaveBeenCalled()
+      expect(updatePortfolioStateSpy).not.toHaveBeenCalled()
       expect(getEthereumPortfolioState(controller).accountOps).toStrictEqual(accountOp['1'])
       expect(getSimulatedCollection(controller)?.amountPostSimulation).toBe(0n)
     })
@@ -1118,6 +1118,57 @@ describe('Portfolio Controller ', () => {
       })
 
       await Promise.all([discardPromise, updatePromise])
+
+      const stateAfter = getEthereumPortfolioState(controller)
+
+      expect(areAccountOpsEqual(stateAfter.accountOps!, newAccountOp['1']!)).toBe(true)
+    })
+    test('discardSimulation does not discard a newer simulation that is already in progress', async () => {
+      const { controller } = await prepareTest({ skipAccountStateFetch: false })
+      const oldAccountOp = await getAccountOp()
+      const newAccountOp = await getAccountOp('0x932261f9fc8da46c4a22e31b45c4de60623848bf', 39118)
+      const accountStates = await getAccountsInfo([account])
+
+      await controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: oldAccountOp,
+        states: accountStates[account.addr]!
+      })
+
+      let resolveNewSimulationStarted: () => void = () => {}
+      const newSimulationStarted = new Promise<void>((resolve) => {
+        resolveNewSimulationStarted = resolve
+      })
+      let resolveNewSimulation: () => void = () => {}
+      const newSimulationCanFinish = new Promise<void>((resolve) => {
+        resolveNewSimulation = resolve
+      })
+      const originalUpdatePortfolioState = (controller as any).updatePortfolioState.bind(controller)
+
+      jest
+        .spyOn(controller as any, 'updatePortfolioState')
+        .mockImplementation(async (...args: any[]) => {
+          const simulatedAccountOp = args[3]?.simulation?.accountOps?.[0]
+
+          if (simulatedAccountOp?.id === newAccountOp['1']![0]!.id) {
+            resolveNewSimulationStarted()
+            await newSimulationCanFinish
+          }
+
+          return originalUpdatePortfolioState(...args)
+        })
+
+      const updatePromise = controller.updateSelectedAccount(account.addr, [ethereum], {
+        accountOps: newAccountOp,
+        states: accountStates[account.addr]!
+      })
+
+      await newSimulationStarted
+      const discardPromise = controller.discardSimulation(oldAccountOp['1']!)
+
+      // Let discardSimulation enqueue its atomic AccountOp ID check behind the running simulation.
+      await wait(0)
+      resolveNewSimulation()
+      await Promise.all([updatePromise, discardPromise])
 
       const stateAfter = getEthereumPortfolioState(controller)
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -1882,6 +1882,11 @@ export class PortfolioController
           )
             return
 
+          // currentAccountOps || simulatedAccountOps means that pendingToBeConfirmed
+          // accountOps will be discarded if a new transaction on the same network comes.
+          // We evaluated the complexity to fix this and decided it's not worth it.
+          // When a new txn comes, pendingToBeConfirmed simulations will be dropped
+          // and that's fine as you care about the simulation of your current txn
           const accountOpsToSimulate = accountOpIdsToDiscardOnNetwork
             ? simulatedAccountOps!.filter((op) => !accountOpIdsToDiscardSet.has(op.id))
             : currentAccountOps || simulatedAccountOps

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -812,28 +812,19 @@ export class PortfolioController
    * Example usage: after an account op is broadcasted and confirmed
    */
   async discardSimulation(accountOps: AccountOp[]) {
-    let networksToUpdate: Network[] = []
-    let accountAddrToUpdate: string | null = null
-    let accountOpsAfterUpdate: { [key: string]: AccountOp[] } = {}
+    const updatesByAccount: {
+      [accountAddr: string]: {
+        networksByChainId: { [chainId: string]: Network }
+        accountOpIdsByChainId: { [chainId: string]: string[] }
+      }
+    } = {}
 
     accountOps.forEach((accountOp) => {
       const { accountAddr, chainId } = accountOp
+      const chainIdString = chainId.toString()
 
-      if (!this.#state[accountAddr] || !this.#state[accountAddr][chainId.toString()]) return
+      if (!this.#state[accountAddr]?.[chainIdString]) return
 
-      const networkState = this.#state[accountAddr][chainId.toString()]!
-
-      if (!networkState.result || !networkState.accountOps) return
-
-      accountOpsAfterUpdate[chainId.toString()] = structuredClone(networkState.accountOps || [])
-
-      const accountOpIndex = accountOpsAfterUpdate[chainId.toString()]!.findIndex(
-        (op) => op.id === accountOp.id
-      )
-
-      if (accountOpIndex === -1) return
-
-      accountOpsAfterUpdate[chainId.toString()]!.splice(accountOpIndex, 1)
       const networkData = this.#networks.networks.find((n) => n.chainId === chainId)
 
       if (!networkData) {
@@ -845,18 +836,35 @@ export class PortfolioController
         return
       }
 
-      networksToUpdate.push(networkData)
-      accountAddrToUpdate = accountAddr
+      if (!updatesByAccount[accountAddr]) {
+        updatesByAccount[accountAddr] = {
+          networksByChainId: {},
+          accountOpIdsByChainId: {}
+        }
+      }
+
+      updatesByAccount[accountAddr].networksByChainId[chainIdString] = networkData
+      updatesByAccount[accountAddr].accountOpIdsByChainId[chainIdString] = [
+        ...(updatesByAccount[accountAddr].accountOpIdsByChainId[chainIdString] || []),
+        accountOp.id
+      ]
     })
 
-    if (!accountAddrToUpdate || networksToUpdate.length === 0) return
-    this.debugLog('simulation', `Discarding simulation for ${accountAddrToUpdate}`, () => ({
-      discardedOpIds: accountOps.map((op) => op.id),
-      chainIds: networksToUpdate.map((n) => n.chainId.toString())
-    }))
-    await this.updateSelectedAccount(accountAddrToUpdate, networksToUpdate, {
-      accountOps: accountOpsAfterUpdate
-    })
+    await Promise.all(
+      Object.entries(updatesByAccount).map(
+        async ([accountAddr, { networksByChainId, accountOpIdsByChainId }]) => {
+          const networksToUpdate = Object.values(networksByChainId)
+
+          this.debugLog('simulation', `Discarding simulation for ${accountAddr}`, () => ({
+            discardedOpIds: Object.values(accountOpIdsByChainId).flat(),
+            chainIds: Object.keys(networksByChainId)
+          }))
+          await this.updateSelectedAccount(accountAddr, networksToUpdate, undefined, {
+            accountOpIdsToDiscard: accountOpIdsByChainId
+          })
+        }
+      )
+    )
   }
 
   async updateTokenValidationByStandard(
@@ -1808,6 +1816,7 @@ export class PortfolioController
       maxDataAgeMsUnused?: number
       isManualUpdate?: boolean
       bypassServerSideCache?: boolean
+      accountOpIdsToDiscard?: { [chainId: string]: string[] }
     }
   ) {
     const {
@@ -1817,7 +1826,8 @@ export class PortfolioController
       // portfolio updates, most of which shouldn't update the defi positions.
       defiMaxDataAgeMs = -1,
       isManualUpdate,
-      bypassServerSideCache
+      bypassServerSideCache,
+      accountOpIdsToDiscard
     } = opts || {}
     await this.initialLoadPromise
     const selectedAccount = this.#accounts.accounts.find((x) => x.addr === accountId)
@@ -1861,14 +1871,27 @@ export class PortfolioController
           const networkAccountState =
             this.#accounts.accountStates?.[accountId]?.[network.chainId.toString()]
           const simulatedAccountOps = accountState[network.chainId.toString()]?.accountOps
-          const accountOpsToSimulate = currentAccountOps || simulatedAccountOps
+          const accountOpIdsToDiscardOnNetwork = accountOpIdsToDiscard?.[network.chainId.toString()]
+          const accountOpIdsToDiscardSet = new Set(accountOpIdsToDiscardOnNetwork)
+
+          // Read and filter the latest simulation inside the queue so an older confirmed
+          // AccountOp cannot discard a newer simulation that was already queued before it.
+          if (
+            accountOpIdsToDiscardOnNetwork &&
+            !simulatedAccountOps?.some((op) => accountOpIdsToDiscardSet.has(op.id))
+          )
+            return
+
+          const accountOpsToSimulate = accountOpIdsToDiscardOnNetwork
+            ? simulatedAccountOps!.filter((op) => !accountOpIdsToDiscardSet.has(op.id))
+            : currentAccountOps || simulatedAccountOps
 
           // Even if maxDataAgeMs is set to a non-zero value, we want to force an update when the AccountOps change.
           // We pass undefined, because setting the value to 0 would imply a manual update by the user.
           const maxDataAgeMs = this.#getMaxDataAgeMs(
             accountId,
             network.chainId,
-            !!currentAccountOps,
+            !!currentAccountOps || !!accountOpIdsToDiscardOnNetwork,
             paramsMaxDataAgeMs,
             paramsMaxDataAgeMsUnused
           )


### PR DESCRIPTION
# Portfolio simulation race condition

## The problem

Portfolio simulations are stored per account and network, not per transaction request.

This means that when two transaction requests happen one after another on the same network, both requests use the same portfolio simulation state.

A common example is:

1. A dapp asks the user to approve a token.
2. The approval is broadcast, and Ambire opens Benzin to track it.
3. The dapp detects that the approval is confirmed.
4. The dapp immediately sends a second transaction request, such as a swap.
5. Ambire starts simulating the second transaction.
6. Shortly afterward, Ambire’s own activity tracker detects that the approval is confirmed and removes its old simulation.

The problem was caused by when Ambire read the simulation state.

## What happened internally

Assume the portfolio currently contains the approval simulation:

```text
Current simulation: request 1
```

The second transaction starts its simulation. Portfolio updates are processed through a queue, so request 2 waits for its turn or begins running.

While request 2 is running, the stored portfolio state may still contain request 1. The new result is written only after the simulation finishes.

At the same time, Ambire detects that request 1 is confirmed and calls `discardSimulation`.

Previously, `discardSimulation` immediately read the current state:

```text
Current simulation: request 1
```

It removed request 1 from that snapshot:

```text
Simulation after removal: empty
```

It then queued a portfolio update using this already-created empty snapshot.

The queue could therefore execute updates in this order:

```text
1. Request 2 simulation finishes
   → Correct request 2 result is displayed

2. Request 1 discard update finishes
   → The simulation is cleared
   → “No token balance changes detected” is displayed
```

This explains why the correct simulation could appear briefly and then disappear.

The portfolio queue itself was working correctly. The problem was that `discardSimulation` decided what to remove before entering the queue.

## The fix

`discardSimulation` no longer reads and modifies the simulation state before entering the queue.

Instead, it sends only the IDs of the confirmed AccountOps into the queue.

When the discard operation reaches its turn, it:

1. Reads the latest portfolio simulation state.
2. Checks whether the confirmed AccountOp is still present.
3. Removes only AccountOps whose IDs match.
4. Leaves all newer simulations untouched.

With the fixed logic, the problematic sequence becomes:

```text
1. Request 2 simulation finishes
   → Current simulation becomes request 2

2. Request 1 discard operation starts
   → Reads the latest state
   → Finds request 2
   → Does not find request 1
   → Makes no changes
```

If the discard operation runs before request 2, it removes request 1 first, and request 2 runs afterward. That ordering is also safe.

Therefore, both possible orderings now produce the correct final result.

## Regression test

A regression test was added for the exact failing sequence:

1. Store request 1 as the current simulation.
2. Start request 2 and pause it before completion.
3. Request the removal of request 1 while request 2 is running.
4. Allow request 2 to finish.
5. Allow the queued discard operation to run.
6. Confirm that request 2 is still the active portfolio simulation.

This test protects against the same race condition being introduced again.