### PR TITLE
Add: additional async protection in the signMessage.ts controller

### DIFF
--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -17,7 +17,7 @@ import { InternalSigner } from '../../../test/keystore'
 import { Session } from '../../classes/session'
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
 import { SAFE_API_TIMEOUT_MS } from '../../consts/safe'
-import { Account, IAccountsController } from '../../interfaces/account'
+import { Account, AccountOnchainState, IAccountsController } from '../../interfaces/account'
 import { DAPP_VERIFICATION_BANNER_IDS, IDappsController } from '../../interfaces/dapp'
 import { Hex } from '../../interfaces/hex'
 import { IInviteController } from '../../interfaces/invite'
@@ -51,6 +51,27 @@ const messageToSign: Message = {
   accountAddr: account.addr,
   chainId: 1n,
   signature: null
+}
+
+const accountOnchainState: AccountOnchainState = {
+  accountAddr: account.addr,
+  isDeployed: true,
+  eoaNonce: null,
+  nonce: 0n,
+  erc4337Nonce: 0n,
+  associatedKeys: account.associatedKeys,
+  importedAccountKeys: [],
+  balance: 0n,
+  isEOA: false,
+  isErc4337Enabled: false,
+  isErc4337Nonce: false,
+  isV2: false,
+  currentBlock: 0n,
+  isSmarterEoa: false,
+  delegatedContract: null,
+  delegatedContractName: null,
+  threshold: 1,
+  updatedAt: 0
 }
 
 const createDeferred = <T>() => {
@@ -94,12 +115,6 @@ const createPermitTypedMessage = (): Message => ({
     }
   }
 })
-
-const dapp = {
-  name: 'Test Dapp',
-  icon: 'https://test-dapp.com/icon.png',
-  url: 'https://Test-Dapp.com'
-}
 
 describe('SignMessageController', () => {
   let signMessageController: ISignMessageController
@@ -156,13 +171,65 @@ describe('SignMessageController', () => {
     expect(signMessageController.signer).toBeUndefined()
   })
 
+  test('does not initialize after being reset while accounts are loading', async () => {
+    const initialLoad = createDeferred<void>()
+    const accountsController = {
+      initialLoadPromise: initialLoad.promise,
+      accounts: [account],
+      getOrFetchAccountOnChainState: jest.fn()
+    } as unknown as IAccountsController
+    const controller = new SignMessageController(
+      keystoreCtrl,
+      providersCtrl,
+      networksCtrl,
+      accountsController,
+      {},
+      inviteCtrl
+    )
+
+    const initPromise = controller.init({ messageToSign })
+    controller.reset()
+    initialLoad.resolve(undefined)
+
+    await expect(initPromise).resolves.toBeUndefined()
+    expect(controller.isInitialized).toBeFalsy()
+    expect(controller.messageToSign).toBeNull()
+    expect(accountsController.getOrFetchAccountOnChainState).not.toHaveBeenCalled()
+  })
+
+  test('does not finish initialization after being reset while fetching account state', async () => {
+    const accountState = createDeferred<AccountOnchainState | undefined>()
+    const accountsController = {
+      initialLoadPromise: Promise.resolve(),
+      accounts: [account],
+      getOrFetchAccountOnChainState: jest.fn(() => accountState.promise)
+    } as unknown as IAccountsController
+    const controller = new SignMessageController(
+      keystoreCtrl,
+      providersCtrl,
+      networksCtrl,
+      accountsController,
+      {},
+      inviteCtrl
+    )
+
+    const initPromise = controller.init({ messageToSign })
+    await Promise.resolve()
+    expect(accountsController.getOrFetchAccountOnChainState).toHaveBeenCalled()
+
+    controller.reset()
+    accountState.resolve(accountOnchainState)
+
+    await expect(initPromise).resolves.toBeUndefined()
+    expect(controller.isInitialized).toBeFalsy()
+    expect(controller.messageToSign).toBeNull()
+  })
+
   test('should resolve when adding a message to Safe Global times out', async () => {
     const accountsController = {
       initialLoadPromise: Promise.resolve(),
       accounts: [account],
-      getOrFetchAccountOnChainState: jest.fn().mockResolvedValue({
-        importedAccountKeys: []
-      })
+      getOrFetchAccountOnChainState: jest.fn(() => Promise.resolve(accountOnchainState))
     } as unknown as IAccountsController
     const controller = new SignMessageController(
       keystoreCtrl,
@@ -210,9 +277,7 @@ describe('SignMessageController', () => {
     const safeAccountsCtrl = {
       initialLoadPromise: Promise.resolve(),
       accounts: [safeAccount],
-      getOrFetchAccountOnChainState: jest.fn().mockResolvedValue({
-        importedAccountKeys: []
-      })
+      getOrFetchAccountOnChainState: jest.fn(() => Promise.resolve(accountOnchainState))
     } as unknown as IAccountsController
     const safeSignMessageController = new SignMessageController(
       keystoreCtrl,

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -84,9 +84,9 @@ export class SignMessageController
 
   #callRelayer?: BindedRelayerCall
 
-  // Bumped on every init()/reset(); a signing op captures it before its first
-  // await and re-checks after each, so a request replacing the message mid-sign
-  // can't be signed under the previous approval.
+  // Bumped when init() starts and whenever reset() is called; async operations
+  // capture it and re-check after each await, so obsolete requests can't update
+  // controller state or be signed under a previous approval.
   #signingGeneration = 0
 
   signer?: KeystoreSignerInterface
@@ -188,14 +188,16 @@ export class SignMessageController
     // displaying the prev sign message request.
     if (this.isInitialized) this.reset()
 
+    const initializationGeneration = ++this.#signingGeneration
+
     await this.#accounts.initialLoadPromise
+    if (this.#signingGeneration !== initializationGeneration) return
 
     if (
       ['message', 'typedMessage', 'authorization-7702', 'siwe'].includes(messageToSign.content.kind)
     ) {
       if (dapp) this.dapp = dapp
       this.messageToSign = messageToSign
-      this.#signingGeneration += 1
       this.signed = signed || []
       this.signatures = signatures || []
       this.isInitialized = true
@@ -219,6 +221,8 @@ export class SignMessageController
         this.#account.addr,
         this.network.chainId
       )
+      if (this.#signingGeneration !== initializationGeneration) return
+
       if (!accountState) {
         if (this.network.disabled) {
           throw new Error(
@@ -262,10 +266,10 @@ export class SignMessageController
   }
 
   reset() {
+    this.#signingGeneration += 1
     if (!this.isInitialized) return
 
     this.#onAbortOperation()
-    this.#signingGeneration += 1
     this.isInitialized = false
     this.dapp = null
     this.messageToSign = null


### PR DESCRIPTION
You can have this race:
* init() assigns this.#account.
* init() pauses at await getOrFetchAccountOnChainState(...).
* Meanwhile, reset() runs and sets this.#account = undefined.
* The awaited operation finishes.
* Execution resumes at line 231 and reads safeCreation from the now-undefined field.

That's why we add an additional async protection that tracks the id of the request