### PR TITLE
Changes: robinhood gas limit overhead, EOA broadcast retry

### DIFF
--- a/src/libs/broadcast/broadcast.test.ts
+++ b/src/libs/broadcast/broadcast.test.ts
@@ -6,6 +6,8 @@ import { RPCProvider } from '../../interfaces/provider'
 import { AccountOp } from '../accountOp/accountOp'
 import { BROADCAST_OPTIONS, buildRawTransaction } from './broadcast'
 
+jest.mock('../../utils/wait', () => jest.fn(async () => undefined))
+
 const safeAddr = '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce'
 const signerAddr = '0xe699999999999999999999999999999999996133'
 
@@ -27,6 +29,13 @@ const account = {
   }
 } as Account
 
+const eoaAccount = {
+  ...account,
+  addr: signerAddr,
+  associatedKeys: [signerAddr],
+  safeCreation: undefined
+} as Account
+
 const accountState = {
   isDeployed: true,
   nonce: 0n
@@ -37,11 +46,15 @@ const network = {
   feeOptions: { is1559: true }
 } as Network
 
-function getAccountOp(simulatedGasLimit: bigint, isCustomGasLimit = false): AccountOp {
+function getAccountOp(
+  simulatedGasLimit: bigint,
+  isCustomGasLimit = false,
+  chainId = network.chainId
+): AccountOp {
   return {
     id: 'safe-op',
     accountAddr: safeAddr,
-    chainId: 6342n,
+    chainId,
     signingKeyAddr: signerAddr,
     signingKeyType: 'internal',
     nonce: 0n,
@@ -76,21 +89,33 @@ function getProvider(estimatedGas: string) {
   } as unknown as RPCProvider
 }
 
+function getEoaBatchOp() {
+  const op = getAccountOp(50000n)
+  return {
+    ...op,
+    accountAddr: signerAddr,
+    calls: [...op.calls, { to: safeAddr, value: 2n, data: '0x' }]
+  }
+}
+
 describe('broadcast', () => {
-  test('uses the final RPC estimate for Safe broadcasts when it is higher than simulated gas', async () => {
+  test.each([
+    { chainId: 6342n, expectedGasLimit: 110000n },
+    { chainId: 4663n, expectedGasLimit: 120000n }
+  ])('adds the expected gas overhead on chain $chainId', async ({ chainId, expectedGasLimit }) => {
     const provider = getProvider('0x186a0')
 
     const rawTxn = await buildRawTransaction(
       account,
-      getAccountOp(50000n),
+      getAccountOp(50000n, false, chainId),
       accountState,
       provider,
-      network,
+      { ...network, chainId },
       7,
       BROADCAST_OPTIONS.byOtherEOA
     )
 
-    expect(rawTxn.gasLimit).toBe(110000n)
+    expect(rawTxn.gasLimit).toBe(expectedGasLimit)
     expect(provider.send).toHaveBeenCalledWith(
       'eth_estimateGas',
       expect.arrayContaining([
@@ -101,6 +126,70 @@ describe('broadcast', () => {
         })
       ])
     )
+  })
+
+  test('retries a failed estimate for a multi-call EOA broadcast', async () => {
+    const provider = getProvider('0x186a0')
+    const estimationError = new Error('estimate failed')
+    jest.mocked(provider.send).mockRejectedValueOnce(estimationError)
+    const op = getEoaBatchOp()
+
+    const rawTxn = await buildRawTransaction(
+      eoaAccount,
+      op,
+      accountState,
+      provider,
+      network,
+      7,
+      BROADCAST_OPTIONS.bySelf,
+      op.calls[0]
+    )
+
+    expect(rawTxn.gasLimit).toBe(110000n)
+    expect(provider.send).toHaveBeenCalledTimes(2)
+  })
+
+  test('stops retrying a failed estimate for a multi-call EOA broadcast at the threshold', async () => {
+    const provider = getProvider('0x186a0')
+    jest.mocked(provider.send).mockRejectedValue(new Error('estimate failed'))
+    const op = getEoaBatchOp()
+
+    await expect(
+      buildRawTransaction(
+        eoaAccount,
+        op,
+        accountState,
+        provider,
+        network,
+        7,
+        BROADCAST_OPTIONS.bySelf,
+        op.calls[0]
+      )
+    ).rejects.toThrow('Failed estimating gas for broadcast')
+
+    expect(provider.send).toHaveBeenCalledTimes(11)
+  })
+
+  test('returns an estimate error immediately for a broadcast that is not a multi-call EOA', async () => {
+    const provider = getProvider('0x186a0')
+    const estimationError = new Error('estimate failed')
+    jest.mocked(provider.send).mockRejectedValue(estimationError)
+    const op = getAccountOp(50000n)
+    op.calls.push({ to: safeAddr, value: 2n, data: '0x' })
+
+    await expect(
+      buildRawTransaction(
+        account,
+        op,
+        accountState,
+        provider,
+        network,
+        7,
+        BROADCAST_OPTIONS.byOtherEOA
+      )
+    ).rejects.toBe(estimationError)
+
+    expect(provider.send).toHaveBeenCalledTimes(1)
   })
 
   test('keeps the simulated gas for Safe broadcasts when it is higher than the final RPC estimate', async () => {

--- a/src/libs/broadcast/broadcast.ts
+++ b/src/libs/broadcast/broadcast.ts
@@ -26,8 +26,17 @@ export const BROADCAST_OPTIONS = {
 }
 
 async function waitBeforeRetry(chainId: bigint) {
-  // block time at ethereum is bigger, so we wait 3s per failures
-  await wait(chainId === 1n ? 3000 : 1500)
+  // wait a bit longer on ethereum as txn confirmations are slower
+  await wait(chainId === 1n ? 2000 : 1000)
+}
+
+/**
+ * The default gas limit overhead for all chains is 10%.
+ * Robinhood uses 20% because transactions there frequently run out of gas.
+ */
+function getGasLimitOverhead(gasLimit: bigint, chainId: bigint) {
+  if (chainId === 4663n) return gasLimit / 5n
+  return gasLimit / 10n
 }
 
 export function getByOtherEOATxnData(
@@ -64,6 +73,8 @@ async function estimateGas(
   call: Call,
   nonce: number,
   chainId: bigint,
+  broadcastOption: string,
+  op: AccountOp,
   error?: Error,
   counter: number = 0
 ): Promise<bigint> {
@@ -109,20 +120,28 @@ async function estimateGas(
     }
   }
 
-  // if there's an error, wait a bit and retry
-  // the error is most likely because of an incorrect RPC pending state
+  // Sequential EOA calls can fail temporarily if the RPC pending state is stale.
   if (gasLimit instanceof Error || hasNonceDiscrepancyOnApproval) {
-    // if the gasLimit is throwing because the smart account is returning INSUFFICIENT_PRIVILEGE,
-    // return the error without retrying
-    if (gasLimit instanceof Error && gasLimit.message.includes('INSUFFICIENT_PRIVILEGE'))
-      throw gasLimit
+    // Other estimation errors are deterministic, so return them immediately.
+    const isEoaBatch = broadcastOption === BROADCAST_OPTIONS.bySelf && op.calls.length > 1
+    if (gasLimit instanceof Error && !isEoaBatch) throw gasLimit
 
     await waitBeforeRetry(chainId)
-    return estimateGas(provider, from, call, nonce, chainId, gasLimit, counter + 1)
+    return estimateGas(
+      provider,
+      from,
+      call,
+      nonce,
+      chainId,
+      broadcastOption,
+      op,
+      gasLimit,
+      counter + 1
+    )
   }
 
-  // add a 10% overhead to prevent OOG
-  return BigInt(gasLimit) + BigInt(gasLimit) / 10n
+  // add gas overhead to prevent OOG
+  return BigInt(gasLimit) + getGasLimitOverhead(BigInt(gasLimit), chainId)
 }
 
 export async function getTxnData(
@@ -151,7 +170,9 @@ export async function getTxnData(
       gasFeePayment.paidBy,
       safeData,
       nonce,
-      op.chainId
+      op.chainId,
+      broadcastOption,
+      op
     )
 
     return {
@@ -187,7 +208,15 @@ export async function getTxnData(
     // for each one seperately
     let gasLimit: bigint | undefined = (op.gasFeePayment as GasFeePayment).simulatedGasLimit
     if (op.calls.length > 1) {
-      gasLimit = await estimateGas(provider, account.addr, call, nonce, op.chainId)
+      gasLimit = await estimateGas(
+        provider,
+        account.addr,
+        call,
+        nonce,
+        op.chainId,
+        broadcastOption,
+        op
+      )
     }
 
     const singleCallTxn = {
@@ -207,7 +236,9 @@ export async function getTxnData(
       (op.gasFeePayment as GasFeePayment).paidBy,
       otherEOACall,
       nonce,
-      op.chainId
+      op.chainId,
+      broadcastOption,
+      op
     )
     return { ...otherEOACall, gasLimit }
   }


### PR DESCRIPTION
Changes:
1. Gas limit overhead for all chains except Robinhood is 10%. For Robinhood, it's changed to 20% as there are a lot of OOG txns
2. When estimateGas() fails, it checks if the account is an EOA account (not 7702) and it has calls > 1. If that is the case, then estimateGas() retries until it reaches the threshold set. Otherwise, it returns an error immediately as this is an always failing txn