### PR TITLE
Fix spacing between Safe network names

### DIFF
--- a/src/controllers/safe/safe.ts
+++ b/src/controllers/safe/safe.ts
@@ -145,7 +145,7 @@ export class SafeController extends EventEmitter implements ISafeController {
     if (!deployedOn) {
       this.importError = {
         address: safeAddr,
-        message: `The Safe account is not deployed on any of your enabled networks that have Safe support: ${safeNetworks.map((n) => n.name).join(',')}. Please deploy it from Safe Global on at least one network before continuing`
+        message: `The Safe account is not deployed on any of your enabled networks that have Safe support: ${safeNetworks.map((n) => n.name).join(', ')}. Please deploy it from Safe Global on at least one network before continuing`
       }
       return
     }


### PR DESCRIPTION
## What
Adds spaces after commas in the list of Safe-supported networks.

## Why
Without spaces, the network list is rendered as a continuous string, causing poor text wrapping in the warning message.

<img width="367" height="238" alt="Screenshot 2026-08-19 at 13 18 38" src="https://github.com/user-attachments/assets/af7a29d3-e6f8-4734-ae8e-24acbd30978f" />
