### PR TITLE
Hotfix/ `new Date().getTime()` ids are not reliable and conflict in the Requests controller

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -111,6 +111,7 @@ import { SquidAPI } from '@/services/squid/api'
 import { SwapProviderParallelExecutor } from '@/services/swapIntegrators/swapProviderParallelExecutor'
 import { UniswapAPI } from '@/services/uniswap/api'
 import { getHdPathFromTemplate } from '@/utils/hdPath'
+import { generateUuid } from '@/utils/uuid'
 import wait from '@/utils/wait'
 
 type AccountsUpdate = {
@@ -1935,7 +1936,7 @@ export class MainController extends EventEmitter implements IMainController {
 
     if (openBenzin) {
       const benzinUserRequest: BenzinUserRequest = {
-        id: new Date().getTime(),
+        id: generateUuid(),
         kind: 'benzin',
         meta,
         dappPromises: []

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1216,7 +1216,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       }
 
       userRequest = {
-        id: new Date().getTime(),
+        id: generateUuid(),
         kind: 'message',
         meta: { params: { message: msg[0] }, accountAddr: msgAddress, chainId: network.chainId },
         dappPromises: [
@@ -1367,7 +1367,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       }
 
       userRequest = {
-        id: new Date().getTime(),
+        id: generateUuid(),
         kind: 'typedMessage',
         meta: {
           params: {
@@ -1383,7 +1383,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       } as TypedMessageUserRequest
     } else {
       userRequest = {
-        id: new Date().getTime(),
+        id: generateUuid(),
         kind,
         meta: { params: request.params },
         dappPromises: [{ ...dappPromise, session: request.session, meta: {} }]

--- a/src/libs/erc7677/erc7677.ts
+++ b/src/libs/erc7677/erc7677.ts
@@ -1,5 +1,7 @@
 import { toBeHex, toQuantity } from 'ethers'
 
+import { generateUuid } from '@/utils/uuid'
+
 import { ERC_4337_ENTRYPOINT } from '../../consts/deploy'
 import { Network } from '../../interfaces/network'
 import { getRpcProvider } from '../../services/provider'
@@ -29,7 +31,7 @@ export function getPaymasterService(
   // this means it's v2
   if ('url' in capabilities.paymasterService) {
     const paymasterService = capabilities.paymasterService
-    paymasterService.id = new Date().getTime()
+    paymasterService.id = generateUuid()
     return paymasterService
   }
 
@@ -43,7 +45,7 @@ export function getPaymasterService(
   if (!foundChainId) return undefined
 
   const paymasterService = capabilities.paymasterService[foundChainId]
-  paymasterService.id = new Date().getTime()
+  paymasterService.id = generateUuid()
   return paymasterService
 }
 
@@ -59,7 +61,7 @@ export function getAmbirePaymasterService(
 
   return {
     url: getAmbireSponsorshipUrl(relayerUrl),
-    id: new Date().getTime(),
+    id: generateUuid(),
     context: {
       policyId: AMBIRE_NETWORK_WIDE_SPONSORSHIP_POLICY
     }

--- a/src/libs/erc7677/types.ts
+++ b/src/libs/erc7677/types.ts
@@ -9,7 +9,7 @@ export interface PaymasterService {
       decimals: number
     }
   }
-  id: number
+  id: string
   failed?: boolean
 }
 

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -1,5 +1,7 @@
 import { AbiCoder, Contract, Interface, toBeHex, ZeroAddress } from 'ethers'
 
+import { generateUuid } from '@/utils/uuid'
+
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import entryPointAbi from '../../../contracts/compiled/EntryPoint.json'
 import { FEE_COLLECTOR } from '../../consts/addresses'
@@ -434,7 +436,7 @@ export class Paymaster extends AbstractPaymaster {
         getPaymasterStubData(
           {
             url: getAmbireSponsorshipUrl(this.#relayerUrl),
-            id: new Date().getTime(),
+            id: generateUuid(),
             context: {
               policyId: AMBIRE_SWAP_POLICY,
               swapSponsorship: {

--- a/src/libs/requests/requests.ts
+++ b/src/libs/requests/requests.ts
@@ -1,3 +1,5 @@
+import { generateUuid } from '@/utils/uuid'
+
 import { DappProviderRequest } from '../../interfaces/dapp'
 import {
   CallsUserRequest,
@@ -87,7 +89,7 @@ export const buildSwitchAccountUserRequest = ({
   dappPromises: UserRequest['dappPromises']
 }): SwitchAccountRequest => {
   return {
-    id: new Date().getTime(),
+    id: generateUuid(),
     kind: 'switchAccount',
     meta: {
       accountAddr: selectedAccountAddr,

--- a/src/services/paymaster/FailedPaymasters.ts
+++ b/src/services/paymaster/FailedPaymasters.ts
@@ -10,7 +10,7 @@ import { RPCProvider } from '../../interfaces/provider'
 
 // so the app can fallback to a standard Paymaster if a sponsorship fails
 export class FailedPaymasters {
-  failedSponsorshipIds: number[] = []
+  failedSponsorshipIds: string[] = []
 
   insufficientFundsNetworks: {
     [chainId: number]: {
@@ -18,11 +18,11 @@ export class FailedPaymasters {
     }
   } = {}
 
-  addFailedSponsorship(id: number) {
+  addFailedSponsorship(id: string) {
     this.failedSponsorshipIds.push(id)
   }
 
-  hasFailedSponsorship(id: number): boolean {
+  hasFailedSponsorship(id: string): boolean {
     return this.failedSponsorshipIds.includes(id)
   }
 


### PR DESCRIPTION
## How to reproduce:
Follow these steps https://github.com/AmbireTech/ambire-common/pull/2628

## Why:
Because both requests' ids are constructed in the same tick. I came to that conclusion by inspecting the logs and seeing that the switch account and sign message requests have the same id. It was resolved immediately after appending `-switch-account` to one of the requests.


<img width="1284" height="495" alt="1787052422991257749" src="https://github.com/user-attachments/assets/065b5e40-2b14-45cb-9f0f-5ae71e6e3173" />

as you can see `kind=message` and `kind=switchAccount` have exactly the same id, excluding the suffix.
