### PR TITLE
refactor: move side-panel request routing out of the controllers

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -622,6 +622,39 @@ describe('RequestsController ', () => {
     await controller.closeRequestWindow()
     expect(controller.requestWindow.windowProps).toBe(null)
   })
+  test('should not open a request window while the panel is open', async () => {
+    const { controller, uiCtrl } = await prepareTest()
+    uiCtrl.panel = { isOpen: () => true }
+
+    await controller.addUserRequests([DAPP_CONNECT_REQUEST])
+
+    expect(controller.currentUserRequest).toBe(DAPP_CONNECT_REQUEST)
+    expect(controller.requestWindow.windowProps).toBe(null)
+  })
+  test('should reject the active request on close when there is no request window', async () => {
+    const { controller, uiCtrl } = await prepareTest()
+    uiCtrl.panel = { isOpen: () => true }
+
+    await controller.addUserRequests([DAPP_CONNECT_REQUEST])
+    await controller.closeRequestWindow()
+
+    expect(controller.currentUserRequest).toBe(null)
+    expect(controller.userRequests.length).toBe(0)
+  })
+  test('should keep transaction requests queued on close when there is no request window', async () => {
+    const { controller, uiCtrl, getCallsRequest } = await prepareTest()
+    uiCtrl.panel = { isOpen: () => true }
+    const SIGN_ACCOUNT_OP_REQUEST = await getCallsRequest({
+      addr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
+      chainId: 10n
+    })
+
+    await controller.addUserRequests([SIGN_ACCOUNT_OP_REQUEST])
+    await controller.closeRequestWindow()
+
+    expect(controller.currentUserRequest).toBe(null)
+    expect(controller.userRequests.length).toBe(1)
+  })
   test('removeAccountData', async () => {
     const { controller, getCallsRequest } = await prepareTest()
     const SIGN_ACCOUNT_OP_REQUEST = await getCallsRequest({

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -33,7 +33,7 @@ import {
 } from '../../interfaces/swapAndBridge'
 import { ITransactionManagerController } from '../../interfaces/transactionManager'
 import { ITransferController } from '../../interfaces/transfer'
-import { FocusWindowParams, isSidePanelView, IUiController, WindowProps } from '../../interfaces/ui'
+import { FocusWindowParams, IUiController, WindowProps } from '../../interfaces/ui'
 import {
   CallsUserRequest,
   OpenRequestWindowParams,
@@ -612,70 +612,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     await this.closeRequestWindow()
   }
 
-  // When the wallet runs in Chrome side-panel mode, action requests are rendered
-  // inside the panel itself instead of a separate request window. Prefer the
-  // persisted mode flag (survives brief view/port races) and fall back to an
-  // already-open side-panel view.
-  get #isSidePanelOpen() {
-    return this.#ui.views.some((view) => isSidePanelView(view))
-  }
-
-  async #shouldHandleRequestsInSidePanel() {
-    if (this.#isSidePanelOpen) return true
-
-    try {
-      return !!(await this.#storage.get('isSidePanelModeEnabled', false))
-    } catch {
-      return false
-    }
-  }
-
-  // Drop a request-window chrome popup without dismissing the active request —
-  // used when side-panel mode should own the request UI instead.
-  async #discardRequestWindowShell() {
-    if (!this.requestWindow.windowProps) return
-
-    const winId = this.requestWindow.windowProps.id
-    this.requestWindow.windowProps = null
-    this.requestWindow.loaded = false
-    this.requestWindow.pendingMessage = null
-
-    try {
-      await this.#ui.window.remove(winId)
-    } catch (error) {
-      console.error('Failed to discard request window shell', error)
-    }
-  }
-
-  async #presentRequestInSidePanel(baseWindowId?: number) {
-    await this.#discardRequestWindowShell()
-
-    if (!this.#isSidePanelOpen) {
-      try {
-        // Side-panel may already be transitioning/open. Awaiting can hang and make
-        // banner actions appear broken, so we trigger it and proceed.
-        const openSidePanelPromise = this.#ui.openSidePanel?.(baseWindowId)
-        if (openSidePanelPromise && typeof (openSidePanelPromise as any).catch === 'function') {
-          ;(openSidePanelPromise as any).catch((error: unknown) => {
-            console.error('Failed to open side panel for request', error)
-          })
-        }
-      } catch (error) {
-        console.error('Failed to open side panel for request', error)
-      }
-    }
-
-    await this.forceEmitUpdate()
-  }
-
   async openRequestWindow(params?: OpenRequestWindowParams) {
     const { skipFocus, baseWindowId } = params || {}
     await this.#awaitPendingPromises()
-
-    if (await this.#shouldHandleRequestsInSidePanel()) {
-      await this.#presentRequestInSidePanel(baseWindowId)
-      return
-    }
 
     if (this.requestWindow.windowProps) {
       if (!skipFocus) {
@@ -695,26 +634,13 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       }
 
       try {
-        await this.#ui.window.remove('popup')
-
-        // Side-panel mode / view can become available while we wait for overlay cleanup.
-        if (await this.#shouldHandleRequestsInSidePanel()) {
-          await this.#presentRequestInSidePanel(baseWindowId)
-          return
-        }
-
-        this.requestWindow.openWindowPromise = this.#ui.window
+        this.requestWindow.openWindowPromise = this.#ui.requestView
           .open({ customSize, baseWindowId })
           .finally(() => {
             this.requestWindow.openWindowPromise = undefined
           })
+        // Stays null when the request is rendered in the panel instead of a window
         this.requestWindow.windowProps = await this.requestWindow.openWindowPromise
-
-        // If side-panel mode took over during window creation, discard the popup shell.
-        if (await this.#shouldHandleRequestsInSidePanel()) {
-          await this.#presentRequestInSidePanel(baseWindowId)
-          return
-        }
 
         this.emitUpdate()
       } catch (err) {
@@ -731,11 +657,6 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   async focusRequestWindow(params?: FocusWindowParams) {
     await this.#awaitPendingPromises()
 
-    if (await this.#shouldHandleRequestsInSidePanel()) {
-      await this.#presentRequestInSidePanel()
-      return
-    }
-
     if (
       !this.visibleUserRequests.length ||
       !this.currentUserRequest ||
@@ -744,8 +665,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       return
 
     try {
-      await this.#ui.window.remove('popup')
-      this.requestWindow.focusWindowPromise = this.#ui.window
+      this.requestWindow.focusWindowPromise = this.#ui.requestView
         .focus(this.requestWindow.windowProps, params)
         .finally(() => {
           this.requestWindow.focusWindowPromise = undefined
@@ -771,10 +691,16 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   async closeRequestWindow() {
     await this.#awaitPendingPromises()
 
-    if (!this.requestWindow.windowProps) return
+    if (!this.requestWindow.windowProps) {
+      // Rendered inline (in the panel), so closing means dismissing the active request.
+      // Guarded, because clearing the current request calls this method too.
+      if (this.currentUserRequest) await this.#handleRequestWindowClose()
 
-    this.requestWindow.closeWindowPromise = this.#ui.window
-      .remove(this.requestWindow.windowProps.id)
+      return
+    }
+
+    this.requestWindow.closeWindowPromise = this.#ui.requestView
+      .close(this.requestWindow.windowProps.id)
       .finally(() => {
         this.requestWindow.closeWindowPromise = undefined
       })
@@ -786,89 +712,67 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     await this.#handleRequestWindowClose(this.requestWindow.windowProps.id)
   }
 
-  async #onActiveRequestDismissed() {
-    const requestIdsSnapshotAtClose = new Set(this.userRequests.map((r) => r.id))
+  /** `winId` is omitted when the request was rendered inline and had no window of its own. */
+  async #handleRequestWindowClose(winId?: number) {
+    const isInlineRequestClosed = winId === undefined && !this.requestWindow.windowProps
 
-    this.requestWindow.windowProps = null
-    this.requestWindow.loaded = false
-    this.requestWindow.pendingMessage = null
-    await this.#setCurrentUserRequest(null)
-
-    const callsCount = this.visibleUserRequests.reduce((acc, request) => {
-      if (request.kind !== 'calls') return acc
-
-      return acc + (request.signAccountOp.accountOp.calls?.length || 0)
-    }, 0)
-
-    if (callsCount) {
-      await this.#ui.notification.create({
-        title: callsCount > 1 ? `${callsCount} transactions queued` : 'Transaction queued',
-        message: 'Queued pending transactions are available on your Dashboard.'
-      })
-    }
-
-    for (const r of this.userRequests) {
-      if (r.kind === 'walletAddEthereumChain') {
-        const chainId = r.meta.params[0].chainId
-
-        if (!chainId) continue
-
-        const network = this.#networks.networks.find((n) => n.chainId === BigInt(chainId))
-        if (network && !network.disabled) await this.resolveUserRequest(null, r.id)
-      }
-    }
-
-    const userRequestsToRejectOnWindowClose = this.userRequests.filter(
-      (r) => r.kind !== 'calls' && !r.meta.keepRequestAlive && requestIdsSnapshotAtClose.has(r.id)
-    )
-
-    await this.rejectUserRequests(
-      ethErrors.provider.userRejectedRequest().message,
-      userRequestsToRejectOnWindowClose.map((r) => r.id),
-      // If the user closes a window and non-calls user requests exist,
-      // the window will reopen with the next request.
-      // For example: if the user has both a sign message and sign account op request,
-      // closing the window will reject the sign message request but immediately
-      // reopen the window for the sign account op request.
-      { shouldOpenNextRequest: false }
-    )
-
-    this.userRequestsWaitingAccountSwitch = []
-    this.emitUpdate()
-  }
-
-  async dismissActiveRequest() {
-    await this.#awaitPendingPromises()
-    if (!this.currentUserRequest) return
-
-    try {
-      // In the side panel there is no window to close; apply the same queue semantics as
-      // closing the request window (keep calls queued, clear the active request).
-      if (this.#isSidePanelOpen) {
-        await this.#onActiveRequestDismissed()
-        return
-      }
-
-      if (this.requestWindow.windowProps) {
-        await this.closeRequestWindow()
-      }
-    } catch (err) {
-      this.emitError({
-        message: 'Failed to dismiss the active request. Please try again.',
-        level: 'major',
-        error: err as Error
-      })
-    }
-  }
-
-  async #handleRequestWindowClose(winId: number) {
     if (
+      isInlineRequestClosed ||
       winId === this.requestWindow.windowProps?.id ||
       (!this.visibleUserRequests.length &&
         this.currentUserRequest &&
         this.requestWindow.windowProps)
     ) {
-      await this.#onActiveRequestDismissed()
+      // Snapshot IDs synchronously before any awaits so requests that arrive
+      // during async operations below are not incorrectly bulk-rejected.
+      const requestIdsSnapshotAtClose = new Set(this.userRequests.map((r) => r.id))
+
+      this.requestWindow.windowProps = null
+      this.requestWindow.loaded = false
+      this.requestWindow.pendingMessage = null
+      await this.#setCurrentUserRequest(null)
+
+      const callsCount = this.visibleUserRequests.reduce((acc, request) => {
+        if (request.kind !== 'calls') return acc
+
+        return acc + (request.signAccountOp.accountOp.calls?.length || 0)
+      }, 0)
+
+      if (callsCount) {
+        await this.#ui.notification.create({
+          title: callsCount > 1 ? `${callsCount} transactions queued` : 'Transaction queued',
+          message: 'Queued pending transactions are available on your Dashboard.'
+        })
+      }
+
+      for (const r of this.userRequests) {
+        if (r.kind === 'walletAddEthereumChain') {
+          const chainId = r.meta.params[0].chainId
+
+          if (!chainId) continue
+
+          const network = this.#networks.networks.find((n) => n.chainId === BigInt(chainId))
+          if (network && !network.disabled) await this.resolveUserRequest(null, r.id)
+        }
+      }
+
+      const userRequestsToRejectOnWindowClose = this.userRequests.filter(
+        (r) => r.kind !== 'calls' && !r.meta.keepRequestAlive && requestIdsSnapshotAtClose.has(r.id)
+      )
+
+      await this.rejectUserRequests(
+        ethErrors.provider.userRejectedRequest().message,
+        userRequestsToRejectOnWindowClose.map((r) => r.id),
+        // If the user closes a window and non-calls user requests exist,
+        // the window will reopen with the next request.
+        // For example: if the user has both a sign message and sign account op request,
+        // closing the window will reject the sign message request but immediately
+        // reopen the window for the sign account op request.
+        { shouldOpenNextRequest: false }
+      )
+
+      this.userRequestsWaitingAccountSwitch = []
+      this.emitUpdate()
     }
   }
 
@@ -2233,13 +2137,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   }
 
   async setCurrentUserRequestById(requestId: UserRequest['id'], params?: OpenRequestWindowParams) {
-    // Prefer `visibleUserRequests` (keeps account-scoped behavior), but fall back to
-    // `userRequests` to avoid no-ops when the UI banner points at a request that is
-    // momentarily not considered "visible" (e.g. during side-panel/port races).
-    const requestIdStr = String(requestId)
-    const request =
-      this.visibleUserRequests.find((r) => String(r.id) === requestIdStr) ||
-      this.userRequests.find((r) => String(r.id) === requestIdStr)
+    const request = this.visibleUserRequests.find((r) => r.id === requestId)
     if (!request)
       throw new EmittableError({
         message:

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -524,14 +524,13 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     })
 
     this.#ui.uiEvent.on('removeView', (view: View) => {
-      // A panel outlives the routes rendered in it, so its session must be unloaded on close for
-      // the form to start fresh next time. The popup keeps its form on purpose (see unloadScreen).
-      if (isSidePanelView(view) && this.sessionIds.includes(view.type))
-        this.unloadScreen(view.type, true)
-
       if (!isSwapAndBridge(view.currentRoute)) return
       this.#isOnSwapAndBridgeRoute = false
       this.updateQuoteInterval.stop()
+
+      // A closing panel destroys its screens without unmounting them, so the session has to be
+      // unloaded here for the form to start fresh next time.
+      if (isSidePanelView(view)) this.unloadScreen(view.type, true)
     })
   }
 

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -524,18 +524,10 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
     })
 
     this.#ui.uiEvent.on('removeView', (view: View) => {
-      if (isSidePanelView(view)) {
-        if (isSwapAndBridge(view.currentRoute)) {
-          this.#isOnSwapAndBridgeRoute = false
-          this.updateQuoteInterval.stop()
-        }
-
-        if (this.sessionIds.includes('side-panel')) {
-          this.unloadScreen('side-panel', true)
-        }
-
-        return
-      }
+      // A panel outlives the routes rendered in it, so its session must be unloaded on close for
+      // the form to start fresh next time. The popup keeps its form on purpose (see unloadScreen).
+      if (isSidePanelView(view) && this.sessionIds.includes(view.type))
+        this.unloadScreen(view.type, true)
 
       if (!isSwapAndBridge(view.currentRoute)) return
       this.#isOnSwapAndBridgeRoute = false

--- a/src/controllers/ui/ui.ts
+++ b/src/controllers/ui/ui.ts
@@ -1,8 +1,27 @@
 import { EventEmitter as UiEventEmitter } from 'events'
 
 import { IEventEmitterRegistryController } from '../../interfaces/eventEmitter'
-import { IUiController, UiManager, View, isExtensionOverlayView } from '../../interfaces/ui'
+import {
+  FocusWindowParams,
+  IUiController,
+  OpenWindowOptions,
+  UiManager,
+  View,
+  WindowId,
+  WindowProps,
+  isExtensionOverlayView
+} from '../../interfaces/ui'
 import EventEmitter from '../eventEmitter/eventEmitter'
+
+/**
+ * The surface that shows a request: the panel when it is open (nothing to open, focus or close
+ * there), a dedicated request window otherwise. Consumers only open, focus and close.
+ */
+type RequestViewManager = {
+  open: (options?: OpenWindowOptions) => Promise<WindowProps>
+  focus: (windowProps: WindowProps, params?: FocusWindowParams) => Promise<WindowProps>
+  close: (winId: WindowId) => Promise<void>
+}
 
 export class UiController extends EventEmitter implements IUiController {
   uiEvent: UiEventEmitter
@@ -11,13 +30,15 @@ export class UiController extends EventEmitter implements IUiController {
 
   window: UiManager['window']
 
+  panel: UiManager['panel']
+
   notification: UiManager['notification']
 
   message: UiManager['message']
 
   dispatchDappTabFocus?: UiManager['dispatchDappTabFocus']
 
-  openSidePanel?: UiManager['openSidePanel']
+  requestView: RequestViewManager
 
   constructor({
     eventEmitterRegistry,
@@ -30,10 +51,27 @@ export class UiController extends EventEmitter implements IUiController {
 
     this.uiEvent = new UiEventEmitter()
     this.window = uiManager.window
+    this.panel = uiManager.panel
     this.notification = uiManager.notification
     this.message = uiManager.message
     this.dispatchDappTabFocus = uiManager.dispatchDappTabFocus
-    this.openSidePanel = uiManager.openSidePanel
+
+    this.requestView = {
+      open: async (options?: OpenWindowOptions) => {
+        if (this.panel?.isOpen()) return null
+
+        // The popup can't stay open next to a request window
+        await this.window.remove('popup')
+
+        return this.window.open(options)
+      },
+      focus: async (windowProps: WindowProps, params?: FocusWindowParams) => {
+        await this.window.remove('popup')
+
+        return this.window.focus(windowProps, params)
+      },
+      close: (winId: WindowId) => this.window.remove(winId)
+    }
   }
 
   addView(view: View) {
@@ -115,9 +153,11 @@ export class UiController extends EventEmitter implements IUiController {
       ...super.toJSON(),
       uiEvent: undefined,
       window: undefined,
+      panel: undefined,
       notification: undefined,
       message: undefined,
-      openSidePanel: undefined
+      dispatchDappTabFocus: undefined,
+      requestView: undefined
     }
   }
 }

--- a/src/interfaces/ui.ts
+++ b/src/interfaces/ui.ts
@@ -20,14 +20,16 @@ export const isExtensionOverlayView = (view: Pick<View, 'type'>) =>
 
 export const isSidePanelView = (view: Pick<View, 'type'>) => view.type === 'side-panel'
 
+export type OpenWindowOptions = {
+  route?: string
+  customSize?: { width: number; height: number }
+  baseWindowId?: number
+}
+
 export type UiManager = {
   window: {
     event: EventEmitter
-    open: (options?: {
-      route?: string
-      customSize?: { width: number; height: number }
-      baseWindowId?: number
-    }) => Promise<WindowProps>
+    open: (options?: OpenWindowOptions) => Promise<WindowProps>
     focus: (windowProps: WindowProps, params?: FocusWindowParams) => Promise<WindowProps>
     remove: (winId: WindowId | 'popup') => Promise<void>
     closePopupWithUrl: (url: string) => Promise<void> // remove window of type popup
@@ -55,10 +57,14 @@ export type UiManager = {
     sendUiMessage: (params: {}) => void
     sendNavigateMessage: (viewId: string, route: string, params: { [key: string]: any }) => void
   }
-  // Extension-only: nudge a dapp tab after side-panel requests so React Query refetches.
+  /** An always-visible surface that renders requests inline, opened and closed by the user only. */
+  panel?: PanelManager
+  /** Sends a synthetic focus to the dapp's tab, so dapp libraries refetch the state they cache. */
   dispatchDappTabFocus?: (targets: { tabId: number; windowId?: number }[]) => void
-  // Extension-only: open the Chrome side panel for in-panel action requests.
-  openSidePanel?: (windowId?: number) => Promise<void>
+}
+
+export type PanelManager = {
+  isOpen: () => boolean
 }
 
 export type WindowId = number


### PR DESCRIPTION
Companion to https://github.com/AmbireTech/ambire-app/pull/7703 — merge this one first (the app PR bumps the submodule to this commit).

## Why

`RequestsController` decided by itself whether a request should be shown in the Chrome side panel. To do that it read the persisted `isSidePanelModeEnabled` flag, called `ui.openSidePanel()`, and tore down request windows it had just created — re-checking the flag at **four** points (before opening, after the overlay cleanup, after window creation, and on focus) to cover the resulting races.

Two problems with that:

- It is web-specific logic in code shared with mobile. `ambire-common` should not know that Chrome has a side panel, that opening one needs a user gesture, or that a "mode" flag exists in extension storage.
- The races it worked around were self-inflicted. `chrome.sidePanel.open()` requires a user gesture, so a dapp-triggered call silently fails — the controller had to create a window anyway and then discard it, which is exactly where the flicker and the "banner does nothing" reports came from.

## What changed

**The surface choice moved into `UiController`, behind a request view with `open`/`focus`/`close`.** It routes to the platform's panel when one is open and to a request window otherwise:

```ts
open:  panel.isOpen() ? null : (remove('popup'), window.open(options))
focus: remove('popup'), window.focus(windowProps, params)
close: window.remove(winId)
```

**`UiManager` gained `panel?: PanelManager`** — a single `isOpen()`, implemented in the extension's `webapi/panel` (see the app PR). The panel is deliberately neither openable nor closable from here: Chrome allows neither without a user gesture, so requests fall back to a request window whenever it is closed. That removes the races rather than handling them.

**`RequestsController` keeps no side-panel knowledge.** Its whole diff vs `v2` is now three hunks (~15 net lines):

- `open`/`focus` go through the request view (the `remove('popup')` calls moved in there too);
- `open()` yielding no window props makes the existing guards do the right thing — `focus` and `close` become no-ops, because the panel is already visible and cannot be closed;
- `closeRequestWindow()` dismisses the active request when there is no window to remove, so the panel reuses the request window's queue semantics (transactions stay queued, everything else is rejected) instead of needing a second entry point. `#handleRequestWindowClose`'s body is untouched.

**Removed:** `ui.openSidePanel`, `requests.dismissActiveRequest` + the `#onActiveRequestDismissed` extraction it forced, the storage-flag reads, and the `String(id)` fallback in `setCurrentUserRequestById` that existed only to paper over the removed races.

**Left in place:** the `'side-panel'` view type, `isExtensionOverlayView` (`dapps`/`main`) and one `isSidePanelView` check each in `transfer`/`swapAndBridge`. Those are view-type semantics of the kind this package already models (`viewType === 'popup'`), not platform machinery. The `swapAndBridge` handler also lost a block that duplicated the fallthrough right below it.

## Tests

`requests` 39/39 (3 new: panel open ⇒ no window; close with no window rejects; close with no window keeps transactions queued), `transfer` 24/24, `swapAndBridge` 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)