### PR TITLE
Set the initial nonce on a safe request through the request controller

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -18,6 +18,7 @@ import { SignAccountOpController } from '../signAccountOp/signAccountOp'
 import type { SafeMultisigConfirmationResponse } from '@safe-global/types-kit'
 
 import type { AccountOp } from '../../libs/accountOp/accountOp'
+import type { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 
 const MOCK_SESSION = new Session({ tabId: 1, url: 'https://test-dApp.com' })
 const SAFE_TX_HASH = `0x${'1'.repeat(64)}` as Hex
@@ -83,6 +84,29 @@ const accounts = [
 const updateAccountOp = (request: CallsUserRequest, accountOpData: Partial<AccountOp>) => {
   request.signAccountOp.update({ accountOpData })
 }
+
+const getActivityAccountOp = (
+  accountAddr: string,
+  chainId: bigint,
+  nonce: bigint,
+  timestamp = Date.now()
+): SubmittedAccountOp => ({
+  id: `activity-account-op-${nonce.toString()}`,
+  accountAddr,
+  chainId,
+  nonce,
+  signingKeyAddr: null,
+  signingKeyType: null,
+  gasLimit: null,
+  gasFeePayment: null,
+  signature: null,
+  calls: [],
+  identifiedBy: {
+    type: 'Transaction',
+    identifier: `activity-account-op-${nonce.toString()}`
+  },
+  timestamp
+})
 
 const prepareTest = async (seedTestDapp = false, isSelectedAccountSafe = false) => {
   const { mainCtrl, eventEmitterRegistry, getWindowId, eventEmitter } = await makeMainController(
@@ -227,6 +251,7 @@ const prepareTest = async (seedTestDapp = false, isSelectedAccountSafe = false) 
     portfolioCtrl: mainCtrl.portfolio,
     storageCtrl: mainCtrl.storage,
     safeCtrl: mainCtrl.safe,
+    activityCtrl: mainCtrl.activity,
     controller: mainCtrl.requests,
     getSignAccountOp,
     getCallsRequest,
@@ -525,11 +550,12 @@ describe('RequestsController ', () => {
     request.signAccountOp.destroy()
   })
 
-  test('adds a new Safe request when two partially signed requests occupy earlier nonces', async () => {
-    const { controller, accountsCtrl } = await prepareTest(false, true)
+  test('assigns the first free nonce to each new Safe request', async () => {
+    const { controller, accountsCtrl, activityCtrl } = await prepareTest(false, true)
     const accountAddr = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
     const chainId = 1n
     accountsCtrl.accountStates[accountAddr]![chainId.toString()]!.nonce = 119n
+    await activityCtrl.addAccountOp(getActivityAccountOp(accountAddr, chainId, 117n))
     const buildRequest = () =>
       controller.build({
         type: 'calls',
@@ -561,11 +587,12 @@ describe('RequestsController ', () => {
     })
 
     await buildRequest()
-    const nonce120Request = controller.userRequests.find(
+    const secondRequest = controller.userRequests.find(
       (request) => request !== nonce119Request
     ) as CallsUserRequest
-    nonce120Request.signAccountOp.setSafeNonce(120n)
-    nonce120Request.signAccountOp.update({
+    expect(secondRequest.signAccountOp.accountOp.nonce).toBe(120n)
+    secondRequest.signAccountOp.setSafeNonce(121n)
+    secondRequest.signAccountOp.update({
       accountOpData: {
         signed: ['0xd6e371526cdaeE04cd8AF225D42e37Bc14688D9E'],
         txnId: `0x${'2'.repeat(64)}`
@@ -573,13 +600,75 @@ describe('RequestsController ', () => {
     })
 
     await buildRequest()
+    const gapRequest = controller.userRequests.find(
+      (request) => request !== nonce119Request && request !== secondRequest
+    ) as CallsUserRequest
 
     expect(controller.userRequests).toHaveLength(3)
     expect(controller.userRequests).toContain(nonce119Request)
-    expect(controller.userRequests).toContain(nonce120Request)
+    expect(controller.userRequests).toContain(secondRequest)
     expect(nonce119Request.signAccountOp.accountOp.nonce).toBe(119n)
-    expect(nonce120Request.signAccountOp.accountOp.nonce).toBe(120n)
+    expect(secondRequest.signAccountOp.accountOp.nonce).toBe(121n)
+    expect(gapRequest.signAccountOp.accountOp.nonce).toBe(120n)
     expect(new Set(controller.userRequests.map((request) => request.id)).size).toBe(3)
+
+    controller.userRequests.forEach((request) => {
+      if (request.kind === 'calls') request.signAccountOp.destroy()
+    })
+  })
+  test('uses the latest activity nonce when the account state is stale', async () => {
+    const { controller, accountsCtrl, activityCtrl } = await prepareTest(false, true)
+    const accountAddr = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+    const chainId = 1n
+    accountsCtrl.accountStates[accountAddr]![chainId.toString()]!.nonce = 119n
+    await activityCtrl.addAccountOp(getActivityAccountOp(accountAddr, chainId, 118n, 1))
+    await activityCtrl.addAccountOp(getActivityAccountOp(accountAddr, chainId, 120n, 2))
+    await activityCtrl.addAccountOp(getActivityAccountOp(accountAddr, 10n, 999n, 3))
+
+    await controller.build({
+      type: 'calls',
+      params: {
+        executionType: 'queue',
+        userRequestParams: {
+          calls: [{ to: ZeroAddress, value: 1n, data: '0x' }],
+          meta: { accountAddr, chainId }
+        }
+      }
+    })
+
+    const request = controller.userRequests[0]
+    expect(request?.kind).toBe('calls')
+    if (request?.kind !== 'calls') throw new Error('Expected calls request')
+    expect(request.signAccountOp.accountOp.nonce).toBe(121n)
+    request.signAccountOp.destroy()
+  })
+  test('keeps the nonce when adding calls to an existing Safe request', async () => {
+    const { controller, accountsCtrl } = await prepareTest(false, true)
+    const accountAddr = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+    const chainId = 1n
+    accountsCtrl.accountStates[accountAddr]![chainId.toString()]!.nonce = 119n
+    const buildRequest = () =>
+      controller.build({
+        type: 'calls',
+        params: {
+          executionType: 'queue',
+          userRequestParams: {
+            calls: [{ to: ZeroAddress, value: 1n, data: '0x' }],
+            meta: { accountAddr, chainId }
+          }
+        }
+      })
+
+    await buildRequest()
+    await buildRequest()
+
+    expect(controller.userRequests).toHaveLength(1)
+    const request = controller.userRequests[0]
+    expect(request?.kind).toBe('calls')
+    if (request?.kind !== 'calls') throw new Error('Expected calls request')
+    expect(request.signAccountOp.accountOp.nonce).toBe(119n)
+    expect(request.signAccountOp.accountOp.calls).toHaveLength(2)
+    request.signAccountOp.destroy()
   })
   test('builds an onchain Safe rejection as the current request at the same nonce', async () => {
     const { accountsCtrl, controller, getCallsRequest, portfolioCtrl } = await prepareTest(
@@ -833,12 +922,12 @@ describe('RequestsController ', () => {
 
     await buildSafeRequest(0n, '0x00')
     await buildSafeRequest(1n, '0x01')
-    await buildSafeRequest(2n, '0x02')
+    await buildSafeRequest(5n, '0x05')
 
     const safeRequests = controller.userRequests.filter(
       (request): request is CallsUserRequest => request.kind === 'calls'
     )
-    expect(safeRequests.map((request) => request.signAccountOp.accountOp.nonce)).toEqual([1n, 2n])
+    expect(safeRequests.map((request) => request.signAccountOp.accountOp.nonce)).toEqual([1n, 5n])
 
     safeRequests.forEach((request) => request.signAccountOp.destroy())
   })

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -63,7 +63,7 @@ import {
 import { isSmartAccount } from '../../libs/account/account'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { AccountOp, getAccountOpNonce } from '../../libs/accountOp/accountOp'
-import { Call } from '../../libs/accountOp/types'
+import { AccountOpStatus, Call } from '../../libs/accountOp/types'
 import {
   getAccountOpBanners,
   getDappUserRequestsBanners,
@@ -216,6 +216,36 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   set currentUserRequest(val: UserRequest | null) {
     this.#currentUserRequest = val
     this.#onSetCurrentUserRequest(val)
+  }
+
+  #getFirstFreeNonce(accountAddr: string, chainId: bigint, startNonce: bigint): bigint {
+    const latestActivityAccountOp = this.#activity.getAccountOpsForAccount({ accountAddr }).find(
+      (accountOp) =>
+        accountOp.chainId === chainId &&
+        // failures do not move the nonce
+        accountOp.status !== AccountOpStatus.Failure &&
+        accountOp.status !== AccountOpStatus.Rejected
+    )
+    const queuedNonces = this.userRequests.reduce<bigint[]>((nonces, request) => {
+      if (
+        request.kind !== 'calls' ||
+        !request.signAccountOp.account.safeCreation ||
+        request.signAccountOp.accountOp.accountAddr !== accountAddr ||
+        request.signAccountOp.accountOp.chainId !== chainId
+      )
+        return nonces
+
+      const nonce = getAccountOpNonce(request.signAccountOp.accountOp)
+      if (nonce !== null) nonces.push(nonce)
+      return nonces
+    }, [])
+
+    const activityNextNonce = latestActivityAccountOp
+      ? latestActivityAccountOp.nonce + 1n
+      : startNonce
+    let firstFreeNonce = activityNextNonce > startNonce ? activityNextNonce : startNonce
+    while (queuedNonces.includes(firstFreeNonce)) firstFreeNonce += 1n
+    return firstFreeNonce
   }
 
   statuses: Statuses<keyof typeof STATUS_WRAPPED_METHODS> = STATUS_WRAPPED_METHODS
@@ -2083,6 +2113,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       const requestId = !!account.safeCreation
         ? `${baseRequestId}-${generateUuid()}`
         : baseRequestId
+      const initialNonce =
+        account.safeCreation && !meta.safeTxnProps && accountOpNonce === undefined
+          ? this.#getFirstFreeNonce(meta.accountAddr, meta.chainId, accountState.nonce)
+          : (accountOpNonce ?? meta.safeTxnProps?.nonce ?? accountState.nonce)
       await this.#signAccountOpPreference.initialLoadPromise
       callUserRequest = {
         id: requestId,
@@ -2106,7 +2140,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           dapps: this.#dapps,
           fromRequestId: requestId,
           accountOp: providedAccountOp
-            ? { ...providedAccountOp, nonce: meta.safeTxnProps?.nonce ?? accountState.nonce }
+            ? { ...providedAccountOp, nonce: initialNonce }
             : {
                 id: generateUuid(),
                 accountAddr: meta.accountAddr,
@@ -2115,7 +2149,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
                 signingKeyType: null,
                 gasLimit: null,
                 gasFeePayment: null,
-                nonce: accountOpNonce ?? meta.safeTxnProps?.nonce ?? accountState.nonce,
+                nonce: initialNonce,
                 signature: meta.safeTxnProps?.signature ?? null,
                 txnId: meta.safeTxnProps?.txnId ?? undefined,
                 calls: [
@@ -2144,6 +2178,11 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       } as CallsUserRequest
 
       if (accountOpNonce !== undefined) callUserRequest.signAccountOp.setSafeNonce(accountOpNonce)
+
+      // disable automatic changes to the Safe nonce if a higher one is set
+      // unless the user changes it manually
+      if (account.safeCreation && initialNonce && initialNonce > accountState.nonce)
+        callUserRequest.signAccountOp.setSafeNonce(initialNonce)
 
       if (executionType !== 'open-request-window') {
         // If the request doesn't open immediately we shouldn't


### PR DESCRIPTION
## Changes

Moved first-free Safe nonce selection from the UI into RequestsController. Brand-new Safe requests now receive the first available nonce when they are created, removing the UI useEffect that previously synchronized the corrected nonce through setSafeNonce. Batched requests, transactions imported from the Safe API, and requests with an explicit nonce remain unchanged.

Made nonce selection resilient to stale account state. The controller now checks the latest recorded account operation for the same account and network, compares its next nonce with the account-state nonce, and uses the higher value before skipping any nonces already occupied by queued Safe requests.