### PR TITLE
Update scheduled updates logic in portfolio to enable pending defi update banner

### DIFF
--- a/src/consts/intervals.ts
+++ b/src/consts/intervals.ts
@@ -21,3 +21,8 @@ export const TRENDING_TOKENS_FAILED_UPDATE_INTERVAL = 60 * 1000 // 1 minute
 export const ESTIMATE_UPDATE_INTERVAL = 30000
 export const GAS_PRICE_UPDATE_INTERVAL = 12000
 export const FETCH_SAFE_TXNS = 3 * 60 * 1000 // 3 minutes
+// How often the runner checks whether any scheduled portfolio update is due
+export const SCHEDULED_PORTFOLIO_UPDATES_RUNNER_INTERVAL = 20 * 1000 // 20 seconds
+// How long a scheduled portfolio update waits before the runner executes it, giving the
+// discovery API time to index the defi position changes caused by the transaction
+export const SCHEDULED_PORTFOLIO_UPDATE_DELAY = 60 * 1000 // 1 minute

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -1590,6 +1590,29 @@ describe('Portfolio Controller ', () => {
       forceFlags.forEach((flag: boolean) => expect(flag).toBe(false))
     })
 
+    test('a manual update does not clear a pending scheduled update', async () => {
+      jest.useFakeTimers()
+      try {
+        const { controller } = await prepareTest({ awaitInitialLoad: false })
+        mockFetchLayer(controller)
+        const updateSpy = jest.spyOn(controller, 'updateSelectedAccount')
+
+        schedule(controller, account.addr, 1n)
+
+        // The user refreshes the portfolio before the scheduled update is due.
+        await controller.updateSelectedAccount(account.addr, [ethereum], undefined, {
+          isManualUpdate: true
+        })
+        expect(controller.scheduledUpdateChainIds).toEqual({ [account.addr]: [1n] })
+
+        // The scheduled cache-busting update still fires afterwards.
+        await jest.advanceTimersByTimeAsync(60 * 1000)
+        expect(getBypassUpdates(updateSpy)).toHaveLength(1)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
     test('without a pending scheduled update, a nonce change does force the server-side bypass (control)', async () => {
       const { controller } = await prepareTest()
       const { discoverySpy } = mockFetchLayer(controller)

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -1394,13 +1394,13 @@ describe('Portfolio Controller ', () => {
       }
     })
 
-    test('a slow scheduled update is removed before the await and is not processed twice', async () => {
+    test('a slow scheduled update is flagged as running and is not processed twice', async () => {
       jest.useFakeTimers()
       try {
         const { controller } = await prepareTest({ awaitInitialLoad: false })
 
-        // Make the scheduled update hang so it's still running on the next ticks. The entry is
-        // removed before the await, so it shouldn't be picked up again.
+        // Make the scheduled update hang so it's still running on the next ticks. The entry stays
+        // in the schedule while it runs, but is flagged, so it shouldn't be picked up again.
         let resolveSlowUpdate: () => void = () => {}
         const slowUpdate = new Promise<void>((resolve) => {
           resolveSlowUpdate = () => resolve()
@@ -1425,6 +1425,139 @@ describe('Portfolio Controller ', () => {
         resolveSlowUpdate()
         await jest.advanceTimersByTimeAsync(40 * 1000)
         expect(getBypassUpdates(updateSpy)).toHaveLength(1)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    test('scheduledUpdateChainIds exposes the chain while the update is pending and while it runs', async () => {
+      jest.useFakeTimers()
+      try {
+        const { controller } = await prepareTest({ awaitInitialLoad: false })
+
+        let resolveSlowUpdate: () => void = () => {}
+        const slowUpdate = new Promise<void>((resolve) => {
+          resolveSlowUpdate = () => resolve()
+        })
+        jest
+          .spyOn(controller, 'updateSelectedAccount')
+          .mockImplementation((...args: any[]) =>
+            args[3]?.bypassServerSideCache ? (slowUpdate as any) : Promise.resolve(undefined)
+          )
+
+        expect(controller.scheduledUpdateChainIds).toEqual({})
+
+        // Pending: visible right away, so the UI can tell the user an update is coming.
+        schedule(controller, account.addr, 1n)
+        expect(controller.scheduledUpdateChainIds).toEqual({ [account.addr]: [1n] })
+
+        // Running: still visible, because the positions haven't been refreshed yet.
+        await jest.advanceTimersByTimeAsync(60 * 1000)
+        expect(controller.scheduledUpdateChainIds).toEqual({ [account.addr]: [1n] })
+
+        // Done: gone, so the UI stops telling the user anything.
+        resolveSlowUpdate()
+        await jest.advanceTimersByTimeAsync(0)
+        expect(controller.scheduledUpdateChainIds).toEqual({})
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    test('a confirmation during a running update schedules a separate update instead of debouncing it', async () => {
+      jest.useFakeTimers()
+      try {
+        const { controller } = await prepareTest({ awaitInitialLoad: false })
+
+        let resolveSlowUpdate: () => void = () => {}
+        const slowUpdate = new Promise<void>((resolve) => {
+          resolveSlowUpdate = () => resolve()
+        })
+        const updateSpy = jest
+          .spyOn(controller, 'updateSelectedAccount')
+          .mockImplementation((...args: any[]) =>
+            args[3]?.bypassServerSideCache ? (slowUpdate as any) : Promise.resolve(undefined)
+          )
+
+        schedule(controller, account.addr, 1n)
+        await jest.advanceTimersByTimeAsync(60 * 1000)
+        expect(getBypassUpdates(updateSpy)).toHaveLength(1)
+
+        // A second tx confirms while the first update is still fetching. Debouncing onto the
+        // running entry would lose it, since that request can't see the new position changes.
+        schedule(controller, account.addr, 1n)
+        expect(controller.scheduledUpdateChainIds).toEqual({ [account.addr]: [1n, 1n] })
+
+        // The running one finishes, but the newly scheduled one keeps the indicator up.
+        resolveSlowUpdate()
+        await jest.advanceTimersByTimeAsync(0)
+        expect(controller.scheduledUpdateChainIds).toEqual({ [account.addr]: [1n] })
+
+        // And it fires 60s after the second confirmation.
+        await jest.advanceTimersByTimeAsync(60 * 1000)
+        expect(getBypassUpdates(updateSpy)).toHaveLength(2)
+        expect(controller.scheduledUpdateChainIds).toEqual({})
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    test('emits an update when a scheduled update is added, starts running and completes', async () => {
+      jest.useFakeTimers()
+      try {
+        const { controller } = await prepareTest({ awaitInitialLoad: false })
+
+        let resolveSlowUpdate: () => void = () => {}
+        const slowUpdate = new Promise<void>((resolve) => {
+          resolveSlowUpdate = () => resolve()
+        })
+        jest
+          .spyOn(controller, 'updateSelectedAccount')
+          .mockImplementation((...args: any[]) =>
+            args[3]?.bypassServerSideCache ? (slowUpdate as any) : Promise.resolve(undefined)
+          )
+
+        // Without these emits the UI never re-renders and the indicator never appears or hides.
+        const onUpdate = jest.fn()
+        controller.onUpdate(onUpdate)
+
+        schedule(controller, account.addr, 1n)
+        expect(onUpdate).toHaveBeenCalledTimes(1)
+
+        // Debouncing the pending entry changes its scheduledAt, which the UI doesn't read, but the
+        // emit keeps the state the UI holds in sync with the controller.
+        schedule(controller, account.addr, 1n)
+        expect(onUpdate).toHaveBeenCalledTimes(2)
+
+        await jest.advanceTimersByTimeAsync(60 * 1000)
+        expect(onUpdate).toHaveBeenCalledTimes(3)
+
+        resolveSlowUpdate()
+        await jest.advanceTimersByTimeAsync(0)
+        expect(onUpdate).toHaveBeenCalledTimes(4)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    test('a scheduled update is forgotten even when the portfolio request fails', async () => {
+      jest.useFakeTimers()
+      try {
+        const { controller } = await prepareTest({ awaitInitialLoad: false })
+
+        jest
+          .spyOn(controller, 'updateSelectedAccount')
+          .mockImplementation((...args: any[]) =>
+            args[3]?.bypassServerSideCache
+              ? Promise.reject(new Error('discovery api is down'))
+              : Promise.resolve(undefined)
+          )
+
+        schedule(controller, account.addr, 1n)
+
+        // A failed update must not leave the indicator stuck on forever.
+        await jest.advanceTimersByTimeAsync(60 * 1000)
+        expect(controller.scheduledUpdateChainIds).toEqual({})
       } finally {
         jest.useRealTimers()
       }

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -5,7 +5,11 @@ import {
   RecurringTimeout
 } from '../../classes/recurringTimeout/recurringTimeout'
 import { STK_WALLET } from '../../consts/addresses'
-import { BLACKLIST_UPDATE_INTERVAL } from '../../consts/intervals'
+import {
+  BLACKLIST_UPDATE_INTERVAL,
+  SCHEDULED_PORTFOLIO_UPDATE_DELAY,
+  SCHEDULED_PORTFOLIO_UPDATES_RUNNER_INTERVAL
+} from '../../consts/intervals'
 import {
   Account,
   AccountId,
@@ -222,7 +226,8 @@ export class PortfolioController
   #scheduledUpdates: ScheduledUpdates = {}
 
   /**
-   * Runs every 20 seconds and checks if there are any scheduled updates to run. If there are, it runs them and removes them from the schedule.
+   * Runs every SCHEDULED_PORTFOLIO_UPDATES_RUNNER_INTERVAL and checks if there are any scheduled updates to run.
+   * If there are, it runs them and removes them from the schedule.
    */
   #scheduledUpdatesRunnerInterval: IRecurringTimeout
 
@@ -267,7 +272,7 @@ export class PortfolioController
     )
     this.#scheduledUpdatesRunnerInterval = new RecurringTimeout(
       this.#runScheduledUpdates.bind(this),
-      20 * 1000,
+      SCHEDULED_PORTFOLIO_UPDATES_RUNNER_INTERVAL,
       this.emitError.bind(this)
     )
 
@@ -725,40 +730,70 @@ export class PortfolioController
     await this.#queue[accountAddr][chainId.toString()]
   }
 
+  /**
+   * Drops the given entries from the schedule, matching them by reference so that a newer entry,
+   * scheduled for the same chain while these were running, is kept.
+   */
+  #forgetScheduledUpdates(accountId: AccountId, updatesToForget: ScheduledUpdates[string]) {
+    const remaining = (this.#scheduledUpdates[accountId] || []).filter(
+      (update) => !updatesToForget.includes(update)
+    )
+
+    if (remaining.length) {
+      this.#scheduledUpdates[accountId] = remaining
+    } else {
+      delete this.#scheduledUpdates[accountId]
+    }
+  }
+
   async #runScheduledUpdates() {
     if (Object.keys(this.#scheduledUpdates).length === 0) return
 
-    const updatesToRun = structuredClone(this.#scheduledUpdates)
+    // The entries are references to the scheduled ones, so flagging them as running below
+    // mutates the schedule itself
+    const dueUpdatesByAccount: ScheduledUpdates = {}
+
+    Object.entries(this.#scheduledUpdates).forEach(([accountId, updates]) => {
+      const dueUpdates = updates.filter(
+        (update) =>
+          !update.isRunning && Date.now() - update.scheduledAt >= SCHEDULED_PORTFOLIO_UPDATE_DELAY
+      )
+
+      if (dueUpdates.length) dueUpdatesByAccount[accountId] = dueUpdates
+    })
+
+    const accountIdsToUpdate = Object.keys(dueUpdatesByAccount)
+
+    if (!accountIdsToUpdate.length) return
+
+    // Flag them as running so a subsequent run doesn't pick them up while the requests are in
+    // flight. They are kept in the schedule (instead of removed upfront) so the UI can tell the
+    // user the update is still happening.
+    accountIdsToUpdate.forEach((accountId) => {
+      dueUpdatesByAccount[accountId]!.forEach((update) => {
+        update.isRunning = true
+      })
+    })
+    this.emitUpdate()
 
     await Promise.all(
-      Object.entries(updatesToRun).map(async ([accountId, updates]) => {
-        const updatesOlderThanThreshold = updates.filter(
-          (update) => Date.now() - update.scheduledAt >= 60 * 1000
-        )
+      accountIdsToUpdate.map(async (accountId) => {
+        const dueUpdates = dueUpdatesByAccount[accountId]!
+        const chainIdsToUpdate = dueUpdates.map((update) => update.chainId)
 
-        if (updatesOlderThanThreshold.length === 0) return
-
-        const networksToUpdate = updatesOlderThanThreshold.map((update) => update.chainId)
-
-        // Remove the updates from the schedule so a second run doesn't pick them up while they are being processed
-        this.#scheduledUpdates[accountId] = updates.filter(
-          (update) => !networksToUpdate.includes(update.chainId)
-        )
-
-        if (this.#scheduledUpdates[accountId].length === 0) {
-          delete this.#scheduledUpdates[accountId]
+        try {
+          await this.updateSelectedAccount(
+            accountId,
+            this.#networks.networks.filter((n) => chainIdsToUpdate.includes(n.chainId)),
+            undefined,
+            {
+              bypassServerSideCache: dueUpdates.some((update) => update.bypassServerSideCache)
+            }
+          )
+        } finally {
+          this.#forgetScheduledUpdates(accountId, dueUpdates)
+          this.emitUpdate()
         }
-
-        await this.updateSelectedAccount(
-          accountId,
-          this.#networks.networks.filter((n) => networksToUpdate.includes(n.chainId)),
-          undefined,
-          {
-            bypassServerSideCache: updatesOlderThanThreshold.some(
-              (update) => update.bypassServerSideCache
-            )
-          }
-        )
       })
     )
   }
@@ -778,22 +813,27 @@ export class PortfolioController
     bypassServerSideCache: true
   }) {
     const existing = this.#scheduledUpdates[accountId] || []
-    const networkAlreadyScheduledForAccount = existing.find((update) => update.chainId === chainId)
+    // A running update is already fetching stale data, so it can't be debounced. The new
+    // transaction gets its own entry, which also keeps the UI indicator up until it runs.
+    const pendingUpdateForNetwork = existing.find(
+      (update) => update.chainId === chainId && !update.isRunning
+    )
 
-    if (networkAlreadyScheduledForAccount) {
-      networkAlreadyScheduledForAccount.bypassServerSideCache =
-        networkAlreadyScheduledForAccount.bypassServerSideCache || bypassServerSideCache
-      // Debounce: start the 60s window from the most recent transaction, not the first
-      networkAlreadyScheduledForAccount.scheduledAt = Date.now()
+    if (pendingUpdateForNetwork) {
+      pendingUpdateForNetwork.bypassServerSideCache =
+        pendingUpdateForNetwork.bypassServerSideCache || bypassServerSideCache
+      // Debounce: start the delay window from the most recent transaction, not the first
+      pendingUpdateForNetwork.scheduledAt = Date.now()
 
       this.debugLog(
         'simulation',
         `${chainId.toString()} Debounced scheduled update for ${accountId}`,
         () => ({
-          bypassServerSideCache: networkAlreadyScheduledForAccount.bypassServerSideCache,
-          scheduledAt: networkAlreadyScheduledForAccount.scheduledAt
+          bypassServerSideCache: pendingUpdateForNetwork.bypassServerSideCache,
+          scheduledAt: pendingUpdateForNetwork.scheduledAt
         })
       )
+      this.emitUpdate()
       return
     }
 
@@ -803,9 +843,23 @@ export class PortfolioController
     }))
 
     this.#scheduledUpdates[accountId] = [
-      ...(this.#scheduledUpdates[accountId] || []),
-      { chainId, bypassServerSideCache, scheduledAt: Date.now() }
+      ...existing,
+      { chainId, bypassServerSideCache, scheduledAt: Date.now(), isRunning: false }
     ]
+    this.emitUpdate()
+  }
+
+  /**
+   * The chains with a portfolio update queued or in flight after a recent transaction, by account.
+   * Read by the UI to tell the user their defi positions are about to refresh.
+   */
+  get scheduledUpdateChainIds(): { [accountId: string]: bigint[] } {
+    return Object.fromEntries(
+      Object.entries(this.#scheduledUpdates).map(([accountId, updates]) => [
+        accountId,
+        updates.map(({ chainId }) => chainId)
+      ])
+    )
   }
 
   /**
@@ -1968,6 +2022,17 @@ export class PortfolioController
             })
           )
 
+          // The manual update just fetched what the scheduled one would have (it forces a defi
+          // refetch when an update is scheduled), so the pending entry is no longer needed. A
+          // running one is kept, as its request is already in flight.
+          if (isManualUpdate && isSuccessful)
+            this.#forgetScheduledUpdates(
+              accountId,
+              (this.#scheduledUpdates[accountId] || []).filter(
+                (update) => !update.isRunning && update.chainId === network.chainId
+              )
+            )
+
           // Learn tokens and nfts from the portfolio lib
           if (isSuccessful && accountState[network.chainId.toString()]?.result) {
             const networkResult = accountState[network.chainId.toString()]!.result
@@ -2229,7 +2294,8 @@ export class PortfolioController
       ...this,
       ...super.toJSON(),
       customTokens: this.customTokens,
-      tokenPreferences: this.tokenPreferences
+      tokenPreferences: this.tokenPreferences,
+      scheduledUpdateChainIds: this.scheduledUpdateChainIds
     }
   }
 }

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -2022,17 +2022,6 @@ export class PortfolioController
             })
           )
 
-          // The manual update just fetched what the scheduled one would have (it forces a defi
-          // refetch when an update is scheduled), so the pending entry is no longer needed. A
-          // running one is kept, as its request is already in flight.
-          if (isManualUpdate && isSuccessful)
-            this.#forgetScheduledUpdates(
-              accountId,
-              (this.#scheduledUpdates[accountId] || []).filter(
-                (update) => !update.isRunning && update.chainId === network.chainId
-              )
-            )
-
           // Learn tokens and nfts from the portfolio lib
           if (isSuccessful && accountState[network.chainId.toString()]?.result) {
             const networkResult = accountState[network.chainId.toString()]!.result

--- a/src/libs/defiPositions/defiPositions.ts
+++ b/src/libs/defiPositions/defiPositions.ts
@@ -561,10 +561,6 @@ const getDefiUpdateMode = (params: {
   // An explicit override always bypasses the server-side cache.
   if (bypassServerSideCache) return DefiUpdateMode.Force
 
-  // A manual update takes over the pending post-transaction update and clears it, so no later
-  // refetch will happen. Force, even if the throttle would otherwise serve cached data.
-  if (isManualUpdate && hasScheduledUpdate) return DefiUpdateMode.Force
-
   // There is a scheduled update coming soon that will update defi positions
   const shouldDeferToScheduledUpdate = hasScheduledUpdate && !isManualUpdate
 

--- a/src/libs/defiPositions/defiPositions.ts
+++ b/src/libs/defiPositions/defiPositions.ts
@@ -561,6 +561,10 @@ const getDefiUpdateMode = (params: {
   // An explicit override always bypasses the server-side cache.
   if (bypassServerSideCache) return DefiUpdateMode.Force
 
+  // A manual update takes over the pending post-transaction update and clears it, so no later
+  // refetch will happen. Force, even if the throttle would otherwise serve cached data.
+  if (isManualUpdate && hasScheduledUpdate) return DefiUpdateMode.Force
+
   // There is a scheduled update coming soon that will update defi positions
   const shouldDeferToScheduledUpdate = hasScheduledUpdate && !isManualUpdate
 

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -600,6 +600,11 @@ export interface ScheduledUpdates {
      * reset the interval, the approval scheduled update will run for no reason, spending resources
      */
     scheduledAt: number
+    /**
+     * Set when the runner picks the update up, so a second run doesn't pick it up again while the
+     * portfolio request is still in flight. The entry is removed once the request settles.
+     */
+    isRunning: boolean
   }[]
 }
 


### PR DESCRIPTION
## Changes:
- Trigger a force update on manual refresh IF there is a pending update (otherwise the user sees a banner for 1min and refreshing does nothing)
- Exposes scheduled updates to the UI
- Adds isRunning to scheduled updates to handle the case where a new txn comes in while the portfolio is being updated (a new update is needed)
- Adds additional unit tests