### PR TITLE
Feature / NFC cards integration on mobile

### DIFF
--- a/src/consts/hardwareWallets.ts
+++ b/src/consts/hardwareWallets.ts
@@ -4,5 +4,6 @@ export const HARDWARE_WALLET_DEVICE_NAMES: { [key in ExternalKey['type']]: strin
   ledger: 'Ledger',
   trezor: 'Trezor',
   lattice: 'GridPlus',
-  qr: 'QR-based'
+  qr: 'QR-based',
+  nfc: 'NFC-based'
 }

--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -871,17 +871,21 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
         ledger: this.#externalSignerControllers.ledger?.deviceId || '',
         trezor: this.#externalSignerControllers.trezor?.deviceId || '',
         lattice: this.#externalSignerControllers?.lattice?.deviceId || '',
-        qr: this.#externalSignerControllers.qr?.deviceId || ''
+        qr: this.#externalSignerControllers.qr?.deviceId || '',
+        nfc: this.#externalSignerControllers.nfc?.deviceId || ''
       }
 
       const deviceModels: { [key in ExternalKey['type']]: string } = {
         ledger: this.#externalSignerControllers.ledger?.deviceModel || '',
         trezor: this.#externalSignerControllers.trezor?.deviceModel || '',
         lattice: this.#externalSignerControllers.lattice?.deviceModel || '',
-        qr: this.#externalSignerControllers.qr?.deviceModel || ''
+        qr: this.#externalSignerControllers.qr?.deviceModel || '',
+        nfc: this.#externalSignerControllers.nfc?.deviceModel || ''
       }
 
       const masterFingerprint = this.#externalSignerControllers.qr?.masterFingerprint || ''
+
+      const nfcWalletType = this.#externalSignerControllers.nfc?.nfcWalletType
 
       const hdPathTemplate = this.hdPathTemplate as HD_PATH_TEMPLATE_TYPE
 
@@ -906,6 +910,11 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
               ...(keyType === 'qr'
                 ? {
                     masterFingerprint
+                  }
+                : {}),
+              ...(keyType === 'nfc'
+                ? {
+                    nfcWalletType
                   }
                 : {}),
               index,

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1413,6 +1413,49 @@ export class MainController extends EventEmitter implements IMainController {
     )
   }
 
+  async #handleAccountPickerInitNfc(
+    NfcKeyIterator: any, // TODO: KeyIterator type mismatch
+    payload: { extendedPublicKey: string; hdPath: string }
+  ) {
+    try {
+      const nfcCtrl = this.#externalSignerControllers.nfc
+
+      if (!nfcCtrl) {
+        const message =
+          'Could not initialize connection with your card. Please try again later or contact Ambire support.'
+        throw new EmittableError({ message, level: 'major', error: new Error(message) })
+      }
+
+      const keyIterator = new NfcKeyIterator({ controller: nfcCtrl })
+      // Initialize the iterator from the extended public key exported by the card
+      // before the AccountPicker init, so it can derive addresses on its own
+      // (the card is tapped only once, not per address).
+      keyIterator.initFromExportedKey(payload)
+
+      // v1 accounts have never supported NFC cards, so there is nothing to look
+      // for on the relayer (same reasoning as the QR flow).
+      this.accountPicker.setInitParams({
+        keyIterator,
+        hdPathTemplate: keyIterator.hdPathTemplate,
+        pageSize: 5,
+        shouldAddNextAccountAutomatically: false,
+        shouldSearchForLinkedAccounts: false
+      })
+    } catch (error: any) {
+      const message = error?.message || 'Could not import the card account. Please try again.'
+      throw new EmittableError({ message, level: 'major', error })
+    }
+  }
+
+  async handleAccountPickerInitNfc(
+    NfcKeyIterator: any, // TODO: KeyIterator type mismatch
+    payload: { extendedPublicKey: string; hdPath: string }
+  ) {
+    await this.withStatus('handleAccountPickerInitNfc', async () =>
+      this.#handleAccountPickerInitNfc(NfcKeyIterator, payload)
+    )
+  }
+
   async updateAccountsOpsStatuses() {
     await this.initialLoadPromise
 

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -58,6 +58,7 @@ export interface ExternalSignerController {
   moveToResponseScan?: () => void //Qr based specific
   submitSignatureResponse?: (payload: string | Uint8Array) => void //Qr based specific
   parseAndSetAccountFromQR?: (payload: string | Uint8Array) => Promise<ParsedQrAccount> //Qr based specific
+  nfcWalletType?: NfcWalletType // NFC (tap-to-sign card) specific
 }
 export type ExternalSignerControllers = Partial<{ [key in Key['type']]: ExternalSignerController }>
 
@@ -159,9 +160,11 @@ export type InternalKey = {
 export type QrWalletType = 'keystone' | 'imtoken' | 'keycard' // We can add more supported QR wallets here in the future, and they will be handled by the QrProtocolAdapter implementations, which are specific to each wallet type
 export type QrProtocolType = 'ur' | 'airgap'
 
+export type NfcWalletType = 'keycard' // We can add more supported NFC (tap-to-sign) cards here in the future
+
 export type ExternalKey = {
   addr: Account['addr']
-  type: 'trezor' | 'ledger' | 'lattice' | 'qr'
+  type: 'trezor' | 'ledger' | 'lattice' | 'qr' | 'nfc'
   label: string
   dedicatedToOneSA: boolean
   meta: {
@@ -174,6 +177,7 @@ export type ExternalKey = {
     qrWalletType?: QrWalletType
     qrProtocol?: QrProtocolType
     masterFingerprint?: string // BIP32 root fingerprint used to identify/verify the originating hardware wallet account set in QR flows
+    nfcWalletType?: NfcWalletType
     [key: string]: any
   }
 }

--- a/src/interfaces/main.ts
+++ b/src/interfaces/main.ts
@@ -10,6 +10,7 @@ export const STATUS_WRAPPED_METHODS = {
   handleAccountPickerInitTrezor: 'INITIAL',
   handleAccountPickerInitLattice: 'INITIAL',
   handleAccountPickerInitQr: 'INITIAL',
+  handleAccountPickerInitNfc: 'INITIAL',
   importSmartAccountFromDefaultSeed: 'INITIAL',
   selectAccount: 'INITIAL'
 } as const

--- a/src/libs/7702/7702.ts
+++ b/src/libs/7702/7702.ts
@@ -4,7 +4,7 @@ import { Network } from '../../interfaces/network'
 
 export function getContractImplementation(
   chainId: bigint,
-  accountKeys: { type: 'internal' | 'lattice' | 'trezor' | 'ledger' | 'qr' }[]
+  accountKeys: { type: 'internal' | 'lattice' | 'trezor' | 'ledger' | 'qr' | 'nfc' }[]
 ): Hex {
   if (accountKeys.find((key) => key.type === 'lattice')) {
     return EIP_7702_GRID_PLUS


### PR DESCRIPTION
Adds a new nfc external key type for tap-to-sign smart cards (Keycard).

- interfaces/keystore.ts — added 'nfc' to ExternalKey['type'], new NfcWalletType type ('keycard', extensible), meta.nfcWalletType field, and optional nfcWalletType on ExternalSignerController.
- interfaces/main.ts — registered handleAccountPickerInitNfc in STATUS_WRAPPED_METHODS.
- controllers/main/main.ts — new handleAccountPickerInitNfc(): builds the NFC key iterator from the card's exported extended public key and initializes the AccountPicker from it, so addresses are derived locally and the card is tapped only once instead of per address. Skips linked-account search (v1 accounts never supported NFC cards).
- controllers/accountPicker/accountPicker.ts — propagates the NFC device id/model and stamps nfcWalletType into the key meta when adding nfc keys.
- consts/hardwareWallets.ts — nfc: 'NFC-based' display name.
- libs/7702/7702.ts — accept 'nfc' in getContractImplementation's key types (falls through to the default implementation).