### PR TITLE
Fix: a dApp-side WalletConnect disconnect left the dApp marked as connected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ambire-common",
-  "version": "2.102.3",
+  "version": "2.107.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ambire-common",
-      "version": "2.102.3",
+      "version": "2.107.1",
       "dependencies": {
         "@ambire/signature-validator": "^1.5.0",
         "@corpus-core/colibri-stateless": "^1.1.30",

--- a/src/controllers/dapps/dapps.test.ts
+++ b/src/controllers/dapps/dapps.test.ts
@@ -1880,6 +1880,84 @@ describe('DappsController', () => {
     })
   })
 
+  describe('disconnectWcSessionByTopic', () => {
+    const wcDapp = (): Dapp =>
+      makeDapp({
+        id: 'aave.com',
+        name: 'Aave',
+        url: 'https://aave.com',
+        isCustom: false,
+        isConnected: true,
+        chainId: 1,
+        blacklisted: 'VERIFIED'
+      })
+
+    const prepareConnectedWcDapp = async () => {
+      const { controller } = await prepareTest(async (storageCtrl) => {
+        await storageCtrl.set('dappsV2', predefinedDapps)
+        await storageCtrl.set('lastDappsUpdateVersion', '1.0.0')
+      })
+      await controller.addDapp(wcDapp(), 'wc')
+
+      return controller
+    }
+
+    test('revokes the wc connection when the dapp terminates its only session', async () => {
+      const controller = await prepareConnectedWcDapp()
+      await controller.getOrCreateDappSession({
+        tabId: 1000001,
+        url: 'https://aave.com',
+        wcTopic: 'topic-a'
+      })
+
+      controller.disconnectWcSessionByTopic('topic-a')
+
+      expect(controller.getDappSessionByWcTopic('topic-a')).toBeUndefined()
+      const stored = controller.getDapp('aave.com')!
+      expect(stored.connectedSources).toEqual([])
+      expect(stored.isConnected).toBe(false)
+      // A later pairing must ask the user for approval again instead of auto-connecting.
+      expect(controller.hasPermission('aave.com', 'wc')).toBe(false)
+    })
+
+    test('keeps the wc connection while another session of the same dapp remains', async () => {
+      const controller = await prepareConnectedWcDapp()
+      await controller.getOrCreateDappSession({
+        tabId: 1000001,
+        url: 'https://aave.com',
+        wcTopic: 'topic-a'
+      })
+      await controller.getOrCreateDappSession({
+        tabId: 1000002,
+        url: 'https://aave.com',
+        wcTopic: 'topic-b'
+      })
+
+      controller.disconnectWcSessionByTopic('topic-a')
+
+      expect(controller.getDappSessionByWcTopic('topic-b')).toBeDefined()
+      expect(controller.getDapp('aave.com')!.connectedSources).toEqual(['wc'])
+      expect(controller.hasPermission('aave.com', 'wc')).toBe(true)
+    })
+
+    test('leaves the injected connection intact', async () => {
+      const controller = await prepareConnectedWcDapp()
+      await controller.addDapp(wcDapp(), 'injected')
+      await controller.getOrCreateDappSession({
+        tabId: 1000001,
+        url: 'https://aave.com',
+        wcTopic: 'topic-a'
+      })
+
+      controller.disconnectWcSessionByTopic('topic-a')
+
+      const stored = controller.getDapp('aave.com')!
+      expect(stored.connectedSources).toEqual(['injected'])
+      expect(stored.isConnected).toBe(true)
+    })
+
+  })
+
   describe('disconnectAllDapps', () => {
     const connectedNonCustomDapp = (id: string): Dapp =>
       makeDapp({

--- a/src/controllers/dapps/dapps.ts
+++ b/src/controllers/dapps/dapps.ts
@@ -678,6 +678,31 @@ export class DappsController extends EventEmitter implements IDappsController {
     }
   }
 
+  /**
+   * Removes a WalletConnect session terminated by the dApp and, once none of its WC sessions
+   * remain, revokes the `'wc'` connection so the next pairing asks for approval again.
+   */
+  disconnectWcSessionByTopic = (wcTopic: string) => {
+    const session = this.getDappSessionByWcTopic(wcTopic)
+    if (!session) return
+
+    const dappId = session.id
+    delete this.dappSessions[session.sessionId]
+    this.emitUpdate()
+
+    const hasOtherWcSession = Object.values(this.dappSessions).some(
+      (s) => s.id === dappId && !!s.wcTopic
+    )
+    if (hasOtherWcSession) return
+
+    const dapp = this.#dapps.get(dappId)
+    if (!dapp?.connectedSources?.includes('wc')) return
+
+    this.updateDapp(dappId, {
+      connectedSources: dapp.connectedSources.filter((source) => source !== 'wc')
+    })
+  }
+
   broadcastDappSessionEvent = async (
     ev: any,
     data?: any,


### PR DESCRIPTION
## Problem

When a dApp terminates its WalletConnect session from its own side, `deleteDappSessionByWcTopic` removed the in-memory session but left the dApp's `connectedSources`/`isConnected` untouched. Two consequences:

1. The dApp kept showing as connected in the Explore → Connected list forever.
2. `hasPermission(id, 'wc')` stayed `true`, so the connect-approval prompt (gated on it in `rpcFlow`) was skipped — the same dApp could re-establish a WalletConnect session without the user approving it again.

## Change

Adds `disconnectWcSessionByTopic`, used for dApp-initiated teardown: it removes the session and, once no WalletConnect session of that dApp remains, revokes the `'wc'` source (`isConnected` stays derived from `connectedSources`).

`deleteDappSessionByWcTopic` is left as-is on purpose — it is also used for temporary handshake topics (session setup, proposal expiry), which must not revoke a connection.

## Tests

Three cases in `dapps.test.ts`: revokes on the last session, keeps the connection while another session of the same dApp remains, leaves an `injected` connection intact.
