### PR TITLE
Add: generate unsigned raw transactions for view-only EOA accounts

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -82,7 +82,8 @@ import { getScamDetectedText } from '../../libs/banners/banners'
 import {
   BROADCAST_OPTIONS,
   broadcastTransaction,
-  buildRawTransaction
+  buildRawTransaction,
+  getUnsignedTransaction
 } from '../../libs/broadcast/broadcast'
 import { PaymasterErrorReponse, PaymasterSuccessReponse, Sponsor } from '../../libs/erc7677/types'
 import { getHumanReadableBroadcastError } from '../../libs/errorHumanizer'
@@ -282,6 +283,10 @@ export class SignAccountOpController
   // "Gas fee updated" confirmation instead of a scary error toast, so the user
   // can accept the new fee and continue without redoing the whole flow.
   gasFeeChangedConfirmationRequired: boolean = false
+
+  // The serialized unsigned raw transaction (RLP preimage hex) generated for
+  // view-only Regular (EOA) accounts, so it can be copied and signed elsewhere.
+  unsignedTransaction: string | null = null
 
   previousFee: SpeedCalc | null = null
 
@@ -3943,6 +3948,93 @@ export class SignAccountOpController
     return (this.accountOp.signed || []).length >= this.threshold
   }
 
+  /**
+   * Generates the serialized unsigned raw transaction for a view-only Regular
+   * (EOA) account so the user can copy it and sign/broadcast it elsewhere.
+   * Storing the result in state and emitting an update lets the UI pick it up
+   * (dispatch is fire-and-forget and does not return a value).
+   */
+  async generateUnsignedTransaction() {
+    // Only view-only Regular (EOA) accounts can generate an unsigned tx
+    // that maps 1:1 to a standard EIP-1559/legacy transaction.
+    const isEOA = !this.account.creation && !this.account.safeCreation
+    const isViewOnly = this.accountKeyStoreKeys.length === 0
+    if (!isEOA || !isViewOnly) {
+      this.emitError({
+        level: 'silent',
+        message: 'Cannot generate an unsigned transaction for this account.',
+        error: new Error('generateUnsignedTransaction called for a non view-only EOA account.')
+      })
+      return
+    }
+
+    if (!this.accountOp.gasFeePayment) {
+      this.emitError({
+        level: 'silent',
+        message: 'Missing gas fee details. Unable to generate an unsigned transaction.',
+        error: new Error('generateUnsignedTransaction: missing gasFeePayment.')
+      })
+      return
+    }
+
+    const rawTxnBroadcast = [
+      BROADCAST_OPTIONS.bySelf,
+      BROADCAST_OPTIONS.bySelf7702,
+      BROADCAST_OPTIONS.delegation
+    ]
+    if (!rawTxnBroadcast.includes(this.accountOp.gasFeePayment.broadcastOption)) {
+      this.emitError({
+        level: 'silent',
+        message: 'This transaction cannot be broadcast as a standard transaction.',
+        error: new Error(
+          `generateUnsignedTransaction: unsupported broadcast option ${this.accountOp.gasFeePayment.broadcastOption}.`
+        )
+      })
+      return
+    }
+
+    if (!this.provider) {
+      this.emitError({
+        level: 'silent',
+        message: 'Provider not found. Unable to generate an unsigned transaction.',
+        error: new Error('generateUnsignedTransaction: provider missing.')
+      })
+      return
+    }
+
+    try {
+      const accountState = await this.#accounts.getOrFetchAccountOnChainState(
+        this.accountOp.accountAddr,
+        this.accountOp.chainId
+      )
+      if (!accountState) {
+        this.emitError({
+          level: 'silent',
+          message: 'Unable to fetch account state. Cannot generate an unsigned transaction.',
+          error: new Error(
+            `generateUnsignedTransaction: account state for ${this.accountOp.accountAddr} missing.`
+          )
+        })
+        return
+      }
+
+      this.unsignedTransaction = await getUnsignedTransaction(
+        this.account,
+        this.accountOp,
+        accountState,
+        this.provider,
+        this.#network
+      )
+      this.emitUpdate()
+    } catch (e) {
+      this.emitError({
+        level: 'silent',
+        message: 'Failed to generate an unsigned transaction.',
+        error: e as Error
+      })
+    }
+  }
+
   toJSON() {
     return {
       ...this,
@@ -3976,6 +4068,7 @@ export class SignAccountOpController
       hardwareWalletSigningRequest: this.hardwareWalletSigningRequest,
       safeEip712Data: this.safeEip712Data,
       gasFeeChangedConfirmationRequired: this.gasFeeChangedConfirmationRequired,
+      unsignedTransaction: this.unsignedTransaction,
       previousFee: this.previousFee
     }
   }

--- a/src/libs/broadcast/broadcast.test.ts
+++ b/src/libs/broadcast/broadcast.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, jest, test } from '@jest/globals'
+import { Transaction } from 'ethers'
 
 import { Account, AccountOnchainState } from '../../interfaces/account'
 import { Network } from '../../interfaces/network'
 import { RPCProvider } from '../../interfaces/provider'
 import { AccountOp } from '../accountOp/accountOp'
-import { BROADCAST_OPTIONS, buildRawTransaction } from './broadcast'
+import { BROADCAST_OPTIONS, buildRawTransaction, getUnsignedTransaction } from './broadcast'
 
 const safeAddr = '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce'
 const signerAddr = '0xe699999999999999999999999999999999996133'
@@ -131,5 +132,90 @@ describe('broadcast', () => {
 
     expect(rawTxn.gasLimit).toBe(50000n)
     expect(provider.send).not.toHaveBeenCalled()
+  })
+
+  test('serializes an unsigned raw transaction (RLP preimage) for a view-only EOA account', async () => {
+    const eoaAccount = {
+      ...account,
+      safeCreation: undefined,
+      addr: '0x4b7e9e6c9f6b4a13f1c2d3e4f5a6b7c8d9e0f1a2'
+    } as Account
+    const eoaOp: AccountOp = {
+      ...getAccountOp(100000n),
+      accountAddr: eoaAccount.addr,
+      nonce: 3n,
+      eoaNonce: 3n,
+      gasFeePayment: {
+        isGasTank: false,
+        paidBy: eoaAccount.addr,
+        paidByKeyType: 'internal',
+        inToken: '0x0000000000000000000000000000000000000000',
+        amount: 0n,
+        simulatedGasLimit: 100000n,
+        gasPrice: 100n,
+        maxPriorityFeePerGas: 5n,
+        broadcastOption: BROADCAST_OPTIONS.bySelf
+      }
+    }
+
+    const unsignedRaw = await getUnsignedTransaction(
+      eoaAccount,
+      eoaOp,
+      accountState,
+      getProvider('0x186a0'),
+      network
+    )
+
+    expect(unsignedRaw).toMatch(/^0x/)
+
+    const tx = Transaction.from(unsignedRaw)
+    // unsigned transaction has no signature
+    expect(tx.signature).toBeNull()
+    expect(tx.chainId).toBe(BigInt(network.chainId))
+    expect(tx.nonce).toBe(3)
+    expect(tx.to).toBe(eoaOp.calls[0]?.to)
+    expect(tx.value).toBe(1n)
+    expect(tx.gasLimit).toBe(100000n)
+    expect(tx.maxPriorityFeePerGas).toBe(5n)
+    expect(tx.maxFeePerGas).toBe(100n)
+  })
+
+  test('uses the accountOp eoaNonce when available for the unsigned transaction', async () => {
+    const eoaAddr = '0x4b7e9e6c9f6b4a13f1e9d3e4f5a6b7c8d9e0f1a2'
+    const eoaAccount = {
+      addr: eoaAddr,
+      associatedKeys: [eoaAddr],
+      initialPrivileges: [],
+      creation: null,
+      preferences: { label: '', pfp: eoaAddr }
+    } as Account
+    const provider = getProvider('0x186a0')
+    const eoaOp: AccountOp = {
+      ...getAccountOp(10000n),
+      accountAddr: eoaAddr,
+      nonce: 9n,
+      eoaNonce: 9n,
+      gasFeePayment: {
+        isGasTank: false,
+        paidBy: eoaAddr,
+        paidByKeyType: 'internal',
+        inToken: '0x0000000000000000000000000000000000000000',
+        amount: 0n,
+        simulatedGasLimit: 10000n,
+        gasPrice: 10n,
+        broadcastOption: BROADCAST_OPTIONS.bySelf
+      }
+    }
+
+    const unsignedRaw = await getUnsignedTransaction(
+      eoaAccount,
+      eoaOp,
+      accountState,
+      provider,
+      network
+    )
+
+    expect(provider.getTransactionCount).not.toHaveBeenCalled()
+    expect(Transaction.from(unsignedRaw).nonce).toBe(9)
   })
 })

--- a/src/libs/broadcast/broadcast.ts
+++ b/src/libs/broadcast/broadcast.ts
@@ -1,4 +1,4 @@
-import { Interface, toQuantity, TransactionResponse } from 'ethers'
+import { Interface, toQuantity, Transaction, TransactionResponse } from 'ethers'
 
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
@@ -260,6 +260,41 @@ export async function buildRawTransaction(
   }
 
   return rawTxn
+}
+
+/**
+ * Serializes an accountOp as an unsigned raw transaction (the RLP pre-image
+ * that external tools can sign and broadcast via `eth_sendRawTransaction`).
+ * Only meaningful for Regular (EOA) accounts where the accountOp maps 1:1 to
+ * a standard legacy or EIP-1559 transaction, signed by the account itself.
+ */
+export async function getUnsignedTransaction(
+  account: Account,
+  op: AccountOp,
+  accountState: AccountOnchainState,
+  provider: RPCProvider,
+  network: Network
+): Promise<string> {
+  if (!op.gasFeePayment) throw new Error('Missing gas fee payment details.')
+  const gasFeePayment = op.gasFeePayment
+
+  const senderNonce =
+    op.eoaNonce != null
+      ? Number(op.eoaNonce)
+      : Number(await provider.getTransactionCount(account.addr))
+
+  const rawTxn = await buildRawTransaction(
+    account,
+    op,
+    accountState,
+    provider,
+    network,
+    senderNonce,
+    gasFeePayment.broadcastOption,
+    op.calls[0]
+  )
+
+  return Transaction.from(rawTxn).unsignedSerialized
 }
 
 export async function broadcastTransaction(


### PR DESCRIPTION
Allows view-only Regular (EOA) accounts to prepare a serialized unsigned raw transaction (RLP pre-image) from the accountOp, so it can be copied, signed and broadcast elsewhere.

- `broadcast.ts`: new `getUnsignedTransaction()` building the unsigned raw txn reusing the existing fee estimation output
- `signAccountOp.ts`: new `generateUnsignedTransaction()` method + `unsignedTransaction` public state
- tests for the new serialization