### PR TITLE
Fetch tokens from uniswap's API

### DIFF
--- a/src/services/uniswap/api.test.ts
+++ b/src/services/uniswap/api.test.ts
@@ -33,6 +33,88 @@ describe('UniswapAPI', () => {
     expect(chains.some((chain) => chain.chainId === Number(CITREA_CHAIN_ID))).toBe(false)
   })
 
+  it('requests the top destination-chain tokens and normalizes the response', async () => {
+    const fetch = jest.fn(async () =>
+      makeResponse({
+        requestId: 'request-id',
+        tokens: [
+          {
+            address: tokenIn.toLowerCase(),
+            chainId: 1,
+            decimals: 6,
+            logoURI: 'https://example.com/usdc.png',
+            name: 'USD Coin',
+            symbol: 'USDC',
+            extensions: { safetyInfo: { safetyLevel: 'verified' } }
+          },
+          {
+            address: ZERO_ADDRESS,
+            chainId: 1,
+            decimals: 18,
+            logoURI: null,
+            name: 'Ether',
+            symbol: 'ETH'
+          },
+          {
+            address: tokenOut,
+            chainId: 1,
+            decimals: 6,
+            logoURI: null,
+            name: 'Blocked token',
+            symbol: 'BLOCKED',
+            extensions: { safetyInfo: { safetyLevel: 'blocked' } }
+          },
+          {
+            address: tokenIn,
+            chainId: 8453,
+            decimals: 6,
+            logoURI: null,
+            name: 'Wrong-chain token',
+            symbol: 'WRONG'
+          }
+        ]
+      })
+    )
+    const uniswapApi = new UniswapAPI({ fetch: fetch as any, apiKey: 'test-key' })
+
+    const tokens = await uniswapApi.getToTokenList({ fromChainId: 1, toChainId: 1 })
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://trade-api.gateway.uniswap.org/v1/tokens?chainId=1&limit=1000&sort=tvl',
+      { headers: expect.any(Object) }
+    )
+    expect(tokens[0]).toMatchObject({ address: ZERO_ADDRESS, icon: '', symbol: 'ETH' })
+    expect(tokens).toContainEqual(
+      expect.objectContaining({
+        address: tokenIn,
+        chainId: 1,
+        icon: 'https://example.com/usdc.png',
+        symbol: 'USDC'
+      })
+    )
+    expect(tokens.some((token) => token.symbol === 'BLOCKED')).toBe(false)
+    expect(tokens.some((token) => token.chainId !== 1)).toBe(false)
+  })
+
+  it('handles an empty token-list response', async () => {
+    const fetch = jest.fn(async () => makeResponse({ requestId: 'request-id' }))
+    const uniswapApi = new UniswapAPI({ fetch: fetch as any, apiKey: 'test-key' })
+
+    await expect(
+      uniswapApi.getToTokenList({ fromChainId: 8453, toChainId: 8453 })
+    ).resolves.toEqual([])
+  })
+
+  it('does not request tokens for an unsupported network pair', async () => {
+    const fetch = jest.fn()
+    const uniswapApi = new UniswapAPI({ fetch: fetch as any, apiKey: 'test-key' })
+
+    await expect(
+      uniswapApi.getToTokenList({ fromChainId: Number(CITREA_CHAIN_ID), toChainId: 1 })
+    ).rejects.toThrow('The requested network pair is not supported')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   it('requests a direct-approval classic quote and normalizes the route', async () => {
     const fetch = jest.fn(async () =>
       makeResponse({

--- a/src/services/uniswap/api.ts
+++ b/src/services/uniswap/api.ts
@@ -42,6 +42,20 @@ import {
 
 const erc20Interface = new Interface(ERC20.abi)
 
+type UniswapTokenListEntry = {
+  address: string
+  chainId: number
+  decimals: number
+  logoURI: string | null
+  name: string
+  symbol: string
+  extensions?: {
+    safetyInfo?: {
+      safetyLevel?: 'verified' | 'info' | 'blocked'
+    }
+  }
+}
+
 const isAcrossBridgeQuote = (quote: UniswapQuote) =>
   quote.exclusiveRelayer !== undefined &&
   quote.exclusivityDeadline !== undefined &&
@@ -226,7 +240,7 @@ const parseApprovalSpender = (approval: UniswapTransactionRequest | null, fallba
   try {
     const decoded = erc20Interface.decodeFunctionData('approve', approval.data)
     return getAddress(decoded[0])
-  } catch (e) {
+  } catch {
     return fallback
   }
 }
@@ -378,7 +392,34 @@ export class UniswapAPI implements SwapProvider {
       )
     }
 
-    return sortNativeTokenFirst(addCustomTokensIfNeeded({ chainId: toChainId, tokens: [] }))
+    const params = new URLSearchParams({
+      chainId: toChainId.toString(),
+      limit: '1000',
+      sort: 'tvl'
+    })
+    const url = `${UNISWAP_API_BASE_URL}/tokens?${params.toString()}`
+
+    const response = await this.#handleResponse<{ tokens?: UniswapTokenListEntry[] }>({
+      fetchPromise: this.#fetch(url, { headers: this.#headers }),
+      errorPrefix:
+        'Unable to retrieve the list of supported receive tokens. Please reload to try again.'
+    })
+
+    const tokens: SwapAndBridgeToToken[] = (response.tokens || [])
+      .filter(
+        (token) =>
+          token.chainId === toChainId && token.extensions?.safetyInfo?.safetyLevel !== 'blocked'
+      )
+      .map((token) => ({
+        address: normalizeAddress(token.address),
+        chainId: token.chainId,
+        decimals: token.decimals,
+        icon: token.logoURI || '',
+        name: token.name,
+        symbol: token.symbol
+      }))
+
+    return sortNativeTokenFirst(addCustomTokensIfNeeded({ chainId: toChainId, tokens }))
   }
 
   async getToken({


### PR DESCRIPTION
Backstory:  
When we implemented the Uniswap's API for trading, it didn't have a route for fetching tokens. It wasn't a problem as we're using other providers as well

However, to make the implementation even more robust, each provider should be able to fetch its own token list (in case other providers are down). That's what we're doing here