### PR TITLE
Allow ERC-7677 sponsorship retry after bundler estimation

### DIFF
--- a/src/libs/erc7677/erc7677.ts
+++ b/src/libs/erc7677/erc7677.ts
@@ -14,6 +14,7 @@ import {
 } from './types'
 
 export const AMBIRE_SWAP_POLICY = 'ambireSwapSponsorship'
+export const AMBIRE_GNOSIS_POLICY = 'ambireGnosisSponsorship'
 
 export function getPaymasterService(
   chainId: bigint,
@@ -54,7 +55,10 @@ export function getAmbirePaymasterService(
 
   return {
     url: getAmbireSponsorshipUrl(relayerUrl),
-    id: new Date().getTime()
+    id: new Date().getTime(),
+    context: {
+      policyId: AMBIRE_GNOSIS_POLICY
+    }
   }
 }
 

--- a/src/libs/erc7677/erc7677.ts
+++ b/src/libs/erc7677/erc7677.ts
@@ -14,7 +14,11 @@ import {
 } from './types'
 
 export const AMBIRE_SWAP_POLICY = 'ambireSwapSponsorship'
-export const AMBIRE_GNOSIS_POLICY = 'ambireGnosisSponsorship'
+
+/**
+ * Currently, only the Gnosis chain is sponsored unconditionally
+ */
+export const AMBIRE_NETWORK_WIDE_SPONSORSHIP_POLICY = 'ambireGnosisSponsorship'
 
 export function getPaymasterService(
   chainId: bigint,
@@ -57,7 +61,7 @@ export function getAmbirePaymasterService(
     url: getAmbireSponsorshipUrl(relayerUrl),
     id: new Date().getTime(),
     context: {
-      policyId: AMBIRE_GNOSIS_POLICY
+      policyId: AMBIRE_NETWORK_WIDE_SPONSORSHIP_POLICY
     }
   }
 }

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -487,7 +487,7 @@ export class Paymaster extends AbstractPaymaster {
     // apply estimation and gas changes to the userOp so a more realistic,
     // final userOp could be sent over for paymaster stub data
     //
-    // do not use a structuredClone here as we don't want mutation on other props
+    // do not use structuredClone here as we rely on mutating nested objects
     const localOp = { ...userOp }
     localOp.preVerificationGas = bundlerEstimateResult.preVerificationGas
     localOp.verificationGasLimit = bundlerEstimateResult.verificationGasLimit

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -16,7 +16,7 @@ import { AccountOp } from '../accountOp/accountOp'
 import { Call } from '../accountOp/types'
 import { getFeeCall } from '../calls/calls'
 import {
-  AMBIRE_GNOSIS_POLICY,
+  AMBIRE_NETWORK_WIDE_SPONSORSHIP_POLICY,
   AMBIRE_SWAP_POLICY,
   getAmbireSponsorshipUrl,
   getPaymasterData,
@@ -119,15 +119,23 @@ export class Paymaster extends AbstractPaymaster {
         ])
       }
 
-      const response = await Promise.race([
-        getPaymasterStubData(this.paymasterService, localOp, this.network),
-        new Promise((_resolve, reject) => {
-          setTimeout(() => reject(new Error('Sponsorship error, request too slow')), 5000)
-        })
-      ])
-      this.sponsorDataEstimation = response as PaymasterEstimationData
-      this.type = 'ERC7677'
-      return
+      let timeout: ReturnType<typeof setTimeout> | undefined
+      try {
+        const response = await Promise.race([
+          getPaymasterStubData(this.paymasterService, localOp, this.network),
+          new Promise((_resolve, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error('Sponsorship error, request too slow')),
+              5000
+            )
+          })
+        ])
+        this.sponsorDataEstimation = response as PaymasterEstimationData
+        this.type = 'ERC7677'
+        return
+      } finally {
+        if (timeout !== undefined) clearTimeout(timeout)
+      }
     } catch (e) {
       console.log('ERC7677 sponsorship declined', e)
     }
@@ -470,11 +478,16 @@ export class Paymaster extends AbstractPaymaster {
     if (this.type === 'ERC7677' || !this.network) return
 
     // do not upgrade over the gnosis paymaster sponsorship
-    if (this.type === 'Ambire' && this.paymasterService?.context?.policyId === AMBIRE_GNOSIS_POLICY)
+    if (
+      this.type === 'Ambire' &&
+      this.paymasterService?.context?.policyId === AMBIRE_NETWORK_WIDE_SPONSORSHIP_POLICY
+    )
       return
 
     // apply estimation and gas changes to the userOp so a more realistic,
     // final userOp could be sent over for paymaster stub data
+    //
+    // do not use a structuredClone here as we don't want mutation on other props
     const localOp = { ...userOp }
     localOp.preVerificationGas = bundlerEstimateResult.preVerificationGas
     localOp.verificationGasLimit = bundlerEstimateResult.verificationGasLimit
@@ -482,7 +495,7 @@ export class Paymaster extends AbstractPaymaster {
     localOp.maxFeePerGas = gasPrices.medium.maxFeePerGas
     localOp.maxPriorityFeePerGas = gasPrices.medium.maxPriorityFeePerGas
 
-    await this.#tryToSetSwapSponsorship(bundlerEstimateResult, gasPrices, userOp)
+    await this.#tryToSetSwapSponsorship(bundlerEstimateResult, gasPrices, localOp)
     if (!!this.op?.meta?.swapSponsorship) return
 
     // try to init ERC-7677 if a paymasterService has been provided and it hasn't failed

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -148,8 +148,10 @@ export class Paymaster extends AbstractPaymaster {
     if (op.meta?.paymasterService) this.paymasterService = op.meta.paymasterService
 
     // try to init ERC-7677 if a paymasterService has been provided and it hasn't failed
-    if (op.meta?.paymasterService && !op.meta?.paymasterService.failed)
+    if (op.meta?.paymasterService && !op.meta?.paymasterService.failed) {
       await this.#tryToSetErc7677(userOp)
+      if (this.type === 'ERC7677') return
+    }
 
     // has the paymaster dried up
     const seenInsufficientFunds =

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -473,11 +473,20 @@ export class Paymaster extends AbstractPaymaster {
     if (this.type === 'Ambire' && this.paymasterService?.context?.policyId === AMBIRE_GNOSIS_POLICY)
       return
 
+    // apply estimation and gas changes to the userOp so a more realistic,
+    // final userOp could be sent over for paymaster stub data
+    const localOp = { ...userOp }
+    localOp.preVerificationGas = bundlerEstimateResult.preVerificationGas
+    localOp.verificationGasLimit = bundlerEstimateResult.verificationGasLimit
+    localOp.callGasLimit = bundlerEstimateResult.callGasLimit
+    localOp.maxFeePerGas = gasPrices.medium.maxFeePerGas
+    localOp.maxPriorityFeePerGas = gasPrices.medium.maxPriorityFeePerGas
+
     await this.#tryToSetSwapSponsorship(bundlerEstimateResult, gasPrices, userOp)
+    if (!!this.op?.meta?.swapSponsorship) return
 
     // try to init ERC-7677 if a paymasterService has been provided and it hasn't failed
-    if (this.op?.meta?.paymasterService && !this.op.meta.paymasterService.failed) {
-      await this.#tryToSetErc7677(userOp)
-    }
+    if (this.op?.meta?.paymasterService && !this.op.meta.paymasterService.failed)
+      await this.#tryToSetErc7677(localOp)
   }
 }

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -16,6 +16,7 @@ import { AccountOp } from '../accountOp/accountOp'
 import { Call } from '../accountOp/types'
 import { getFeeCall } from '../calls/calls'
 import {
+  AMBIRE_GNOSIS_POLICY,
   AMBIRE_SWAP_POLICY,
   getAmbireSponsorshipUrl,
   getPaymasterData,
@@ -79,6 +80,8 @@ export class Paymaster extends AbstractPaymaster {
 
   op: AccountOp | null = null
 
+  #account: Account | null = null
+
   paymasterService: PaymasterService | null = null
 
   network: Network | null = null
@@ -100,6 +103,36 @@ export class Paymaster extends AbstractPaymaster {
     this.#relayerUrl = relayerUrl
   }
 
+  async #tryToSetErc7677(userOp: UserOperation) {
+    if (!this.paymasterService || !this.#account || !this.network) return
+
+    try {
+      // when requesting stub data with an empty account, send over
+      // the deploy data as per EIP-7677 standard
+      const localOp = { ...userOp }
+      if (BigInt(localOp.nonce) === 0n && this.#account.creation) {
+        const factoryInterface = new Interface(AmbireFactory.abi)
+        localOp.factory = this.#account.creation.factoryAddr
+        localOp.factoryData = factoryInterface.encodeFunctionData('deploy', [
+          this.#account.creation.bytecode,
+          this.#account.creation.salt
+        ])
+      }
+
+      const response = await Promise.race([
+        getPaymasterStubData(this.paymasterService, localOp, this.network),
+        new Promise((_resolve, reject) => {
+          setTimeout(() => reject(new Error('Sponsorship error, request too slow')), 5000)
+        })
+      ])
+      this.sponsorDataEstimation = response as PaymasterEstimationData
+      this.type = 'ERC7677'
+      return
+    } catch (e) {
+      console.log('ERC7677 sponsorship declined', e)
+    }
+  }
+
   async init(
     op: AccountOp,
     userOp: UserOperation,
@@ -110,38 +143,13 @@ export class Paymaster extends AbstractPaymaster {
     this.op = op
     this.network = network
     this.provider = provider
+    this.#account = account
     this.ambirePaymasterUrl = `/v2/paymaster/${this.network.chainId}/request`
+    if (op.meta?.paymasterService) this.paymasterService = op.meta.paymasterService
 
-    if (op.meta?.paymasterService && !op.meta?.paymasterService.failed) {
-      try {
-        this.paymasterService = op.meta.paymasterService
-
-        // when requesting stub data with an empty account, send over
-        // the deploy data as per EIP-7677 standard
-        const localOp = { ...userOp }
-        if (BigInt(localOp.nonce) === 0n && account.creation) {
-          const factoryInterface = new Interface(AmbireFactory.abi)
-          localOp.factory = account.creation.factoryAddr
-          localOp.factoryData = factoryInterface.encodeFunctionData('deploy', [
-            account.creation.bytecode,
-            account.creation.salt
-          ])
-        }
-
-        const response = await Promise.race([
-          getPaymasterStubData(op.meta.paymasterService, localOp, network),
-          new Promise((_resolve, reject) => {
-            setTimeout(() => reject(new Error('Sponsorship error, request too slow')), 5000)
-          })
-        ])
-        this.sponsorDataEstimation = response as PaymasterEstimationData
-        this.type = 'ERC7677'
-        return
-      } catch (e) {
-        // TODO: error handling
-        console.log(e)
-      }
-    }
+    // try to init ERC-7677 if a paymasterService has been provided and it hasn't failed
+    if (op.meta?.paymasterService && !op.meta?.paymasterService.failed)
+      await this.#tryToSetErc7677(userOp)
 
     // has the paymaster dried up
     const seenInsufficientFunds =
@@ -382,21 +390,12 @@ export class Paymaster extends AbstractPaymaster {
     )
   }
 
-  /**
-   * We use the upgrade method when we initially need to start with another
-   * paymaster type, e.g. Ambire, but then we understand we can use another
-   * one because special conditions apply.
-   * One such case is the swap&bridge where we first need to know the estimation
-   * from the bundler so we could calculate the txn fee. If the swap fee is
-   * bigger than the txn fee, we upgrade the paymaster to SwapSponsorship.
-   */
-  async upgrade(
+  async #tryToSetSwapSponsorship(
     bundlerEstimateResult: BundlerEstimateResult,
     gasPrices: GasSpeeds,
     userOp: UserOperation
-  ): Promise<void> {
-    // ERC7677 is already sponsoring the userOperation so we don't upgrade over it
-    if (!this.op?.meta?.swapSponsorship || this.type === 'ERC7677' || !this.network) return
+  ) {
+    if (!this.op?.meta?.swapSponsorship || !this.network) return
 
     const gas =
       BigInt(bundlerEstimateResult.callGasLimit) + BigInt(bundlerEstimateResult.preVerificationGas)
@@ -449,6 +448,34 @@ export class Paymaster extends AbstractPaymaster {
       console.log('Sponsorship declined', e)
     } finally {
       if (sponsorshipTimeout !== undefined) clearTimeout(sponsorshipTimeout)
+    }
+  }
+
+  /**
+   * We use the upgrade method when we initially need to start with another
+   * paymaster type, e.g. Ambire, but then we understand we can use another
+   * one because special conditions apply.
+   * One such case is the swap&bridge where we first need to know the estimation
+   * from the bundler so we could calculate the txn fee. If the swap fee is
+   * bigger than the txn fee, we upgrade the paymaster to SwapSponsorship.
+   */
+  async upgrade(
+    bundlerEstimateResult: BundlerEstimateResult,
+    gasPrices: GasSpeeds,
+    userOp: UserOperation
+  ): Promise<void> {
+    // ERC7677 is already sponsoring the userOperation so we don't upgrade over it
+    if (this.type === 'ERC7677' || !this.network) return
+
+    // do not upgrade over the gnosis paymaster sponsorship
+    if (this.type === 'Ambire' && this.paymasterService?.context?.policyId === AMBIRE_GNOSIS_POLICY)
+      return
+
+    await this.#tryToSetSwapSponsorship(bundlerEstimateResult, gasPrices, userOp)
+
+    // try to init ERC-7677 if a paymasterService has been provided and it hasn't failed
+    if (this.op?.meta?.paymasterService && !this.op.meta.paymasterService.failed) {
+      await this.#tryToSetErc7677(userOp)
     }
   }
 }


### PR DESCRIPTION
## What changed

ERC-7677 paymaster services are now retried during `upgrade()` when:

- The initial sponsorship request did not succeed.
- The service is still available.
- The service has not previously failed.

The retry uses the gas limits returned by the bundler together with the medium gas price. This provides the paymaster service with a more realistic UserOperation than the initial request, whose gas-related fields may still be empty.

The paymaster selection logic was also reorganized into dedicated helpers for ERC-7677 and swap sponsorship.

## Why

In the case of heyAura, we need to have a proper estimation to know whether the paysmater will be willing to sponsor the transaction or not (it will depend on the cost of the txn). Therefore, we attach the estimation data to the userOp and send to to the paymaster for a retry

## Additional changes

- Added the `ambireGnosisSponsorship` policy identifier to Ambire’s internal paymaster service context.
- Preserved an existing ERC-7677 sponsorship instead of replacing it with another paymaster type.
- Preserved swap sponsorship priority when applicable.
- Kept the account deployment fields in ERC-7677 requests for undeployed accounts.