### PR TITLE
fix: report a batch that was only broadcast in part

### DIFF
--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -946,8 +946,7 @@ export class MainController extends EventEmitter implements IMainController {
 
   async commonHandlerForBroadcastSuccess({
     submittedAccountOp,
-    accountOp,
-    fromRequestId
+    accountOp
   }: OnboardingSuccessProps) {
     // add the txnIds from each transaction to each Call from the accountOp
     // if identifiedBy is MultipleTxns
@@ -971,17 +970,6 @@ export class MainController extends EventEmitter implements IMainController {
       })
 
       submittedAccountOp.calls = calls
-
-      const userRequest = this.requests.userRequests.find((r) => r.id === fromRequestId)
-
-      if (userRequest) {
-        // Handle the calls that weren't signed
-        const rejectedCalls = accountOp.calls.filter((call) =>
-          submittedAccountOp.calls.every((c) => c.id !== call.id)
-        )
-
-        await this.requests.rejectCalls({ callIds: rejectedCalls.map((c) => c.id) })
-      }
     }
 
     if (accountOp.meta?.swapTxn) {
@@ -2095,10 +2083,27 @@ export class MainController extends EventEmitter implements IMainController {
       }
     })
 
-    await this.requests.removeUserRequests([accountOpRequest.id], {
-      shouldRemoveSwapAndBridgeRoute: false,
-      shouldOpenNextRequest: false
-    })
+    // Calls that made it out are done with. Anything left was never signed, so the
+    // request stays with those in it and the user can come back and sign them.
+    const sentCallIds = submittedAccountOp.calls
+      .filter((call) => call.status !== AccountOpStatus.Rejected)
+      .map((call) => call.id)
+    const notSentCalls = signAccountOp.accountOp.calls.filter(
+      (call) => !sentCallIds.includes(call.id)
+    )
+
+    if (notSentCalls.length) {
+      signAccountOp.update({ accountOpData: { calls: notSentCalls } })
+      // Their promises have just been answered, so the request must not hold them
+      accountOpRequest.dappPromises = accountOpRequest.dappPromises.filter((promise) =>
+        dappHandlers.every((handler) => handler.promise.id !== promise.id)
+      )
+    } else {
+      await this.requests.removeUserRequests([accountOpRequest.id], {
+        shouldRemoveSwapAndBridgeRoute: false,
+        shouldOpenNextRequest: false
+      })
+    }
 
     this.resolveDappBroadcast(submittedAccountOp, dappHandlers)
 

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -2088,12 +2088,9 @@ export class MainController extends EventEmitter implements IMainController {
     const sentCallIds = submittedAccountOp.calls
       .filter((call) => call.status !== AccountOpStatus.Rejected)
       .map((call) => call.id)
-    const notSentCalls = signAccountOp.accountOp.calls.filter(
-      (call) => !sentCallIds.includes(call.id)
-    )
+    const notSentCalls = signAccountOp.cleanupAfterBroadcast(sentCallIds)
 
     if (notSentCalls.length) {
-      signAccountOp.update({ accountOpData: { calls: notSentCalls } })
       // Their promises have just been answered, so the request must not hold them
       accountOpRequest.dappPromises = accountOpRequest.dappPromises.filter((promise) =>
         dappHandlers.every((handler) => handler.promise.id !== promise.id)

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -13,7 +13,7 @@ import {
 import fetch from 'node-fetch'
 
 import { WARNINGS } from '@/consts/signAccountOp/errorHandling'
-import { describe, expect, jest, test } from '@jest/globals'
+import { afterEach, describe, expect, jest, test } from '@jest/globals'
 import { recoverTypedSignature, SignTypedDataVersion } from '@metamask/eth-sig-util'
 
 import { relayerUrl, trezorSlot7v24337Deployed, velcroUrl } from '../../../test/config'
@@ -45,6 +45,8 @@ import { Storage } from '../../interfaces/storage'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { AccountOp, accountOpSignableHash } from '../../libs/accountOp/accountOp'
 import { BROADCAST_OPTIONS } from '../../libs/broadcast/broadcast'
+// Namespace import, so the broadcast helpers can be stood in for with jest.spyOn
+import * as broadcastLib from '../../libs/broadcast/broadcast'
 import { InnerCallFailureError } from '../../libs/errorDecoder/customErrors'
 import * as estimationLib from '../../libs/estimate/estimate'
 import { FullEstimationSummary } from '../../libs/estimate/interfaces'
@@ -78,6 +80,7 @@ import { BannerController } from '../banner/banner'
 import { DappsController } from '../dapps/dapps'
 import { EstimationController } from '../estimation/estimation'
 import { EstimationStatus } from '../estimation/types'
+import { FeatureFlags } from '../../consts/featureFlags'
 import { FeatureFlagsController } from '../featureFlags/featureFlags'
 import { GasPriceController } from '../gasPrice/gasPrice'
 import { InviteController } from '../invite/invite'
@@ -462,6 +465,8 @@ const init = async (
     initialSetStorage?: (storageCtrl: StorageController) => Promise<void>
     onUpdateAfterTraceCallSuccess?: () => Promise<void>
     externalSignerControllers?: ExternalSignerControllers
+    onBroadcastSuccess?: (params: any) => Promise<void>
+    featureFlags?: Partial<FeatureFlags>
   }
 ) => {
   const storage: Storage = produceMemoryStore()
@@ -560,7 +565,7 @@ const init = async (
   await networksCtrl.initialLoadPromise
   await providersCtrl.initialLoadPromise
 
-  const featureFlagsCtrl = new FeatureFlagsController({}, storageCtrl)
+  const featureFlagsCtrl = new FeatureFlagsController(options?.featureFlags || {}, storageCtrl)
   const portfolio = new PortfolioController(
     storageCtrl,
     fetch,
@@ -641,8 +646,8 @@ const init = async (
     account,
     accountsCtrl.accountStates[account.addr]![network.chainId.toString()]!,
     network,
-    true,
-    true
+    featureFlagsCtrl.isFeatureEnabled('erc4337'),
+    featureFlagsCtrl.isFeatureEnabled('eip7702')
   )
 
   const callRelayer = options?.callRelayer || relayerCall.bind({ url: '', fetch })
@@ -737,7 +742,7 @@ const init = async (
     accountOp: op,
     shouldSimulate: false,
     onUpdateAfterTraceCallSuccess: options?.onUpdateAfterTraceCallSuccess,
-    onBroadcastSuccess: async () => {},
+    onBroadcastSuccess: options?.onBroadcastSuccess || (async () => {}),
     estimateController: estimationController,
     gasPriceController
   })
@@ -3786,5 +3791,169 @@ describe('unlimited approval warnings', () => {
     } finally {
       catalogSpy.mockRestore()
     }
+  })
+})
+
+describe('broadcasting a batch one transaction at a time', () => {
+  suppressConsoleBeforeEach(true)
+  afterEach(() => jest.restoreAllMocks())
+
+  const batchGasPrices = {
+    slow: { maxFeePerGas: toBeHex(200n) as Hex, maxPriorityFeePerGas: toBeHex(100n) as Hex },
+    medium: { maxFeePerGas: toBeHex(400n) as Hex, maxPriorityFeePerGas: toBeHex(200n) as Hex },
+    fast: { maxFeePerGas: toBeHex(600n) as Hex, maxPriorityFeePerGas: toBeHex(300n) as Hex },
+    ape: { maxFeePerGas: toBeHex(800n) as Hex, maxPriorityFeePerGas: toBeHex(400n) as Hex }
+  }
+
+  /** An EOA broadcasts every call as its own transaction, so three calls take three signatures. */
+  const createThreeCallBatch = (account: Account) => {
+    const batch = createEOAAccountOp(account)
+    batch.op.calls = [1n, 2n, 3n].map((value) => ({
+      to: '0x0000000000000000000000000000000000000000',
+      value,
+      data: '0x' as Hex
+    }))
+    // Set, so the nonce is not read off the network during the test
+    ;(batch.op as any).eoaNonce = 7n
+
+    return batch
+  }
+
+  const initBatch = async () => {
+    const submittedAccountOps: any[] = []
+    const feePaymentOptions = [
+      {
+        paidBy: eoaAccount.addr,
+        availableAmount: 1000000000000000000n,
+        gasUsed: 0n,
+        addedNative: 5000n,
+        token: nativeFeeToken
+      }
+    ]
+    const { controller } = await init(
+      eoaAccount,
+      createThreeCallBatch(eoaAccount),
+      eoaSigner,
+      {
+        providerEstimation: { gasUsed: 10000n, feePaymentOptions },
+        flags: {},
+        updatedAt: Date.now()
+      } as any,
+      batchGasPrices,
+      false,
+      {
+        // Without this the account broadcasts through an EIP-7702 delegation, which
+        // sends the whole batch as one transaction and takes a single signature.
+        featureFlags: { eip7702: false },
+        callRelayer: (async () => ({})) as any,
+        onBroadcastSuccess: async ({ submittedAccountOp }: any) => {
+          submittedAccountOps.push(submittedAccountOp)
+        }
+      }
+    )
+
+    return { controller, submittedAccountOps }
+  }
+
+  /**
+   * Stands in for the network: every call becomes a transaction that is signed and
+   * sent, with `failFromIndex` naming the first signature that refuses.
+   */
+  const mockBroadcastChain = (failFromIndex: number | null) => {
+    jest
+      .spyOn(broadcastLib, 'buildRawTransaction')
+      .mockImplementation(async () => ({ to: '0x', value: 0n }) as any)
+
+    let signedCount = 0
+    const signRawTransaction = jest
+      .spyOn(KeystoreSigner.prototype, 'signRawTransaction')
+      .mockImplementation(async () => {
+        if (failFromIndex !== null && signedCount >= failFromIndex) {
+          throw new Error('Card operation cancelled.')
+        }
+        signedCount += 1
+
+        return `0xsigned${signedCount}`
+      })
+
+    const broadcastTransaction = jest
+      .spyOn(broadcastLib, 'broadcastTransaction')
+      .mockImplementation(async () => ({ hash: `0xhash${signedCount}` }) as any)
+
+    return { signRawTransaction, broadcastTransaction }
+  }
+
+  const getPartialBroadcastError = (controller: any) =>
+    controller.emittedErrors.find((e: any) => e.message.startsWith('Only '))
+
+  test('records every call and reports no error when the whole batch goes out', async () => {
+    const { controller, submittedAccountOps } = await initBatch()
+    const { signRawTransaction, broadcastTransaction } = mockBroadcastChain(null)
+
+    await controller.signAndBroadcast().catch(() => {})
+
+    expect(signRawTransaction).toHaveBeenCalledTimes(3)
+    expect(broadcastTransaction).toHaveBeenCalledTimes(3)
+    expect(submittedAccountOps).toHaveLength(1)
+    expect(submittedAccountOps[0].calls).toHaveLength(3)
+    expect(submittedAccountOps[0].identifiedBy.type).toBe('MultipleTxns')
+    expect(getPartialBroadcastError(controller)).toBeUndefined()
+  })
+
+  test('records only the calls that were sent when the batch stops part-way', async () => {
+    const { controller, submittedAccountOps } = await initBatch()
+    const { broadcastTransaction } = mockBroadcastChain(1)
+
+    await controller.signAndBroadcast().catch(() => {})
+
+    // The first call was signed and sent, the second was refused, so the third was
+    // never reached. Recording all three would list transactions that were never sent
+    // and line their hashes up with the wrong calls.
+    expect(broadcastTransaction).toHaveBeenCalledTimes(1)
+    expect(submittedAccountOps).toHaveLength(1)
+    expect(submittedAccountOps[0].calls).toHaveLength(1)
+    expect(submittedAccountOps[0].calls[0].value).toBe(1n)
+    expect(submittedAccountOps[0].identifiedBy.type).toBe('MultipleTxns')
+    expect(submittedAccountOps[0].identifiedBy.identifier.split('-')).toHaveLength(1)
+  })
+
+  test('tells the user how much of the batch was sent, and why the rest was not', async () => {
+    const { controller } = await initBatch()
+    mockBroadcastChain(1)
+
+    await controller.signAndBroadcast().catch(() => {})
+
+    // Reporting only the part that succeeded would leave the user believing all three
+    // transactions were sent.
+    const partialBroadcastError = getPartialBroadcastError(controller)
+
+    expect(partialBroadcastError).toBeDefined()
+    expect(partialBroadcastError.level).toBe('major')
+    expect(partialBroadcastError.message).toContain('Only 1 of 3 transactions')
+    expect(partialBroadcastError.message).toContain('The remaining 2 could not be sent')
+    expect(partialBroadcastError.message).toContain('Card operation cancelled.')
+  })
+
+  test('words the message for a single remaining transaction', async () => {
+    const { controller } = await initBatch()
+    mockBroadcastChain(2)
+
+    await controller.signAndBroadcast().catch(() => {})
+
+    expect(getPartialBroadcastError(controller).message).toContain(
+      'Only 2 of 3 transactions in this batch were sent. The remaining one could not be sent'
+    )
+  })
+
+  test('reports a plain failure, not a partial success, when nothing was sent', async () => {
+    const { controller, submittedAccountOps } = await initBatch()
+    mockBroadcastChain(0)
+
+    await controller.signAndBroadcast().catch(() => {})
+
+    // Nothing reached the network, so there is no account op worth recording and the
+    // failure is the whole story.
+    expect(submittedAccountOps).toHaveLength(0)
+    expect(getPartialBroadcastError(controller)).toBeUndefined()
   })
 })

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -3900,19 +3900,18 @@ describe('broadcasting a batch one transaction at a time', () => {
     expect(getPartialBroadcastError(controller)).toBeUndefined()
   })
 
-  test('records only the calls that were sent when the batch stops part-way', async () => {
+  test('keeps every call but reports only the hashes that went out', async () => {
     const { controller, submittedAccountOps } = await initBatch()
     const { broadcastTransaction } = mockBroadcastChain(1)
 
     await controller.signAndBroadcast().catch(() => {})
 
-    // The first call was signed and sent, the second was refused, so the third was
-    // never reached. Recording all three would list transactions that were never sent
-    // and line their hashes up with the wrong calls.
+    // Only the first went out. Every call is still recorded, with fewer hashes than
+    // calls - that gap is what tells apart the calls that never went out, so they can
+    // be marked as such instead of quietly disappearing from the account op.
     expect(broadcastTransaction).toHaveBeenCalledTimes(1)
     expect(submittedAccountOps).toHaveLength(1)
-    expect(submittedAccountOps[0].calls).toHaveLength(1)
-    expect(submittedAccountOps[0].calls[0].value).toBe(1n)
+    expect(submittedAccountOps[0].calls).toHaveLength(3)
     expect(submittedAccountOps[0].identifiedBy.type).toBe('MultipleTxns')
     expect(submittedAccountOps[0].identifiedBy.identifier.split('-')).toHaveLength(1)
   })

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -3819,7 +3819,7 @@ describe('broadcasting a batch one transaction at a time', () => {
     return batch
   }
 
-  const initBatch = async () => {
+  const initBatch = async (overrides?: { callRelayer?: any }) => {
     const submittedAccountOps: any[] = []
     const feePaymentOptions = [
       {
@@ -3845,7 +3845,7 @@ describe('broadcasting a batch one transaction at a time', () => {
         // Without this the account broadcasts through an EIP-7702 delegation, which
         // sends the whole batch as one transaction and takes a single signature.
         featureFlags: { eip7702: false },
-        callRelayer: (async () => ({})) as any,
+        callRelayer: overrides?.callRelayer || ((async () => ({})) as any),
         onBroadcastSuccess: async ({ submittedAccountOp }: any) => {
           submittedAccountOps.push(submittedAccountOp)
         }
@@ -3943,6 +3943,25 @@ describe('broadcasting a batch one transaction at a time', () => {
     expect(getPartialBroadcastError(controller).message).toContain(
       'Only 2 of 3 transactions in this batch were sent. The remaining one could not be sent'
     )
+  })
+
+  test('sends the whole batch even when the gas tank bookkeeping throws', async () => {
+    const { controller, submittedAccountOps } = await initBatch({
+      callRelayer: () => {
+        throw new Error('relayer is unavailable')
+      }
+    })
+    const { signRawTransaction } = mockBroadcastChain(null)
+
+    await controller.signAndBroadcast().catch(() => {})
+
+    // Recording the transaction for the gas tank is bookkeeping the broadcast does
+    // not depend on. Letting it stop the batch would strand the calls after it, and
+    // the ones already sent cannot be taken back.
+    expect(signRawTransaction).toHaveBeenCalledTimes(3)
+    expect(submittedAccountOps).toHaveLength(1)
+    expect(submittedAccountOps[0].calls).toHaveLength(3)
+    expect(getPartialBroadcastError(controller)).toBeUndefined()
   })
 
   test('reports a plain failure, not a partial success, when nothing was sent', async () => {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -79,7 +79,7 @@ import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { Safe } from '../../libs/account/Safe'
 import { AccountOp, GasFeePayment, getSignableCalls } from '../../libs/accountOp/accountOp'
 import { AccountOpIdentifiedBy, SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
-import { AccountOpStatus } from '../../libs/accountOp/types'
+import { AccountOpStatus, Call } from '../../libs/accountOp/types'
 import { getScamDetectedText } from '../../libs/banners/banners'
 import {
   BROADCAST_OPTIONS,
@@ -4089,13 +4089,42 @@ export class SignAccountOpController
    * Use this only when you are sure there's no way to continue, or
    * a promise waiting to resolve that might change the state
    */
-  cancelSignReq() {
+  #resetToReadyToSign() {
     this.signPromise = undefined
     this.broadcastPromise = undefined
     this.signAndBroadcastPromise = undefined
     this.status = { type: SigningStatus.ReadyToSign }
     this.#hwCleanup()
+  }
+
+  cancelSignReq() {
+    this.#resetToReadyToSign()
     this.emitUpdate()
+  }
+
+  /**
+   * Winds a broadcast up. The calls that went out are done with, so only the ones left
+   * unsigned stay on the op and the controller goes back to where it was before
+   * signing, ready for them. Its status has to be put back first: while it is signing,
+   * every update to the op is frozen and the calls would not go in.
+   *
+   * Returns the calls still waiting to be signed, so the caller can tell whether the
+   * request is finished with or has to stay.
+   */
+  cleanupAfterBroadcast(sentCallIds: Call['id'][]): Call[] {
+    const notSentCalls = this.accountOp.calls.filter((call) => !sentCallIds.includes(call.id))
+
+    this.#resetToReadyToSign()
+
+    if (!notSentCalls.length) {
+      this.emitUpdate()
+
+      return notSentCalls
+    }
+
+    this.update({ accountOpData: { calls: notSentCalls } })
+
+    return notSentCalls
   }
 
   get type() {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -3623,15 +3623,7 @@ export class SignAccountOpController
 
           // record the EOA txn only if isErc4337Enabled as
           // we need this for the gas tank
-          if (this.isErc4337Enabled) {
-            this.#callRelayer(`/v2/eoaSubmitTxn/${accountOp.chainId}`, 'POST', {
-              rawTxn: signedTxn
-            }).catch((e: any) => {
-              console.log('failed to record EOA txn to relayer', accountOp.chainId)
-
-              console.log(e)
-            })
-          }
+          if (this.isErc4337Enabled) this.#recordEoaTxnForGasTank(accountOp.chainId, signedTxn)
         }
 
         transactionRes = {
@@ -3891,6 +3883,26 @@ export class SignAccountOpController
     })
 
     await this.signAndBroadcastPromise
+  }
+
+  /**
+   * Bookkeeping for the gas tank, which the broadcast does not depend on. It is
+   * deliberately not awaited and never allowed to throw: it runs between the
+   * transactions of a batch, where anything escaping it would stop the rest of the
+   * batch from being sent - and the transactions before it cannot be taken back.
+   */
+  #recordEoaTxnForGasTank(chainId: bigint, rawTxn: string) {
+    const onFailedToRecord = (e: any) => {
+      console.log('failed to record EOA txn to relayer', chainId)
+
+      console.log(e)
+    }
+
+    try {
+      this.#callRelayer(`/v2/eoaSubmitTxn/${chainId}`, 'POST', { rawTxn }).catch(onFailedToRecord)
+    } catch (e: any) {
+      onFailedToRecord(e)
+    }
   }
 
   #hwCleanup() {

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -3531,6 +3531,9 @@ export class SignAccountOpController
       nonce: number
       identifiedBy: AccountOpIdentifiedBy
     } | null = null
+    // Set only when a batch was broadcast in part, so the account op that gets
+    // recorded holds the transactions that were actually sent and no others.
+    let sentCallsCount: number | null = null
 
     // broadcasting by EOA is quite the same:
     // 1) build a rawTxn 2) sign 3) broadcast
@@ -3656,6 +3659,7 @@ export class SignAccountOpController
         // unless it's the build-in swap - we want to throw an error and
         // allow the user to retry in this case
         if (multipleTxnsBroadcastRes.length && this.#type !== 'one-click-swap-and-bridge') {
+          sentCallsCount = multipleTxnsBroadcastRes.length
           transactionRes = {
             nonce: senderNonce,
             identifiedBy: {
@@ -3664,6 +3668,20 @@ export class SignAccountOpController
             },
             txnId: multipleTxnsBroadcastRes[multipleTxnsBroadcastRes.length - 1]?.hash
           }
+
+          // The part that went out is reported as broadcast, so without saying this
+          // the rest of the batch looks sent when it never was.
+          const notSentCount = accountOp.calls.length - sentCallsCount
+          const reason = error?.message || 'the transaction could not be signed'
+          this.emitError({
+            level: 'major',
+            message: `Only ${sentCallsCount} of ${accountOp.calls.length} transactions in this batch ${
+              sentCallsCount === 1 ? 'was' : 'were'
+            } sent. The remaining ${notSentCount === 1 ? 'one' : notSentCount} could not be sent: ${
+              reason.endsWith('.') ? reason : `${reason}.`
+            } You can send ${notSentCount === 1 ? 'it' : 'them'} again.`,
+            error
+          })
         } else {
           return this.throwBroadcastAccountOp({ error, accountState })
         }
@@ -3774,17 +3792,23 @@ export class SignAccountOpController
       submittedAccountOpMeta.clearSigningHumanization = clearSigningHumanization
     }
 
+    // A batch broadcast one transaction at a time can stop part-way through. The
+    // calls are sent in order, so the ones that made it out are the leading ones -
+    // and only those may be recorded, or the activity would list transactions that
+    // were never sent and their hashes would line up with the wrong calls.
+    const sentCalls =
+      sentCallsCount === null ? accountOp.calls : accountOp.calls.slice(0, sentCallsCount)
+
     const submittedAccountOp: SubmittedAccountOp = {
       ...accountOp,
+      calls: sentCalls,
       eoaNonce: this.accountOp.eoaNonce,
       status: AccountOpStatus.BroadcastedButNotConfirmed,
       txnId: transactionRes.txnId,
       nonce: BigInt(transactionRes.nonce),
       identifiedBy: transactionRes.identifiedBy,
       timestamp: new Date().getTime(),
-      isSingletonDeploy: !!accountOp.calls.find(
-        (call) => call.to && getAddress(call.to) === SINGLETON
-      )
+      isSingletonDeploy: !!sentCalls.find((call) => call.to && getAddress(call.to) === SINGLETON)
     }
     if (Object.keys(submittedAccountOpMeta).length) submittedAccountOp.meta = submittedAccountOpMeta
     else delete submittedAccountOp.meta

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -3531,10 +3531,6 @@ export class SignAccountOpController
       nonce: number
       identifiedBy: AccountOpIdentifiedBy
     } | null = null
-    // Set only when a batch was broadcast in part, so the account op that gets
-    // recorded holds the transactions that were actually sent and no others.
-    let sentCallsCount: number | null = null
-
     // broadcasting by EOA is quite the same:
     // 1) build a rawTxn 2) sign 3) broadcast
     // we have one handle, just a diff rawTxn for each case
@@ -3651,7 +3647,6 @@ export class SignAccountOpController
         // unless it's the build-in swap - we want to throw an error and
         // allow the user to retry in this case
         if (multipleTxnsBroadcastRes.length && this.#type !== 'one-click-swap-and-bridge') {
-          sentCallsCount = multipleTxnsBroadcastRes.length
           transactionRes = {
             nonce: senderNonce,
             identifiedBy: {
@@ -3663,12 +3658,13 @@ export class SignAccountOpController
 
           // The part that went out is reported as broadcast, so without saying this
           // the rest of the batch looks sent when it never was.
-          const notSentCount = accountOp.calls.length - sentCallsCount
+          const sentCount = multipleTxnsBroadcastRes.length
+          const notSentCount = accountOp.calls.length - sentCount
           const reason = error?.message || 'the transaction could not be signed'
           this.emitError({
             level: 'major',
-            message: `Only ${sentCallsCount} of ${accountOp.calls.length} transactions in this batch ${
-              sentCallsCount === 1 ? 'was' : 'were'
+            message: `Only ${sentCount} of ${accountOp.calls.length} transactions in this batch ${
+              sentCount === 1 ? 'was' : 'were'
             } sent. The remaining ${notSentCount === 1 ? 'one' : notSentCount} could not be sent: ${
               reason.endsWith('.') ? reason : `${reason}.`
             } You can send ${notSentCount === 1 ? 'it' : 'them'} again.`,
@@ -3784,23 +3780,17 @@ export class SignAccountOpController
       submittedAccountOpMeta.clearSigningHumanization = clearSigningHumanization
     }
 
-    // A batch broadcast one transaction at a time can stop part-way through. The
-    // calls are sent in order, so the ones that made it out are the leading ones -
-    // and only those may be recorded, or the activity would list transactions that
-    // were never sent and their hashes would line up with the wrong calls.
-    const sentCalls =
-      sentCallsCount === null ? accountOp.calls : accountOp.calls.slice(0, sentCallsCount)
-
     const submittedAccountOp: SubmittedAccountOp = {
       ...accountOp,
-      calls: sentCalls,
       eoaNonce: this.accountOp.eoaNonce,
       status: AccountOpStatus.BroadcastedButNotConfirmed,
       txnId: transactionRes.txnId,
       nonce: BigInt(transactionRes.nonce),
       identifiedBy: transactionRes.identifiedBy,
       timestamp: new Date().getTime(),
-      isSingletonDeploy: !!sentCalls.find((call) => call.to && getAddress(call.to) === SINGLETON)
+      isSingletonDeploy: !!accountOp.calls.find(
+        (call) => call.to && getAddress(call.to) === SINGLETON
+      )
     }
     if (Object.keys(submittedAccountOpMeta).length) submittedAccountOp.meta = submittedAccountOpMeta
     else delete submittedAccountOp.meta


### PR DESCRIPTION
## Why

An EOA sends every call of a batch as its own transaction, signing and broadcasting them one at a time. Stopping half way — a refused signature on the second of two — left things in a bad state, found while signing with an NFC card:

1. The failure only reached `console.error`. The transaction status screen appeared with **no error at all** and the user never learned the rest had not been sent.
2. The calls that never went out were **rejected and the whole request removed**, so there was nothing left to come back to and sign.
3. Bookkeeping unrelated to the broadcast could abort a batch part-way.

## What changed

### 1. A partial send is reported

```
Only 1 of 2 transactions in this batch was sent. The remaining one could not be sent: … You can send it again.
```

Emitted as a `major` error. The calls already sent cannot be recalled, so the account op is still recorded as broadcast — that part is unchanged and intentional.

### 2. The calls that never went out are marked, not dropped

Every call stays on the submitted account op, with only the sent hashes in `identifiedBy.identifier`. The gap between the two is what `commonHandlerForBroadcastSuccess` uses to mark the rest `AccountOpStatus.Rejected`, which is what the UI shows.

An earlier commit here trimmed those calls off the op instead. That was wrong: it removed the very calls the marking needs, so they silently disappeared rather than showing as not sent.

### 3. The request stays, with the unsigned calls in it

New on the controller:

```ts
cleanupAfterBroadcast(sentCallIds: Call['id'][]): Call[]
```

It drops the calls that went out, puts the controller back to `ReadyToSign`, and returns whatever is left so the caller can tell if the request is finished with.

The status reset is not cosmetic. `SigningStatus.Done` is in `noStateUpdateStatuses`, and `update()` returns early for those (`signAccountOp.ts:1688`) — so updating the calls while the op still counted as signing was a silent no-op, and the request sat there saying "Signing…" with every call still listed. The reset is shared with `cancelSignReq` through a private `#resetToReadyToSign`.

`main.ts` no longer rejects the unsigned calls, and only removes the request when nothing is left.

### 4. Gas tank bookkeeping can no longer stop a batch

```ts
this.#callRelayer(`/v2/eoaSubmitTxn/${chainId}`, 'POST', { rawTxn }).catch(...)
```

`.catch` only covers a *rejected* promise; anything thrown **synchronously** escaped into the batch's error handling and stranded every call after it. Moved into `#recordEoaTxnForGasTank`, which cannot throw. Without the guard the test shows **1 of 3 transactions signed instead of 3**.