### PR TITLE
Fix: allow gs013 errors to enter the retry loop

### DIFF
--- a/src/libs/broadcast/broadcast.test.ts
+++ b/src/libs/broadcast/broadcast.test.ts
@@ -167,7 +167,7 @@ describe('broadcast', () => {
       )
     ).rejects.toThrow('Failed estimating gas for broadcast')
 
-    expect(provider.send).toHaveBeenCalledTimes(11)
+    expect(provider.send).toHaveBeenCalledTimes(10)
   })
 
   test('returns an estimate error immediately for a broadcast that is not a multi-call EOA', async () => {

--- a/src/libs/broadcast/broadcast.ts
+++ b/src/libs/broadcast/broadcast.ts
@@ -79,7 +79,7 @@ async function estimateGas(
   counter: number = 0
 ): Promise<bigint> {
   // this should happen only in the case of internet issues
-  if (counter > 10) {
+  if (counter > 9) {
     throw new Error(
       `Failed estimating gas for broadcast${
         error ? `: ${getErrorCodeStringFromReason(error.message)}` : ''
@@ -122,9 +122,12 @@ async function estimateGas(
 
   // Sequential EOA calls can fail temporarily if the RPC pending state is stale.
   if (gasLimit instanceof Error || hasNonceDiscrepancyOnApproval) {
-    // Other estimation errors are deterministic, so return them immediately.
-    const isEoaBatch = broadcastOption === BROADCAST_OPTIONS.bySelf && op.calls.length > 1
-    if (gasLimit instanceof Error && !isEoaBatch) throw gasLimit
+    const isGS013 = gasLimit.message.includes('GS013')
+    if (gasLimit instanceof Error) {
+      // Other estimation errors are deterministic, so return them immediately.
+      const isEoaBatch = broadcastOption === BROADCAST_OPTIONS.bySelf && op.calls.length > 1
+      if (!isGS013 && !isEoaBatch) throw gasLimit
+    }
 
     await waitBeforeRetry(chainId)
     return estimateGas(

--- a/src/libs/broadcast/broadcast.ts
+++ b/src/libs/broadcast/broadcast.ts
@@ -122,9 +122,9 @@ async function estimateGas(
 
   // Sequential EOA calls can fail temporarily if the RPC pending state is stale.
   if (gasLimit instanceof Error || hasNonceDiscrepancyOnApproval) {
-    const isGS013 = gasLimit.message.includes('GS013')
     if (gasLimit instanceof Error) {
       // Other estimation errors are deterministic, so return them immediately.
+      const isGS013 = gasLimit.message.includes('GS013')
       const isEoaBatch = broadcastOption === BROADCAST_OPTIONS.bySelf && op.calls.length > 1
       if (!isGS013 && !isEoaBatch) throw gasLimit
     }


### PR DESCRIPTION
The bug is very complex as it's not a bug on Ambire's side only. You have this sequence on a Safe account:

1. I go to a dapp with a Safe account, it's 2/2 threshold
2. I quickly sign with both signers, they are imported in the extension, and broadcast with an EOA
3. The dapp then sends a second request
4. I quickly sign with both signers and attempt to broadcast the transaction, but the RPC returns a "GS013" error

After debugging the GS013 error, I found out that the RPC's onchain read of the Safe account's nonce is returning the old nonce, the one before the current transaction. Hence, the Safe contract is returning invalid signatures.

Well, the signatures are valid, and the nonce is correct as it's the last one - just the RPC doesn't know about it yet. The error goes away by itself in due time, we just have to wait it out for the RPC to get the correct latest state read