### PR TITLE
UX/ Truncate swap usd amount to a sane value

### DIFF
--- a/src/controllers/swapAndBridge/swapAndBridge.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.ts
@@ -96,7 +96,8 @@ import { validateSendTransferAmount, Validation } from '../../services/validatio
 import batcher from '../../utils/batcher'
 import {
   convertTokenPriceToBigInt,
-  getSafeAmountFromFieldValue
+  getSafeAmountFromFieldValue,
+  truncateFiatAmountDecimals
 } from '../../utils/numbers/formatters'
 import { generateUuid } from '../../utils/uuid'
 import wait from '../../utils/wait'
@@ -658,10 +659,15 @@ export class SwapAndBridgeController extends EventEmitter implements ISwapAndBri
 
       const { tokenPriceBigInt, tokenPriceDecimals } = convertTokenPriceToBigInt(tokenPrice)
 
-      this.fromAmountInFiat = formatUnits(
-        formattedAmount * tokenPriceBigInt,
-        // Shift the decimal point by the number of decimals in the token price
-        this.fromSelectedToken.decimals + tokenPriceDecimals
+      // There is absolutely 0 reason to display the same amount of decimals for the usd
+      // amount as it's only used for display and validation purposes and the amount being sent is
+      // the token amount. So we truncate the amount to a reasonable number that can be displayed nicely.
+      this.fromAmountInFiat = truncateFiatAmountDecimals(
+        formatUnits(
+          formattedAmount * tokenPriceBigInt,
+          // Shift the decimal point by the number of decimals in the token price
+          this.fromSelectedToken.decimals + tokenPriceDecimals
+        )
       )
     }
   }

--- a/src/libs/transaction/conversion.test.ts
+++ b/src/libs/transaction/conversion.test.ts
@@ -1,0 +1,72 @@
+import { FromToken } from '../../interfaces/swapAndBridge'
+import { handleAmountConversion } from './conversion'
+
+const HARD_CODED_CURRENCY = 'usd'
+const WETH_PRICE = 2491.4335691077707
+
+const weth: FromToken = {
+  symbol: 'WETH',
+  name: 'Wrapped Ether',
+  decimals: 18,
+  address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  chainId: 1n,
+  amount: 330000000000000000n,
+  priceIn: [{ baseCurrency: HARD_CODED_CURRENCY, price: WETH_PRICE }],
+  marketDataIn: [],
+  flags: {
+    onGasTank: false,
+    rewardsType: null,
+    canTopUpGasTank: true,
+    isFeeToken: true
+  }
+}
+
+const convert = (amount: string, isInFiatMode: boolean, token: FromToken | null = weth) =>
+  handleAmountConversion(amount, amount, token, isInFiatMode, HARD_CODED_CURRENCY)
+
+describe('handleAmountConversion', () => {
+  describe('token to fiat', () => {
+    it('converts a token amount to a fiat amount a currency field can display', () => {
+      const { tokenAmount, fiatAmount } = convert('0.33', false)
+
+      expect(tokenAmount).toBe('0.33')
+      expect(fiatAmount).toBe('822.17')
+    })
+
+    it('keeps the full precision of the token amount, which is the amount being sent', () => {
+      const maxAmount = '0.334876543210987654'
+      const { tokenAmount, fiatAmount } = convert(maxAmount, false)
+
+      expect(tokenAmount).toBe(maxAmount)
+      expect(fiatAmount).toBe('834.32')
+    })
+
+    it('keeps meaningful decimals for a sub-cent fiat amount', () => {
+      const { fiatAmount } = convert('0.0000001', false)
+
+      expect(fiatAmount).toBe('0.00024')
+    })
+
+    it('returns an empty fiat amount when the token has no price', () => {
+      const { tokenAmount, fiatAmount } = convert('0.33', false, { ...weth, priceIn: [] })
+
+      expect(tokenAmount).toBe('0.33')
+      expect(fiatAmount).toBe('')
+    })
+  })
+
+  describe('fiat to token', () => {
+    it('keeps the typed fiat amount and converts it to a token amount', () => {
+      const { tokenAmount, fiatAmount } = convert('822.17', true)
+
+      expect(fiatAmount).toBe('822.17')
+      // Not truncated, as this is the amount being sent
+      expect(tokenAmount).toBe('0.329998')
+    })
+  })
+
+  it('returns empty amounts for an empty input', () => {
+    expect(convert('', false)).toEqual({ tokenAmount: '', fiatAmount: '' })
+    expect(convert('', true)).toEqual({ tokenAmount: '', fiatAmount: '' })
+  })
+})

--- a/src/libs/transaction/conversion.ts
+++ b/src/libs/transaction/conversion.ts
@@ -1,6 +1,10 @@
 import { formatUnits, parseUnits } from 'ethers'
-import { convertTokenPriceToBigInt } from '../../utils/numbers/formatters'
+
 import { FromToken } from '../../interfaces/swapAndBridge'
+import {
+  convertTokenPriceToBigInt,
+  truncateFiatAmountDecimals
+} from '../../utils/numbers/formatters'
 import { getSanitizedAmount } from '../transfer/amount'
 
 const CONVERSION_PRECISION = 16
@@ -58,7 +62,7 @@ const handleTokenToFiatConversion = (
     fromSelectedToken.decimals + tokenPriceDecimals
   )
 
-  return { tokenAmount: amount, fiatAmount }
+  return { tokenAmount: amount, fiatAmount: truncateFiatAmountDecimals(fiatAmount) }
 }
 
 export const handleAmountConversion = (

--- a/src/utils/numbers/formatters.test.ts
+++ b/src/utils/numbers/formatters.test.ts
@@ -39,11 +39,20 @@ describe('truncateFiatAmountDecimals', () => {
     expect(truncateFiatAmountDecimals('12')).toBe('12')
     expect(truncateFiatAmountDecimals('0.0001')).toBe('0.0001')
     expect(truncateFiatAmountDecimals('')).toBe('')
+    expect(truncateFiatAmountDecimals('0.0000000000000001')).toBe('0.0000000000000001')
   })
 
-  it('handles a zero amount with a long decimal tail', () => {
-    expect(truncateFiatAmountDecimals('0.000000000000000000')).toBe('0.00')
-    expect(truncateFiatAmountDecimals('0.0')).toBe('0.0')
+  it('normalizes every zero amount to a plain zero', () => {
+    expect(truncateFiatAmountDecimals('0.000000000000000000')).toBe('0')
+    expect(truncateFiatAmountDecimals('0.0')).toBe('0')
+    expect(truncateFiatAmountDecimals('0.00')).toBe('0')
     expect(truncateFiatAmountDecimals('0')).toBe('0')
+  })
+
+  it('returns zero for amounts too small to be displayed', () => {
+    // `formatDecimals` shows these as `$0.00`, so there are no meaningful
+    // decimals left to keep
+    expect(truncateFiatAmountDecimals('0.00000000000000000012345')).toBe('0')
+    expect(formatDecimals(Number('0.00000000000000000012345'), 'price')).toBe('$0.00')
   })
 })

--- a/src/utils/numbers/formatters.test.ts
+++ b/src/utils/numbers/formatters.test.ts
@@ -1,0 +1,49 @@
+import formatDecimals from '../formatDecimals/formatDecimals'
+import { truncateFiatAmountDecimals } from './formatters'
+
+describe('truncateFiatAmountDecimals', () => {
+  it('keeps two decimals for amounts of a dollar or more', () => {
+    // The exact value produced by converting 0.33 WETH at ~$2491 to fiat
+    expect(truncateFiatAmountDecimals('822.17306780556431192506')).toBe('822.17')
+    expect(truncateFiatAmountDecimals('1000.000000000000000000')).toBe('1000.00')
+  })
+
+  it('keeps as many decimals as the same amount is shown with as a label', () => {
+    // `formatDecimals` counts the meaningful decimals from the first non-zero
+    // one, so an amount whose cents start with a zero keeps a third decimal
+    expect(truncateFiatAmountDecimals('822.017306780556431192506')).toBe('822.017')
+    expect(formatDecimals(Number('822.017306780556431192506'), 'price')).toBe('$822.017')
+    expect(
+      formatDecimals(Number(truncateFiatAmountDecimals('1000.000000000000000000')), 'price')
+    ).toBe('$1,000.00')
+  })
+
+  it('keeps two meaningful decimals for sub-cent amounts', () => {
+    expect(truncateFiatAmountDecimals('0.00034567')).toBe('0.00034')
+    // Two decimals counted from the first non-zero one, same as `formatDecimals`
+    expect(truncateFiatAmountDecimals('0.09999999')).toBe('0.099')
+    expect(truncateFiatAmountDecimals('0.0000000000012345678')).toBe('0.0000000000012')
+  })
+
+  it('never rounds up, so the result never exceeds the given amount', () => {
+    const amounts = ['822.17999999999', '0.00999999', '5.999', '0.0000199999']
+
+    amounts.forEach((amount) => {
+      expect(Number(truncateFiatAmountDecimals(amount))).toBeLessThanOrEqual(Number(amount))
+    })
+  })
+
+  it('returns amounts that are already short enough untouched', () => {
+    expect(truncateFiatAmountDecimals('12.34')).toBe('12.34')
+    expect(truncateFiatAmountDecimals('12.3')).toBe('12.3')
+    expect(truncateFiatAmountDecimals('12')).toBe('12')
+    expect(truncateFiatAmountDecimals('0.0001')).toBe('0.0001')
+    expect(truncateFiatAmountDecimals('')).toBe('')
+  })
+
+  it('handles a zero amount with a long decimal tail', () => {
+    expect(truncateFiatAmountDecimals('0.000000000000000000')).toBe('0.00')
+    expect(truncateFiatAmountDecimals('0.0')).toBe('0.0')
+    expect(truncateFiatAmountDecimals('0')).toBe('0')
+  })
+})

--- a/src/utils/numbers/formatters.ts
+++ b/src/utils/numbers/formatters.ts
@@ -91,10 +91,12 @@ const truncateFiatAmountDecimals = (fiatAmount: string): string => {
   if (!decimals) return fiatAmount
 
   const decimalsToKeep = getDisplayedDecimalsCount(fiatAmount)
+  const truncated =
+    decimals.length <= decimalsToKeep
+      ? fiatAmount
+      : `${wholePart}.${decimals.slice(0, decimalsToKeep)}`
 
-  if (decimals.length <= decimalsToKeep) return fiatAmount
-
-  return `${wholePart}.${decimals.slice(0, decimalsToKeep)}`
+  return Number(truncated) === 0 ? '0' : truncated
 }
 
 const textToValidDecimal = (text: string) => {

--- a/src/utils/numbers/formatters.ts
+++ b/src/utils/numbers/formatters.ts
@@ -1,6 +1,7 @@
 import { formatUnits, parseUnits } from 'ethers'
 
 import { getSanitizedAmount } from '../../libs/transfer/amount'
+import formatDecimals from '../formatDecimals/formatDecimals'
 
 /**
  * Converts floating point token price to big int
@@ -72,6 +73,30 @@ const getSafeAmountFromFieldValue = (fieldValue: string, tokenDecimals?: number)
   return getSanitizedAmount(parsedFieldValue, tokenDecimals)
 }
 
+const getDisplayedDecimalsCount = (fiatAmount: string): number => {
+  const formatted = formatDecimals(Number(fiatAmount), 'price')
+  const indexOfDot = formatted.indexOf('.')
+
+  return indexOfDot === -1 ? 0 : formatted.length - indexOfDot - 1
+}
+
+/**
+ * Cuts a fiat amount down to the precision a currency field can display. The
+ * number of decimals is taken from what `formatDecimals` shows for the same
+ * amount.
+ */
+const truncateFiatAmountDecimals = (fiatAmount: string): string => {
+  const [wholePart, decimals] = fiatAmount.split('.')
+
+  if (!decimals) return fiatAmount
+
+  const decimalsToKeep = getDisplayedDecimalsCount(fiatAmount)
+
+  if (decimals.length <= decimalsToKeep) return fiatAmount
+
+  return `${wholePart}.${decimals.slice(0, decimalsToKeep)}`
+}
+
 const textToValidDecimal = (text: string) => {
   let formatted = text
 
@@ -99,5 +124,6 @@ export {
   convertTokenPriceToBigInt,
   getSafeAmountFromFieldValue,
   safeTokenAmountAndNumberMultiplication,
-  textToValidDecimal
+  textToValidDecimal,
+  truncateFiatAmountDecimals
 }


### PR DESCRIPTION
After clicking "MAX" in usd amount mode
## Before (absolute insanity):
<img width="485" height="616" alt="image" src="https://github.com/user-attachments/assets/33a7a928-55c9-4d94-97a3-4c14716c3a8c" />

## After:
<img width="485" height="616" alt="image" src="https://github.com/user-attachments/assets/58bc010e-db52-45f2-8ae4-bbd3751b07b9" />
