### PR TITLE
Reject portfolio updates if the data is from a block, older than our thresholds

### DIFF
--- a/src/classes/ProviderError.ts
+++ b/src/classes/ProviderError.ts
@@ -1,3 +1,5 @@
+import { INVICTUS_RPC_URL_IDENTIFIER } from '../consts/networks'
+
 export class ProviderError extends Error {
   isProviderInvictus?: boolean
 
@@ -18,7 +20,7 @@ export class ProviderError extends Error {
     // Copy all properties from the original error to this error
     Object.assign(this, originalError)
     const statusCode = originalError?.response?.statusCode
-    const isProviderInvictus = providerUrl?.includes('invictus')
+    const isProviderInvictus = providerUrl?.includes(INVICTUS_RPC_URL_IDENTIFIER)
 
     this.name = 'ProviderError'
     this.providerUrl = providerUrl

--- a/src/classes/StaleRpcBlockError.ts
+++ b/src/classes/StaleRpcBlockError.ts
@@ -1,0 +1,29 @@
+/**
+ * Thrown when the RPC returns the state of a block older than the one the portfolio
+ * already displays, which would take the balances and the simulation backwards.
+ */
+export class StaleRpcBlockError extends Error {
+  receivedBlockNumber: number
+
+  blocksBehind: number
+
+  simulationErrorMsg: string
+
+  constructor({
+    receivedBlockNumber,
+    blocksBehind
+  }: {
+    receivedBlockNumber: number
+    blocksBehind: number
+  }) {
+    super(
+      `The RPC returned the state of block ${receivedBlockNumber}, which is ${blocksBehind} block(s) behind the state already displayed`
+    )
+
+    this.name = 'StaleRpcBlockError'
+    this.receivedBlockNumber = receivedBlockNumber
+    this.blocksBehind = blocksBehind
+    this.simulationErrorMsg =
+      "Network data is behind, so the transaction preview isn't available right now. It should recover shortly."
+  }
+}

--- a/src/consts/networks.ts
+++ b/src/consts/networks.ts
@@ -1,6 +1,8 @@
 import { Network } from '../interfaces/network'
 import { PIMLICO } from './bundlers'
 
+export const INVICTUS_RPC_URL_IDENTIFIER = 'invictus.ambire.com'
+
 const networks: Network[] = [
   {
     name: 'Ethereum',

--- a/src/consts/portfolio.ts
+++ b/src/consts/portfolio.ts
@@ -1,0 +1,5 @@
+// Different invictus requests can hit different providers so we allow a few blocks of difference
+export const DEFAULT_STALE_RPC_BLOCK_THRESHOLD = 10
+
+// Ethereum blocks are ~12s apart, so every tolerated block is a long stretch of stale data
+export const ETHEREUM_STALE_RPC_BLOCK_THRESHOLD = 2

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -646,8 +646,10 @@ describe('Portfolio Controller ', () => {
     expect(colibriBehindVerification?.error).toBe('Colibri is 6 blocks behind the RPC latest block')
 
     // 5) RPC is more than the threshold behind Colibri -> stale, no Colibri fetch.
-    rpcResultBlockNumber = 100
-    verifiedProvider.getBlockNumber.mockResolvedValue(111)
+    // The block must still move forward, otherwise the update is rejected as stale
+    // by the controller before the verification result lands.
+    rpcResultBlockNumber = 124
+    verifiedProvider.getBlockNumber.mockResolvedValue(135)
     portfolioGetCalls.length = 0
     await controller.updateSelectedAccount(account.addr, [colibriEthereum])
     const staleVerification = await waitForVerification()

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -4,8 +4,14 @@ import {
   IRecurringTimeout,
   RecurringTimeout
 } from '../../classes/recurringTimeout/recurringTimeout'
+import { StaleRpcBlockError } from '../../classes/StaleRpcBlockError'
 import { STK_WALLET } from '../../consts/addresses'
 import { BLACKLIST_UPDATE_INTERVAL } from '../../consts/intervals'
+import { ETHEREUM_CHAIN_ID, INVICTUS_RPC_URL_IDENTIFIER } from '../../consts/networks'
+import {
+  DEFAULT_STALE_RPC_BLOCK_THRESHOLD,
+  ETHEREUM_STALE_RPC_BLOCK_THRESHOLD
+} from '../../consts/portfolio'
 import {
   Account,
   AccountId,
@@ -70,6 +76,7 @@ import {
   GetOptions,
   NetworkState,
   PortfolioControllerState,
+  PortfolioNetworkResult,
   PortfolioVerification,
   ScheduledUpdates,
   TemporaryTokens,
@@ -1191,6 +1198,69 @@ export class PortfolioController
     this.emitUpdate()
   }
 
+  /**
+   * How many blocks behind the stored result a freshly fetched one is.
+   */
+  static #getBlocksBehind(
+    networkState: NetworkState<PortfolioNetworkResult> | undefined,
+    newBlockNumber: number,
+    rpcUrl: string
+  ) {
+    const storedBlockNumber = networkState?.result?.blockNumber
+
+    if (!storedBlockNumber || networkState?.rpcInfo?.url !== rpcUrl) return 0
+
+    return Math.max(storedBlockNumber - newBlockNumber, 0)
+  }
+
+  /**
+   * Records how far behind the RPC is after an update was rejected for being older than
+   * the one already displayed, and reports our own RPC falling behind once per episode.
+   */
+  #onStaleRpcBlock(accountId: AccountId, network: Network, error: StaleRpcBlockError) {
+    const state = this.#state[accountId]?.[network.chainId.toString()]
+
+    if (!state) return
+
+    const rpcUrl = network.selectedRpcUrl
+    const isFirstRejection = !state.rpcInfo?.since
+
+    state.rpcInfo = {
+      url: rpcUrl,
+      behindBy: error.blocksBehind,
+      since: state.rpcInfo?.since ?? Date.now()
+    }
+
+    this.debugLog(
+      'update',
+      `${network.chainId.toString()} update rejected for ${accountId}`,
+      () => ({
+        rpcUrl,
+        receivedBlockNumber: error.receivedBlockNumber,
+        blocksBehind: error.blocksBehind
+      })
+    )
+
+    const message = '[PORTFOLIO_STALE_RPC_BLOCK] The RPC returned the state of an older block'
+    const reportedError = new Error(message)
+
+    ;(reportedError as any).debugInfo = {
+      accountId,
+      chainId: network.chainId.toString(),
+      rpcUrl,
+      receivedBlockNumber: error.receivedBlockNumber,
+      storedBlockNumber: error.receivedBlockNumber + error.blocksBehind,
+      blocksBehind: error.blocksBehind
+    }
+
+    this.emitError({
+      level: 'silent',
+      sendCrashReport: isFirstRejection && rpcUrl.includes(INVICTUS_RPC_URL_IDENTIFIER),
+      message,
+      error: reportedError
+    })
+  }
+
   static #getCanSkipUpdate(networkState?: NetworkState, maxDataAgeMs?: number) {
     const hasImportantErrors = networkState?.errors.some((e) => e.level === 'critical')
 
@@ -1528,6 +1598,29 @@ export class PortfolioController
 
       this.tokenDataCache[network.chainId.toString()] = portfolioResult.tokenDataCache
 
+      const rpcUrl = network.selectedRpcUrl
+
+      const blocksBehind = PortfolioController.#getBlocksBehind(
+        accountState[network.chainId.toString()],
+        portfolioResult.blockNumber,
+        rpcUrl
+      )
+
+      // A lagging RPC returns the state of an older block, which would take the portfolio
+      // backwards - outdated balances and an outdated nonce for the simulation. Keep what
+      // is already displayed until the RPC catches up.
+      const staleBlockThreshold =
+        network.chainId === ETHEREUM_CHAIN_ID
+          ? ETHEREUM_STALE_RPC_BLOCK_THRESHOLD
+          : DEFAULT_STALE_RPC_BLOCK_THRESHOLD
+
+      if (blocksBehind > staleBlockThreshold) {
+        throw new StaleRpcBlockError({
+          receivedBlockNumber: portfolioResult.blockNumber,
+          blocksBehind
+        })
+      }
+
       const hasError = combinedErrors.some((e) => e.level !== 'silent')
       let lastSuccessfulUpdate = accountState[network.chainId.toString()]?.lastSuccessfulUpdate || 0
 
@@ -1547,6 +1640,7 @@ export class PortfolioController
         errors: combinedErrors,
         lastSuccessfulUpdate,
         verification,
+        rpcInfo: { url: rpcUrl },
         result: {
           ...portfolioResult,
           // Overwrite the discovery time from the portfolio lib
@@ -1613,11 +1707,16 @@ export class PortfolioController
 
       return [true, discoveryData]
     } catch (e: any) {
-      this.emitError({
-        level: 'silent',
-        message: `Error while executing the 'get' function in the portfolio library on ${network.name} (${network.chainId})`,
-        error: e
-      })
+      if (e instanceof StaleRpcBlockError) {
+        this.#onStaleRpcBlock(account.addr, network, e)
+      } else {
+        this.emitError({
+          level: 'silent',
+          message: `Error while executing the 'get' function in the portfolio library on ${network.name} (${network.chainId})`,
+          error: e
+        })
+      }
+
       state.accountOps = portfolioProps?.simulation?.accountOps
       state.isLoading = false
       if (state.verification?.status === 'loading') {

--- a/src/libs/deployless/deployless.ts
+++ b/src/libs/deployless/deployless.ts
@@ -12,6 +12,7 @@ import { decodeFunctionResult, encodeFunctionData } from 'viem'
 
 import DeploylessCompiled from '../../../contracts/compiled/Deployless.json'
 import { ProviderError } from '../../classes/ProviderError'
+import { INVICTUS_RPC_URL_IDENTIFIER } from '../../consts/networks'
 
 // this is a magic contract that is constructed like `constructor(bytes memory contractBytecode, bytes memory data)` and returns the result from the call
 // compiled from relayer:a7ea373559d8c419577ac05527bd37fbee8856ae/src/velcro-v3/contracts/Deployless.sol with solc 0.8.17
@@ -94,7 +95,7 @@ export class Deployless {
 
     if (provider && provider instanceof JsonRpcProvider) {
       this.providerUrl = provider._getConnection().url
-      this.isProviderInvictus = this.providerUrl?.includes('invictus')
+      this.isProviderInvictus = this.providerUrl?.includes(INVICTUS_RPC_URL_IDENTIFIER)
     }
 
     if (codeAtRuntime !== undefined) {

--- a/src/libs/portfolio/getOnchainBalances.ts
+++ b/src/libs/portfolio/getOnchainBalances.ts
@@ -410,7 +410,8 @@ export async function getTokens(
         ]
       }),
       {
-        blockNumber
+        // The getter returns a uint256, so it has to be brought back to a number
+        blockNumber: Number(blockNumber)
       }
     ]
   }
@@ -488,7 +489,8 @@ export async function getTokens(
       ]
     }),
     {
-      blockNumber,
+      // The getter returns a uint256, so it has to be brought back to a number
+      blockNumber: Number(blockNumber),
       beforeNonce,
       afterNonce
     }

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -502,6 +502,18 @@ export type PortfolioKeyResult =
   | PortfolioNetworkResult
   | PortfolioDefiAppsResult
 
+export type PortfolioRpcInfo = {
+  /** The RPC that produced the currently stored result. */
+  url: string
+  /**
+   * How many blocks behind the stored result the RPC's latest response was.
+   * Absent while the RPC is up to date.
+   */
+  behindBy?: number
+  /** When the RPC first started serving older blocks. Absent while the RPC is up to date. */
+  since?: number
+}
+
 export type NetworkState<T = PortfolioKeyResult> = {
   isReady: boolean
   isLoading: boolean
@@ -509,6 +521,7 @@ export type NetworkState<T = PortfolioKeyResult> = {
   errors: ExtendedErrorWithLevel[]
   lastSuccessfulUpdate?: number
   verification?: PortfolioVerification
+  rpcInfo?: PortfolioRpcInfo
   result?: T
   // We store the previously simulated AccountOps only for the pending state.
   // Prior to triggering a pending state update, we compare the newly passed AccountOp[] (updateSelectedAccount) with the cached version.

--- a/src/libs/selectedAccount/errors.ts
+++ b/src/libs/selectedAccount/errors.ts
@@ -19,6 +19,8 @@ export type SelectedAccountBalanceError = {
     | `custom-rpcs-down-${string}`
     | 'rpcs-down'
     | 'portfolio-critical'
+    | 'portfolio-stale-block'
+    | `stale-block-${string}`
     | 'loading-too-long'
     | 'defi-critical'
     | 'defi-prices'
@@ -83,6 +85,53 @@ export const addRPCError = (
       actions
     })
   }
+
+  return newErrors
+}
+
+/**
+ * Tells the user that the network data we are getting is behind, so the displayed balances
+ * are the last ones we could trust. Offers switching the RPC when there is another one.
+ */
+export const addStaleBlockError = (errors: SelectedAccountBalanceError[], network: Network) => {
+  const newErrors = [...errors]
+  const hasMultipleRpcUrls = network.rpcUrls && network.rpcUrls.length > 1
+  // Networks with another RPC to switch to get a banner of their own, so the action
+  // knows which network it applies to. The rest are grouped in a single banner.
+  const errorId: `stale-block-${string}` | 'portfolio-stale-block' = hasMultipleRpcUrls
+    ? `stale-block-${network.chainId.toString()}`
+    : 'portfolio-stale-block'
+  const existingError = newErrors.find((error) => error.id === errorId)
+
+  if (existingError) {
+    if (!existingError.networkNames.includes(network.name)) {
+      existingError.networkNames.push(network.name)
+      existingError.title = `${existingError.networkNames.join(', ')} data is behind`
+    }
+
+    return newErrors
+  }
+
+  const text = hasMultipleRpcUrls
+    ? "The network data we're getting is behind, so balances may be out of date. You can try selecting another RPC URL."
+    : "The network data we're getting is behind, so balances may be out of date. We keep checking and will show the new balances as soon as they arrive."
+
+  newErrors.push({
+    id: errorId,
+    networkNames: [network.name],
+    type: 'error',
+    title: `${network.name} data is behind`,
+    text,
+    actions: hasMultipleRpcUrls
+      ? [
+          {
+            label: 'Select',
+            actionName: 'select-rpc-url',
+            meta: { network }
+          }
+        ]
+      : undefined
+  })
 
   return newErrors
 }
@@ -220,6 +269,13 @@ export const getNetworksWithErrors = ({
 
     if (!networkName) {
       console.error('Network name not found for network in getNetworksWithErrors', chainId)
+      return
+    }
+
+    // The RPC serving older blocks freezes the portfolio, so the user is told about it
+    // right away, without the grace period the other errors have.
+    if (portfolioForNetwork?.rpcInfo?.behindBy) {
+      errors = addStaleBlockError(errors, network)
       return
     }
 


### PR DESCRIPTION
Read the issue. The only thing I'm worried about is if RPC providers, and especially invictus, can return a lower block number for a short duration. E.g., 100 -> 101 -> 100 -> 102. I've added a threshold for this reason, but we can remove it if that is not applicable.

Closes https://github.com/AmbireTech/ambire-app/issues/7313