### PR TITLE
Add timeout to AAVE getReservesCount staticCall

### DIFF
--- a/src/consts/intervals.ts
+++ b/src/consts/intervals.ts
@@ -18,3 +18,5 @@ export const TRENDING_TOKENS_FAILED_UPDATE_INTERVAL = 60 * 1000 // 1 minute
 export const ESTIMATE_UPDATE_INTERVAL = 30000
 export const GAS_PRICE_UPDATE_INTERVAL = 12000
 export const FETCH_SAFE_TXNS = 3 * 60 * 1000 // 3 minutes
+/** Timeout for AAVE's pre-deployless reservesLength staticCall (raw ethers has no timeout). */
+export const AAVE_STATIC_CALL_TIMEOUT_MS = 15 * 1000

--- a/src/consts/intervals.ts
+++ b/src/consts/intervals.ts
@@ -18,5 +18,3 @@ export const TRENDING_TOKENS_FAILED_UPDATE_INTERVAL = 60 * 1000 // 1 minute
 export const ESTIMATE_UPDATE_INTERVAL = 30000
 export const GAS_PRICE_UPDATE_INTERVAL = 12000
 export const FETCH_SAFE_TXNS = 3 * 60 * 1000 // 3 minutes
-/** Timeout for AAVE's pre-deployless reservesLength staticCall (raw ethers has no timeout). */
-export const AAVE_STATIC_CALL_TIMEOUT_MS = 15 * 1000

--- a/src/libs/defiPositions/defiPositions.test.ts
+++ b/src/libs/defiPositions/defiPositions.test.ts
@@ -1,9 +1,10 @@
-import { ZeroAddress } from 'ethers'
+import { Contract, ZeroAddress } from 'ethers'
 
-import { describe, expect, test } from '@jest/globals'
+import { describe, expect, jest, test } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
 import { STK_WALLET } from '../../consts/addresses'
+import { AAVE_STATIC_CALL_TIMEOUT_MS } from '../../consts/intervals'
 import { networks } from '../../consts/networks'
 import { getRpcProvider } from '../../services/provider'
 import { NetworkState, PortfolioNetworkResult, TokenResult } from '../portfolio/interfaces'
@@ -134,6 +135,22 @@ describe('DeFi positions providers', () => {
       expect(pos.additionalData.positionInUSD).toBeGreaterThan(0)
       expect(pos.additionalData.healthRate).toBeGreaterThan(0)
       expect(pos.additionalData.collateralInUSD).toBeGreaterThan(0)
+    })
+    test('AAVE getReservesCount times out instead of hanging forever', async () => {
+      jest.useFakeTimers()
+      const getFunctionSpy = jest.spyOn(Contract.prototype, 'getFunction').mockReturnValue({
+        staticCall: () => new Promise(() => {})
+      } as ReturnType<Contract['getFunction']>)
+
+      try {
+        const promise = getAAVEPositions(userAddrAave, providerEthereum, ethereum)
+        const expectation = expect(promise).rejects.toThrow(/took too long/i)
+        await jest.advanceTimersByTimeAsync(AAVE_STATIC_CALL_TIMEOUT_MS + 50)
+        await expectation
+      } finally {
+        getFunctionSpy.mockRestore()
+        jest.useRealTimers()
+      }
     })
   })
 })

--- a/src/libs/defiPositions/defiPositions.test.ts
+++ b/src/libs/defiPositions/defiPositions.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, jest, test } from '@jest/globals'
 
 import { suppressConsole } from '../../../test/helpers/console'
 import { STK_WALLET } from '../../consts/addresses'
-import { AAVE_STATIC_CALL_TIMEOUT_MS } from '../../consts/intervals'
 import { networks } from '../../consts/networks'
 import { getRpcProvider } from '../../services/provider'
 import { NetworkState, PortfolioNetworkResult, TokenResult } from '../portfolio/interfaces'
@@ -24,6 +23,7 @@ import {
   getUniV3Positions
 } from './providers'
 import { AssetType, PositionsByProvider } from './types'
+import { AAVE_STATIC_CALL_TIMEOUT_MS } from './providers/aaveV3'
 
 describe('DeFi positions providers', () => {
   // If this test ever fails because the accounts remove their positions, you can:

--- a/src/libs/defiPositions/providers/aaveV3.ts
+++ b/src/libs/defiPositions/providers/aaveV3.ts
@@ -1,7 +1,6 @@
 import { Contract, JsonRpcProvider, Provider } from 'ethers'
 
 import DeFiPositionsDeploylessCode from '../../../../contracts/compiled/DeFiAAVEPosition.json'
-import { AAVE_STATIC_CALL_TIMEOUT_MS } from '../../../consts/intervals'
 import { Network } from '../../../interfaces/network'
 import { generateUuid } from '../../../utils/uuid'
 import { withTimeout } from '../../../utils/with-timeout'
@@ -12,6 +11,8 @@ import { AssetType, Position, PositionAsset, PositionsByProvider } from '../type
 
 const AAVE_NO_HEALTH_FACTOR_MAGIC_NUMBER =
   115792089237316195423570985008687907853269984665640564039457584007913129639935n
+
+export const AAVE_STATIC_CALL_TIMEOUT_MS = 15 * 1000
 
 export async function getAAVEPositions(
   userAddr: string,

--- a/src/libs/defiPositions/providers/aaveV3.ts
+++ b/src/libs/defiPositions/providers/aaveV3.ts
@@ -1,8 +1,10 @@
 import { Contract, JsonRpcProvider, Provider } from 'ethers'
 
 import DeFiPositionsDeploylessCode from '../../../../contracts/compiled/DeFiAAVEPosition.json'
+import { AAVE_STATIC_CALL_TIMEOUT_MS } from '../../../consts/intervals'
 import { Network } from '../../../interfaces/network'
 import { generateUuid } from '../../../utils/uuid'
+import { withTimeout } from '../../../utils/with-timeout'
 import { fromDescriptor } from '../../deployless/deployless'
 import { AAVE_V3 } from '../defiAddresses'
 import { getAssetValue } from '../helpers'
@@ -32,7 +34,14 @@ export async function getAAVEPositions(
     network.rpcNoStateOverride // Why?
   )
 
-  const reservesLength = await poolContract.getFunction('getReservesCount').staticCall()
+  // Raw ethers staticCall has no timeout; without this, a hung RPC can pin DeFi/portfolio updates.
+  const reservesLength = await withTimeout(
+    () => poolContract.getFunction('getReservesCount').staticCall(),
+    {
+      timeoutMs: AAVE_STATIC_CALL_TIMEOUT_MS,
+      message: `Fetching AAVE positions on ${network.name} took too long`
+    }
+  )
   const PAGE_SIZE = 15
   const numberOfPages = Math.ceil(Number(reservesLength) / PAGE_SIZE)
   const promises = []


### PR DESCRIPTION
## Summary
- Wraps AAVE’s pre-deployless `getReservesCount().staticCall()` in `withTimeout` (15s).
- Raw ethers calls have no timeout; a hung RPC here can pin custom DeFi / portfolio work.
- Deployless AAVE pages already time out; this closes the one gap before them.