### PR TITLE
fix(accounts-sync): let the payload carry an AES-CTR wrapped main key

### DIFF
--- a/src/controllers/keystore/keystore.gcm.test.ts
+++ b/src/controllers/keystore/keystore.gcm.test.ts
@@ -10,12 +10,19 @@ import wait from '@/utils/wait'
 import { describe, expect } from '@jest/globals'
 import { CTR_STORAGE, LedgerSigner } from '@test/keystore'
 
+import {
+  ACCOUNTS_SYNC_PAYLOAD_VERSION,
+  AccountsSyncPayload,
+  parseAccountsSyncPayload,
+  serializeAccountsSyncPayload
+} from '../../libs/accountsSync/accountsSync'
 import { produceMemoryStore } from '../../../test/helpers'
 import { suppressConsole } from '../../../test/helpers/console'
 import { mockUiManager } from '../../../test/helpers/ui'
 import { BIP44_STANDARD_DERIVATION_TEMPLATE, HD_PATH_TEMPLATE_TYPE } from '../../consts/derivation'
 import { Hex } from '../../interfaces/hex'
 import { StoredKey, StoredKeystoreSeed } from '../../interfaces/keystore'
+import { stripHexPrefix } from '../../utils/stripHexPrefix'
 import { StorageController } from '../storage/storage'
 import { UiController } from '../ui/ui'
 import { KeystoreController } from './keystore'
@@ -281,6 +288,14 @@ const createGcmSecretEntry = async (
     scryptParams: { ...SCRYPT_PARAMS, salt: hexlify(salt) },
     aesEncrypted
   }
+}
+
+// Flips the first byte of a hex string, to simulate a scanned payload that was tampered with.
+const tamperFirstByte = (hex: string) => {
+  const bytes = getBytes(hex)
+  bytes[0] = bytes[0]! ^ 0xff
+
+  return hexlify(bytes)
 }
 
 // Flips the first byte of a GCM payload's ciphertext to simulate tampering/corruption at rest.
@@ -1031,5 +1046,419 @@ describe('CTR to GCM migration', () => {
     ).rejects.toThrow()
 
     restore()
+  })
+})
+
+describe('accounts sync from a device that never unlocked with its password', () => {
+  const MOCK_BIOMETRICS_SECRET = 'mockBiometricsSecret'
+  const IMPORTING_PASS = 'importingDevicePass'
+  const SYNCED_SEED_ID = 'seed-12-word'
+  const IMPORTING_OWN_KEY_PRIV = `0x${'11'.repeat(32)}`
+  const IMPORTING_OWN_KEY_ADDR = new Wallet(IMPORTING_OWN_KEY_PRIV).address
+
+  // A legacy keystore where biometrics were turned on after the GCM migration shipped, so that
+  // secret is GCM while the password one, migrated only on an unlock that uses it, stays CTR
+  const prepareLegacyBiometricsDevice = async ({
+    seedId = SYNCED_SEED_ID,
+    biometricsAsCtr = false,
+    mapPasswordEntry = (entry: any) => entry
+  }: {
+    seedId?: string
+    biometricsAsCtr?: boolean
+    mapPasswordEntry?: (entry: any) => any
+  } = {}) => {
+    let mainKeyOld: { key: Uint8Array; iv: Uint8Array } | undefined
+
+    const prepared = await prepareTest(async (storageCtrl) => {
+      const fixture = await createMockOldAesStorageFixture()
+      mainKeyOld = fixture.mainKey
+
+      await storageCtrl.set('keystoreSecrets', [
+        mapPasswordEntry(await fixture.createSecretEntry('password', MOCK_MIGRATION_PASS)),
+        biometricsAsCtr
+          ? await fixture.createSecretEntry('biometrics', MOCK_BIOMETRICS_SECRET)
+          : await createGcmSecretEntry('biometrics', MOCK_BIOMETRICS_SECRET, fixture.mainKey)
+      ])
+      await storageCtrl.set('keystoreSeeds', fixture.mockSeeds)
+      // Link the internal key to a seed, so the recovery phrase travels with it
+      await storageCtrl.set(
+        'keystoreKeys',
+        fixture.mockKeys.map((key) =>
+          key.type === 'internal' && key.addr === MOCK_INTERNAL_KEY.addr
+            ? { ...key, meta: { ...key.meta, fromSeedId: seedId } }
+            : key
+        )
+      )
+    }, true)
+
+    return { ...prepared, mainKeyOld: mainKeyOld! }
+  }
+
+  /** A legacy device the user just unlocked with biometrics, ready to export. */
+  const prepareUnlockedLegacyDevice = async (
+    options?: Parameters<typeof prepareLegacyBiometricsDevice>[0]
+  ) => {
+    const prepared = await prepareLegacyBiometricsDevice(options)
+    await prepared.keystoreCtrl.unlockWithSecret('biometrics', MOCK_BIOMETRICS_SECRET)
+
+    return prepared
+  }
+
+  const createImportingKeystore = async ({ withOwnKey = false } = {}) => {
+    const importingStorageCtrl = new StorageController(produceMemoryStore())
+    const importingCtrl = new KeystoreController(
+      'default',
+      importingStorageCtrl,
+      keystoreSigners,
+      new UiController({ uiManager })
+    )
+    await importingCtrl.initialLoadPromise
+    await importingCtrl.addSecret('password', IMPORTING_PASS, '', true)
+
+    if (withOwnKey)
+      await importingCtrl.addKeys([
+        {
+          addr: IMPORTING_OWN_KEY_ADDR,
+          label: 'Own Key',
+          type: 'internal',
+          privateKey: IMPORTING_OWN_KEY_PRIV,
+          dedicatedToOneSA: false,
+          meta: { createdAt: Date.now() }
+        }
+      ])
+
+    return { importingCtrl, importingStorageCtrl }
+  }
+
+  const buildSyncPayload = (
+    exported: Awaited<ReturnType<KeystoreController['exportForSync']>>
+  ): AccountsSyncPayload => ({
+    v: ACCOUNTS_SYNC_PAYLOAD_VERSION,
+    accounts: [
+      {
+        addr: MOCK_INTERNAL_KEY.addr,
+        associatedKeys: [MOCK_INTERNAL_KEY.addr],
+        initialPrivileges: [],
+        creation: null,
+        preferences: { label: 'Account 1', pfp: MOCK_INTERNAL_KEY.addr }
+      }
+    ],
+    ...exported
+  })
+
+  // Goes through the QR codes, so the payload has to survive the parser as well
+  const throughTheQrCodes = (exported: Awaited<ReturnType<KeystoreController['exportForSync']>>) =>
+    parseAccountsSyncPayload(getBytes(serializeAccountsSyncPayload(buildSyncPayload(exported))))
+
+  const readImportedPrivateKey = async (importingCtrl: KeystoreController, addr: string) => {
+    const json = await importingCtrl.exportKeyWithPasscode(addr, 'internal', 'tempPass')
+
+    return (await Wallet.fromEncryptedJson(JSON.parse(json), 'tempPass')).privateKey
+  }
+
+  describe('exporting', () => {
+    it('exports the main key still wrapped with AES-CTR after a biometrics only unlock', async () => {
+      const { keystoreCtrl, storageCtrl } = await prepareUnlockedLegacyDevice()
+      expect(keystoreCtrl.isUnlocked).toBe(true)
+
+      // The unlock migrates the keys and seeds, but leaves the password secret where it was
+      const secrets = await storageCtrl.get('keystoreSecrets', [])
+      expect(secrets.find((s) => s.id === 'password')!.aesEncrypted.cipherType).toBe(CIPHER_OLD)
+      expect(secrets.find((s) => s.id === 'biometrics')!.aesEncrypted.cipherType).toBe(CIPHER)
+
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+
+      expect(exported.secret.id).toBe('password')
+      expect(exported.secret.aesEncrypted.cipherType).toBe(CIPHER_OLD)
+      // Only the main key stays legacy - keys and seeds migrate on any unlock
+      expect(exported.keys[0]!.privKey).toMatchObject({ cipherType: CIPHER })
+      expect(exported.seeds[0]!.seed).toMatchObject({ cipherType: CIPHER })
+    })
+
+    it('exports after a biometrics unlock that migrated the biometrics secret itself', async () => {
+      const { keystoreCtrl, storageCtrl } = await prepareUnlockedLegacyDevice({
+        biometricsAsCtr: true
+      })
+
+      const secrets = await storageCtrl.get('keystoreSecrets', [])
+      expect(secrets.find((s) => s.id === 'biometrics')!.aesEncrypted.cipherType).toBe(CIPHER)
+      expect(secrets.find((s) => s.id === 'password')!.aesEncrypted.cipherType).toBe(CIPHER_OLD)
+
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+      expect(exported.secret.aesEncrypted.cipherType).toBe(CIPHER_OLD)
+    })
+
+    it('stamps the cipher of a secret stored before the cipher was recorded', async () => {
+      const { keystoreCtrl, storageCtrl } = await prepareUnlockedLegacyDevice({
+        mapPasswordEntry: (entry) => {
+          const aesEncrypted = { ...entry.aesEncrypted }
+          delete aesEncrypted.cipherType
+
+          return { ...entry, aesEncrypted }
+        }
+      })
+
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+      expect(exported.secret.aesEncrypted.cipherType).toBe(CIPHER_OLD)
+
+      // Stamped only on the way out - the entry at rest is left exactly as it was
+      const stored = await storageCtrl.get('keystoreSecrets', [])
+      expect(stored.find((s) => s.id === 'password')!.aesEncrypted.cipherType).toBeUndefined()
+
+      const { importingCtrl } = await createImportingKeystore()
+      await importingCtrl.importFromSync(throughTheQrCodes(exported), MOCK_MIGRATION_PASS)
+      expect(importingCtrl.keys).toHaveLength(1)
+    })
+
+    it('refuses to export a main key wrapped with a cipher it cannot unwrap', async () => {
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice({
+        mapPasswordEntry: (entry) => ({
+          ...entry,
+          aesEncrypted: { ...entry.aesEncrypted, cipherType: 'aes-256-cbc' }
+        })
+      })
+
+      await expect(keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])).rejects.toThrow(
+        'Something went wrong when preparing your accounts for syncing. Please unlock the app again'
+      )
+    })
+
+    it('still refuses to export keys and seeds that are not migrated yet', async () => {
+      // Never unlocked, so the stored keys and seeds are still AES-CTR
+      const { keystoreCtrl } = await prepareLegacyBiometricsDevice()
+
+      await expect(keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])).rejects.toThrow(
+        'Something went wrong when preparing your accounts for syncing. Please try again.'
+      )
+    })
+
+    it('exports a GCM wrapped main key once the user finally unlocks with the password', async () => {
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const legacyExport = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+      expect(legacyExport.secret.aesEncrypted.cipherType).toBe(CIPHER_OLD)
+
+      keystoreCtrl.lock()
+      await keystoreCtrl.unlockWithSecret('password', MOCK_MIGRATION_PASS)
+
+      const migratedExport = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+      expect(migratedExport.secret.aesEncrypted.cipherType).toBe(CIPHER)
+
+      const { importingCtrl } = await createImportingKeystore()
+      await importingCtrl.importFromSync(throughTheQrCodes(migratedExport), MOCK_MIGRATION_PASS)
+
+      expect(await readImportedPrivateKey(importingCtrl, MOCK_INTERNAL_KEY.addr)).toBe(
+        MOCK_INTERNAL_KEY.privKey
+      )
+    })
+
+    it('puts nothing decrypted into the payload', async () => {
+      const { keystoreCtrl, mainKeyOld } = await prepareUnlockedLegacyDevice()
+
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+      const serialized = JSON.stringify(buildSyncPayload(exported))
+      const mainKeyHex = hexlify(concat([mainKeyOld.key, mainKeyOld.iv]))
+
+      expect(serialized).not.toContain(MOCK_12_WORD_SEED)
+      expect(serialized).not.toContain(MOCK_12_WORD_SEED.split(' ')[0])
+      expect(serialized).not.toContain(MOCK_INTERNAL_KEY.privKey)
+      expect(serialized).not.toContain(stripHexPrefix(MOCK_INTERNAL_KEY.privKey as string))
+      expect(serialized).not.toContain(MOCK_MIGRATION_PASS)
+      // The main key travels wrapped with the password, never in the clear
+      expect(serialized).not.toContain(stripHexPrefix(mainKeyHex))
+    })
+  })
+
+  describe('importing', () => {
+    it('imports keys and seeds from an AES-CTR wrapped main key', async () => {
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+
+      const { importingCtrl, importingStorageCtrl } = await createImportingKeystore()
+      await importingCtrl.importFromSync(throughTheQrCodes(exported), MOCK_MIGRATION_PASS)
+
+      expect(await readImportedPrivateKey(importingCtrl, MOCK_INTERNAL_KEY.addr)).toBe(
+        MOCK_INTERNAL_KEY.privKey
+      )
+      expect(importingCtrl.seeds).toHaveLength(1)
+      expect((await importingCtrl.getSavedSeed(importingCtrl.seeds[0]!.id)).seed).toBe(
+        MOCK_12_WORD_SEED
+      )
+
+      // Everything is re-encrypted with the importing device's own main key, so nothing
+      // legacy is left behind on it
+      const importedSecrets = await importingStorageCtrl.get('keystoreSecrets', [])
+      expect(importedSecrets[0]!.aesEncrypted.cipherType).toBe(CIPHER)
+      const importedStoredSeeds = await importingStorageCtrl.get('keystoreSeeds', [])
+      expect(importedStoredSeeds[0]!.seed).toMatchObject({ cipherType: CIPHER })
+      const importedStoredKeys = await importingStorageCtrl.get('keystoreKeys', [])
+      expect(importedStoredKeys[0]!.privKey).toMatchObject({ cipherType: CIPHER })
+    })
+
+    it('carries the passphrase of a recovery phrase across the legacy path', async () => {
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice({
+        seedId: 'seed-24-word-with-passphrase'
+      })
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+
+      const { importingCtrl } = await createImportingKeystore()
+      await importingCtrl.importFromSync(throughTheQrCodes(exported), MOCK_MIGRATION_PASS)
+
+      const importedSeed = await importingCtrl.getSavedSeed(importingCtrl.seeds[0]!.id)
+      expect(importedSeed.seed).toBe(MOCK_24_WORD_SEED)
+      expect(importedSeed.seedPassphrase).toBe(SEED_PASSPHRASE)
+    })
+
+    it('leaves the recovery phrase behind when the user opted out of exporting it', async () => {
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr], false)
+      expect(exported.seeds).toHaveLength(0)
+
+      const { importingCtrl } = await createImportingKeystore()
+      await importingCtrl.importFromSync(throughTheQrCodes(exported), MOCK_MIGRATION_PASS)
+
+      expect(importingCtrl.seeds).toHaveLength(0)
+      // The key still signs on the other device, it is just no longer tied to a seed
+      expect(await readImportedPrivateKey(importingCtrl, MOCK_INTERNAL_KEY.addr)).toBe(
+        MOCK_INTERNAL_KEY.privKey
+      )
+      expect(importingCtrl.keys[0]!.meta.fromSeedId).toBeUndefined()
+    })
+
+    it('carries hardware wallet keys, which have no private key to decrypt', async () => {
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([
+        MOCK_INTERNAL_KEY.addr,
+        MOCK_LEDGER_KEY.addr
+      ])
+      expect(exported.keys).toHaveLength(2)
+
+      const { importingCtrl } = await createImportingKeystore()
+      await importingCtrl.importFromSync(throughTheQrCodes(exported), MOCK_MIGRATION_PASS)
+
+      const importedLedgerKey = importingCtrl.keys.find((k) => k.addr === MOCK_LEDGER_KEY.addr)
+      expect(importedLedgerKey!.type).toBe('ledger')
+      expect(importedLedgerKey!.isExternallyStored).toBe(true)
+      expect(await readImportedPrivateKey(importingCtrl, MOCK_INTERNAL_KEY.addr)).toBe(
+        MOCK_INTERNAL_KEY.privKey
+      )
+    })
+
+    it('does not duplicate keys or seeds when the same payload is imported twice', async () => {
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+      const payload = throughTheQrCodes(exported)
+
+      const { importingCtrl } = await createImportingKeystore()
+      await importingCtrl.importFromSync(payload, MOCK_MIGRATION_PASS)
+      await importingCtrl.importFromSync(payload, MOCK_MIGRATION_PASS)
+
+      expect(importingCtrl.keys).toHaveLength(1)
+      expect(importingCtrl.seeds).toHaveLength(1)
+    })
+
+    it('does not touch the main key or the secrets of the importing device', async () => {
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+
+      const { importingCtrl, importingStorageCtrl } = await createImportingKeystore({
+        withOwnKey: true
+      })
+      const secretsBefore = await importingStorageCtrl.get('keystoreSecrets', [])
+
+      await importingCtrl.importFromSync(throughTheQrCodes(exported), MOCK_MIGRATION_PASS)
+
+      // The legacy unwrap must not leak into this device's own unlock state, so its own
+      // key still decrypts with the main key it had before the import
+      expect(importingCtrl.isUnlocked).toBe(true)
+      expect(await readImportedPrivateKey(importingCtrl, IMPORTING_OWN_KEY_ADDR)).toBe(
+        IMPORTING_OWN_KEY_PRIV
+      )
+      // The password of the exporting device does not become a way into this device
+      expect(await importingStorageCtrl.get('keystoreSecrets', [])).toEqual(secretsBefore)
+    })
+  })
+
+  describe('Negative cases', () => {
+    it('does not import anything when the password of the legacy device is wrong', async () => {
+      const { restore } = suppressConsole()
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+
+      const { importingCtrl } = await createImportingKeystore()
+
+      await expect(
+        importingCtrl.importFromSync(throughTheQrCodes(exported), 'wrongPass')
+      ).rejects.toThrow('Incorrect password. Please try again.')
+
+      expect(importingCtrl.errorMessage).toBe('Incorrect password. Please try again.')
+      expect(importingCtrl.keys).toHaveLength(0)
+      expect(importingCtrl.seeds).toHaveLength(0)
+
+      restore()
+    })
+
+    it('does not import anything when the scanned AES-CTR main key was tampered with', async () => {
+      const { restore } = suppressConsole()
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+
+      // AES-CTR is malleable, so the keccak mac is the only thing standing between a
+      // tampered main key and the importing device decrypting garbage into its keystore
+      const payload = throughTheQrCodes(exported)
+      payload.secret.aesEncrypted.ciphertext = tamperFirstByte(
+        payload.secret.aesEncrypted.ciphertext
+      )
+
+      const { importingCtrl } = await createImportingKeystore()
+
+      await expect(importingCtrl.importFromSync(payload, MOCK_MIGRATION_PASS)).rejects.toThrow(
+        'Incorrect password. Please try again.'
+      )
+      expect(importingCtrl.keys).toHaveLength(0)
+      expect(importingCtrl.seeds).toHaveLength(0)
+
+      restore()
+    })
+
+    it('does not import anything when the scanned iv was tampered with', async () => {
+      const { restore } = suppressConsole()
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+
+      // The legacy mac covers the ciphertext only, so a tampered iv passes it and yields a
+      // wrong main key. The GCM tag on the keys and seeds is what catches it
+      const payload = throughTheQrCodes(exported)
+      payload.secret.aesEncrypted.iv = tamperFirstByte(payload.secret.aesEncrypted.iv)
+
+      const { importingCtrl } = await createImportingKeystore()
+
+      await expect(importingCtrl.importFromSync(payload, MOCK_MIGRATION_PASS)).rejects.toThrow()
+      // The mac did pass, so this is not reported to the user as a wrong password
+      expect(importingCtrl.errorMessage).toBe('')
+      expect(importingCtrl.keys).toHaveLength(0)
+      expect(importingCtrl.seeds).toHaveLength(0)
+
+      restore()
+    })
+
+    it('does not import anything when the scanned scrypt salt was tampered with', async () => {
+      const { restore } = suppressConsole()
+      const { keystoreCtrl } = await prepareUnlockedLegacyDevice()
+      const exported = await keystoreCtrl.exportForSync([MOCK_INTERNAL_KEY.addr])
+
+      // The parser cannot tell one salt from another, so a swapped one derives a different
+      // key from the right password and has to fail the same way a wrong password does
+      const payload = throughTheQrCodes(exported)
+      payload.secret.scryptParams.salt = tamperFirstByte(payload.secret.scryptParams.salt)
+
+      const { importingCtrl } = await createImportingKeystore()
+
+      await expect(importingCtrl.importFromSync(payload, MOCK_MIGRATION_PASS)).rejects.toThrow(
+        'Incorrect password. Please try again.'
+      )
+      expect(importingCtrl.keys).toHaveLength(0)
+
+      restore()
+    })
   })
 })

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -19,6 +19,7 @@ import {
   encryptWithKey,
   extractEntropyFromSeed,
   getBytesForSecret,
+  importSyncedMainKeyOld,
   migrateStoredPayloadsToGCM,
   SCRYPT_PARAMS
 } from '@/libs/keystore/keystore'
@@ -54,7 +55,7 @@ import {
 import { Platform } from '../../interfaces/platform'
 import { IStorageController } from '../../interfaces/storage'
 import { IUiController } from '../../interfaces/ui'
-import { AccountsSyncPayload } from '../../libs/accountsSync/accountsSync'
+import { AccountsSyncPayload, toSyncableSecret } from '../../libs/accountsSync/accountsSync'
 import { EntropyGenerator } from '../../libs/entropyGenerator/entropyGenerator'
 import { getDefaultKeyLabel } from '../../libs/keys/keys'
 import { ScryptAdapter } from '../../libs/scrypt/scryptAdapter'
@@ -345,7 +346,8 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
   }
 
   /**
-   * Used only once to decrypt the main key with AES-CTR, in order to migrate the secrets and stored keys/seeds to AES-GCM.
+   * Decrypts a main key wrapped the legacy AES-CTR way, to migrate this device's secrets and
+   * stored keys/seeds to AES-GCM, or to unwrap the main key of a synced device that hasn't.
    */
   #unlockWithSecretOld(secretKey: Uint8Array, secretEntry: MainKeyEncryptedWithSecret): MainKeyOld {
     const aesEncrypted = secretEntry.aesEncrypted
@@ -400,13 +402,24 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
 
   /**
    * Unwraps the main key of another device from a scanned accounts sync payload, with the
-   * same wrong password handling as unlocking this device.
+   * same wrong password handling as unlocking this device. A device that has only ever
+   * unlocked with biometrics sends it AES-CTR wrapped, which unwraps the legacy way.
    */
   async #unwrapSyncedMainKey(
     secretKey: Uint8Array<ArrayBuffer>,
-    aesEncrypted: AESGCMEncrypted
+    secretEntry: MainKeyEncryptedWithSecret
   ): Promise<MainKey> {
-    return this.#decryptMainKeyWithSecret(secretKey, aesEncrypted, decryptSyncedMainKeyWithSecret)
+    const { aesEncrypted } = secretEntry
+
+    if (aesEncrypted.cipherType === CIPHER)
+      return this.#decryptMainKeyWithSecret(secretKey, aesEncrypted, decryptSyncedMainKeyWithSecret)
+
+    if (aesEncrypted.cipherType !== CIPHER_OLD)
+      throw new Error(
+        `keystore: synced main key has an unsupported cipherType ${aesEncrypted.cipherType}`
+      )
+
+    return importSyncedMainKeyOld(this.#unlockWithSecretOld(secretKey, secretEntry))
   }
 
   /**
@@ -1257,12 +1270,17 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
         error: new Error('keystore: no password secret to sync with')
       })
 
-    if (secret.aesEncrypted.cipherType !== CIPHER)
+    // A secret is only migrated on an unlock that uses it, so a biometrics only device still
+    // wraps its main key with AES-CTR. It travels as stored, unwrapped the legacy way
+    const syncedSecret = toSyncableSecret(secret)
+    if (!syncedSecret)
       throw new EmittableError({
         level: 'major',
         message:
           'Something went wrong when preparing your accounts for syncing. Please unlock the app again or contact support if the problem persists.',
-        error: new Error('keystore: password secret not migrated to GCM yet')
+        error: new Error(
+          `keystore: password secret has an unsupported cipherType ${secret.aesEncrypted.cipherType}`
+        )
       })
 
     const keys = this.#keystoreKeys.filter((key) => keyAddrs.includes(key.addr))
@@ -1288,7 +1306,7 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
         error: new Error('keystore: keys or seeds not migrated to GCM yet')
       })
 
-    return { secret, keys, seeds }
+    return { secret: syncedSecret, keys, seeds }
   }
 
   /**
@@ -1304,13 +1322,11 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
     await this.initialLoadPromise
 
     const { secret, keys, seeds } = payload
-    if (secret.aesEncrypted.cipherType !== CIPHER)
-      throw new Error('keystore: synced main key is not encrypted with GCM')
 
     const secretKey = await deriveSecret(this.#scryptAdapter, password, secret.scryptParams)
     // The exporting device's main key. Kept in this scope only, never persisted, and only
     // able to decrypt, so its bytes never reach this app.
-    const exportedMainKey = await this.#unwrapSyncedMainKey(secretKey, secret.aesEncrypted)
+    const exportedMainKey = await this.#unwrapSyncedMainKey(secretKey, secret)
 
     try {
       // Seeds first, so the keys below can be linked to the seed they were derived from

--- a/src/libs/accountsSync/accountsSync.test.ts
+++ b/src/libs/accountsSync/accountsSync.test.ts
@@ -2,7 +2,7 @@ import { getBytes, getCreate2Address, keccak256, toUtf8Bytes } from 'ethers'
 import { gzip } from 'pako'
 
 import { AMBIRE_ACCOUNT_FACTORY } from '@/consts/deploy'
-import { CIPHER } from '@/libs/keystore/keystore'
+import { CIPHER, CIPHER_OLD } from '@/libs/keystore/keystore'
 
 import {
   ACCOUNTS_SYNC_PAYLOAD_VERSION,
@@ -30,6 +30,14 @@ const gcmPayload = (byteLength: number) => ({
   cipherType: CIPHER as 'AES-GCM',
   ciphertext: `0x${'ab'.repeat(byteLength)}`,
   iv: `0x${'cd'.repeat(12)}`
+})
+
+// The legacy main key is 16 bytes of key plus 16 bytes of iv, CTR encrypted and keccak maced
+const ctrMainKeyPayload = () => ({
+  cipherType: CIPHER_OLD as 'aes-128-ctr',
+  ciphertext: `0x${'ab'.repeat(32)}`,
+  iv: `0x${'cd'.repeat(16)}`,
+  mac: `0x${'ef'.repeat(32)}`
 })
 
 const buildPayload = (): AccountsSyncPayload => ({
@@ -159,14 +167,62 @@ describe('accountsSync payload', () => {
     expect(() => serializeAndParse(payload)).toThrow('invalid scrypt params')
   })
 
-  it('rejects a main key that is not AES-GCM encrypted', () => {
+  // A secret is only migrated to AES-GCM on an unlock that uses it, so a device that has
+  // only ever unlocked with biometrics exports a main key that is still AES-CTR wrapped
+  it('accepts a legacy AES-CTR wrapped main key', () => {
     const payload: any = buildPayload()
-    payload.secret.aesEncrypted = {
-      cipherType: 'aes-128-ctr',
-      ciphertext: '0xabab',
-      iv: '0xcdcd',
-      mac: '0xefef'
-    }
+    payload.secret.aesEncrypted = ctrMainKeyPayload()
+
+    expect(serializeAndParse(payload)).toEqual(payload)
+  })
+
+  it('rejects a legacy main key that is not the length the ciphers expect', () => {
+    const shapes = [
+      { ...ctrMainKeyPayload(), ciphertext: `0x${'ab'.repeat(31)}` },
+      { ...ctrMainKeyPayload(), ciphertext: 'not hex at all' },
+      { ...ctrMainKeyPayload(), iv: `0x${'cd'.repeat(12)}` },
+      { ...ctrMainKeyPayload(), mac: `0x${'ef'.repeat(16)}` },
+      { ...ctrMainKeyPayload(), mac: 'not hex at all' },
+      { ...ctrMainKeyPayload(), mac: undefined }
+    ]
+
+    shapes.forEach((aesEncrypted) => {
+      const payload: any = buildPayload()
+      payload.secret.aesEncrypted = aesEncrypted
+
+      expect(() => serializeAndParse(payload)).toThrow(
+        'the main key is not a valid aes-128-ctr one'
+      )
+    })
+  })
+
+  it('rejects a legacy main key that does not say which cipher wraps it', () => {
+    const payload: any = buildPayload()
+    const withoutCipherType: any = ctrMainKeyPayload()
+    delete withoutCipherType.cipherType
+    payload.secret.aesEncrypted = withoutCipherType
+
+    // `tryParseGcmPayload` treats a missing cipherType as a legacy string payload
+    expect(() => serializeAndParse(payload)).toThrow(`the main key is not encrypted with ${CIPHER}`)
+  })
+
+  it('does not let a legacy main key relax the checks on the keys and seeds', () => {
+    const withCtrKey: any = buildPayload()
+    withCtrKey.secret.aesEncrypted = ctrMainKeyPayload()
+    withCtrKey.keys[0].privKey = `0x${'ab'.repeat(48)}`
+
+    expect(() => serializeAndParse(withCtrKey)).toThrow(`key ${KEY_ADDR} is not encrypted`)
+
+    const withCtrSeed: any = buildPayload()
+    withCtrSeed.secret.aesEncrypted = ctrMainKeyPayload()
+    withCtrSeed.seeds[0].seed = `0x${'ab'.repeat(32)}`
+
+    expect(() => serializeAndParse(withCtrSeed)).toThrow('seed seed-1 is not encrypted')
+  })
+
+  it('rejects a main key wrapped with a cipher no Ambire product knows', () => {
+    const payload: any = buildPayload()
+    payload.secret.aesEncrypted = { ...ctrMainKeyPayload(), cipherType: 'aes-256-cbc' }
 
     // `tryParseGcmPayload` rejects a known but unsupported cipher itself
     expect(() => serializeAndParse(payload)).toThrow('unsupported payload cipherType')

--- a/src/libs/accountsSync/accountsSync.ts
+++ b/src/libs/accountsSync/accountsSync.ts
@@ -15,7 +15,7 @@ import {
   StoredKey,
   StoredKeystoreSeed
 } from '../../interfaces/keystore'
-import { CIPHER, SCRYPT_PARAMS, tryParseGcmPayload } from '../keystore/keystore'
+import { CIPHER, CIPHER_OLD, SCRYPT_PARAMS, tryParseGcmPayload } from '../keystore/keystore'
 
 /**
  * The UR type used to transport the accounts sync payload over animated QR codes.
@@ -45,6 +45,36 @@ const requireGcmPayload = (payload: any, what: string) => {
     throw new Error(`accountsSync: ${what} is not encrypted with ${CIPHER}`)
 }
 
+/**
+ * Prepares the stored password secret for the payload, stamping the implicit cipher of a legacy
+ * AES-CTR one so it is stated, not inferred. Null when no Ambire product can unwrap it.
+ */
+export const toSyncableSecret = (
+  secret: MainKeyEncryptedWithSecret
+): MainKeyEncryptedWithSecret | null => {
+  const { aesEncrypted } = secret
+
+  if (aesEncrypted.cipherType === CIPHER) return secret
+
+  if (aesEncrypted.cipherType === CIPHER_OLD || aesEncrypted.cipherType === undefined)
+    return { ...secret, aesEncrypted: { ...aesEncrypted, cipherType: CIPHER_OLD } }
+
+  return null
+}
+
+/**
+ * The legacy main key is 16 bytes of key plus iv, CTR encrypted and keccak maced. Every part is
+ * pinned to its exact length before any of it reaches the ciphers.
+ */
+const requireCtrMainKeyPayload = (aesEncrypted: any) => {
+  const hasValidShape =
+    isHexString(aesEncrypted.ciphertext, 32) &&
+    isHexString(aesEncrypted.iv, 16) &&
+    isHexString(aesEncrypted.mac, 32)
+
+  if (!hasValidShape) throw new Error(`accountsSync: the main key is not a valid ${CIPHER_OLD} one`)
+}
+
 const validateSecret = (secret: any) => {
   if (!secret || secret.id !== 'password')
     throw new Error('accountsSync: missing the password protected main key')
@@ -59,6 +89,11 @@ const validateSecret = (secret: any) => {
     p === SCRYPT_PARAMS.p &&
     dkLen === SCRYPT_PARAMS.dkLen
   if (!hasValidScryptParams) throw new Error('accountsSync: invalid scrypt params')
+
+  // Keys and seeds migrate on any unlock, so the main key is the only part of the payload
+  // that can still arrive AES-CTR wrapped
+  if (secret.aesEncrypted?.cipherType === CIPHER_OLD)
+    return requireCtrMainKeyPayload(secret.aesEncrypted)
 
   requireGcmPayload(secret.aesEncrypted, 'the main key')
 }

--- a/src/libs/keystore/keystore.test.ts
+++ b/src/libs/keystore/keystore.test.ts
@@ -15,6 +15,7 @@ import {
   encryptWithKey,
   extractEntropyFromSeed,
   getBytesForSecret,
+  importSyncedMainKeyOld,
   migrateStoredPayloadsToGCM,
   reconstructSeedFromEntropy,
   SCRYPT_PARAMS,
@@ -593,6 +594,36 @@ describe('Keystore lib', () => {
       expect(result.hasMigrated).toBe(false)
       expect(result.failedMigrations.keyAddrs).toEqual([SECONDARY_INTERNAL_ADDR])
       expect(result.failedMigrations.seedIds).toEqual(['seed-broken'])
+    })
+  })
+
+  describe('importSyncedMainKeyOld', () => {
+    test('rebuilds the key the migration derives from the same legacy key and iv', async () => {
+      const migratedMainKey = await createMainKey()
+      const syncedMainKey = await importSyncedMainKeyOld(TEST_MAIN_KEY_OLD)
+      const encrypted = await encryptWithKey(migratedMainKey, getBytes(TEST_PRIVATE_KEY))
+
+      expect(hexlify(await decryptWithKey(syncedMainKey, encrypted))).toBe(TEST_PRIVATE_KEY)
+    })
+
+    test('rebuilds a different key when the legacy key and iv differ', async () => {
+      const migratedMainKey = await createMainKey()
+      const otherMainKey = await importSyncedMainKeyOld({
+        key: TEST_MAIN_KEY_OLD.iv,
+        iv: TEST_MAIN_KEY_OLD.key
+      })
+      const encrypted = await encryptWithKey(migratedMainKey, getBytes(TEST_PRIVATE_KEY))
+
+      await expect(decryptWithKey(otherMainKey, encrypted)).rejects.toThrow()
+    })
+
+    test('cannot leave the app or be used to encrypt', async () => {
+      const syncedMainKey = await importSyncedMainKeyOld(TEST_MAIN_KEY_OLD)
+
+      expect(syncedMainKey.extractable).toBe(false)
+      expect(syncedMainKey.usages).toEqual(['decrypt'])
+      await expect(crypto.subtle.exportKey('raw', syncedMainKey)).rejects.toThrow()
+      await expect(encryptWithKey(syncedMainKey, getBytes(TEST_PRIVATE_KEY))).rejects.toThrow()
     })
   })
 })

--- a/src/libs/keystore/keystore.ts
+++ b/src/libs/keystore/keystore.ts
@@ -1,5 +1,5 @@
 import aes from 'aes-js'
-import { getBytes, hexlify, Mnemonic, toUtf8Bytes } from 'ethers'
+import { concat, getBytes, hexlify, Mnemonic, toUtf8Bytes } from 'ethers'
 
 import {
   AESGCMEncrypted,
@@ -242,6 +242,19 @@ export const decryptSyncedMainKeyWithSecret = async (
     'decrypt'
   ])
 }
+
+/**
+ * Rebuilds a synced legacy main key out of its 16 byte key and iv, the way the migration derives
+ * it on the exporting device. Non-extractable and decrypt only, like the GCM one.
+ */
+export const importSyncedMainKeyOld = (mainKeyOld: MainKeyOld): Promise<MainKey> =>
+  crypto.subtle.importKey(
+    'raw',
+    new Uint8Array(getBytes(concat([mainKeyOld.key, mainKeyOld.iv]))),
+    { name: CIPHER },
+    false,
+    ['decrypt']
+  )
 
 /**
  * Used during migration to read legacy payloads


### PR DESCRIPTION
**Resolves: https://goodmorning-dev.slack.com/archives/C02MBU92V5H/p1787308378690089**

## The issue

Users reported that exporting accounts to the extension fails with:

> Something went wrong when preparing your accounts for syncing. Please unlock the app again or contact support if the problem persists.

Reported from mobile, reproducible every time until the user unlocks with their **password** instead of Face ID — after which it works permanently, biometrics included.

## Root cause

A keystore secret can only be migrated to AES-GCM on an unlock that **uses that secret**, because re-wrapping the main key needs the key derived from that secret's plaintext, and the app never stores the password. So the migration is lazy and per-secret:

- **Keys and seeds** hang off the main key, which every unlock puts in memory → migrated on *any* unlock.
- **Secret entries** hang off their own plaintext → a `password` entry only migrates on a password unlock.

`#addSecret` always writes GCM, so a `biometrics` secret is GCM from birth. A legacy user who only ever unlocks with biometrics therefore keeps an AES-CTR wrapped `password` entry indefinitely — `keystore.gcm.test.ts` already asserted the mirror image of this (after a password unlock, `biometrics` is still `CIPHER_OLD`); nobody had written the reversed case.

`exportForSync` required that entry to be GCM and refused outright. It has to be the `password` one: the importing device unwraps the main key from `scrypt(the password the user types there)`, so a random biometrics blob is meaningless off-device. This was the **only** place hard-requiring GCM (`grep cipherType` — every other path already tolerates CTR), which is why sync export was the single symptom.

This affects **both products** — the extension has WebAuthn biometrics unlock too, so extension → mobile breaks the same way.

## The fix

The payload now carries the main key exactly as it is stored, and the importing device unwraps a legacy one the same way a legacy unlock does, then re-encrypts everything under its own main key as before. Nothing legacy is persisted on the importing device.

- `toSyncableSecret` passes a GCM secret through and stamps the implicit cipher on a pre-tagging entry, so a scanned payload always **states** how the main key is wrapped rather than the importer inferring it from a missing field. Returns `null` for anything unknown, which keeps the existing user-facing error.
- `validateSecret` accepts the legacy shape with every part pinned to its exact length (ciphertext 32 bytes, iv 16, mac 32) before any of it reaches the ciphers. Keys and seeds stay **GCM only** — they migrate on any unlock, so they can never legitimately arrive CTR.
- `#unwrapSyncedMainKey` branches on the cipher and reuses `#unlockWithSecretOld` for the legacy path, so the keccak mac check and the "Incorrect password" handling come along unchanged.
- `importSyncedMainKeyOld` rebuilds the 256-bit key the same way the migration does (`concat(key, iv)`), imported **non-extractable and decrypt-only**.

## Tests

95 passing across three levels; the two guards were mutation-checked (neutering the length validation and making the rebuilt key extractable each failed exactly the one test meant to catch it).

- **`libs/keystore`** (3) — the rebuilt key reproduces what the migration derives, differs when key/iv are swapped, and cannot be exported or used to encrypt.
- **`libs/accountsSync`** (5) — accepts a well-formed legacy secret; rejects six malformed shapes, a missing `cipherType`, and an unknown cipher; and a legacy main key does **not** relax validation of keys and seeds.
- **`controllers/keystore`** (17) — both legacy sub-cases; pre-tagging entries stamped on the way out while the entry at rest is untouched; the "keys/seeds not migrated" guard still fires; the GCM path still works from the same device after a password unlock; the payload contains nothing decrypted (not the mnemonic, private key, password, or raw main key bytes); full round trip through `serialize → parse → import` verifying the exact private key and seed phrase; seed passphrase; `includeSeeds: false`; hardware wallet keys; double import; and the import leaves the importing device's own main key and secrets byte-identical.
- **Negative** — wrong password, tampered ciphertext, tampered **iv**, tampered scrypt salt.

The iv case is worth a look on review: the legacy mac is `keccak256(macPrefix || ciphertext)` and does **not** cover the iv, so a flipped iv passes the integrity check and silently yields a wrong main key. The test pins that the GCM tag on the keys and seeds catches what the mac can't, and that it is not misreported to the user as a wrong password.

- **A sync does not heal the exporting device.** Its `password` entry stays on AES-CTR until someone unlocks that device with the password. The legacy branch in the parser therefore cannot be deleted later — we can never prove the last legacy device migrated.