### PR TITLE
Feature: quick to token list

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -15,6 +15,7 @@ import humanizerInfo from '../../consts/humanizer/humanizerInfo.json'
 import { IProvidersController } from '../../interfaces/provider'
 import { IRequestsController } from '../../interfaces/requests'
 import { Storage } from '../../interfaces/storage'
+import { SwapAndBridgeToToken } from '../../interfaces/swapAndBridge'
 import { HumanizerMeta } from '../../libs/humanizer/interfaces'
 import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import wait from '../../utils/wait'
@@ -434,6 +435,57 @@ describe('SwapAndBridge Controller', () => {
     )
     expect(swapAndBridgeController.fromChainId).toEqual(10)
     expect(swapAndBridgeController.toChainId).toEqual(10)
+  })
+  test('should emit token list updates while providers are still loading', async () => {
+    const partialToken: SwapAndBridgeToToken = {
+      address: '0x0000000000000000000000000000000000000001',
+      chainId: 137,
+      decimals: 18,
+      name: 'Partial token',
+      symbol: 'PARTIAL'
+    }
+    const finalToken: SwapAndBridgeToToken = {
+      address: '0x0000000000000000000000000000000000000002',
+      chainId: 137,
+      decimals: 18,
+      name: 'Final token',
+      symbol: 'FINAL'
+    }
+    let resolveTokenList!: (tokens: SwapAndBridgeToToken[]) => void
+    const getToTokenListSpy = jest.spyOn(socketAPIMock, 'getToTokenList').mockImplementation(
+      (params: any) =>
+        new Promise((resolve) => {
+          resolveTokenList = resolve
+          params.onUpdate([partialToken])
+        })
+    )
+    let unsubscribe = () => {}
+    const partialUpdatePromise = new Promise<void>((resolve) => {
+      unsubscribe = swapAndBridgeController.onUpdate(() => {
+        if (!swapAndBridgeController.toTokenShortList.includes(partialToken)) return
+
+        unsubscribe()
+        resolve()
+      })
+    })
+
+    const updatePromise = swapAndBridgeController.updateForm(
+      { toChainId: 137 },
+      { updateQuote: false }
+    )
+
+    await partialUpdatePromise
+    expect(swapAndBridgeController.updateToTokenListStatus).toEqual('LOADING')
+    expect(swapAndBridgeController.toTokenShortList).toContain(partialToken)
+
+    resolveTokenList([partialToken, finalToken])
+    await updatePromise
+    expect(swapAndBridgeController.updateToTokenListStatus).toEqual('INITIAL')
+    expect(swapAndBridgeController.toTokenShortList).toContain(finalToken)
+
+    getToTokenListSpy.mockRestore()
+    swapAndBridgeController.reset()
+    await swapAndBridgeController.updatePortfolioTokenList(PORTFOLIO_TOKENS)
   })
   test('should sync toChainId to the preselected from token chain when no to token is provided', async () => {
     const preselectedToken = PORTFOLIO_TOKENS[1]!

--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -1402,7 +1402,14 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
       try {
         toTokenList.apiTokens = await this.#serviceProviderAPI.getToTokenList({
           fromChainId,
-          toChainId
+          toChainId,
+          onUpdate: (apiTokens) => {
+            toTokenList.apiTokens = apiTokens
+            toTokenList.tokens = this.#getToTokens(fromChainId, toChainId)
+            toTokenList.lastUpdate = Date.now()
+
+            if (toTokenListKeyAtStart === this.#toTokenListKey) this.#emitUpdateIfNeeded()
+          }
         })
         toTokenList.lastUpdate = Date.now()
       } catch (error: any) {

--- a/src/interfaces/swapAndBridge.ts
+++ b/src/interfaces/swapAndBridge.ts
@@ -613,10 +613,13 @@ export interface SwapProvider {
   getSupportedChains(): Promise<SwapAndBridgeSupportedChain[]>
   getToTokenList({
     fromChainId,
-    toChainId
+    toChainId,
+    onUpdate
   }: {
     fromChainId: number
     toChainId: number
+    /** Reports the merged token list whenever another provider completes successfully. */
+    onUpdate?: (tokens: SwapAndBridgeToToken[]) => void
   }): Promise<SwapAndBridgeToToken[]>
   getToken({
     address,

--- a/src/services/swapIntegrators/swapProviderParallelExecutor.test.ts
+++ b/src/services/swapIntegrators/swapProviderParallelExecutor.test.ts
@@ -68,6 +68,113 @@ describe('Swap Provider Parallel execution', () => {
     const uniqueIds = new Set(ids)
     expect(uniqueIds.size).toBe(ids.length)
   })
+
+  it('Requests every provider once and reports token lists as providers complete', async () => {
+    const createToken = (address: string, symbol: string) => ({
+      address,
+      chainId: 1,
+      decimals: 18,
+      name: symbol,
+      symbol
+    })
+    const firstToken = createToken('0x0000000000000000000000000000000000000001', 'FIRST')
+    const secondToken = createToken('0x0000000000000000000000000000000000000002', 'SECOND')
+    let resolveFirstProvider!: (tokens: (typeof firstToken)[]) => void
+    let resolveSecondProvider!: (tokens: (typeof firstToken)[]) => void
+    const firstProvider = createProvider(async () => [])
+    const secondProvider = createProvider(async () => [])
+    firstProvider.getToTokenList = jest.fn(
+      () => new Promise<(typeof firstToken)[]>((resolve) => (resolveFirstProvider = resolve))
+    )
+    secondProvider.getToTokenList = jest.fn(
+      () => new Promise<(typeof firstToken)[]>((resolve) => (resolveSecondProvider = resolve))
+    )
+    let resolveFirstUpdate!: () => void
+    const firstUpdatePromise = new Promise<void>((resolve) => (resolveFirstUpdate = resolve))
+    const onUpdate = jest.fn(resolveFirstUpdate)
+    const executor = new SwapProviderParallelExecutor([firstProvider, secondProvider])
+
+    const tokenListPromise = executor.getToTokenList({
+      fromChainId: 1,
+      toChainId: 1,
+      onUpdate
+    })
+
+    expect(firstProvider.getToTokenList).toHaveBeenCalledTimes(1)
+    expect(secondProvider.getToTokenList).toHaveBeenCalledTimes(1)
+
+    resolveSecondProvider([secondToken])
+    await firstUpdatePromise
+    expect(onUpdate).toHaveBeenLastCalledWith([secondToken])
+
+    resolveFirstProvider([firstToken, secondToken])
+    await expect(tokenListPromise).resolves.toEqual([secondToken, firstToken])
+    expect(onUpdate).toHaveBeenLastCalledWith([secondToken, firstToken])
+    expect(onUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  it('Keeps successful token results when another provider times out', async () => {
+    jest.useFakeTimers()
+
+    try {
+      const token = {
+        address: '0x0000000000000000000000000000000000000001',
+        chainId: 1,
+        decimals: 18,
+        name: 'Token',
+        symbol: 'TOKEN'
+      }
+      const successfulProvider = createProvider(async () => [])
+      const hangingProvider = createProvider(async () => [])
+      successfulProvider.getToTokenList = jest.fn(async () => [token])
+      hangingProvider.getToTokenList = jest.fn(() => new Promise(() => {}))
+      let resolveUpdate!: () => void
+      const updatePromise = new Promise<void>((resolve) => (resolveUpdate = resolve))
+      const onUpdate = jest.fn(resolveUpdate)
+      const executor = new SwapProviderParallelExecutor([successfulProvider, hangingProvider])
+      const tokenListPromise = executor.getToTokenList({
+        fromChainId: 1,
+        toChainId: 1,
+        onUpdate
+      })
+
+      await updatePromise
+      expect(onUpdate).toHaveBeenCalledWith([token])
+
+      await jest.advanceTimersByTimeAsync(30000)
+      await expect(tokenListPromise).resolves.toEqual([token])
+      expect(successfulProvider.getToTokenList).toHaveBeenCalledTimes(1)
+      expect(hangingProvider.getToTokenList).toHaveBeenCalledTimes(1)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('Fails after all providers fail or time out without retrying them automatically', async () => {
+    jest.useFakeTimers()
+
+    try {
+      const failingProvider = createProvider(async () => [])
+      const hangingProvider = createProvider(async () => [])
+      failingProvider.getToTokenList = jest.fn(async () => {
+        throw new Error('Provider failed')
+      })
+      hangingProvider.getToTokenList = jest.fn(() => new Promise(() => {}))
+      const executor = new SwapProviderParallelExecutor([failingProvider, hangingProvider])
+      const tokenListPromise = executor.getToTokenList({ fromChainId: 1, toChainId: 1 })
+      const expectedFailure = expect(tokenListPromise).rejects.toThrow(
+        'Our service providers are currently unavailable. Please try again later.'
+      )
+
+      await jest.advanceTimersByTimeAsync(30000)
+      await expectedFailure
+      expect(failingProvider.getToTokenList).toHaveBeenCalledTimes(1)
+      expect(hangingProvider.getToTokenList).toHaveBeenCalledTimes(1)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   it('Fetch to token successfully', async () => {
     const toToken = await swapProviderParallelExecutor.getToken({
       address: '0x4200000000000000000000000000000000000042',

--- a/src/services/swapIntegrators/swapProviderParallelExecutor.ts
+++ b/src/services/swapIntegrators/swapProviderParallelExecutor.ts
@@ -12,6 +12,7 @@ import {
 import wait, { waitWithAbort } from '../../utils/wait'
 
 const GET_SUPPORTED_CHAINS_TIMEOUT = 10000
+const GET_TO_TOKEN_LIST_TIMEOUT = 30000
 
 export class SwapProviderParallelExecutor {
   id: string = 'parallel'
@@ -212,18 +213,69 @@ export class SwapProviderParallelExecutor {
 
   async getToTokenList({
     fromChainId,
-    toChainId
+    toChainId,
+    onUpdate
   }: {
     fromChainId: number
     toChainId: number
+    onUpdate?: (tokens: SwapAndBridgeToToken[]) => void
   }): Promise<SwapAndBridgeToToken[]> {
-    const toTokenList = await this.#fetchFromAll<SwapAndBridgeToToken[]>(
-      (provider: SwapProvider) =>
-        provider.getToTokenList({ fromChainId, toChainId }).catch((e) => e),
-      { chainIds: [fromChainId, toChainId] }
-    )
+    const supportedProviders = this.#providers.filter((provider) => {
+      if (provider.areChainsSupported) {
+        return provider.areChainsSupported({ fromChainId, toChainId })
+      }
 
-    // filter duplicates
+      if (provider.supportedChains === null) return true
+
+      const supportedChainIds = provider.supportedChains.map(({ chainId }) => chainId)
+      return supportedChainIds.includes(fromChainId) && supportedChainIds.includes(toChainId)
+    })
+
+    if (!supportedProviders.length) {
+      throw new SwapAndBridgeProviderApiError(
+        `The requested network(s) are not supported by any available service provider. Chain IDs: ${[
+          ...new Set([fromChainId, toChainId])
+        ].join(', ')}`
+      )
+    }
+
+    let toTokenList: SwapAndBridgeToToken[] = []
+    const requests = supportedProviders.map(async (provider) => {
+      const waitPromise = waitWithAbort(GET_TO_TOKEN_LIST_TIMEOUT)
+
+      try {
+        const result = await Promise.race([
+          provider
+            .getToTokenList({ fromChainId, toChainId })
+            .catch((error) =>
+              error instanceof Error ? error : new Error('Get to token list failed')
+            ),
+          waitPromise.promise.then(() => new Error('Get to token list timeout'))
+        ])
+
+        if (result instanceof Error) return result
+
+        toTokenList = this.#removeDuplicateTokens([...toTokenList, ...result])
+        onUpdate?.(toTokenList)
+
+        return result
+      } finally {
+        if (waitPromise.abort) waitPromise.abort()
+      }
+    })
+
+    const results = await Promise.all(requests)
+
+    if (!results.some((result) => !(result instanceof Error))) {
+      throw new SwapAndBridgeProviderApiError(
+        'Our service providers are currently unavailable. Please try again later.'
+      )
+    }
+
+    return toTokenList
+  }
+
+  #removeDuplicateTokens(toTokenList: SwapAndBridgeToToken[]) {
     return [
       ...new Map(
         toTokenList.map((item: SwapAndBridgeToToken) => [`${item.chainId}-${item.address}`, item])


### PR DESCRIPTION
## Problem

We did #fetchFromAll(), which awaits each provider with a mix of sophisticated logic that might retry a request if conditions met. That kind of logic is appropriate for quote() requests but not for token fetches.

## Solution

We still request the tokens from each provider but we update the UI immediately when one of them finishes. When the second one finishes, we again update the UI until all of them are done