### PR TITLE
Require password unlock if not GCM

### DIFF
--- a/src/controllers/keystore/keystore.gcm.test.ts
+++ b/src/controllers/keystore/keystore.gcm.test.ts
@@ -624,6 +624,66 @@ describe('CTR to GCM migration', () => {
     )
     expect(biometricsWallet.address).toBe(MOCK_INTERNAL_KEY.addr)
   })
+  it('should require a password unlock until the password secret itself is migrated', async () => {
+    const { keystoreCtrl } = await prepareTest(async (storageCtrl) => {
+      await mockOldAesStorageWithBiometrics(storageCtrl)
+    })
+
+    expect(keystoreCtrl.isPasswordUnlockRequired).toBe(true)
+
+    // A biometrics unlock migrates the biometrics secret only, so the password secret
+    // (the one accounts sync needs on GCM) stays on the legacy cipher
+    await keystoreCtrl.unlockWithSecret('biometrics', MOCK_MIGRATION_PASS)
+
+    expect(keystoreCtrl.isUnlocked).toBe(true)
+    expect(keystoreCtrl.isPasswordUnlockRequired).toBe(true)
+
+    keystoreCtrl.lock()
+    await keystoreCtrl.unlockWithSecret('password', MOCK_MIGRATION_PASS)
+
+    expect(keystoreCtrl.isUnlocked).toBe(true)
+    expect(keystoreCtrl.isPasswordUnlockRequired).toBe(false)
+  })
+  it('should not require a password unlock when there are no biometrics, no password secret, or the password secret is already migrated', async () => {
+    const { keystoreCtrl: freshKeystoreCtrl } = await prepareTest(undefined, true)
+
+    expect(freshKeystoreCtrl.hasPasswordSecret).toBe(false)
+    expect(freshKeystoreCtrl.isPasswordUnlockRequired).toBe(false)
+
+    const { keystoreCtrl: passwordOnlyKeystoreCtrl } = await prepareTest()
+
+    expect(passwordOnlyKeystoreCtrl.hasPasswordSecret).toBe(true)
+    expect(passwordOnlyKeystoreCtrl.hasBiometricsSecret).toBe(false)
+    expect(passwordOnlyKeystoreCtrl.isPasswordUnlockRequired).toBe(false)
+
+    const { keystoreCtrl: biometricsOnlyKeystoreCtrl } = await prepareTest(async (storageCtrl) => {
+      const fixture = await createMockOldAesStorageFixture()
+
+      await storageCtrl.set('keystoreSecrets', [
+        await fixture.createSecretEntry('biometrics', MOCK_MIGRATION_PASS)
+      ])
+      await storageCtrl.set('keystoreSeeds', fixture.mockSeeds)
+      await storageCtrl.set('keystoreKeys', fixture.mockKeys)
+    })
+
+    expect(biometricsOnlyKeystoreCtrl.hasBiometricsSecret).toBe(true)
+    expect(biometricsOnlyKeystoreCtrl.isPasswordUnlockRequired).toBe(false)
+
+    const { keystoreCtrl: migratedKeystoreCtrl } = await prepareTest(async (storageCtrl) => {
+      const fixture = await createMockOldAesStorageFixture()
+
+      await storageCtrl.set('keystoreSecrets', [
+        await createGcmSecretEntry('password', MOCK_MIGRATION_PASS, fixture.mainKey),
+        await fixture.createSecretEntry('biometrics', MOCK_MIGRATION_PASS)
+      ])
+      await storageCtrl.set('keystoreSeeds', fixture.mockSeeds)
+      await storageCtrl.set('keystoreKeys', fixture.mockKeys)
+    })
+
+    expect(migratedKeystoreCtrl.hasPasswordSecret).toBe(true)
+    expect(migratedKeystoreCtrl.hasBiometricsSecret).toBe(true)
+    expect(migratedKeystoreCtrl.isPasswordUnlockRequired).toBe(false)
+  })
   it('should not fail the entire migration if there is an invalid seed/private key entry that cannot be migrated', async () => {
     const { restore } = suppressConsole()
     const { keystoreCtrl, storageCtrl } = await prepareTest(async (storageCtrl) => {

--- a/src/controllers/keystore/keystore.ts
+++ b/src/controllers/keystore/keystore.ts
@@ -1310,6 +1310,20 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
     return this.#keystoreSecrets.some((x) => x.id === 'biometrics')
   }
 
+  /**
+   * Whether the user must unlock with their password instead of biometrics, because the
+   * password secret still awaits its AES-GCM migration. A secret can only be migrated by
+   * unlocking with it, so unlocking with biometrics leaves the password secret on the legacy
+   * cipher.
+   */
+  get isPasswordUnlockRequired() {
+    if (!this.hasBiometricsSecret) return false
+
+    const passwordSecret = this.#keystoreSecrets.find((x) => x.id === 'password')
+
+    return !!passwordSecret && passwordSecret.aesEncrypted.cipherType !== CIPHER
+  }
+
   get hasKeystoreTempSeed() {
     return !!this.#tempSeed
   }
@@ -1428,6 +1442,7 @@ export class KeystoreController extends EventEmitter implements IKeystoreControl
       seeds: this.seeds,
       hasPasswordSecret: this.hasPasswordSecret,
       hasBiometricsSecret: this.hasBiometricsSecret,
+      isPasswordUnlockRequired: this.isPasswordUnlockRequired,
       hasKeystoreTempSeed: this.hasKeystoreTempSeed,
       hasTempSeed: this.hasTempSeed,
       isReadyToStoreKeys: this.isReadyToStoreKeys


### PR DESCRIPTION
Adds isPasswordUnlockRequired flag to the keystore controller.