### PR TITLE
Fix Send infinite loading after hung portfolio updates

### DIFF
--- a/src/consts/intervals.ts
+++ b/src/consts/intervals.ts
@@ -15,3 +15,11 @@ export const PHISHING_FAILED_TO_GET_UPDATE_INTERVAL = 600000 // 10 minutes
 export const ESTIMATE_UPDATE_INTERVAL = 30000
 export const GAS_PRICE_UPDATE_INTERVAL = 12000
 export const FETCH_SAFE_TXNS = 3 * 60 * 1000 // 3 minutes
+/** Hard ceiling for a single network portfolio update (tokens + custom DeFi). */
+export const PORTFOLIO_NETWORK_UPDATE_TIMEOUT_MS = 60 * 1000
+/** isLoading older than this is treated as stuck — later updates must not skip forever. */
+export const PORTFOLIO_LOADING_MAX_AGE_MS = 60 * 1000
+/** Timeout for custom on-chain DeFi position fetches (AAVE / Uni V3). */
+export const CUSTOM_DEFI_POSITIONS_TIMEOUT_MS = 30 * 1000
+/** Timeout for AAVE's pre-deployless reservesLength staticCall. */
+export const AAVE_STATIC_CALL_TIMEOUT_MS = 15 * 1000

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -9,7 +9,11 @@ import { suppressConsole, suppressConsoleBeforeEach } from '../../../test/helper
 import { makeMainController } from '../../../test/helpers/mainController'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { BALANCE_GETTER, NFT_GETTER } from '../../consts/deploy'
-import { BLACKLIST_UPDATE_INTERVAL } from '../../consts/intervals'
+import {
+  BLACKLIST_UPDATE_INTERVAL,
+  PORTFOLIO_LOADING_MAX_AGE_MS,
+  PORTFOLIO_NETWORK_UPDATE_TIMEOUT_MS
+} from '../../consts/intervals'
 import { networks } from '../../consts/networks'
 import { PINNED_TOKENS } from '../../consts/pinnedTokens'
 import { Account, AccountOnchainState, AccountStates } from '../../interfaces/account'
@@ -3925,6 +3929,167 @@ describe('Portfolio Controller ', () => {
 
       expect(networkParams).toContain('1')
       expect(networkParams).toContain('customAppChain')
+    })
+  })
+
+  describe('hung portfolio update recovery', () => {
+    const minimalPortfolioGetResult = {
+      updateStarted: Date.now(),
+      discoveryTime: 0,
+      oracleCallTime: 0,
+      priceUpdateTime: 0,
+      tokenDataCache: new Map(),
+      tokens: [],
+      feeTokens: [],
+      toBeLearned: { erc20s: {}, erc721s: {} },
+      tokenErrors: [],
+      collectionErrors: [],
+      collections: [],
+      errors: [],
+      blockNumber: 1,
+      beforeNonce: 0n,
+      afterNonce: 0n
+    } as PortfolioLibGetResult
+
+    async function seedAccountNetworkState(controller: PortfolioController) {
+      jest
+        .spyOn(Portfolio.prototype, 'get')
+        .mockResolvedValue(minimalPortfolioGetResult)
+      jest.spyOn(defiPositionsLib, 'getCustomProviderPositions').mockResolvedValue({
+        positionsByProvider: [],
+        providerErrors: []
+      })
+      // @ts-expect-error private method
+      jest.spyOn(controller, 'getPortfolioFromApiDiscovery').mockResolvedValue(null)
+
+      await controller.updateSelectedAccount(account.addr, [ethereum], undefined, {
+        maxDataAgeMs: 0,
+        defiMaxDataAgeMs: -1,
+        isManualUpdate: true
+      })
+
+      jest.restoreAllMocks()
+    }
+
+    it('does not skip a network update when isLoading is older than PORTFOLIO_LOADING_MAX_AGE_MS', async () => {
+      const { restore } = suppressConsole()
+      const { controller } = await prepareTest()
+      await seedAccountNetworkState(controller)
+
+      const networkState = controller.getAccountPortfolioState(account.addr)['1']
+      expect(networkState).toBeDefined()
+      networkState!.isLoading = true
+      networkState!.loadingStartedAt = Date.now() - PORTFOLIO_LOADING_MAX_AGE_MS - 1000
+      // Age-based skip must not apply either — otherwise we cannot isolate the isLoading fix
+      if (networkState!.result) {
+        ;(networkState!.result as PortfolioNetworkResult).updateStarted =
+          Date.now() - 60 * 1000 - 1000
+      }
+      networkState!.lastSuccessfulUpdate = Date.now() - 60 * 1000 - 1000
+
+      let getCalledAfterStaleLoading = false
+      jest.spyOn(Portfolio.prototype, 'get').mockImplementation(async () => {
+        getCalledAfterStaleLoading = true
+        return minimalPortfolioGetResult
+      })
+      jest.spyOn(defiPositionsLib, 'getCustomProviderPositions').mockResolvedValue({
+        positionsByProvider: [],
+        providerErrors: []
+      })
+      // @ts-expect-error private method
+      jest.spyOn(controller, 'getPortfolioFromApiDiscovery').mockResolvedValue(null)
+
+      await controller.updateSelectedAccount(account.addr, [ethereum], undefined, {
+        maxDataAgeMs: 60 * 1000,
+        defiMaxDataAgeMs: -1,
+        isManualUpdate: false
+      })
+
+      expect(getCalledAfterStaleLoading).toBe(true)
+      expect(controller.getAccountPortfolioState(account.addr)['1']?.isLoading).toBe(false)
+      restore()
+    })
+
+    it('still skips a network update while isLoading is recent', async () => {
+      const { restore } = suppressConsole()
+      const { controller } = await prepareTest()
+      await seedAccountNetworkState(controller)
+
+      const networkState = controller.getAccountPortfolioState(account.addr)['1']
+      expect(networkState).toBeDefined()
+      networkState!.isLoading = true
+      networkState!.loadingStartedAt = Date.now()
+      if (networkState!.result) {
+        ;(networkState!.result as PortfolioNetworkResult).updateStarted =
+          Date.now() - 60 * 1000 - 1000
+      }
+      networkState!.lastSuccessfulUpdate = Date.now() - 60 * 1000 - 1000
+
+      let getCalled = false
+      jest.spyOn(Portfolio.prototype, 'get').mockImplementation(async () => {
+        getCalled = true
+        return minimalPortfolioGetResult
+      })
+      jest.spyOn(defiPositionsLib, 'getCustomProviderPositions').mockResolvedValue({
+        positionsByProvider: [],
+        providerErrors: []
+      })
+      // @ts-expect-error private method
+      jest.spyOn(controller, 'getPortfolioFromApiDiscovery').mockResolvedValue(null)
+
+      await controller.updateSelectedAccount(account.addr, [ethereum], undefined, {
+        maxDataAgeMs: 60 * 1000,
+        defiMaxDataAgeMs: -1,
+        isManualUpdate: false
+      })
+
+      expect(getCalled).toBe(false)
+      expect(controller.getAccountPortfolioState(account.addr)['1']?.isLoading).toBe(true)
+      restore()
+    })
+
+    it('clears isLoading when portfolioLib.get hangs past PORTFOLIO_NETWORK_UPDATE_TIMEOUT_MS', async () => {
+      const { restore } = suppressConsole()
+      const { controller } = await prepareTest()
+      await seedAccountNetworkState(controller)
+
+      jest
+        .spyOn(Portfolio.prototype, 'get')
+        .mockImplementation(() => new Promise(() => {}) as Promise<PortfolioLibGetResult>)
+      jest.spyOn(defiPositionsLib, 'getCustomProviderPositions').mockResolvedValue({
+        positionsByProvider: [],
+        providerErrors: []
+      })
+      // @ts-expect-error private method
+      jest.spyOn(controller, 'getPortfolioFromApiDiscovery').mockResolvedValue(null)
+
+      jest.useFakeTimers()
+      try {
+        // @ts-expect-error protected method
+        const updatePromise = controller.updatePortfolioState(
+          account,
+          ethereum,
+          controller.initializePortfolioLibIfNeeded(account.addr, ethereum.chainId, ethereum),
+          { defiMaxDataAgeMs: -1, hasKeys: true, maxDataAgeMs: 0, isManualUpdate: true }
+        )
+
+        // Runs sync until the first await; isLoading is already set
+        expect(controller.getAccountPortfolioState(account.addr)['1']?.isLoading).toBe(true)
+
+        // Let mocked discovery resolve, then fire the network-update timeout
+        await Promise.resolve()
+        await jest.advanceTimersByTimeAsync(PORTFOLIO_NETWORK_UPDATE_TIMEOUT_MS + 50)
+        const [success] = await updatePromise
+
+        expect(success).toBe(false)
+        expect(controller.getAccountPortfolioState(account.addr)['1']?.isLoading).toBe(false)
+        expect(
+          controller.getAccountPortfolioState(account.addr)['1']?.criticalError?.message
+        ).toMatch(/took too long/i)
+      } finally {
+        jest.useRealTimers()
+        restore()
+      }
     })
   })
 })

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -5,7 +5,11 @@ import {
   RecurringTimeout
 } from '../../classes/recurringTimeout/recurringTimeout'
 import { STK_WALLET } from '../../consts/addresses'
-import { BLACKLIST_UPDATE_INTERVAL } from '../../consts/intervals'
+import {
+  BLACKLIST_UPDATE_INTERVAL,
+  PORTFOLIO_LOADING_MAX_AGE_MS,
+  PORTFOLIO_NETWORK_UPDATE_TIMEOUT_MS
+} from '../../consts/intervals'
 import {
   Account,
   AccountId,
@@ -85,6 +89,7 @@ import { PORTFOLIO_LIB_ERROR_NAMES } from '../../libs/portfolio/portfolio'
 import { getFlags } from '../../libs/portfolio/tokenProcessing'
 import { BindedRelayerCall, relayerCall } from '../../libs/relayerCall/relayerCall'
 import { isInternalChain } from '../../libs/selectedAccount/selectedAccount'
+import { withTimeout } from '../../utils/with-timeout'
 import EventEmitter from '../eventEmitter/eventEmitter'
 import { HintsController } from '../hintsController/hintsController'
 
@@ -616,6 +621,11 @@ export class PortfolioController
     if (!accountState) return
     if (!accountState[network]) accountState[network] = { errors: [], isReady: false, isLoading }
     accountState[network]!.isLoading = isLoading
+    if (isLoading) {
+      accountState[network]!.loadingStartedAt = Date.now()
+    } else {
+      delete accountState[network]!.loadingStartedAt
+    }
     if (error)
       accountState[network]!.criticalError = {
         message:
@@ -1190,7 +1200,14 @@ export class PortfolioController
         : 0
     const isWithinMinUpdateInterval = !!updateStarted && Date.now() - updateStarted < maxDataAgeMs
 
-    return isWithinMinUpdateInterval || networkState.isLoading
+    // Only treat isLoading as a skip while the update is still within the max age.
+    // A hung update that never clears isLoading must not block retries forever.
+    const isLoadingRecently =
+      networkState.isLoading &&
+      !!networkState.loadingStartedAt &&
+      Date.now() - networkState.loadingStartedAt < PORTFOLIO_LOADING_MAX_AGE_MS
+
+    return isWithinMinUpdateInterval || isLoadingRecently
   }
 
   /**
@@ -1387,8 +1404,8 @@ export class PortfolioController
     if (!accountState) return [false, null]
 
     if (!accountState[network.chainId.toString()]) {
-      // isLoading must be false here, otherwise canSkipUpdate will return true
-      // and portfolio will not be updated
+      // isLoading must be false here (and without a fresh loadingStartedAt), otherwise
+      // canSkipUpdate may treat the network as mid-update and skip the real fetch
       accountState[network.chainId.toString()] = { isLoading: false, isReady: false, errors: [] }
     }
 
@@ -1413,6 +1430,7 @@ export class PortfolioController
 
     this.#setNetworkLoading(account.addr, network.chainId.toString(), true)
     const state = accountState[network.chainId.toString()]!
+    const loadingStartedAt = state.loadingStartedAt
     if (isManualUpdate) state.criticalError = undefined
 
     this.emitUpdate()
@@ -1420,6 +1438,9 @@ export class PortfolioController
     const hasNonZeroTokens = !!Object.values(
       this.#networksWithAssetsByAccounts?.[account.addr] || {}
     ).some(Boolean)
+
+    const isCurrentUpdate = () =>
+      accountState[network.chainId.toString()]?.loadingStartedAt === loadingStartedAt
 
     try {
       if (!portfolioLib)
@@ -1463,28 +1484,41 @@ export class PortfolioController
         delete state.verification
       }
 
-      // Fetch the portfolio and custom defi positions in parallel
-      const [portfolioResult, customPositionsResult] = await Promise.all([
-        portfolioLib.get(account.addr, {
-          tokenDataRecency: 60000 * 5,
-          tokenDataCache: networkTokenDataCache,
-          fetchPinned: !hasNonZeroTokens,
-          ...allHints,
-          ...portfolioProps,
-          blockTag: 'both',
-          disableAutoDiscovery: true,
-          blacklist: this.#blacklist
-        }),
-        getCustomProviderPositions(
-          account.addr,
-          portfolioLib.provider,
-          network,
-          this.#fetch,
-          state.result?.defiPositions.positionsByProvider || [],
-          discoveryData?.data?.defi?.positions,
-          getIsExternalApiDefiPositionsCallSuccessful(discoveryData)
-        )
-      ])
+      // Fetch the portfolio and custom defi positions in parallel.
+      // Hard timeout so a hung RPC cannot leave isLoading=true forever (blocks Send and
+      // the per-network update queue). Soft timeout: late results are discarded via
+      // loadingStartedAt if a newer update has already started.
+      const [portfolioResult, customPositionsResult] = await withTimeout(
+        () =>
+          Promise.all([
+            portfolioLib.get(account.addr, {
+              tokenDataRecency: 60000 * 5,
+              tokenDataCache: networkTokenDataCache,
+              fetchPinned: !hasNonZeroTokens,
+              ...allHints,
+              ...portfolioProps,
+              blockTag: 'both',
+              disableAutoDiscovery: true,
+              blacklist: this.#blacklist
+            }),
+            getCustomProviderPositions(
+              account.addr,
+              portfolioLib.provider,
+              network,
+              this.#fetch,
+              state.result?.defiPositions.positionsByProvider || [],
+              discoveryData?.data?.defi?.positions,
+              getIsExternalApiDefiPositionsCallSuccessful(discoveryData)
+            )
+          ]),
+        {
+          timeoutMs: PORTFOLIO_NETWORK_UPDATE_TIMEOUT_MS,
+          message: `Fetching balances on ${network.name} took too long. Please try again.`
+        }
+      )
+
+      // A newer update superseded this one (e.g. after we timed out and retried).
+      if (!isCurrentUpdate()) return [false, null]
 
       const stkWalletToken =
         portfolioResult.tokens.find(
@@ -1598,6 +1632,9 @@ export class PortfolioController
 
       return [true, discoveryData]
     } catch (e: any) {
+      // Timed-out / failed update that was superseded by a newer one — do not touch state.
+      if (!isCurrentUpdate()) return [false, null]
+
       this.emitError({
         level: 'silent',
         message: `Error while executing the 'get' function in the portfolio library on ${network.name} (${network.chainId})`,
@@ -1605,6 +1642,7 @@ export class PortfolioController
       })
       state.accountOps = portfolioProps?.simulation?.accountOps
       state.isLoading = false
+      delete state.loadingStartedAt
       if (state.verification?.status === 'loading') {
         state.verification = {
           provider: 'colibri',

--- a/src/libs/defiPositions/defiPositions.test.ts
+++ b/src/libs/defiPositions/defiPositions.test.ts
@@ -1,9 +1,13 @@
-import { ZeroAddress } from 'ethers'
+import { Contract, ZeroAddress } from 'ethers'
 
-import { describe, expect, test } from '@jest/globals'
+import { describe, expect, jest, test } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
 import { STK_WALLET } from '../../consts/addresses'
+import {
+  AAVE_STATIC_CALL_TIMEOUT_MS,
+  CUSTOM_DEFI_POSITIONS_TIMEOUT_MS
+} from '../../consts/intervals'
 import { networks } from '../../consts/networks'
 import { getRpcProvider } from '../../services/provider'
 import { NetworkState, PortfolioNetworkResult, TokenResult } from '../portfolio/interfaces'
@@ -12,6 +16,7 @@ import {
   DefiUpdateMode,
   enhancePortfolioTokensWithDefiPositions,
   getAllAssetsAsHints,
+  getCustomProviderPositions,
   getDefiUpdateMode,
   getFormattedApiPositions,
   getUniqueMergedPositions
@@ -22,7 +27,8 @@ import {
   getStakedWalletPositions,
   getUniV3Positions
 } from './providers'
-import { AssetType, PositionsByProvider } from './types'
+import * as defiProviders from './providers'
+import { AssetType, DeFiPositionsError, PositionsByProvider } from './types'
 
 describe('DeFi positions providers', () => {
   // If this test ever fails because the accounts remove their positions, you can:
@@ -135,6 +141,71 @@ describe('DeFi positions providers', () => {
       expect(pos.additionalData.healthRate).toBeGreaterThan(0)
       expect(pos.additionalData.collateralInUSD).toBeGreaterThan(0)
     })
+    test('AAVE getReservesCount times out instead of hanging forever', async () => {
+      jest.useFakeTimers()
+      const getFunctionSpy = jest.spyOn(Contract.prototype, 'getFunction').mockReturnValue({
+        staticCall: () => new Promise(() => {})
+      } as ReturnType<Contract['getFunction']>)
+
+      try {
+        const promise = getAAVEPositions(userAddrAave, providerEthereum, ethereum)
+        const expectation = expect(promise).rejects.toThrow(/took too long/i)
+        await jest.advanceTimersByTimeAsync(AAVE_STATIC_CALL_TIMEOUT_MS + 50)
+        await expectation
+      } finally {
+        getFunctionSpy.mockRestore()
+        jest.useRealTimers()
+      }
+    })
+  })
+})
+
+describe('getCustomProviderPositions timeouts', () => {
+  const ethereum = networks.find((n) => n.chainId === 1n)!
+  if (!ethereum) throw new Error('unable to find ethereum network in consts')
+  const providerEthereum = getRpcProvider(['https://invictus.ambire.com/ethereum'], 1n)
+
+  test('returns previous custom positions when AAVE/Uni providers hang past timeout', async () => {
+    jest.useFakeTimers()
+    try {
+      jest
+        .spyOn(defiProviders, 'getAAVEPositions')
+        .mockImplementation(() => new Promise(() => {}))
+      jest
+        .spyOn(defiProviders, 'getDebankEnhancedUniV3Positions')
+        .mockImplementation(() => new Promise(() => {}))
+
+      const previousCustom: PositionsByProvider[] = [
+        {
+          providerName: 'AAVE v3',
+          chainId: 1n,
+          source: 'custom',
+          iconUrl: '',
+          siteUrl: '',
+          type: 'common',
+          positions: []
+        }
+      ]
+
+      const promise = getCustomProviderPositions(
+        '0xe40d278afd00e6187db21ff8c96d572359ef03bf',
+        providerEthereum,
+        ethereum,
+        async () => ({}),
+        previousCustom,
+        [],
+        true
+      )
+
+      await jest.advanceTimersByTimeAsync(CUSTOM_DEFI_POSITIONS_TIMEOUT_MS + 50)
+      const result = await promise
+
+      expect(result.error).toBe(DeFiPositionsError.CriticalError)
+      expect(result.positionsByProvider).toEqual(previousCustom)
+    } finally {
+      jest.useRealTimers()
+      jest.restoreAllMocks()
+    }
   })
 })
 

--- a/src/libs/defiPositions/defiPositions.ts
+++ b/src/libs/defiPositions/defiPositions.ts
@@ -3,11 +3,13 @@ import { isHex } from 'viem'
 
 import { getSanitizedAmount } from '@/libs/transfer/amount'
 
+import { CUSTOM_DEFI_POSITIONS_TIMEOUT_MS } from '../../consts/intervals'
 import { AccountId } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
 import { RPCProvider, RPCProviders } from '../../interfaces/provider'
 import { safeTokenAmountAndNumberMultiplication } from '../../utils/numbers/formatters'
 import shortenAddress from '../../utils/shortenAddress'
+import { withTimeout } from '../../utils/with-timeout'
 import { TokenResult } from '../portfolio'
 import {
   AccountState,
@@ -75,33 +77,40 @@ const getCustomProviderPositions = async (
     let error: any
 
     let newPositions = (
-      await Promise.all([
-        getAAVEPositions(addr, provider, network).catch((e: any) => {
-          providerErrors.push({
-            providerName: 'AAVE v3',
-            error: e?.message || 'Unknown error'
-          })
+      await withTimeout(
+        () =>
+          Promise.all([
+            getAAVEPositions(addr, provider, network).catch((e: any) => {
+              providerErrors.push({
+                providerName: 'AAVE v3',
+                error: e?.message || 'Unknown error'
+              })
 
-          return null
-        }),
-        // Uniswap is a bit of an odd case. We return the positions merged with Debank data
-        getDebankEnhancedUniV3Positions(
-          addr,
-          provider,
-          network,
-          previousPositions,
-          debankNetworkPositionsByProvider ||
-            previousPositions.filter((p) => p.source !== 'custom'),
-          isDebankCallSuccessful
-        ).catch((e: any) => {
-          providerErrors.push({
-            providerName: 'Uniswap V3',
-            error: e?.message || 'Unknown error'
-          })
+              return null
+            }),
+            // Uniswap is a bit of an odd case. We return the positions merged with Debank data
+            getDebankEnhancedUniV3Positions(
+              addr,
+              provider,
+              network,
+              previousPositions,
+              debankNetworkPositionsByProvider ||
+                previousPositions.filter((p) => p.source !== 'custom'),
+              isDebankCallSuccessful
+            ).catch((e: any) => {
+              providerErrors.push({
+                providerName: 'Uniswap V3',
+                error: e?.message || 'Unknown error'
+              })
 
-          return null
-        })
-      ])
+              return null
+            })
+          ]),
+        {
+          timeoutMs: CUSTOM_DEFI_POSITIONS_TIMEOUT_MS,
+          message: `Fetching DeFi positions on ${network.name} took too long`
+        }
+      )
     ).filter(Boolean) as PositionsByProvider[]
 
     if (newPositions.length) {

--- a/src/libs/defiPositions/providers/aaveV3.ts
+++ b/src/libs/defiPositions/providers/aaveV3.ts
@@ -1,8 +1,10 @@
 import { Contract, JsonRpcProvider, Provider } from 'ethers'
 
 import DeFiPositionsDeploylessCode from '../../../../contracts/compiled/DeFiAAVEPosition.json'
+import { AAVE_STATIC_CALL_TIMEOUT_MS } from '../../../consts/intervals'
 import { Network } from '../../../interfaces/network'
 import { generateUuid } from '../../../utils/uuid'
+import { withTimeout } from '../../../utils/with-timeout'
 import { fromDescriptor } from '../../deployless/deployless'
 import { AAVE_V3 } from '../defiAddresses'
 import { getAssetValue } from '../helpers'
@@ -32,7 +34,14 @@ export async function getAAVEPositions(
     network.rpcNoStateOverride // Why?
   )
 
-  const reservesLength = await poolContract.getFunction('getReservesCount').staticCall()
+  // Raw ethers staticCall has no timeout; without this, a hung RPC pins the portfolio update.
+  const reservesLength = await withTimeout(
+    () => poolContract.getFunction('getReservesCount').staticCall(),
+    {
+      timeoutMs: AAVE_STATIC_CALL_TIMEOUT_MS,
+      message: `Fetching AAVE positions on ${network.name} took too long`
+    }
+  )
   const PAGE_SIZE = 15
   const numberOfPages = Math.ceil(Number(reservesLength) / PAGE_SIZE)
   const promises = []

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -439,6 +439,11 @@ export type PortfolioKeyResult =
 export type NetworkState<T = PortfolioKeyResult> = {
   isReady: boolean
   isLoading: boolean
+  /**
+   * Set when isLoading flips to true. Used so a hung update cannot skip forever
+   * via canSkipUpdate, and so timed-out background work cannot overwrite a newer update.
+   */
+  loadingStartedAt?: number
   criticalError?: ExtendedError
   errors: ExtendedErrorWithLevel[]
   lastSuccessfulUpdate?: number


### PR DESCRIPTION
closes https://github.com/AmbireTech/ambire-app/issues/7574

## Summary
- Prevents the Send token form from staying on an infinite skeleton when a portfolio network update hangs (e.g. after long idle / bad connectivity).
- Adds age-bounded `isLoading` skip logic and a 60s hard timeout around network portfolio fetches so stuck updates clear loading, unblock the per-network queue, and can be retried.
- Adds timeouts for AAVE `staticCall` (15s) and custom DeFi position fetches (30s) so one hung RPC cannot pin the portfolio update forever.

## Root cause
SendForm gates the token UI on `portfolio.isReadyToVisualize`. A hung portfolio update left `isLoading=true`, which made later updates skip forever and kept Send stuck until the extension was disabled/enabled.

## Test plan
- [ ] Leave Send open for a long idle period (or throttle network), confirm the token form recovers instead of skeleton-locking forever
- [ ] Manual refresh after a failed/timeout portfolio update still works
- [ ] Unit: `hung portfolio update recovery` in `portfolio.test.ts`
- [ ] Unit: AAVE / `getCustomProviderPositions` timeout cases in `defiPositions.test.ts`