### PR TITLE
Flashing banners when switchign accounts

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -545,6 +545,9 @@ describe('RequestsController ', () => {
     await controller.addUserRequests([SIGN_ACCOUNT_OP_REQUEST])
 
     expect(controller.banners).toHaveLength(2)
+    controller.banners.forEach((banner) => {
+      expect(banner.meta?.accountAddr).toEqual('0x77777777789A8BBEE6C64381e5E89E501fb0e4c8')
+    })
   })
   test('should update visible requests on account change', async () => {
     const { controller, selectedAccountCtrl, getCallsRequest } = await prepareTest()

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -810,6 +810,9 @@ describe('SwapAndBridge Controller', () => {
     expect(swapAndBridgeController.activeRoutes[0]!.routeStatus).toEqual('in-progress')
     expect(swapAndBridgeController.banners).toHaveLength(1)
     expect(swapAndBridgeController.banners[0]!.actions).toHaveLength(1)
+    expect(swapAndBridgeController.banners[0]!.meta?.accountAddr).toEqual(
+      '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+    )
   })
   describe('continuous active-route updates', () => {
     beforeEach(() => {

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -2931,7 +2931,11 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
     // Swap banners aren't generated because swaps are completed instantly,
     // thus the activity banner on broadcast is sufficient
-    return getBridgeBanners(activeRoutesForSelectedAccount, callsUserRequests)
+    return getBridgeBanners(
+      activeRoutesForSelectedAccount,
+      callsUserRequests,
+      this.#selectedAccount.account.addr
+    )
   }
 
   get #shouldAutoUpdateQuote() {

--- a/src/libs/banners/banners.test.ts
+++ b/src/libs/banners/banners.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { Account, SafeAccountCreation } from '../../interfaces/account'
+import { Banner } from '../../interfaces/banner'
+import { SwapAndBridgeActiveRoute } from '../../interfaces/swapAndBridge'
+import { DappConnectRequest, PlainTextMessageUserRequest } from '../../interfaces/userRequest'
+import {
+  getBridgeBanners,
+  getCurrentAccountBanners,
+  getDappUserRequestsBanners,
+  getSafeMessageRequestBanners
+} from './banners'
+
+const ACCOUNT_ADDR = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+const OTHER_ACCOUNT_ADDR = '0x8888888888888888888888888888888888888a'
+
+const account: Account = {
+  addr: ACCOUNT_ADDR,
+  associatedKeys: [],
+  initialPrivileges: [],
+  creation: null,
+  preferences: { label: '', pfp: '' }
+}
+
+describe('getCurrentAccountBanners', () => {
+  test('keeps only banners matching the selected account', () => {
+    const banners: Banner[] = [
+      { id: 1, type: 'info', title: '', actions: [], meta: { accountAddr: ACCOUNT_ADDR } },
+      { id: 2, type: 'info', title: '', actions: [], meta: { accountAddr: OTHER_ACCOUNT_ADDR } }
+    ]
+
+    expect(getCurrentAccountBanners(banners, ACCOUNT_ADDR)).toEqual([banners[0]])
+  })
+
+  test('keeps banners without meta.accountAddr regardless of the selected account', () => {
+    const globalBanner: Banner = { id: 'global', type: 'info', title: '', actions: [] }
+
+    expect(getCurrentAccountBanners([globalBanner], ACCOUNT_ADDR)).toEqual([globalBanner])
+    expect(getCurrentAccountBanners([globalBanner], undefined)).toEqual([globalBanner])
+  })
+})
+
+describe('getDappUserRequestsBanners', () => {
+  test('tags the banner with the account it was built for', () => {
+    const dappConnectRequest: DappConnectRequest = {
+      id: 1,
+      kind: 'dappConnect',
+      meta: {},
+      dappPromises: [
+        {
+          id: 'testID',
+          resolve: () => {},
+          reject: () => {},
+          session: {} as DappConnectRequest['dappPromises'][0]['session'],
+          meta: {}
+        }
+      ]
+    }
+
+    const banners = getDappUserRequestsBanners(account, [dappConnectRequest])
+
+    expect(banners).toHaveLength(1)
+    expect(banners[0]!.meta?.accountAddr).toEqual(ACCOUNT_ADDR)
+  })
+})
+
+describe('getSafeMessageRequestBanners', () => {
+  test('tags the banner with the Safe account it was built for', () => {
+    const safeCreation: SafeAccountCreation = {
+      factoryAddr: '0x0',
+      singleton: '0x0',
+      saltNonce: '0x0',
+      setupData: '0x0',
+      version: '1.4.1'
+    }
+    const safeAccount: Account = { ...account, safeCreation }
+    const messageRequest: PlainTextMessageUserRequest = {
+      id: 1,
+      kind: 'message',
+      meta: {
+        params: { message: '0x0' },
+        accountAddr: ACCOUNT_ADDR,
+        chainId: 1n
+      },
+      dappPromises: []
+    }
+
+    const banners = getSafeMessageRequestBanners(safeAccount, [messageRequest])
+
+    expect(banners).toHaveLength(1)
+    expect(banners[0]!.meta?.accountAddr).toEqual(ACCOUNT_ADDR)
+  })
+})
+
+describe('getBridgeBanners', () => {
+  test('tags the banner with the account the active routes belong to', () => {
+    const activeRoutes: SwapAndBridgeActiveRoute[] = [
+      {
+        serviceProviderId: 'squid',
+        fromAssetAddress: '0x0',
+        toAssetAddress: '0x0',
+        steps: [],
+        sender: ACCOUNT_ADDR,
+        activeRouteId: 'route-1',
+        userTxIndex: 0,
+        userTxHash: null,
+        identifiedBy: null,
+        // Only the fields getIsBridgeRoute/getBridgeBanners actually read are filled in.
+        route: {
+          routeStatus: 'in-progress',
+          fromChainId: 1,
+          toChainId: 10,
+          currentUserTxIndex: 0,
+          transactionData: null,
+          userAddress: ACCOUNT_ADDR
+        } as unknown as SwapAndBridgeActiveRoute['route'],
+        routeStatus: 'in-progress'
+      }
+    ]
+
+    const banners = getBridgeBanners(activeRoutes, [], ACCOUNT_ADDR)
+
+    expect(banners).toHaveLength(1)
+    expect(banners[0]!.meta?.accountAddr).toEqual(ACCOUNT_ADDR)
+  })
+})

--- a/src/libs/banners/banners.ts
+++ b/src/libs/banners/banners.ts
@@ -19,7 +19,8 @@ export const getCurrentAccountBanners = (banners: Banner[], selectedAccount?: Ac
 
 export const getBridgeBanners = (
   activeRoutes: SwapAndBridgeActiveRoute[],
-  callsUserRequests: CallsUserRequest[]
+  callsUserRequests: CallsUserRequest[],
+  accountAddr: AccountId
 ): Banner[] => {
   const isRouteTurnedIntoAccountOp = (route: SwapAndBridgeActiveRoute) => {
     return callsUserRequests.some((req) => {
@@ -99,6 +100,9 @@ export const getBridgeBanners = (
       category: 'bridge-in-progress',
       title,
       text,
+      meta: {
+        accountAddr
+      },
       actions: [
         {
           actionName: 'view-bridge',
@@ -134,6 +138,9 @@ export const getSafeMessageRequestBanners = (
       type: 'info',
       title: `You have ${requests.length} pending signature request${requests.length > 1 ? 's' : ''}`,
       text: '',
+      meta: {
+        accountAddr: account.addr
+      },
       actions: [
         {
           actionName: 'open-pending-dapp-requests',
@@ -161,6 +168,9 @@ export const getDappUserRequestsBanners = (
       type: 'info',
       title: `You have ${requests.length} pending app request${requests.length > 1 ? 's' : ''}`,
       text: '',
+      meta: {
+        accountAddr: account.addr
+      },
       actions: [
         {
           actionName: 'open-pending-dapp-requests',
@@ -190,7 +200,7 @@ const getSafeBanner = ({
     type: 'info',
     category: 'pending-to-be-signed-acc-op',
     title: `${requestCount === 1 ? 'Pending transaction' : `${requestCount} Pending transactions`} on`,
-    meta: { chainId: network.chainId },
+    meta: { chainId: network.chainId, accountAddr: selectedAccount.addr },
     actions: [
       {
         actionName: 'open-accountOp',
@@ -254,7 +264,7 @@ export const getAccountOpBanners = ({
           callCount === 1 ? 'Pending transaction' : `${callCount} Pending transactions`
         } on`,
         text: '',
-        meta: { chainId: network.chainId },
+        meta: { chainId: network.chainId, accountAddr: selectedAccount.addr },
         actions: [
           {
             actionName: 'open-accountOp',


### PR DESCRIPTION
fixes: https://github.com/ambireTech/ambire-app/issues/7532


We add the account address to the banner so the banner is not displayed in the brief moment after account change, while the controllers/banners are not removed because of briefly-stale state

## To test
Case 1
- start a safe tx from account A, do not execute anything and go back to the dashboard via "sign later"
- there should be a banner, switch to another account and the banner should appear briefly
This is also testable with unsigned EOA tx

Case 2
- start a bridge and pick slow gas
- there should be a banner on the dash board about the bridge
- switch to another account, that same banner should still be there