### PR TITLE
Fix: request after account switch should not end with JSON-RPC error

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -520,6 +520,83 @@ describe('RequestsController ', () => {
     expect(controller.userRequestsWaitingAccountSwitch).toHaveLength(0)
     expect(controller.userRequests).toHaveLength(0)
   })
+  test('resolving an account switch continues with the already built transaction request', async () => {
+    const { controller, getCallsRequest, selectedAccountCtrl, accountsCtrl } = await prepareTest()
+    const req = await getCallsRequest({
+      addr: accounts[0]!.addr,
+      chainId: 1n
+    })
+    const resolveMock = jest.fn()
+    const rejectMock = jest.fn()
+    req.dappPromises = [
+      {
+        id: 'account-switch-request',
+        resolve: resolveMock,
+        reject: rejectMock,
+        session: MOCK_SESSION,
+        meta: {}
+      }
+    ]
+    const forceFetchPendingStateSpy = jest
+      .spyOn(accountsCtrl, 'forceFetchPendingState')
+      .mockImplementation(() => Promise.resolve(undefined!))
+
+    await controller.addUserRequests([req], { allowAccountSwitch: true })
+
+    const switchAccountRequest = controller.userRequests[0]!
+    expect(switchAccountRequest.kind).toBe('switchAccount')
+
+    await selectedAccountCtrl.setAccount(accounts[0]!)
+    await controller.resolveUserRequest(null, switchAccountRequest.id)
+
+    expect(forceFetchPendingStateSpy).not.toHaveBeenCalled()
+    expect(controller.userRequestsWaitingAccountSwitch).toHaveLength(0)
+    expect(controller.userRequests).toStrictEqual([req])
+    expect(resolveMock).not.toHaveBeenCalled()
+    expect(rejectMock).not.toHaveBeenCalled()
+  })
+  test('resolving an account switch does not continue before the requested account is selected', async () => {
+    const { controller, getCallsRequest } = await prepareTest()
+    const req = await getCallsRequest({
+      addr: accounts[0]!.addr,
+      chainId: 1n
+    })
+
+    await controller.addUserRequests([req], { allowAccountSwitch: true })
+
+    const switchAccountRequest = controller.userRequests[0]!
+    expect(switchAccountRequest.kind).toBe('switchAccount')
+
+    await controller.resolveUserRequest(null, switchAccountRequest.id)
+
+    expect(controller.userRequests).toHaveLength(0)
+    expect(controller.userRequestsWaitingAccountSwitch).toStrictEqual([req])
+  })
+  test('a new transaction request still requires current account state', async () => {
+    const { controller, getCallsRequest, accountsCtrl } = await prepareTest()
+    const req = await getCallsRequest({
+      addr: '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8',
+      chainId: 1n
+    })
+    const rejectMock = jest.fn()
+    req.dappPromises = [
+      {
+        id: 'transaction-request',
+        resolve: jest.fn(),
+        reject: rejectMock,
+        session: MOCK_SESSION,
+        meta: {}
+      }
+    ]
+    jest
+      .spyOn(accountsCtrl, 'forceFetchPendingState')
+      .mockImplementation(() => Promise.resolve(undefined!))
+
+    await controller.addUserRequests([req])
+
+    expect(controller.userRequests).toHaveLength(0)
+    expect(rejectMock).toHaveBeenCalledWith(expect.objectContaining({ code: -32603 }))
+  })
   test('add multiple user requests', async () => {
     const { controller, getCallsRequest } = await prepareTest()
     const SIGN_ACCOUNT_OP_REQUEST = await getCallsRequest({

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -375,12 +375,14 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       position = 'last',
       executionType = 'open-request-window',
       allowAccountSwitch = false,
-      skipFocus = false
+      skipFocus = false,
+      shouldRefreshAccountState = true
     }: {
       position?: RequestPosition
       executionType?: RequestExecutionType
       allowAccountSwitch?: boolean
       skipFocus?: boolean
+      shouldRefreshAccountState?: boolean
     } = {}
   ) {
     await this.initialLoadPromise
@@ -460,37 +462,39 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           return
         }
 
-        const accountStateBefore =
-          this.#accounts.accountStates?.[meta.accountAddr]?.[meta.chainId.toString()]
+        if (shouldRefreshAccountState) {
+          const accountStateBefore =
+            this.#accounts.accountStates?.[meta.accountAddr]?.[meta.chainId.toString()]
 
-        // Try to update the account state for 3 seconds. If that fails, use the previous account state if it exists,
-        // otherwise wait for the fetch to complete (no matter how long it takes).
-        // This is done in an attempt to always have the latest nonce, but without blocking the UI for too long if the RPC is slow to respond.
-        const accountState = await Promise.race([
-          this.#accounts.forceFetchPendingState(meta.accountAddr, meta.chainId),
-          // Fallback to the old account state if it exists and the fetch takes too long
-          accountStateBefore
-            ? // `undefined` included intentionally - previous `accountStateBefore` may not always exist
-              new Promise<AccountOnchainState | undefined>((res) => {
-                setTimeout(() => res(accountStateBefore), 2000)
-              })
-            : new Promise<AccountOnchainState>(() => {}) // Explicitly never-resolving promise
-        ])
+          // Try to update the account state for 3 seconds. If that fails, use the previous account state if it exists,
+          // otherwise wait for the fetch to complete (no matter how long it takes).
+          // This is done in an attempt to always have the latest nonce, but without blocking the UI for too long if the RPC is slow to respond.
+          const accountState = await Promise.race([
+            this.#accounts.forceFetchPendingState(meta.accountAddr, meta.chainId),
+            // Fallback to the old account state if it exists and the fetch takes too long
+            accountStateBefore
+              ? // `undefined` included intentionally - previous `accountStateBefore` may not always exist
+                new Promise<AccountOnchainState | undefined>((res) => {
+                  setTimeout(() => res(accountStateBefore), 2000)
+                })
+              : new Promise<AccountOnchainState>(() => {}) // Explicitly never-resolving promise
+          ])
 
-        if (!accountState) {
-          const message =
-            "Transaction couldn't be processed because required account data couldn't be retrieved. Please try again later or contact Ambire support."
-          const error = new Error(
-            `requestsController error: accountState for ${meta.accountAddr} is undefined on network with id ${meta.chainId}`
-          )
-          this.emitError({ level: 'major', message, error })
+          if (!accountState) {
+            const message =
+              "Transaction couldn't be processed because required account data couldn't be retrieved. Please try again later or contact Ambire support."
+            const error = new Error(
+              `requestsController error: accountState for ${meta.accountAddr} is undefined on network with id ${meta.chainId}`
+            )
+            this.emitError({ level: 'major', message, error })
 
-          req.dappPromises.forEach((p) => {
-            p.reject(ethErrors.rpc.internal())
-          })
-          await this.#ui.notification.create({ title: "Couldn't Process Request", message })
+            req.dappPromises.forEach((p) => {
+              p.reject(ethErrors.rpc.internal())
+            })
+            await this.#ui.notification.create({ title: "Couldn't Process Request", message })
 
-          return
+            return
+          }
         }
 
         userRequestsToAdd.push(req)
@@ -962,7 +966,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     if (safeResolveIds.length) await this.#safe.resolveTxnId(safeResolveIds)
 
     if (userRequestsToAdd.length) {
-      await this.addUserRequests(userRequestsToAdd, { skipFocus: true })
+      await this.addUserRequests(userRequestsToAdd, {
+        skipFocus: true,
+        shouldRefreshAccountState: false
+      })
     }
 
     if (!this.visibleUserRequests.length) {


### PR DESCRIPTION
We have this bug:
1. I'm connected to an app (safe global) with an account
2. But the selectedAccount in the extension is a different one than the one I'm connected to the app with
3. I initiate a request from the app
4. The extension opens an account switch request correctly
5. The moment I switch the account (it happens successfully on the extension side), I receive an "An internal error was received. Details: Internal JSON-RPC error. Version: viem@2.52.2" on the app side

Root cause: after a successful account switch, the already-built transaction was unnecessarily refreshing account state again. If that refresh returned no data, the app promise was rejected with JSON-RPC error -32603

The fix resumes the existing transaction without that redundant refresh, while preserving:
* Account-address matching before continuation
* State validation for genuinely new transactions
* Normal rejection behavior