### PR TITLE
Fix: add overhead to eoa 7702; make the overhead 20%

### DIFF
--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -1513,8 +1513,8 @@ describe('SignAccountOp Controller ', () => {
       isGasTank: false,
       inToken: '0x0000000000000000000000000000000000000000',
       feeTokenChainId: 1n,
-      amount: 6005000n, // ((300 + 300) × 10000) + 10000, i.e. ((baseFee + priorityFee) * gasUsed) + addedNative
-      simulatedGasLimit: 10000n, // 10000, i.e. gasUsed,
+      amount: 7205000n, // ((300 + 300) × 12000) + 5000, i.e. ((baseFee + priorityFee) * gasUsed) + addedNative
+      simulatedGasLimit: 12000n, // 10000 gas used plus 20% overhead
       maxPriorityFeePerGas: 300n,
       gasPrice: 600n
     })

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -11,6 +11,7 @@ import {
 } from 'ethers'
 import { maxUint256 } from 'viem'
 
+import { getGasLimitWithOverhead } from '@/libs/estimate/estimate'
 import { isNative } from '@/libs/portfolio/helpers'
 import { BindedRelayerCall } from '@/libs/relayerCall/relayerCall'
 
@@ -173,7 +174,6 @@ import {
 } from './signAccountOpPreference'
 
 import type { SpeedCalc, Status } from '../../interfaces/signAccountOp'
-
 // Re-exporting for backwards compatibility with existing importers
 export { FeeSpeed, noStateUpdateStatuses, SigningStatus }
 export type { SpeedCalc, Status }
@@ -2461,6 +2461,7 @@ export class SignAccountOpController
           if (!estimation.bundlerEstimation) return
 
           usesPaymaster = !!estimation.bundlerEstimation?.paymaster.isUsable()
+          // no gas overhead for bundler broadcast
           simulatedGasLimit =
             BigInt(gasUsed) +
             BigInt(estimation.bundlerEstimation.preVerificationGas) +
@@ -2473,7 +2474,7 @@ export class SignAccountOpController
           broadcastOption === BROADCAST_OPTIONS.bySelf ||
           broadcastOption === BROADCAST_OPTIONS.bySelf7702
         ) {
-          simulatedGasLimit = gasUsed
+          simulatedGasLimit = getGasLimitWithOverhead(gasUsed)
           gasPrice = BigInt(increasedPrices.maxFeePerGas)
           maxPriorityFeePerGas = BigInt(increasedPrices.maxPriorityFeePerGas)
           amountGasPrice = BigInt(receivedPrices.maxFeePerGas)
@@ -2486,7 +2487,7 @@ export class SignAccountOpController
         } else if (broadcastOption === BROADCAST_OPTIONS.byOtherEOA) {
           // Smart account, but EOA pays the fee
           // 7702, and it pays for the fee by itself
-          simulatedGasLimit = gasUsed
+          simulatedGasLimit = getGasLimitWithOverhead(gasUsed)
           gasPrice = BigInt(increasedPrices.maxFeePerGas)
           maxPriorityFeePerGas = BigInt(increasedPrices.maxPriorityFeePerGas)
           amountGasPrice = BigInt(receivedPrices.maxFeePerGas)

--- a/src/libs/account/EOA.ts
+++ b/src/libs/account/EOA.ts
@@ -87,8 +87,7 @@ export class EOA extends BaseAccount {
       estimation.providerEstimation.gasUsed > ambireGasUsed
         ? estimation.providerEstimation.gasUsed
         : ambireGasUsed
-    // add a 10% overhead to prevent OOG
-    return gasUsed + gasUsed / 10n + revokeGas
+    return gasUsed + revokeGas
   }
 
   getBroadcastOption(

--- a/src/libs/broadcast/broadcast.test.ts
+++ b/src/libs/broadcast/broadcast.test.ts
@@ -100,9 +100,9 @@ function getEoaBatchOp() {
 
 describe('broadcast', () => {
   test.each([
-    { chainId: 6342n, expectedGasLimit: 110000n },
+    { chainId: 6342n, expectedGasLimit: 120000n },
     { chainId: 4663n, expectedGasLimit: 120000n }
-  ])('adds the expected gas overhead on chain $chainId', async ({ chainId, expectedGasLimit }) => {
+  ])('adds 20% gas overhead on chain $chainId', async ({ chainId, expectedGasLimit }) => {
     const provider = getProvider('0x186a0')
 
     const rawTxn = await buildRawTransaction(
@@ -145,8 +145,27 @@ describe('broadcast', () => {
       op.calls[0]
     )
 
-    expect(rawTxn.gasLimit).toBe(110000n)
+    expect(rawTxn.gasLimit).toBe(120000n)
     expect(provider.send).toHaveBeenCalledTimes(2)
+  })
+
+  test('keeps the simulated gas limit with 20% overhead for an EIP-7702 broadcast', async () => {
+    const provider = getProvider('0x186a0')
+    const op = getEoaBatchOp()
+    op.gasFeePayment!.simulatedGasLimit = 120000n
+
+    const rawTxn = await buildRawTransaction(
+      eoaAccount,
+      op,
+      accountState,
+      provider,
+      network,
+      7,
+      BROADCAST_OPTIONS.bySelf7702
+    )
+
+    expect(rawTxn.gasLimit).toBe(120000n)
+    expect(provider.send).not.toHaveBeenCalled()
   })
 
   test('stops retrying a failed estimate for a multi-call EOA broadcast at the threshold', async () => {

--- a/src/libs/broadcast/broadcast.ts
+++ b/src/libs/broadcast/broadcast.ts
@@ -1,5 +1,7 @@
 import { Interface, toQuantity, TransactionResponse } from 'ethers'
 
+import { getGasLimitWithOverhead } from '@/libs/estimate/estimate'
+
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import ERC20 from '../../../contracts/compiled/IERC20.json'
@@ -28,15 +30,6 @@ export const BROADCAST_OPTIONS = {
 async function waitBeforeRetry(chainId: bigint) {
   // wait a bit longer on ethereum as txn confirmations are slower
   await wait(chainId === 1n ? 2000 : 1000)
-}
-
-/**
- * The default gas limit overhead for all chains is 10%.
- * Robinhood uses 20% because transactions there frequently run out of gas.
- */
-function getGasLimitOverhead(gasLimit: bigint, chainId: bigint) {
-  if (chainId === 4663n) return gasLimit / 5n
-  return gasLimit / 10n
 }
 
 export function getByOtherEOATxnData(
@@ -144,7 +137,7 @@ async function estimateGas(
   }
 
   // add gas overhead to prevent OOG
-  return BigInt(gasLimit) + getGasLimitOverhead(BigInt(gasLimit), chainId)
+  return getGasLimitWithOverhead(BigInt(gasLimit))
 }
 
 export async function getTxnData(

--- a/src/libs/estimate/estimate.ts
+++ b/src/libs/estimate/estimate.ts
@@ -112,3 +112,11 @@ export function getEstimationSummary(estimation: FullEstimation): FullEstimation
     updatedAt: Date.now()
   }
 }
+
+/**
+ * Push extra gas limit for EOA / EOA7702 accounts to avoid OOG.
+ * This extra gas limit is 20% as 10% was might not be enough for swaps
+ */
+export function getGasLimitWithOverhead(gasLimit: bigint): bigint {
+  return gasLimit + gasLimit / 5n
+}


### PR DESCRIPTION
There was a bug that skipped adding the gas overhead to EOA 7702 native broadcasts. Along with that, we're changing the gas overhead to 20%