### PR TITLE
Safe/ reduce network requests for executed safe txns

### DIFF
--- a/src/controllers/continuousUpdates/continuousUpdates.ts
+++ b/src/controllers/continuousUpdates/continuousUpdates.ts
@@ -16,6 +16,7 @@ import { Hex } from '../../interfaces/hex'
 import { IMainController } from '../../interfaces/main'
 import { Network } from '../../interfaces/network'
 import { CallsUserRequest } from '../../interfaces/userRequest'
+import { getAccountOpNonce } from '../../libs/accountOp/accountOp'
 import { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus } from '../../libs/accountOp/types'
 import { getNetworksWithFailedRPC } from '../../libs/networks/networks'
@@ -505,33 +506,46 @@ export class ContinuousUpdatesController extends EventEmitter {
     // do not make Safe requests if the extension is locked
     if (!this.#main.keystore.isUnlocked) return
 
-    const pendingSafeTxns = this.#main.requests.userRequests
-      .filter(
-        (r) =>
-          r.meta.accountAddr === this.#main.selectedAccount.account?.addr &&
-          r.kind === 'calls' &&
-          !!r.signAccountOp.account.safeCreation &&
-          r.signAccountOp.accountOp.txnId &&
-          r.signAccountOp.accountOp.signed?.length
-      )
-      .map((r) => {
-        const accountOp = (r as CallsUserRequest).signAccountOp.accountOp
-        return {
-          chainId: accountOp.chainId,
-          safeTxnHash: accountOp.txnId as Hex
-        }
-      })
-    if (!pendingSafeTxns.length) return
+    const safeAddr = this.#main.selectedAccount.account.addr as Hex
+    if (!safeAddr) return
 
-    const confirmed = await this.#main.safe.fetchExecuted(pendingSafeTxns).catch((e) => {
+    // Ask each chain only for the transactions that can still resolve a request we
+    // are waiting on, which is everything from the smallest pending nonce upwards
+    const minNonceByChainId = new Map<bigint, bigint>()
+    this.#main.requests.userRequests.forEach((r) => {
+      if (
+        r.meta.accountAddr !== safeAddr ||
+        r.kind !== 'calls' ||
+        !r.signAccountOp.account.safeCreation ||
+        !r.signAccountOp.accountOp.txnId ||
+        !r.signAccountOp.accountOp.signed?.length
+      )
+        return
+
+      const { accountOp } = r.signAccountOp
+      // A request with no nonce cannot narrow the range, so fetch the chain in full
+      const nonce = getAccountOpNonce(accountOp) ?? 0n
+
+      const currentMin = minNonceByChainId.get(accountOp.chainId)
+      if (currentMin === undefined || nonce < currentMin)
+        minNonceByChainId.set(accountOp.chainId, nonce)
+    })
+
+    if (!minNonceByChainId.size) return
+
+    const chains = [...minNonceByChainId].map(([chainId, minNonce]) => ({
+      chainId,
+      minNonce: Number(minNonce)
+    }))
+
+    const confirmed = await this.#main.safe.fetchExecuted(safeAddr, chains).catch((e) => {
       console.log('failed to retrieve executed Safe txns', e)
       return []
     })
     if (!confirmed.length) return
 
     // resolve each request
-    for (let i = 0; i < confirmed.length; i++) {
-      const oneConfirmed = confirmed[i]!
+    for (const oneConfirmed of confirmed) {
       const userR = this.#main.requests.userRequests.find(
         (r) =>
           r.kind === 'calls' &&

--- a/src/controllers/safe/safe.ts
+++ b/src/controllers/safe/safe.ts
@@ -379,7 +379,10 @@ export class SafeController extends EventEmitter implements ISafeController {
     return this.#filterOutHidden(pending, safeAddr)
   }
 
-  async fetchExecuted(txns: { chainId: bigint; safeTxnHash: Hex }[]): Promise<
+  async fetchExecuted(
+    safeAddr: Hex,
+    chains: { chainId: bigint; minNonce: number }[]
+  ): Promise<
     {
       safeTxnHash: Hex
       nonce: string
@@ -387,7 +390,7 @@ export class SafeController extends EventEmitter implements ISafeController {
       confirmations?: SafeMultisigConfirmationResponse[]
     }[]
   > {
-    return fetchExecutedTransactions(txns)
+    return fetchExecutedTransactions(safeAddr, chains)
   }
 
   async rejectTxnId(safeTxnIds: string[]) {

--- a/src/libs/portfolio/gecko.ts
+++ b/src/libs/portfolio/gecko.ts
@@ -1,7 +1,7 @@
 import { geckoIdMapper } from '../../consts/coingecko'
 import { Network } from '../../interfaces/network'
 import { QueueElement, Request } from './batcher'
-import { paginate } from './pagination'
+import { paginate } from '../../utils/paginate'
 
 // max tokens per request; we seem to have faster results when it's lower
 const BATCH_LIMIT = 40

--- a/src/libs/portfolio/pagination.ts
+++ b/src/libs/portfolio/pagination.ts
@@ -1,14 +1,4 @@
-import { CollectionResult, MetaData, TokenError, TokenResult } from './interfaces'
-
-export function paginate(input: string[] | [string, bigint[]][], limit: number): any[][] {
-  const pages = []
-  let from = 0
-  for (let i = 1; i <= Math.ceil(input.length / limit); i++) {
-    pages.push(input.slice(from, i * limit))
-    from += limit
-  }
-  return pages
-}
+import { MetaData, TokenError } from './interfaces'
 
 export function flattenResults<T>(
   everything: Promise<[[string, T][], MetaData][]>[]

--- a/src/libs/portfolio/portfolio.ts
+++ b/src/libs/portfolio/portfolio.ts
@@ -37,7 +37,8 @@ import {
   TokenError,
   TokenResult
 } from './interfaces'
-import { flattenResults, paginate } from './pagination'
+import { paginate } from '../../utils/paginate'
+import { flattenResults } from './pagination'
 
 export const LIMITS: Limits = {
   // we have to be conservative with erc721Tokens because if we pass 30x20 (worst case) tokenIds, that's 30x20 extra words which is 19kb

--- a/src/libs/safe/safe.ts
+++ b/src/libs/safe/safe.ts
@@ -27,6 +27,7 @@ import {
   TypedMessageUserRequest,
   UserRequest
 } from '../../interfaces/userRequest'
+import { paginate } from '../../utils/paginate'
 import wait from '../../utils/wait'
 import { withTimeout } from '../../utils/with-timeout'
 import { AccountOp, getAccountOpNonce } from '../accountOp/accountOp'
@@ -432,14 +433,6 @@ export async function getLatestMessages(
   return { ...response, results: finalRes, chainId, type: 'message' }
 }
 
-export async function getTransaction(
-  chainId: bigint,
-  safeTxnHash: Hex
-): Promise<SafeMultisigTransactionResponse> {
-  const apiKit = getApiKit(chainId)
-  return apiKit.getTransaction(safeTxnHash)
-}
-
 export async function fetchAllPending(
   networks: { chainId: bigint; threshold: number }[],
   safeAddr: Hex
@@ -697,8 +690,15 @@ export function sortSigs(
   return concat(sorted.map((s) => s.sig)) as Hex
 }
 
+/**
+ * Fetch the Safe transactions of an account on each of the passed chains.
+ * `minNonce` is the smallest nonce we are still waiting on for that chain -
+ * transactions below it can no longer execute, so the API does not have to
+ * return them.
+ */
 export async function fetchExecutedTransactions(
-  txns: { chainId: bigint; safeTxnHash: Hex }[]
+  safeAddr: Hex,
+  chains: { chainId: bigint; minNonce: number }[]
 ): Promise<
   {
     safeTxnHash: Hex
@@ -707,40 +707,52 @@ export async function fetchExecutedTransactions(
     confirmations?: SafeMultisigConfirmationResponse[]
   }[]
 > {
-  let promises = []
   const results: {
     safeTxnHash: Hex
     nonce: string
     transactionHash?: Hex
     confirmations?: SafeMultisigConfirmationResponse[]
   }[] = []
+  const pages = paginate(chains, 3)
 
-  for (let i = 0; i < txns.length; i++) {
-    const txn = txns[i]!
-    promises.push(getTransaction(txn.chainId, txn.safeTxnHash))
-
+  for (let i = 0; i < pages.length; i++) {
+    const page = pages[i]!
     // we're allowed a max of 5 req to the API per second so we
     // have to be careful - making 3 at a time from here
-    if ((i + 1) % 3 === 0 || i + 1 === txns.length) {
-      const responses = await Promise.all(promises)
-      responses.forEach((r) => {
-        if (r.transactionHash) {
+    const responses = await Promise.all(
+      page.map(({ chainId, minNonce }) => {
+        const apiKit = getApiKit(chainId)
+        // @TODO this method can be used to get safe tx history
+        // @TODO make rate limit tracking for the whole library
+        // Cut the response size down: the account may have a long history, but
+        // everything below minNonce can no longer execute, so it cannot resolve a
+        // request we are waiting on. The double underscore is the filter syntax of
+        // the Safe Transaction Service, not a typo
+        return apiKit.getMultisigTransactions(safeAddr, {
+          ordering: 'nonce',
+          nonce__gte: minNonce
+        })
+      })
+    )
+    responses.forEach(({ results: txns }) => {
+      txns.forEach((tx) => {
+        if (tx.transactionHash) {
           results.push({
-            safeTxnHash: r.safeTxHash as Hex,
-            transactionHash: r.transactionHash as Hex,
-            nonce: r.nonce
+            safeTxnHash: tx.safeTxHash as Hex,
+            transactionHash: tx.transactionHash as Hex,
+            nonce: tx.nonce
           })
         } else {
           results.push({
-            safeTxnHash: r.safeTxHash as Hex,
-            nonce: r.nonce,
-            confirmations: r.confirmations
+            safeTxnHash: tx.safeTxHash as Hex,
+            nonce: tx.nonce,
+            confirmations: tx.confirmations
           })
         }
       })
-      await wait(1100)
-      promises = []
-    }
+    })
+    // no need to throttle after the last page, nothing follows it
+    if (i + 1 < pages.length) await wait(1100)
   }
 
   return results

--- a/src/libs/scamFilter/scamFilter.ts
+++ b/src/libs/scamFilter/scamFilter.ts
@@ -4,7 +4,7 @@ import { geckoIdMapper } from '../../consts/coingecko'
 import { Fetch } from '../../interfaces/fetch'
 import { Network } from '../../interfaces/network'
 import { fetchWithTimeout } from '../../utils/fetch'
-import { paginate } from '../portfolio/pagination'
+import { paginate } from '../../utils/paginate'
 
 const CENA_API_URL = 'https://cena.ambire.com'
 const BATCH_LIMIT = 40

--- a/src/utils/paginate.ts
+++ b/src/utils/paginate.ts
@@ -1,0 +1,13 @@
+/**
+ * Split a list into pages of at most `limit` items each.
+ * Use it to keep batched requests below the limits of an external API.
+ */
+export function paginate<T>(input: T[], limit: number): T[][] {
+  const pages = []
+  let from = 0
+  for (let i = 1; i <= Math.ceil(input.length / limit); i++) {
+    pages.push(input.slice(from, i * limit))
+    from += limit
+  }
+  return pages
+}


### PR DESCRIPTION
Instead of polling the API for each tx for each chain, we can make 1 req for each chain for the account

There should be no change in behavior 