### PR TITLE
fix(swap-and-bridge): base slippage warning percentage on input value, not quote

### DIFF
--- a/src/libs/swapAndBridge/swapAndBridge.test.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.test.ts
@@ -445,7 +445,9 @@ describe('swapAndBridge lib', () => {
       expect(result).not.toBeNull()
       expect(result?.type).toBe('slippageImpact')
       if (result?.type === 'slippageImpact') {
-        expect(result.possibleSlippage).toBeGreaterThan(81.8)
+        // possibleSlippage is relative to inputValueInUsd (100), not the more favorable
+        // outputValueInUsd (110), so it doesn't understate the risk of the low minAmountOut
+        expect(result.possibleSlippage).toBeCloseTo(80, 5)
         expect(result.minInUsd).toBe(20)
       }
     })
@@ -462,6 +464,26 @@ describe('swapAndBridge lib', () => {
       const result = calculateAmountWarnings(selectedRoute, '200', '0.1', 18)
 
       expect(result).toBeNull()
+    })
+
+    test('should return slippage warning when quote-to-min gap is small but the loss vs. input exceeds $50', () => {
+      // Input: $1000, Output (quote): $960 (4% price impact, under the 5% threshold)
+      // minAmountOut: $930 -> quote-to-min gap is only $30, but the loss vs. input is $70,
+      // which is what should gate the $50 noise filter (not the quote-relative gap)
+      const selectedRoute = createMockRoute({
+        inputValueInUsd: 1000,
+        outputValueInUsd: 960,
+        fromAmount: 0.5,
+        minAmountOut: 930
+      })
+      const result = calculateAmountWarnings(selectedRoute, '1000', '0.5', 18)
+
+      expect(result).not.toBeNull()
+      expect(result?.type).toBe('slippageImpact')
+      if (result?.type === 'slippageImpact') {
+        expect(result.severity).toBe('elevated')
+        expect(result.estimatedLossUsd).toBeCloseTo(70, 5)
+      }
     })
 
     test('should calculate slippage correctly for very large swaps', () => {
@@ -530,6 +552,29 @@ describe('swapAndBridge lib', () => {
       if (result?.type === 'slippageImpact') {
         expect(result.severity).toBe('extreme')
         expect(result.estimatedLossUsd).toBeGreaterThan(100_000)
+      }
+    })
+
+    test('extreme slippage percentage should reflect the loss relative to the input, not the already-discounted quote', () => {
+      // Input: $140,000, quote (outputValueInUsd): $93,000 -> the quote itself already
+      // reflects ~33.6% price impact. minAmountOut: $92,900, so the quote -> min-out gap
+      // is a negligible ~0.1%, but the slippage-based loss ($47,100) still edges out the
+      // quote-based loss ($47,000), routing this into the "extreme slippage" branch.
+      const selectedRoute = createMockRoute({
+        inputValueInUsd: 140_000,
+        outputValueInUsd: 93_000,
+        fromAmount: 70,
+        minAmountOut: 92_900
+      })
+      const result = calculateAmountWarnings(selectedRoute, '140000', '70', 18)
+
+      expect(result).not.toBeNull()
+      expect(result?.type).toBe('slippageImpact')
+      if (result?.type === 'slippageImpact') {
+        expect(result.severity).toBe('extreme')
+        expect(result.estimatedLossUsd).toBeCloseTo(47_100, 0)
+        // Must reflect the ~33.6% total loss vs. input, not the ~0.1% quote-to-floor gap
+        expect(result.possibleSlippage).toBeGreaterThan(30)
       }
     })
 

--- a/src/libs/swapAndBridge/swapAndBridge.ts
+++ b/src/libs/swapAndBridge/swapAndBridge.ts
@@ -658,10 +658,11 @@ export const calculateAmountWarnings = (
       Number(inputValueInUsd) < 400
         ? 1.05
         : Number((0.005 / Math.ceil(Number(inputValueInUsd) / 20000)).toPrecision(2)) * 100 + 0.01
-    const possibleSlippage = (1 - minInUsdNumber / outputValueInUsd) * 100
-    // @precautionary if
-    const diffBetweenQuoteAndMinAmount =
-      outputValueInUsd > minInUsdNumber ? outputValueInUsd - minInUsdNumber : 0
+    // Percentage of the loss relative to the amount the user is putting in (not the quote),
+    // so it stays consistent with `estimatedLossUsd` below, which is also input-based. Using
+    // the quote as the denominator would understate this when the quote itself is already
+    // far below the input (large price impact already baked into the quote).
+    const possibleSlippage = (1 - minInUsdNumber / inputValueInUsd) * 100
 
     const quoteLossUsd = getSwapQuoteLossUsd(inputValueInUsd, outputValueInUsd)
     const slippageLossUsd = getSwapSlippageLossUsd(inputValueInUsd, minInUsdNumber)
@@ -675,8 +676,7 @@ export const calculateAmountWarnings = (
     // It seems a bit odd to display a slippage warning only if the difference
     // is > $50?
     const isElevatedSlippage =
-      possibleSlippage > allowedSlippage &&
-      diffBetweenQuoteAndMinAmount > SLIPPAGE_MIN_QUOTE_DIFF_USD
+      possibleSlippage > allowedSlippage && slippageLossUsd > SLIPPAGE_MIN_QUOTE_DIFF_USD
 
     if (isExtreme && slippageLossUsd > quoteLossUsd) {
       return {


### PR DESCRIPTION
closes https://github.com/AmbireTech/ambire-app/issues/7771

before:

<img width="1086" height="830" alt="Screenshot 2026-08-20 at 18 49 51" src="https://github.com/user-attachments/assets/6301d1b3-d467-4c74-9eb8-9069390efa27" />

after:
<img width="376" height="1028" alt="Screenshot 2026-08-24 at 11 58 30" src="https://github.com/user-attachments/assets/92ba1824-9c44-4fc7-8394-1faae9103725" />
-

## Summary
- `calculateAmountWarnings` computed `possibleSlippage` (the % shown in the "Critical slippage warning" / "Warning! This route has a higher slippage than usual" modal title) relative to `outputValueInUsd` (the quote), while the paired `estimatedLossUsd` dollar figure shown right below it was always relative to `inputValueInUsd`. When a quote already reflected heavy price impact, this let the modal show a misleadingly tiny percentage (e.g. `0.07%`) next to a large dollar loss (e.g. `$46,091`), since the quote-to-floor gap can be small even when the input-to-floor loss is not.
- The `$50` noise-filter in `isElevatedSlippage` had the same issue: it gated on the quote-relative `diffBetweenQuoteAndMinAmount` instead of the already-computed, input-relative `slippageLossUsd`, which could silently suppress a legitimate warning whenever price impact had already eaten into the quote-to-floor gap.

Both now use the same input-relative basis as the dollar loss that's displayed alongside them.

## Test plan
- [x] `npm run jest -- src/libs/swapAndBridge/swapAndBridge.test.ts` — 29/29 passing, including two new regression tests for the extreme-branch percentage mismatch and the noise-filter false negative
- [x] Updated the one pre-existing test whose assertion depended on the old (incorrect) quote-relative percentage
