### PR TITLE
accounts sync: transfer keys with a one-time key, never the main key

### DIFF
--- a/src/controllers/keystore/keystore.test.ts
+++ b/src/controllers/keystore/keystore.test.ts
@@ -550,18 +550,14 @@ describe('accounts sync between two devices', () => {
   const importingPass = 'importingDevicePass'
 
   let exportingKeystore: IKeystoreController
+  let exportingStore: ReturnType<typeof produceMemoryStore>
   let importingKeystore: IKeystoreController
   let exportedSeedId: string
 
   const uiCtrl = new UiController({ uiManager })
 
-  const createKeystore = () =>
-    new KeystoreController(
-      'default',
-      new StorageController(produceMemoryStore()),
-      keystoreSigners,
-      uiCtrl
-    )
+  const createKeystore = (store = produceMemoryStore()) =>
+    new KeystoreController('default', new StorageController(store), keystoreSigners, uiCtrl)
 
   // The in-memory store resolves writes immediately, which hides ordering a real
   // (async) device store would expose
@@ -580,7 +576,8 @@ describe('accounts sync between two devices', () => {
       .then((exported) => ({ v: 1 as const, accounts: [], ...exported }))
 
   beforeEach(async () => {
-    exportingKeystore = createKeystore()
+    exportingStore = produceMemoryStore()
+    exportingKeystore = createKeystore(exportingStore)
     await exportingKeystore.addSecret('password', exportingPass, '', false)
     await exportingKeystore.unlockWithSecret('password', exportingPass)
 
@@ -620,18 +617,42 @@ describe('accounts sync between two devices', () => {
     importingKeystore = createKeystore()
   })
 
-  test('exports the selected keys, their seed and the password wrapped main key', async () => {
+  test('exports the selected keys, their seed and the password wrapped transfer key', async () => {
     const exported = await exportingKeystore.exportForSync([keyPublicAddress])
 
-    expect(exported.secret.id).toBe('password')
-    expect(exported.secret.aesEncrypted.cipherType).toBe('AES-GCM')
-    // The private key must leave the device encrypted, exactly as it is stored
+    expect(exported.transferKey.aesEncrypted.cipherType).toBe('AES-GCM')
+    expect(typeof exported.transferKey.scryptParams.salt).toBe('string')
+    // The private key must leave the device encrypted
     expect(exported.keys).toHaveLength(1)
     expect(exported.keys[0]!.addr).toBe(keyPublicAddress)
     expect(exported.keys[0]!.privKey).toMatchObject({ cipherType: 'AES-GCM' })
     expect(JSON.stringify(exported)).not.toContain(privKey)
     // Only the seed the exported key was derived from
     expect(exported.seeds.map((s) => s.id)).toEqual([exportedSeedId])
+  })
+
+  test('never lets the main key of the exporting device travel', async () => {
+    const exported = await exportingKeystore.exportForSync([keyPublicAddress])
+
+    // Whoever films the QR codes and cracks the password must not end up with the key
+    // that decrypts everything this device stores, now and in the future
+    const storedSecrets: any = await exportingStore.get('keystoreSecrets')
+    expect(JSON.stringify(exported)).not.toContain(storedSecrets[0].aesEncrypted.ciphertext)
+
+    // The payload is keyed per export, so two exports share no ciphertext either
+    const secondExport = await exportingKeystore.exportForSync([keyPublicAddress])
+    expect(secondExport.transferKey.aesEncrypted.ciphertext).not.toBe(
+      exported.transferKey.aesEncrypted.ciphertext
+    )
+    expect(secondExport.keys[0]!.privKey).not.toEqual(exported.keys[0]!.privKey)
+  })
+
+  test('re-encrypts the exported keys away from how they are stored', async () => {
+    const exported = await exportingKeystore.exportForSync([keyPublicAddress])
+    const storedKeys: any = await exportingStore.get('keystoreKeys')
+    const storedKey = storedKeys.find((k: any) => k.addr === keyPublicAddress)
+
+    expect(exported.keys[0]!.privKey).not.toEqual(storedKey.privKey)
   })
 
   test('does not export keys that were not selected', async () => {
@@ -668,6 +689,25 @@ describe('accounts sync between two devices', () => {
       await expect(biometricsOnlyKeystore.exportForSync([keyPublicAddress])).rejects.toThrow(
         'Set a password for this device before syncing your accounts.'
       )
+    })
+
+    test('asks for the password once when it was never typed on this device', async () => {
+      await exportingKeystore.addSecret('biometrics', 'biometricsSecret', '', true)
+      // A device that last unlocked with biometrics has no stored password derived key,
+      // so there is nothing to wrap the transfer key with
+      await exportingStore.set('keystorePasswordSecretKey', null)
+
+      const biometricsSession = createKeystore(exportingStore)
+      await biometricsSession.unlockWithSecret('biometrics', 'biometricsSecret')
+
+      await expect(biometricsSession.exportForSync([keyPublicAddress])).rejects.toThrow(
+        'Unlock the app with your password once before syncing your accounts.'
+      )
+
+      // Typing the password once stores it, and the export works from then on
+      await biometricsSession.unlockWithSecret('password', exportingPass)
+
+      await expect(biometricsSession.exportForSync([keyPublicAddress])).resolves.toBeDefined()
     })
 
     test('does not import anything when the password of the other device is wrong', async () => {

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -12,11 +12,14 @@ import {
   CIPHER_OLD,
   decryptMainKeyWithSecret,
   decryptStoredSeed,
+  decryptTransferKeyWithSecret,
   decryptWithKey,
   deriveSecret,
   encryptMainKeyWithSecret,
+  encryptTransferKeyWithSecret,
   encryptWithKey,
   extractEntropyFromSeed,
+  generateTransferKey,
   getBytesForSecret,
   migrateStoredPayloadsToGCM,
   SCRYPT_PARAMS
@@ -32,7 +35,6 @@ import { Account } from '../../interfaces/account'
 import { IEventEmitterRegistryController, Statuses } from '../../interfaces/eventEmitter'
 import { KeyIterator } from '../../interfaces/keyIterator'
 import {
-  AESGCMEncrypted,
   ExternalKey,
   IKeystoreController,
   InternalKey,
@@ -341,6 +343,12 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
         })
       }
     }
+
+    // Kept for the accounts sync export, which has to wrap its one-time transfer key
+    // with the password of this device without asking the user for it again. Written on
+    // every password unlock (both ciphers keep the same salt, so the key stays valid)
+    if (secretId === 'password' && this.#mainKey)
+      await this.#storePasswordSecretKey(this.#mainKey, secretKey)
   }
 
   /**
@@ -388,27 +396,55 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
     secretKey: Uint8Array<ArrayBuffer>,
     secretEntry: MainKeyEncryptedWithSecret
   ) {
-    if (secretEntry.aesEncrypted.cipherType !== CIPHER) {
+    const aesEncrypted = secretEntry.aesEncrypted
+    if (aesEncrypted.cipherType !== CIPHER) {
       throw new Error('keystore: invalid gcm secret cipher type')
     }
 
-    this.#mainKey = await this.#decryptMainKeyWithSecret(secretKey, secretEntry.aesEncrypted)
+    this.#mainKey = await this.#unwrapKeyWithSecret(() =>
+      decryptMainKeyWithSecret(secretKey, aesEncrypted)
+    )
 
     this.errorMessage = ''
   }
 
   /**
-   * Decrypts a main key wrapped with the provided secret, translating a wrong
-   * secret into the user facing "Incorrect password" error. Used both when
-   * unlocking this device and when importing keys synced from another device
-   * (where the main key of the other device gets unwrapped with its password).
+   * Persists the key derived from the device password, encrypted with the main key. It
+   * is what lets the accounts sync export wrap a one-time transfer key for the other
+   * device without the password being typed again, and without the main key ever
+   * leaving this device. Knowing it grants nothing the main key does not already grant.
    */
-  async #decryptMainKeyWithSecret(
-    secretKey: Uint8Array<ArrayBuffer>,
-    aesEncrypted: AESGCMEncrypted
-  ): Promise<MainKey> {
+  async #storePasswordSecretKey(mainKey: MainKey, secretKey: Uint8Array<ArrayBuffer>) {
+    await this.#storage.set(
+      'keystorePasswordSecretKey',
+      await encryptWithKey(mainKey, secretKey.slice(0, 32))
+    )
+  }
+
+  /**
+   * The stored password derived key, or null when this device has not been unlocked with
+   * its password since the key started being stored (e.g. biometrics only sessions).
+   */
+  async #getPasswordSecretKey(): Promise<Uint8Array<ArrayBuffer> | null> {
+    if (!this.#mainKey) return null
+
+    const encryptedSecretKey = await this.#storage.get('keystorePasswordSecretKey', null)
+    if (!encryptedSecretKey) return null
+
+    const secretKey = await decryptWithKey(this.#mainKey, encryptedSecretKey)
+
+    return secretKey as Uint8Array<ArrayBuffer>
+  }
+
+  /**
+   * Unwraps a key that was wrapped with a secret derived from a password, translating a
+   * wrong password into the user facing "Incorrect password" error. Used both when
+   * unlocking this device and when importing accounts synced from another device (where
+   * the one time transfer key gets unwrapped with the other device's password).
+   */
+  async #unwrapKeyWithSecret(unwrap: () => Promise<CryptoKey>): Promise<CryptoKey> {
     try {
-      return await decryptMainKeyWithSecret(secretKey, aesEncrypted)
+      return await unwrap()
     } catch (error: any) {
       // Either wrong password or corrupted/tampered ciphertext
       if (error?.name === 'OperationError') {
@@ -592,6 +628,10 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
     // Persist the new secrets
     await this.#storage.set('keystoreSecrets', this.#keystoreSecrets)
 
+    // Kept for the accounts sync export, which has to wrap its one-time transfer key
+    // with the password of this device without asking the user for it again
+    if (secretId === 'password') await this.#storePasswordSecretKey(mainKey, secretKey)
+
     // produce uid if one doesn't exist (should be created when the first secret is added)
     if (!this.keyStoreUid) {
       const exportedMainKeyUint8Array = new Uint8Array(
@@ -626,6 +666,9 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
 
     this.#keystoreSecrets = this.#keystoreSecrets.filter((x) => x.id !== secretId)
     await this.#storage.set('keystoreSecrets', this.#keystoreSecrets)
+
+    // The stored derived key belongs to the removed password, so it must not outlive it
+    if (secretId === 'password') await this.#storage.set('keystorePasswordSecretKey', null)
   }
 
   async removeSecret(secretId: string) {
@@ -1221,9 +1264,10 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
 
   /**
    * Collects everything another Ambire product needs in order to take over the given
-   * keys: the keys themselves and the seeds they were derived from (still encrypted
-   * with this device's main key), plus this device's main key wrapped with its password.
-   * Nothing gets decrypted here, so this works even when the keystore is locked.
+   * keys: the keys themselves and the seeds they were derived from, re-encrypted with a
+   * one-time transfer key, plus that transfer key wrapped with this device's password.
+   * This device's main key never travels, so a leaked payload exposes only the accounts
+   * inside it. Requires the keystore to be unlocked, since the data gets re-encrypted.
    *
    * `includeSeeds` is what the user chose on the confirmation screen: with it off the
    * keys still travel (so the accounts can sign on the other device), but the recovery
@@ -1232,8 +1276,16 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
   async exportForSync(
     keyAddrs: Key['addr'][],
     includeSeeds: boolean = true
-  ): Promise<Pick<AccountsSyncPayload, 'secret' | 'keys' | 'seeds'>> {
+  ): Promise<Pick<AccountsSyncPayload, 'transferKey' | 'keys' | 'seeds'>> {
     await this.initialLoadPromise
+
+    const mainKey = this.#mainKey
+    if (!mainKey)
+      throw new EmittableError({
+        level: 'expected',
+        message: 'Unlock the app before syncing your accounts.',
+        error: new Error('keystore: needs to be unlocked')
+      })
 
     const secret = this.#keystoreSecrets.find((s) => s.id === 'password')
     if (!secret)
@@ -1249,6 +1301,16 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
         message:
           'Something went wrong when preparing your accounts for syncing. Please unlock the app again or contact support if the problem persists.',
         error: new Error('keystore: password secret not migrated to GCM yet')
+      })
+
+    // Missing only for devices that have not been unlocked with their password since the
+    // key started being stored, so asking for it once is enough to have it from then on
+    const passwordSecretKey = await this.#getPasswordSecretKey()
+    if (!passwordSecretKey)
+      throw new EmittableError({
+        level: 'expected',
+        message: 'Unlock the app with your password once before syncing your accounts.',
+        error: new Error('keystore: no stored password secret key to sync with')
       })
 
     const keys = this.#keystoreKeys.filter((key) => keyAddrs.includes(key.addr))
@@ -1274,13 +1336,42 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
         error: new Error('keystore: keys or seeds not migrated to GCM yet')
       })
 
-    return { secret, keys, seeds }
+    // Generated for this export alone and never persisted, so that the main key of this
+    // device stays on it. A leaked payload then exposes only the accounts inside it
+    const transferKey = await generateTransferKey()
+    const reEncryptForTransfer = async (payload: KeystoreEncryptedPayload) =>
+      encryptWithKey(transferKey, await decryptWithKey(mainKey, payload))
+
+    const keysForTransfer = await Promise.all(
+      keys.map(async (key) =>
+        key.type === 'internal' ? { ...key, privKey: await reEncryptForTransfer(key.privKey) } : key
+      )
+    )
+    const seedsForTransfer = await Promise.all(
+      seeds.map(async (seed) => ({
+        ...seed,
+        seed: await reEncryptForTransfer(seed.seed),
+        seedPassphrase: seed.seedPassphrase ? await reEncryptForTransfer(seed.seedPassphrase) : null
+      }))
+    )
+
+    return {
+      // The salt of this device's password is reused, because the transfer key has to be
+      // wrapped without the password itself, which is never stored
+      transferKey: {
+        scryptParams: secret.scryptParams,
+        aesEncrypted: await encryptTransferKeyWithSecret(transferKey, passwordSecretKey)
+      },
+      keys: keysForTransfer,
+      seeds: seedsForTransfer
+    }
   }
 
   /**
    * Takes over the keys and seeds exported by another Ambire product. The password of
-   * that other device unwraps its main key, which is used only to decrypt the synced
-   * data in memory - everything is then re-encrypted with this device's main key.
+   * that other device unwraps the one-time key its payload was encrypted with, which is
+   * used only to decrypt the synced data in memory - everything is then re-encrypted
+   * with this device's main key.
    *
    * Intentionally not wrapped in `withStatus` and lets errors propagate, because the
    * MainController orchestrates the whole migration (and must not add the accounts if
@@ -1289,18 +1380,25 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
   async importFromSync(payload: AccountsSyncPayload, password: string) {
     await this.initialLoadPromise
 
-    const { secret, keys, seeds } = payload
-    if (secret.aesEncrypted.cipherType !== CIPHER)
-      throw new Error('keystore: synced main key is not encrypted with GCM')
+    const { transferKey, keys, seeds } = payload
+    if (transferKey.aesEncrypted.cipherType !== CIPHER)
+      throw new Error('keystore: synced transfer key is not encrypted with GCM')
 
-    const secretKey = await deriveSecret(this.#scryptAdapter, password, secret.scryptParams.salt)
-    // The exporting device's main key. Kept in this scope only, never persisted.
-    const exportedMainKey = await this.#decryptMainKeyWithSecret(secretKey, secret.aesEncrypted)
+    const secretKey = await deriveSecret(
+      this.#scryptAdapter,
+      password,
+      transferKey.scryptParams.salt
+    )
+    // The one-time key the payload was encrypted with on the other device. Kept in this
+    // scope only, never persisted, and imported so that it can only ever decrypt.
+    const payloadKey = await this.#unwrapKeyWithSecret(() =>
+      decryptTransferKeyWithSecret(secretKey, transferKey.aesEncrypted)
+    )
 
     // Seeds first, so the keys below can be linked to the seed they were derived from
     const syncedSeedIds: { [exportedSeedId: string]: StoredKeystoreSeed['id'] } = {}
     for (const seed of seeds) {
-      const { seed: decryptedSeed, seedPassphrase } = await decryptStoredSeed(exportedMainKey, seed)
+      const { seed: decryptedSeed, seedPassphrase } = await decryptStoredSeed(payloadKey, seed)
 
       syncedSeedIds[seed.id] = await this.#storeSyncedSeed({
         id: seed.id,
@@ -1329,7 +1427,7 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
         type: 'internal',
         label: key.label,
         dedicatedToOneSA: key.dedicatedToOneSA,
-        privateKey: hexlify(await decryptWithKey(exportedMainKey, key.privKey)),
+        privateKey: hexlify(await decryptWithKey(payloadKey, key.privKey)),
         meta: syncedFromSeedId ? { ...restMeta, fromSeedId: syncedFromSeedId } : restMeta
       })
     }

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1715,11 +1715,11 @@ export class MainController extends EventEmitter implements IMainController {
         })
 
       const keyAddrs = Array.from(new Set(accounts.flatMap((account) => account.associatedKeys)))
-      const { secret, keys, seeds } = await this.keystore.exportForSync(keyAddrs, includeSeeds)
+      const { transferKey, keys, seeds } = await this.keystore.exportForSync(keyAddrs, includeSeeds)
 
       return serializeAccountsSyncPayload({
         v: ACCOUNTS_SYNC_PAYLOAD_VERSION,
-        secret,
+        transferKey,
         accounts,
         keys,
         seeds

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -136,6 +136,22 @@ export type MainKeyEncryptedWithSecret = {
   aesEncrypted: AESEncryptedOld | AESGCMEncrypted
 }
 
+/**
+ * The key derived from the device password, encrypted with the main key. Persisted so
+ * that the accounts sync export can wrap its one-time transfer key for the importing
+ * device without asking for the password again (and without ever sending the main key).
+ */
+export type StoredPasswordSecretKey = AESGCMEncrypted
+
+/**
+ * The one-time key an accounts sync payload is encrypted with, wrapped with the key
+ * derived from the exporting device's password.
+ */
+export type AccountsSyncTransferKey = {
+  scryptParams: ScryptParams
+  aesEncrypted: AESGCMEncrypted
+}
+
 export type MainKeyOld = {
   key: Uint8Array
   iv: Uint8Array

--- a/src/interfaces/storage.ts
+++ b/src/interfaces/storage.ts
@@ -19,7 +19,13 @@ import { Selectors } from './contractInfo'
 import { ControllerInterface } from './controller'
 import { Dapp, RecentDappEntry, TrendingToken } from './dapp'
 import { Domains } from './domains'
-import { Key, MainKeyEncryptedWithSecret, StoredKey, StoredKeystoreSeed } from './keystore'
+import {
+  Key,
+  MainKeyEncryptedWithSecret,
+  StoredKey,
+  StoredKeystoreSeed,
+  StoredPasswordSecretKey
+} from './keystore'
 import { Network } from './network'
 import type { FeeSpeed } from './signAccountOp'
 import { SwapAndBridgeActiveRoute } from './swapAndBridge'
@@ -50,6 +56,7 @@ export type StorageProps = {
   // Keystore
   keyStoreUid: string | null
   keystoreSecrets: MainKeyEncryptedWithSecret[]
+  keystorePasswordSecretKey: StoredPasswordSecretKey | null
   keyPreferences: { addr: Key['addr']; type: Key['type']; label: string }[]
   keystoreKeys: StoredKey[]
   keystoreSeeds: StoredKeystoreSeed[]

--- a/src/libs/accountsSync/accountsSync.test.ts
+++ b/src/libs/accountsSync/accountsSync.test.ts
@@ -22,8 +22,7 @@ const gcmPayload = (byteLength: number) => ({
 
 const buildPayload = (): AccountsSyncPayload => ({
   v: ACCOUNTS_SYNC_PAYLOAD_VERSION,
-  secret: {
-    id: 'password',
+  transferKey: {
     scryptParams: { salt: `0x${'ef'.repeat(32)}`, N: 131072, r: 8, p: 1, dkLen: 64 },
     aesEncrypted: gcmPayload(48)
   },
@@ -128,25 +127,23 @@ describe('accountsSync payload', () => {
     )
   })
 
-  it('rejects a payload without the password protected main key', () => {
-    const withBiometricsSecret = buildPayload()
-    withBiometricsSecret.secret.id = 'biometrics'
+  it('rejects a payload without the password protected transfer key', () => {
+    const payload: any = buildPayload()
+    delete payload.transferKey
 
-    expect(() => serializeAndParse(withBiometricsSecret)).toThrow(
-      'missing the password protected main key'
-    )
+    expect(() => serializeAndParse(payload)).toThrow('missing the password protected transfer key')
   })
 
   it('rejects invalid scrypt params', () => {
     const payload: any = buildPayload()
-    delete payload.secret.scryptParams.N
+    delete payload.transferKey.scryptParams.N
 
     expect(() => serializeAndParse(payload)).toThrow('invalid scrypt params')
   })
 
-  it('rejects a main key that is not AES-GCM encrypted', () => {
+  it('rejects a transfer key that is not AES-GCM encrypted', () => {
     const payload: any = buildPayload()
-    payload.secret.aesEncrypted = {
+    payload.transferKey.aesEncrypted = {
       cipherType: 'aes-128-ctr',
       ciphertext: '0xabab',
       iv: '0xcdcd',

--- a/src/libs/accountsSync/accountsSync.ts
+++ b/src/libs/accountsSync/accountsSync.ts
@@ -2,11 +2,7 @@ import { hexlify, isAddress, toUtf8Bytes, toUtf8String } from 'ethers'
 import { gzip, Inflate } from 'pako'
 
 import { Account } from '../../interfaces/account'
-import {
-  MainKeyEncryptedWithSecret,
-  StoredKey,
-  StoredKeystoreSeed
-} from '../../interfaces/keystore'
+import { AccountsSyncTransferKey, StoredKey, StoredKeystoreSeed } from '../../interfaces/keystore'
 import { CIPHER, tryParseGcmPayload } from '../keystore/keystore'
 
 /**
@@ -18,15 +14,17 @@ export const ACCOUNTS_SYNC_PAYLOAD_VERSION = 1
 
 /**
  * Everything needed to move accounts (and the keys controlling them) from one
- * Ambire product to another. Sensitive data travels exactly as it is stored:
- * private keys and seeds stay encrypted with the exporting device's main key,
- * which itself travels wrapped with the exporting device's password (`secret`).
- * The importing device unwraps the main key with that password, decrypts and
- * re-encrypts everything with its own main key.
+ * Ambire product to another. Private keys and seeds are re-encrypted with a one-time
+ * transfer key generated for this export alone, which itself travels wrapped with the
+ * exporting device's password. The importing device unwraps the transfer key with that
+ * password, decrypts everything and re-encrypts it with its own main key.
+ *
+ * The exporting device's main key never travels, so a leaked payload exposes only the
+ * accounts inside it, and never the device it came from.
  */
 export type AccountsSyncPayload = {
   v: typeof ACCOUNTS_SYNC_PAYLOAD_VERSION
-  secret: MainKeyEncryptedWithSecret
+  transferKey: AccountsSyncTransferKey
   accounts: Account[]
   keys: StoredKey[]
   seeds: StoredKeystoreSeed[]
@@ -37,11 +35,10 @@ const requireGcmPayload = (payload: any, what: string) => {
     throw new Error(`accountsSync: ${what} is not encrypted with ${CIPHER}`)
 }
 
-const validateSecret = (secret: any) => {
-  if (!secret || secret.id !== 'password')
-    throw new Error('accountsSync: missing the password protected main key')
+const validateTransferKey = (transferKey: any) => {
+  if (!transferKey) throw new Error('accountsSync: missing the password protected transfer key')
 
-  const { salt, N, r, p, dkLen } = secret.scryptParams || {}
+  const { salt, N, r, p, dkLen } = transferKey.scryptParams || {}
   const hasValidScryptParams =
     typeof salt === 'string' &&
     typeof N === 'number' &&
@@ -50,7 +47,7 @@ const validateSecret = (secret: any) => {
     typeof dkLen === 'number'
   if (!hasValidScryptParams) throw new Error('accountsSync: invalid scrypt params')
 
-  requireGcmPayload(secret.aesEncrypted, 'the main key')
+  requireGcmPayload(transferKey.aesEncrypted, 'the transfer key')
 }
 
 const validateAccounts = (accounts: any) => {
@@ -156,7 +153,7 @@ export const parseAccountsSyncPayload = (bytes: Uint8Array): AccountsSyncPayload
   if (payload?.v !== ACCOUNTS_SYNC_PAYLOAD_VERSION)
     throw new Error(`accountsSync: unsupported payload version ${payload?.v}`)
 
-  validateSecret(payload.secret)
+  validateTransferKey(payload.transferKey)
   validateAccounts(payload.accounts)
   validateKeys(payload.keys)
   validateSeeds(payload.seeds)

--- a/src/libs/keystore/keystore.ts
+++ b/src/libs/keystore/keystore.ts
@@ -188,6 +188,56 @@ export const decryptWithKey = async (
 }
 
 /**
+ * Imports a raw scrypt output as the AES key it was derived to be. Only the first 32
+ * bytes (256 bits) are used, matching how the main key is wrapped with a secret.
+ */
+export const importSecretKey = async (
+  secretKey: Uint8Array<ArrayBuffer>,
+  usages: KeyUsage[]
+): Promise<CryptoKey> =>
+  crypto.subtle.importKey('raw', secretKey.slice(0, 32), { name: CIPHER }, false, usages)
+
+/**
+ * The one-time key an accounts sync payload is encrypted with. Generated per export and
+ * never persisted, so that the exporting device's main key never leaves it.
+ */
+export const generateTransferKey = (): Promise<CryptoKey> =>
+  crypto.subtle.generateKey({ name: CIPHER, length: 256 }, true, ['encrypt', 'decrypt'])
+
+/**
+ * Wraps the one-time transfer key of an accounts sync payload with the key derived from
+ * the exporting device's password, which is the only thing the importing device can
+ * derive from what its user types.
+ */
+export const encryptTransferKeyWithSecret = async (
+  transferKey: CryptoKey,
+  secretKey: Uint8Array<ArrayBuffer>
+): Promise<AESGCMEncrypted> => {
+  const importedSecretKey = await importSecretKey(secretKey, ['encrypt'])
+  const exportedTransferKey = new Uint8Array(await crypto.subtle.exportKey('raw', transferKey))
+
+  return encryptWithKey(importedSecretKey, exportedTransferKey)
+}
+
+/**
+ * Unwraps the transfer key of a scanned accounts sync payload. Imported as
+ * non-extractable and for decryption only, because that is all the importing device
+ * ever does with it.
+ */
+export const decryptTransferKeyWithSecret = async (
+  secretKey: Uint8Array<ArrayBuffer>,
+  aesEncrypted: AESGCMEncrypted
+): Promise<CryptoKey> => {
+  const importedSecretKey = await importSecretKey(secretKey, ['decrypt'])
+
+  const decrypted = await decryptWithKey(importedSecretKey, aesEncrypted)
+
+  return crypto.subtle.importKey('raw', decrypted.slice(0, 32), { name: CIPHER }, false, [
+    'decrypt'
+  ])
+}
+
+/**
  * Decrypts a stored seed entry with the main key it was encrypted with. Handles both
  * the entropy bytes seeds are stored as after the GCM migration and the plain mnemonic
  * legacy ones stored before it.


### PR DESCRIPTION
The sync payload used to carry this device's main key, wrapped with its password, and the keys and seeds encrypted with that same main key. Anyone who filmed the QR codes and later cracked the password ended up with the main key itself, which decrypts everything the keystore holds - including keys the user left out of the export and anything added afterwards. Because the main key never rotates, changing the password could not undo that.

Now every export generates a one-time transfer key, re-encrypts the exported keys and seeds with it and wraps only that key with the password. The main key stays on the device, so a leaked payload exposes just the accounts inside it, each export is independently keyed, and a password change afterwards genuinely protects the device.

To wrap the transfer key the export needs the key derived from the password, which is not something an unlocked keystore holds (and biometrics unlocks never see the password at all). So the derived key is now persisted, encrypted with the main key, on every password set, change and unlock. It reveals nothing beyond the main key: it cannot be reversed into the password, and its only power is decrypting the main key, which whoever holds it already has. It is decrypted for the duration of a single export and never kept in memory. The salt of the device password is reused, because the password itself is never stored and a fresh salt could not be derived without it.

The scanned transfer key is imported non-extractable and for decryption only, since that is all the importing device ever does with it.

Devices that have not seen their password since this change have nothing stored yet, so the export asks for it once, which stores it.