### PR TITLE
Do not await overriding simulation results as rejecting a txn becomes very slow

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -645,6 +645,9 @@ export class PortfolioController
    *
    * If you instead need to remove a specific accountOp from the simulation results, use `discardSimulation`
    * (e.g., after an account op is broadcasted and confirmed)
+   *
+   * If possible, this method shouldn't be awaited as we run the
+   * risks of slowing the extension down unintentionally
    */
   async overrideSimulationResults(accountOp: AccountOp) {
     const { accountAddr, chainId } = accountOp

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1028,7 +1028,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       ...waitingUserRequestsToReject
     ].filter((r) => r.kind === 'calls') as CallsUserRequest[]
 
-    await Promise.all(
+    // do not await overrideSimulationResults as the Reject handle becomes slow
+    void Promise.all(
       callsUserRequestsToReject.map((r) =>
         this.#portfolio.overrideSimulationResults(r.signAccountOp.accountOp)
       )

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -588,7 +588,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           this.visibleUserRequests.filter((r) => r.kind === 'calls')
         )
       ) {
-        await this.#portfolio.overrideSimulationResults(
+        // this should not be awaited as it gets added to
+        // the queue and that could slow things down
+        void this.#portfolio.overrideSimulationResults(
           this.currentUserRequest.signAccountOp.accountOp
         )
       }


### PR DESCRIPTION
@PetromirDev we need to be careful here and not break the simulation in certain cases because of this