### PR TITLE
Fix / Dapp phishing protection - Trailing-dot hostnames bypassed the checks

### DIFF
--- a/src/classes/session.ts
+++ b/src/classes/session.ts
@@ -116,6 +116,11 @@ export class Session {
 
   constructor({ tabId, windowId, url, wcTopic, frameId, topFrameUrl }: SessionInitProps = {}) {
     if (url) {
+      // SECURITY: kept exactly as the browser reports it, including the trailing dot of a
+      // fully-qualified host. Platform messengers compare it byte-for-byte against the page's
+      // read-only `location.origin` before delivering a response or a broadcast (see the mobile
+      // WebView), so a canonicalized origin would no longer match the page it belongs to.
+      // The dApp's identity - what every security check resolves - is `id`, not `origin`.
       this.origin = new URL(url).origin
     } else {
       this.origin = 'internal'

--- a/src/classes/session.ts
+++ b/src/classes/session.ts
@@ -116,11 +116,13 @@ export class Session {
 
   constructor({ tabId, windowId, url, wcTopic, frameId, topFrameUrl }: SessionInitProps = {}) {
     if (url) {
-      // SECURITY: kept exactly as the browser reports it, including the trailing dot of a
-      // fully-qualified host. Platform messengers compare it byte-for-byte against the page's
-      // read-only `location.origin` before delivering a response or a broadcast (see the mobile
-      // WebView), so a canonicalized origin would no longer match the page it belongs to.
-      // The dApp's identity - what every security check resolves - is `id`, not `origin`.
+      // SECURITY: `origin` must stay exactly what the browser/WebView reports, trailing dot and
+      // all - it is later compared byte-for-byte against the page's own read-only `location.origin`
+      // before a response or broadcast is delivered to it (see the mobile WebView's origin gate).
+      // A live, unmodified page cannot be "canonicalized" - only our copy of its origin could be -
+      // so normalizing it here would make that comparison fail for a legitimate page and silently
+      // drop data meant for it. `id` (below) is the canonicalized identity that every phishing and
+      // permission check resolves against; do not canonicalize `origin` to "fix" that too.
       this.origin = new URL(url).origin
     } else {
       this.origin = 'internal'

--- a/src/controllers/dapps/dapps.test.ts
+++ b/src/controllers/dapps/dapps.test.ts
@@ -5,7 +5,7 @@ import wait from '@/utils/wait'
 import { expect } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
-import { makeDapp } from '../../../test/helpers/dapps'
+import { blacklistedDapp, makeDapp } from '../../../test/helpers/dapps'
 import { makeMainController } from '../../../test/helpers/mainController'
 import { Session } from '../../classes/session'
 import { predefinedDapps } from '../../consts/dapps/dapps'
@@ -998,6 +998,144 @@ describe('DappsController', () => {
       expect(emitCount).toBe(1)
 
       unsubscribe()
+    })
+  })
+
+  // A fully-qualified hostname ("my-dapp.vercel.app.") loads the identical site as its
+  // dotted-free form, so it must resolve to the same dApp identity everywhere - otherwise
+  // appending one dot turns a flagged dApp into an unknown one.
+  describe('fully-qualified (trailing dot) dApp urls', () => {
+    test('a suspicious hosting dApp visited with a trailing dot still shows the SUSPICIOUS_HOSTING banner', async () => {
+      const vercelDapp = makeDapp({
+        id: 'my-dapp.vercel.app',
+        name: 'Fake Uniswap on Vercel',
+        url: 'https://my-dapp.vercel.app',
+        blacklisted: 'LOADING',
+        isCustom: true
+      })
+
+      const { controller } = await prepareTest(async (storageCtrl) => {
+        await storageCtrl.set('dappsV2', [...predefinedDapps, vercelDapp])
+        await storageCtrl.set('lastDappsUpdateVersion', '1.0.0')
+      })
+      await controller.fetchAndUpdatePromise
+
+      const banner = controller.getDappVerificationBanner(['https://my-dapp.vercel.app./claim'])
+      expect(banner?.id).toBe(DAPP_VERIFICATION_BANNER_IDS.SUSPICIOUS_HOSTING)
+      expect(banner?.type).toBe('warning')
+    })
+
+    test('a BLACKLISTED dApp visited with a trailing dot still shows the BLACKLISTED banner', async () => {
+      const { controller } = await prepareTest(async (storageCtrl) => {
+        await storageCtrl.set('dappsV2', [...predefinedDapps, blacklistedDapp])
+        await storageCtrl.set('lastDappsUpdateVersion', '1.0.0')
+      })
+      await controller.fetchAndUpdatePromise
+
+      expect(controller.getDappVerificationBanner(['https://blacklisted-dapp.com./'])?.id).toBe(
+        DAPP_VERIFICATION_BANNER_IDS.BLACKLISTED
+      )
+    })
+
+    test('a suspicious hosting top frame written with a trailing dot still poisons the frame context', async () => {
+      const { controller } = await prepareTest(async (storageCtrl) => {
+        await storageCtrl.set('dappsV2', predefinedDapps)
+        await storageCtrl.set('lastDappsUpdateVersion', 'test-version')
+      })
+      await controller.fetchAndUpdatePromise
+
+      const aave = controller.dapps.find((d) => d.name === 'AAVE')!
+      expect(aave.blacklisted).toBe('VERIFIED')
+
+      const aaveSession = new Session({
+        tabId: 90,
+        windowId: 1,
+        url: aave.url,
+        frameId: 3,
+        topFrameUrl: 'https://sites.google.com./view/fake-aave'
+      })
+      controller.dappSessions[aaveSession.sessionId] = aaveSession
+
+      const banner = controller.getDappVerificationBanner([aave.url], {
+        sessionId: aaveSession.sessionId
+      })
+      expect(banner?.id).toBe(DAPP_VERIFICATION_BANNER_IDS.SUSPICIOUS_HOSTING)
+    })
+
+    test('getOrCreateDappSession reuses the session of the dotted-free url', async () => {
+      const { controller } = await prepareTest()
+
+      const session = await controller.getOrCreateDappSession({
+        tabId: 91,
+        windowId: 1,
+        url: 'https://app.aave.com',
+        frameId: 0,
+        topFrameUrl: 'https://app.aave.com'
+      })
+      const dottedSession = await controller.getOrCreateDappSession({
+        tabId: 91,
+        windowId: 1,
+        url: 'https://app.aave.com./',
+        frameId: 0,
+        topFrameUrl: 'https://app.aave.com./'
+      })
+
+      expect(dottedSession).toBe(session)
+      expect(dottedSession.id).toBe('app.aave.com')
+    })
+
+    test('a session created from a dotted url keeps the origin the browser reported', async () => {
+      const { controller } = await prepareTest()
+
+      const session = await controller.getOrCreateDappSession({
+        tabId: 92,
+        windowId: 1,
+        url: 'https://app.aave.com./',
+        frameId: 0,
+        topFrameUrl: 'https://app.aave.com./'
+      })
+
+      // The identity is canonical, while the origin stays byte-identical to the page's own
+      // `location.origin` - platform messengers compare against it before delivering data.
+      expect(session.id).toBe('app.aave.com')
+      expect(session.origin).toBe('https://app.aave.com.')
+    })
+
+    test('canonicalizes stored dApp ids on load, dropping a trailing-dot duplicate', async () => {
+      const canonicalDapp = makeDapp({
+        id: 'my-dapp.vercel.app',
+        name: 'Canonical',
+        url: 'https://my-dapp.vercel.app',
+        blacklisted: 'SUSPICIOUS_HOSTING'
+      })
+      const dottedDuplicate = makeDapp({
+        id: 'my-dapp.vercel.app.',
+        name: 'Trailing dot duplicate',
+        url: 'https://my-dapp.vercel.app./',
+        blacklisted: 'VERIFIED',
+        isConnected: true,
+        connectedSources: ['injected']
+      })
+      const dottedOnly = makeDapp({
+        id: 'other-dapp.vercel.app.',
+        name: 'Trailing dot only',
+        url: 'https://other-dapp.vercel.app./',
+        blacklisted: 'VERIFIED'
+      })
+
+      const { controller } = await prepareTest(async (storageCtrl) => {
+        await storageCtrl.set('dappsV2', [dottedDuplicate, canonicalDapp, dottedOnly])
+        await storageCtrl.set('lastDappsUpdateVersion', '1.0.0')
+      })
+
+      // The canonical record wins over the duplicate, together with its reviewed permissions.
+      expect(controller.getDapp('my-dapp.vercel.app')!.name).toBe('Canonical')
+      expect(controller.getDapp('my-dapp.vercel.app')!.isConnected).toBe(false)
+      expect(controller.getDapp('my-dapp.vercel.app.')).toBeUndefined()
+
+      // A record that only exists in dotted form is renamed, so it stays reachable.
+      expect(controller.getDapp('other-dapp.vercel.app')!.name).toBe('Trailing dot only')
+      expect(controller.getDapp('other-dapp.vercel.app.')).toBeUndefined()
     })
   })
 

--- a/src/controllers/dapps/dapps.ts
+++ b/src/controllers/dapps/dapps.ts
@@ -45,8 +45,10 @@ import {
   getDappIdFromUrl,
   getDappNameFromId,
   getDomainFromUrl,
+  getNormalizedHostnameFromUrl,
   modifyDappPropsIfNeeded,
   normalizeDappConnection,
+  normalizeHostname,
   normalizeTrendingTokens,
   sortDapps,
   unifyDefiLlamaDappUrl
@@ -273,7 +275,18 @@ export class DappsController extends EventEmitter implements IDappsController {
     ])
     // Normalize on read so a drifted record (e.g. isConnected: true but connectedSources: [])
     // can't show a dapp as connected in the UI while permission checks force a reconnect.
-    this.#dapps = new Map(storedDapps.map((d) => [d.id, normalizeDappConnection(d)]))
+    // Ids are canonicalized as well: a record stored before trailing-dot normalization
+    // ("my-dapp.vercel.app.") is unreachable by any lookup, so it would linger as an orphan
+    // entry in the UI while its permissions can never be resolved again.
+    this.#dapps = new Map()
+    storedDapps.forEach((dapp) => {
+      const id = normalizeHostname(dapp.id)
+      // The canonical record wins over its trailing-dot duplicate - it is the one every lookup
+      // resolves to, and its permissions are the ones the user reviewed for it.
+      if (id !== dapp.id && this.#dapps.has(id)) return
+
+      this.#dapps.set(id, normalizeDappConnection({ ...dapp, id }))
+    })
     this.#recentDapps = storedRecentDapps
     this.#trendingTokens = storedTrending.tokens
     this.#trendingTokensUpdatedAt = storedTrending.updatedAt || null
@@ -1324,7 +1337,10 @@ export class DappsController extends EventEmitter implements IDappsController {
             : this.initialLoadPromise
               ? 'LOADING'
               : (contextStatus ?? intrinsic),
-        name: dapp?.name || new URL(url).hostname
+        // The canonical hostname, so the banner names the site the user believes they are on
+        // instead of the fully-qualified spelling a phishing page may navigate to. Falls back to
+        // the raw url for inputs the URL parser rejects, which must not throw here.
+        name: dapp?.name || getNormalizedHostnameFromUrl(url) || url
       }
     })
 

--- a/src/controllers/phishing/phishing.test.ts
+++ b/src/controllers/phishing/phishing.test.ts
@@ -128,6 +128,51 @@ describe('PhishingController', () => {
       expect(controller.getDomainBlacklistedStatus('https://sites.google.com')).toBe('BLACKLISTED')
     })
 
+    test('getDomainBlacklistedStatus returns SUSPICIOUS_HOSTING for a fully-qualified host with a trailing dot', async () => {
+      const { controller } = await prepareTest(['some-other-phishing-site.com'])
+
+      // "my-dapp.vercel.app." loads the identical site as "my-dapp.vercel.app" - DNS, TLS and the
+      // browser treat the trailing root-label dot as the same host - so it must not slip through.
+      expect(controller.getDomainBlacklistedStatus('https://my-dapp.vercel.app./')).toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+      expect(controller.getDomainBlacklistedStatus('https://yombadge.web.app./claim')).toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+      expect(controller.getDomainBlacklistedStatus('https://sites.google.com./view/fake')).toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+    })
+
+    test('getDomainBlacklistedStatus flags a trailing-dot host regardless of casing, www. or repeated dots', async () => {
+      const { controller } = await prepareTest(['some-other-phishing-site.com'])
+
+      expect(controller.getDomainBlacklistedStatus('https://My-Dapp.Vercel.App./')).toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+      expect(controller.getDomainBlacklistedStatus('https://www.my-dapp.vercel.app./')).toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+      expect(controller.getDomainBlacklistedStatus('https://my-dapp.vercel.app../')).toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+      // The URL parser maps the ideographic full stop to a regular dot, trailing one included.
+      expect(controller.getDomainBlacklistedStatus('https://my-dapp。vercel。app。/')).toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+    })
+
+    test('getDomainBlacklistedStatus keeps not flagging parent domains written with a trailing dot', async () => {
+      const { controller } = await prepareTest(['some-other-phishing-site.com'])
+
+      expect(controller.getDomainBlacklistedStatus('https://google.com./')).not.toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+      expect(controller.getDomainBlacklistedStatus('https://vercel.com./')).not.toBe(
+        'SUSPICIOUS_HOSTING'
+      )
+    })
+
     test('updateDomainsBlacklistedStatus callback receives SUSPICIOUS_HOSTING for all suspicious hosting domains', async () => {
       const { controller } = await prepareTest()
       const results: Record<string, string> = {}
@@ -140,6 +185,58 @@ describe('PhishingController', () => {
       for (const domain of SUSPICIOUS_HOSTING_DOMAINS) {
         expect(results[domain]).toBe('SUSPICIOUS_HOSTING')
       }
+    })
+  })
+
+  describe('fully-qualified (trailing dot) hostnames', () => {
+    test('getDomainBlacklistedStatus returns BLACKLISTED for a host-level phishing DB entry visited with a trailing dot', async () => {
+      const { controller } = await prepareTest(['yombadge.web.app'])
+
+      expect(controller.getDomainBlacklistedStatus('https://yombadge.web.app')).toBe('BLACKLISTED')
+      expect(controller.getDomainBlacklistedStatus('https://yombadge.web.app./')).toBe(
+        'BLACKLISTED'
+      )
+      expect(controller.getDomainBlacklistedStatus('https://yombadge.web.app./claim?ref=1')).toBe(
+        'BLACKLISTED'
+      )
+    })
+
+    test('getDomainBlacklistedStatus returns BLACKLISTED for an apex phishing DB entry and its subdomains visited with a trailing dot', async () => {
+      const { controller } = await prepareTest(['foourmemez.com'])
+
+      expect(controller.getDomainBlacklistedStatus('https://foourmemez.com./')).toBe('BLACKLISTED')
+      expect(controller.getDomainBlacklistedStatus('https://claim.foourmemez.com./')).toBe(
+        'BLACKLISTED'
+      )
+    })
+
+    test('getDomainBlacklistedStatus matches an internationalized phishing DB entry written in unicode with a trailing dot', async () => {
+      // The DB stores punycode, which is also what the URL parser produces for a unicode host.
+      const { controller } = await prepareTest(['xn--e1afmkfd.xn--90ae'])
+
+      expect(controller.getDomainBlacklistedStatus('https://пример.бг./')).toBe('BLACKLISTED')
+      expect(controller.getDomainBlacklistedStatus('https://xn--e1afmkfd.xn--90ae./')).toBe(
+        'BLACKLISTED'
+      )
+    })
+
+    test('getDomainBlacklistedStatus returns VERIFIED for an unrelated host with a trailing dot', async () => {
+      const { controller } = await prepareTest(['yombadge.web.app'])
+
+      expect(controller.getDomainBlacklistedStatus('https://rewards.ambire.com./')).toBe('VERIFIED')
+    })
+
+    test('updateDomainsBlacklistedStatus keys the callback by the canonical dApp id', async () => {
+      const { controller } = await prepareTest(['some-other-phishing-site.com'])
+      const results: Record<string, string> = {}
+
+      await controller.updateDomainsBlacklistedStatus(
+        ['https://yombadge.web.app./claim'],
+        (statuses) => Object.assign(results, statuses)
+      )
+
+      expect(results['yombadge.web.app']).toBe('SUSPICIOUS_HOSTING')
+      expect(results['yombadge.web.app.']).toBeUndefined()
     })
   })
 })

--- a/src/controllers/phishing/phishing.test.ts
+++ b/src/controllers/phishing/phishing.test.ts
@@ -136,7 +136,7 @@ describe('PhishingController', () => {
       expect(controller.getDomainBlacklistedStatus('https://my-dapp.vercel.app./')).toBe(
         'SUSPICIOUS_HOSTING'
       )
-      expect(controller.getDomainBlacklistedStatus('https://yombadge.web.app./claim')).toBe(
+      expect(controller.getDomainBlacklistedStatus('https://example.web.app./claim')).toBe(
         'SUSPICIOUS_HOSTING'
       )
       expect(controller.getDomainBlacklistedStatus('https://sites.google.com./view/fake')).toBe(
@@ -190,13 +190,13 @@ describe('PhishingController', () => {
 
   describe('fully-qualified (trailing dot) hostnames', () => {
     test('getDomainBlacklistedStatus returns BLACKLISTED for a host-level phishing DB entry visited with a trailing dot', async () => {
-      const { controller } = await prepareTest(['yombadge.web.app'])
+      const { controller } = await prepareTest(['example.web.app'])
 
-      expect(controller.getDomainBlacklistedStatus('https://yombadge.web.app')).toBe('BLACKLISTED')
-      expect(controller.getDomainBlacklistedStatus('https://yombadge.web.app./')).toBe(
+      expect(controller.getDomainBlacklistedStatus('https://example.web.app')).toBe('BLACKLISTED')
+      expect(controller.getDomainBlacklistedStatus('https://example.web.app./')).toBe(
         'BLACKLISTED'
       )
-      expect(controller.getDomainBlacklistedStatus('https://yombadge.web.app./claim?ref=1')).toBe(
+      expect(controller.getDomainBlacklistedStatus('https://example.web.app./claim?ref=1')).toBe(
         'BLACKLISTED'
       )
     })
@@ -221,7 +221,7 @@ describe('PhishingController', () => {
     })
 
     test('getDomainBlacklistedStatus returns VERIFIED for an unrelated host with a trailing dot', async () => {
-      const { controller } = await prepareTest(['yombadge.web.app'])
+      const { controller } = await prepareTest(['example.web.app'])
 
       expect(controller.getDomainBlacklistedStatus('https://rewards.ambire.com./')).toBe('VERIFIED')
     })
@@ -231,12 +231,12 @@ describe('PhishingController', () => {
       const results: Record<string, string> = {}
 
       await controller.updateDomainsBlacklistedStatus(
-        ['https://yombadge.web.app./claim'],
+        ['https://example.web.app./claim'],
         (statuses) => Object.assign(results, statuses)
       )
 
-      expect(results['yombadge.web.app']).toBe('SUSPICIOUS_HOSTING')
-      expect(results['yombadge.web.app.']).toBeUndefined()
+      expect(results['example.web.app']).toBe('SUSPICIOUS_HOSTING')
+      expect(results['example.web.app.']).toBeUndefined()
     })
   })
 })

--- a/src/controllers/phishing/phishing.ts
+++ b/src/controllers/phishing/phishing.ts
@@ -14,7 +14,7 @@ import { Fetch } from '../../interfaces/fetch'
 import { BlacklistedStatus, IPhishingController } from '../../interfaces/phishing'
 import { IStorageController } from '../../interfaces/storage'
 import { IUiController } from '../../interfaces/ui'
-import { getDappIdFromUrl } from '../../libs/dapps/helpers'
+import { getDappIdFromUrl, getNormalizedHostnameFromUrl } from '../../libs/dapps/helpers'
 
 import { fetchWithTimeout } from '../../utils/fetch'
 import EventEmitter from '../eventEmitter/eventEmitter'
@@ -38,6 +38,9 @@ const PHISHING_ACTIVE_VIEW_TYPES = new Set(['request-window', 'popup', 'tab'])
  *
  * 1. Intrinsic status — the dApp's own domain, resolved by getDomainBlacklistedStatus().
  *    Priority: BLACKLISTED (phishing DB) > SUSPICIOUS_HOSTING (this list) > VERIFIED.
+ *    Both lookups are string comparisons, so they run on the canonical hostname produced by
+ *    getNormalizedHostnameFromUrl()/getDappIdFromUrl() — never on a raw URL hostname, which keeps
+ *    the trailing dot of a fully-qualified host and would miss every entry in both lists.
  *
  * 2. Frame context — if a dApp is loaded as an iframe inside a tab whose top-level document is
  *    on a SUSPICIOUS_HOSTING or BLACKLISTED domain, #getFrameContextStatus() returns
@@ -156,12 +159,12 @@ export const SUSPICIOUS_HOSTING_DOMAINS = [
 ]
 
 function isSuspiciousHostingDomain(url: string): boolean {
-  try {
-    const { hostname } = new URL(url)
-    return SUSPICIOUS_HOSTING_DOMAINS.some((d) => hostname === d || hostname.endsWith(`.${d}`))
-  } catch {
-    return false
-  }
+  // The canonical hostname, so a fully-qualified host ("my-dapp.vercel.app.") is matched against
+  // the list just like the form the user believes they are on.
+  const hostname = getNormalizedHostnameFromUrl(url)
+  if (hostname === null) return false
+
+  return SUSPICIOUS_HOSTING_DOMAINS.some((d) => hostname === d || hostname.endsWith(`.${d}`))
 }
 
 export class PhishingController extends EventEmitter implements IPhishingController {

--- a/src/libs/dapps/helpers.test.ts
+++ b/src/libs/dapps/helpers.test.ts
@@ -1,0 +1,92 @@
+import { expect } from '@jest/globals'
+
+import { predefinedDapps } from '../../consts/dapps/dapps'
+import { getDappIdFromUrl, getNormalizedHostnameFromUrl, normalizeHostname } from './helpers'
+
+describe('dapps helpers', () => {
+  describe('normalizeHostname', () => {
+    it('strips the trailing dot of a fully-qualified hostname', () => {
+      expect(normalizeHostname('yombadge.web.app.')).toBe('yombadge.web.app')
+      expect(normalizeHostname('app.aave.com.')).toBe('app.aave.com')
+    })
+
+    it('strips repeated trailing dots', () => {
+      expect(normalizeHostname('yombadge.web.app..')).toBe('yombadge.web.app')
+      expect(normalizeHostname('yombadge.web.app...')).toBe('yombadge.web.app')
+    })
+
+    it('leaves an already canonical hostname untouched', () => {
+      expect(normalizeHostname('app.aave.com')).toBe('app.aave.com')
+      expect(normalizeHostname('localhost')).toBe('localhost')
+      expect(normalizeHostname('127.0.0.1')).toBe('127.0.0.1')
+      expect(normalizeHostname('')).toBe('')
+    })
+
+    it('does not touch dots that are not trailing', () => {
+      expect(normalizeHostname('sites.google.com')).toBe('sites.google.com')
+    })
+  })
+
+  describe('getNormalizedHostnameFromUrl', () => {
+    it('returns the canonical hostname of a fully-qualified host', () => {
+      expect(getNormalizedHostnameFromUrl('https://yombadge.web.app./')).toBe('yombadge.web.app')
+      expect(getNormalizedHostnameFromUrl('https://yombadge.web.app./claim?ref=1')).toBe(
+        'yombadge.web.app'
+      )
+      expect(getNormalizedHostnameFromUrl('https://yombadge.web.app.:8443/claim')).toBe(
+        'yombadge.web.app'
+      )
+    })
+
+    it('normalizes casing and the ideographic full stop the URL parser maps to a dot', () => {
+      expect(getNormalizedHostnameFromUrl('https://YomBadge.WEB.App./')).toBe('yombadge.web.app')
+      expect(getNormalizedHostnameFromUrl('https://yombadge。web。app。/')).toBe('yombadge.web.app')
+    })
+
+    it('keeps internationalized hostnames in punycode, as the phishing lists store them', () => {
+      expect(getNormalizedHostnameFromUrl('https://пример.бг./')).toBe('xn--e1afmkfd.xn--90ae')
+      expect(getNormalizedHostnameFromUrl('https://xn--e1afmkfd.xn--90ae./')).toBe(
+        'xn--e1afmkfd.xn--90ae'
+      )
+    })
+
+    it('ignores the userinfo part instead of reading it as the host', () => {
+      expect(getNormalizedHostnameFromUrl('https://app.uniswap.org@evil.com/')).toBe('evil.com')
+    })
+
+    it('returns null for urls the parser rejects', () => {
+      expect(getNormalizedHostnameFromUrl('not a url')).toBe(null)
+      expect(getNormalizedHostnameFromUrl('')).toBe(null)
+    })
+  })
+
+  describe('getDappIdFromUrl', () => {
+    it('resolves a fully-qualified host to the same id as its canonical form', () => {
+      expect(getDappIdFromUrl('https://yombadge.web.app./')).toBe('yombadge.web.app')
+      expect(getDappIdFromUrl('https://yombadge.web.app./')).toBe(
+        getDappIdFromUrl('https://yombadge.web.app/')
+      )
+      expect(getDappIdFromUrl('https://app.aave.com.')).toBe('app.aave.com')
+    })
+
+    it('strips www. from a fully-qualified host as well', () => {
+      expect(getDappIdFromUrl('https://www.yombadge.web.app./')).toBe('yombadge.web.app')
+    })
+
+    it('keeps resolving the existing cases', () => {
+      expect(getDappIdFromUrl('https://app.uniswap.org/swap')).toBe('app.uniswap.org')
+      expect(getDappIdFromUrl('https://www.aave.com')).toBe('aave.com')
+      expect(getDappIdFromUrl('internal')).toBe('internal')
+      expect(getDappIdFromUrl('')).toBe('internal')
+    })
+
+    it('still returns predefined ids by url', () => {
+      const predefinedDapp = predefinedDapps[0]
+      expect(getDappIdFromUrl(predefinedDapp.url)).toBe(predefinedDapp.id)
+    })
+
+    it('falls back to the raw input when it is not a url', () => {
+      expect(getDappIdFromUrl('not a url')).toBe('not a url')
+    })
+  })
+})

--- a/src/libs/dapps/helpers.test.ts
+++ b/src/libs/dapps/helpers.test.ts
@@ -6,13 +6,13 @@ import { getDappIdFromUrl, getNormalizedHostnameFromUrl, normalizeHostname } fro
 describe('dapps helpers', () => {
   describe('normalizeHostname', () => {
     it('strips the trailing dot of a fully-qualified hostname', () => {
-      expect(normalizeHostname('yombadge.web.app.')).toBe('yombadge.web.app')
+      expect(normalizeHostname('example.web.app.')).toBe('example.web.app')
       expect(normalizeHostname('app.aave.com.')).toBe('app.aave.com')
     })
 
     it('strips repeated trailing dots', () => {
-      expect(normalizeHostname('yombadge.web.app..')).toBe('yombadge.web.app')
-      expect(normalizeHostname('yombadge.web.app...')).toBe('yombadge.web.app')
+      expect(normalizeHostname('example.web.app..')).toBe('example.web.app')
+      expect(normalizeHostname('example.web.app...')).toBe('example.web.app')
     })
 
     it('leaves an already canonical hostname untouched', () => {
@@ -29,18 +29,18 @@ describe('dapps helpers', () => {
 
   describe('getNormalizedHostnameFromUrl', () => {
     it('returns the canonical hostname of a fully-qualified host', () => {
-      expect(getNormalizedHostnameFromUrl('https://yombadge.web.app./')).toBe('yombadge.web.app')
-      expect(getNormalizedHostnameFromUrl('https://yombadge.web.app./claim?ref=1')).toBe(
-        'yombadge.web.app'
+      expect(getNormalizedHostnameFromUrl('https://example.web.app./')).toBe('example.web.app')
+      expect(getNormalizedHostnameFromUrl('https://example.web.app./claim?ref=1')).toBe(
+        'example.web.app'
       )
-      expect(getNormalizedHostnameFromUrl('https://yombadge.web.app.:8443/claim')).toBe(
-        'yombadge.web.app'
+      expect(getNormalizedHostnameFromUrl('https://example.web.app.:8443/claim')).toBe(
+        'example.web.app'
       )
     })
 
     it('normalizes casing and the ideographic full stop the URL parser maps to a dot', () => {
-      expect(getNormalizedHostnameFromUrl('https://YomBadge.WEB.App./')).toBe('yombadge.web.app')
-      expect(getNormalizedHostnameFromUrl('https://yombadge。web。app。/')).toBe('yombadge.web.app')
+      expect(getNormalizedHostnameFromUrl('https://ExAmple.WEB.App./')).toBe('example.web.app')
+      expect(getNormalizedHostnameFromUrl('https://example。web。app。/')).toBe('example.web.app')
     })
 
     it('keeps internationalized hostnames in punycode, as the phishing lists store them', () => {
@@ -62,15 +62,15 @@ describe('dapps helpers', () => {
 
   describe('getDappIdFromUrl', () => {
     it('resolves a fully-qualified host to the same id as its canonical form', () => {
-      expect(getDappIdFromUrl('https://yombadge.web.app./')).toBe('yombadge.web.app')
-      expect(getDappIdFromUrl('https://yombadge.web.app./')).toBe(
-        getDappIdFromUrl('https://yombadge.web.app/')
+      expect(getDappIdFromUrl('https://example.web.app./')).toBe('example.web.app')
+      expect(getDappIdFromUrl('https://example.web.app./')).toBe(
+        getDappIdFromUrl('https://example.web.app/')
       )
       expect(getDappIdFromUrl('https://app.aave.com.')).toBe('app.aave.com')
     })
 
     it('strips www. from a fully-qualified host as well', () => {
-      expect(getDappIdFromUrl('https://www.yombadge.web.app./')).toBe('yombadge.web.app')
+      expect(getDappIdFromUrl('https://www.example.web.app./')).toBe('example.web.app')
     })
 
     it('keeps resolving the existing cases', () => {

--- a/src/libs/dapps/helpers.ts
+++ b/src/libs/dapps/helpers.ts
@@ -9,18 +9,48 @@ import {
   TrendingToken
 } from '../../interfaces/dapp'
 
+/**
+ * Strips the trailing dot(s) a hostname may carry when written in fully-qualified form
+ * ("app.example.com."). DNS, TLS and the browser resolve such a host to the exact same site as the
+ * dotted-free form, but the WHATWG URL parser keeps the dot, so the resulting string matches none
+ * of the canonical forms the wallet compares against - the phishing blacklist, the suspicious
+ * hosting list and the stored dApp records. Left unnormalized, appending a single dot is enough to
+ * turn a known-malicious dApp into an unknown one.
+ */
+const normalizeHostname = (hostname: string): string => {
+  let end = hostname.length
+  while (end > 0 && hostname[end - 1] === '.') end -= 1
+
+  return hostname.slice(0, end)
+}
+
+/**
+ * The dApp's canonical hostname, or `null` when the url is not parsable.
+ *
+ * Normalization deliberately starts from `new URL().hostname` - the parser already lowercases the
+ * host and converts internationalized ones to punycode, which is the form the phishing blacklist
+ * and the stored dApp records use. `tldts.getHostname()` also drops the trailing dot, but returns
+ * the unicode form of internationalized hostnames, so using it here would silently change the
+ * identity of every non-ASCII dApp.
+ */
+const getNormalizedHostnameFromUrl = (url: string): string | null => {
+  try {
+    return normalizeHostname(new URL(url).hostname)
+  } catch {
+    return null
+  }
+}
+
 const getDappIdFromUrl = (url: string): string => {
   if (!url || url === 'internal') return 'internal'
 
   const predefinedDapp = predefinedDapps.find((d) => d.url === url)
   if (predefinedDapp) return predefinedDapp.id
 
-  try {
-    const { hostname } = new URL(url)
-    return hostname.startsWith('www.') ? hostname.slice(4) : hostname
-  } catch {
-    return url
-  }
+  const hostname = getNormalizedHostnameFromUrl(url)
+  if (hostname === null) return url
+
+  return hostname.startsWith('www.') ? hostname.slice(4) : hostname
 }
 
 // Safe messages co-signed from another device carry only the dapp name and url
@@ -194,6 +224,8 @@ function normalizeTrendingTokens(raw: RawTrendingToken[]): TrendingToken[] {
 }
 
 export {
+  normalizeHostname,
+  getNormalizedHostnameFromUrl,
   getDappIdFromUrl,
   getDappIconFromUrl,
   getDomainFromUrl,


### PR DESCRIPTION
Fix: trailing-dot hostnames bypassed the dApp phishing checks

A fully-qualified hostname ("example.web.app.") loads the identical site, but new URL().hostname keeps the dot, so the dApp id matched neither the phishing blacklist nor SUSPICIOUS_HOSTING_DOMAINS and a flagged dApp showed as VERIFIED.

`getDappIdFromUrl` now derives the canonical hostname, which closes every check at once - ids key the sessions, the #dapps records and the phishing lookups. Stored ids are canonicalized on load, dropping trailing-dot duplicates. Session.origin stays raw on purpose: platform messengers compare it to the page's location.origin.
