### PR TITLE
Feature/ Throttled(delayed emits) and implement them in portfolio and account state

### DIFF
--- a/src/controllers/accounts/accounts.ts
+++ b/src/controllers/accounts/accounts.ts
@@ -199,6 +199,8 @@ export class AccountsController extends EventEmitter implements IAccountsControl
 
     this.emitUpdate()
 
+    let readyNetworks = 0
+
     await Promise.all(
       networksToUpdate.map(async (network) => {
         try {
@@ -260,9 +262,14 @@ export class AccountsController extends EventEmitter implements IAccountsControl
           })
           this.#updateProviderIsWorking(network.chainId, false)
         } finally {
+          readyNetworks++
           this.accountStatesLoadingState[network.chainId.toString()] = undefined
         }
-        this.emitUpdate()
+
+        const areAllReady = readyNetworks === networksToUpdate.length
+        // Prevent spamming updates as users may have dozens of networks and updating
+        // every tick causes a lot of rerenders in the UI
+        this.emitUpdate({ throttleMs: areAllReady ? 0 : 200 })
       })
     )
 

--- a/src/controllers/eventEmitter/eventEmitter.test.ts
+++ b/src/controllers/eventEmitter/eventEmitter.test.ts
@@ -104,6 +104,108 @@ describe('EventEmitter', () => {
     expect(mockErrorCallback).not.toHaveBeenCalled()
     restore()
   })
+  describe('throttled emitUpdate', () => {
+    const THROTTLE_MS = 100
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.clearAllTimers()
+      jest.useRealTimers()
+    })
+
+    const emit = (options?: { throttleMs?: number }) =>
+      // Accessing the protected method for testing
+      (eventEmitter as any).emitUpdate(options)
+
+    it('should emit immediately on the first emit', () => {
+      const cb = jest.fn()
+      eventEmitter.onUpdate(cb)
+
+      emit({ throttleMs: THROTTLE_MS })
+
+      expect(cb).toHaveBeenCalledTimes(1)
+    })
+
+    it('should coalesce multiple throttled emits within the window into one trailing emit', () => {
+      const cb = jest.fn()
+      eventEmitter.onUpdate(cb)
+
+      emit({ throttleMs: THROTTLE_MS }) // leading -> 1
+      emit({ throttleMs: THROTTLE_MS })
+      emit({ throttleMs: THROTTLE_MS })
+      expect(cb).toHaveBeenCalledTimes(1)
+
+      jest.advanceTimersByTime(THROTTLE_MS) // trailing -> 2
+      expect(cb).toHaveBeenCalledTimes(2)
+
+      // Window is reopened after a trailing emit; with nothing pending it must
+      // not fire again and must release the timer.
+      jest.advanceTimersByTime(THROTTLE_MS)
+      expect(cb).toHaveBeenCalledTimes(2)
+    })
+
+    it('should keep throttling a continuous stream to one emit per window', () => {
+      const cb = jest.fn()
+      eventEmitter.onUpdate(cb)
+
+      emit({ throttleMs: THROTTLE_MS }) // leading -> 1
+      emit({ throttleMs: THROTTLE_MS })
+      jest.advanceTimersByTime(THROTTLE_MS) // trailing -> 2
+
+      emit({ throttleMs: THROTTLE_MS })
+      jest.advanceTimersByTime(THROTTLE_MS) // trailing -> 3
+
+      expect(cb).toHaveBeenCalledTimes(3)
+    })
+
+    it('should flush a pending throttled emit immediately on a plain emitUpdate', () => {
+      const cb = jest.fn()
+      eventEmitter.onUpdate(cb)
+
+      emit({ throttleMs: THROTTLE_MS }) // leading -> 1
+      emit({ throttleMs: THROTTLE_MS }) // pending trailing
+
+      emit() // plain emit supersedes the pending trailing -> 2
+      expect(cb).toHaveBeenCalledTimes(2)
+
+      // The superseded trailing emit must not fire afterwards
+      jest.advanceTimersByTime(THROTTLE_MS)
+      expect(cb).toHaveBeenCalledTimes(2)
+    })
+
+    it('should cancel a pending throttled emit on forceEmitUpdate', async () => {
+      const cb = jest.fn()
+      eventEmitter.onUpdate(cb)
+
+      emit({ throttleMs: THROTTLE_MS }) // leading -> 1
+      emit({ throttleMs: THROTTLE_MS }) // pending trailing
+
+      const forced = eventEmitter.forceEmitUpdate()
+      await jest.advanceTimersByTimeAsync(1) // forceEmitUpdate awaits wait(1)
+      await forced
+      expect(cb).toHaveBeenCalledTimes(2)
+
+      jest.advanceTimersByTime(THROTTLE_MS)
+      expect(cb).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not fire a pending throttled emit after destroy', () => {
+      const cb = jest.fn()
+      eventEmitter.onUpdate(cb)
+
+      emit({ throttleMs: THROTTLE_MS }) // leading -> 1
+      emit({ throttleMs: THROTTLE_MS }) // pending trailing
+
+      eventEmitter.destroy()
+
+      jest.advanceTimersByTime(THROTTLE_MS)
+      expect(cb).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('EventEmitter memory leak with nested controllers', () => {
     suppressConsoleBeforeEach()
     const externalClosure = {}

--- a/src/controllers/eventEmitter/eventEmitter.ts
+++ b/src/controllers/eventEmitter/eventEmitter.ts
@@ -32,6 +32,11 @@ export default class EventEmitter<DebugFlow extends string = string> {
 
   #errors: ErrorRef[] = []
 
+  // Trailing throttle used by `emitUpdate({ throttleMs })`
+  #throttleTimeout: ReturnType<typeof setTimeout> | null = null
+
+  #hasTrailingUpdate = false
+
   statuses: Statuses<string> = {}
 
   /**
@@ -87,20 +92,73 @@ export default class EventEmitter<DebugFlow extends string = string> {
    * normal batching may skip intermediate states and only emit the first and last ones.
    */
   async forceEmitUpdate() {
+    // An immediate emit supersedes any pending throttled update
+    this.#clearThrottle()
+
     // Bypassing background batching on the same tick
     await wait(1)
 
     // Passing `true` to the cb will bypass React batching
-
-    for (const i of this.#callbacksWithId) i.cb(true)
-
-    for (const cb of this.#callbacks) cb(true)
+    this.#doEmit(true)
   }
 
-  protected emitUpdate() {
-    for (const i of this.#callbacksWithId) i.cb()
+  #doEmit(forceEmit?: boolean) {
+    for (const i of this.#callbacksWithId) i.cb(forceEmit)
 
-    for (const cb of this.#callbacks) cb()
+    for (const cb of this.#callbacks) cb(forceEmit)
+  }
+
+  #clearThrottle() {
+    if (this.#throttleTimeout !== null) {
+      clearTimeout(this.#throttleTimeout)
+      this.#throttleTimeout = null
+    }
+    this.#hasTrailingUpdate = false
+  }
+
+  #openThrottleWindow(throttleMs: number) {
+    this.#throttleTimeout = setTimeout(() => {
+      // Keep throttling as long as updates keep arriving; stop once a window
+      // passes with nothing pending so an idle controller holds no timer.
+      if (this.#hasTrailingUpdate) {
+        this.#hasTrailingUpdate = false
+        this.#doEmit()
+        this.#openThrottleWindow(throttleMs)
+      } else {
+        this.#throttleTimeout = null
+      }
+    }, throttleMs)
+  }
+
+  /**
+   * Emits an update to all subscribers.
+   *
+   * Pass `throttleMs` for high-frequency background updates (e.g. portfolio
+   * ticks) that don't need to reach the UI on every single change. The first
+   * emit fires immediately, while further throttled emits within the
+   * window are coalesced into a single trailing emit that carries the latest
+   * state. A plain `emitUpdate()` or `forceEmitUpdate()` in the meantime flushes
+   * the pending update instantly, so user interactions are never delayed.
+   */
+  protected emitUpdate(options?: { throttleMs?: number }) {
+    const throttleMs = options?.throttleMs ?? 0
+
+    if (throttleMs <= 0) {
+      // An immediate emit supersedes any pending throttled update
+      this.#clearThrottle()
+      this.#doEmit()
+      return
+    }
+
+    // Leading edge: emit now and open the throttle window
+    if (this.#throttleTimeout === null) {
+      this.#doEmit()
+      this.#openThrottleWindow(throttleMs)
+      return
+    }
+
+    // Within the window: defer to a single trailing emit
+    this.#hasTrailingUpdate = true
   }
 
   /**
@@ -130,9 +188,9 @@ export default class EventEmitter<DebugFlow extends string = string> {
    *     and the controller updates its own state), use `emitUpdate()` or `forceEmitUpdate()`.
    */
   protected propagateUpdate(forceEmit?: boolean) {
-    for (const i of this.#callbacksWithId) i.cb(forceEmit)
-
-    for (const cb of this.#callbacks) cb(forceEmit)
+    // An immediate emit supersedes any pending throttled update
+    this.#clearThrottle()
+    this.#doEmit(forceEmit)
   }
 
   /** True when this controller's debug logging is toggled on. */
@@ -285,6 +343,7 @@ export default class EventEmitter<DebugFlow extends string = string> {
    * clearing all callbacks and errors.
    */
   destroy() {
+    this.#clearThrottle()
     this.unregisterFromRegistry()
     this.#callbacks = []
     this.#callbacksWithId = []

--- a/src/controllers/selectedAccount/selectedAccount.ts
+++ b/src/controllers/selectedAccount/selectedAccount.ts
@@ -36,6 +36,10 @@ import {
 import { getProjectedRewardsStatsAndToken } from '../../utils/rewards'
 import EventEmitter from '../eventEmitter/eventEmitter'
 
+// Portfolio recalculations fire back-to-back as per-network results stream in.
+// Throttle their UI emit so the state isn't serialized on every partial tick.
+const PORTFOLIO_UPDATE_THROTTLE_MS = 100
+
 export class SelectedAccountController extends EventEmitter implements ISelectedAccountController {
   #storage: IStorageController
 
@@ -327,8 +331,11 @@ export class SelectedAccountController extends EventEmitter implements ISelected
       })
     }
 
+    let justLoaded = false
+
     // Reset the loading timestamp if the portfolio is ready
     if (this.#portfolioLoadingTimeout && newSelectedAccountPortfolio.isAllReady) {
+      justLoaded = true
       clearTimeout(this.#portfolioLoadingTimeout)
       this.#portfolioLoadingTimeout = null
     }
@@ -365,7 +372,7 @@ export class SelectedAccountController extends EventEmitter implements ISelected
     this.#updatePortfolioErrors(true)
 
     if (!skipUpdate) {
-      this.emitUpdate()
+      this.emitUpdate({ throttleMs: justLoaded ? 0 : PORTFOLIO_UPDATE_THROTTLE_MS })
     }
   }
 


### PR DESCRIPTION
We are bombarding the extension with useless updates when doing emitUpdate after every network change (users can have 15+, 20+ networks). The idea is very simple - throttle every emit until the last one so isLoading flags are not delayed.

Closes https://github.com/AmbireTech/ambire-app/issues/7658