### PR TITLE
fix: reply to the UI request that triggered addAccounts

### DIFF
--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -75,6 +75,8 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
 
   #externalSignerControllers: ExternalSignerControllers
 
+  #sendUiMessage: (params: {}) => void
+
   initParams: {
     keyIterator: KeyIterator | null
     hdPathTemplate: HD_PATH_TEMPLATE_TYPE
@@ -169,6 +171,7 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
 
   #addAccountsOnKeystoreReady: {
     accounts?: SelectedAccountForImport[]
+    requestId?: string
   } | null = null
 
   constructor({
@@ -180,6 +183,7 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     externalSignerControllers,
     relayerUrl,
     fetch,
+    sendUiMessage,
     onAddAccountsSuccessCallback
   }: {
     eventEmitterRegistry?: IEventEmitterRegistryController
@@ -190,6 +194,7 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     externalSignerControllers: ExternalSignerControllers
     relayerUrl: string
     fetch: Fetch
+    sendUiMessage: (params: {}) => void
     onAddAccountsSuccessCallback: () => Promise<void>
   }) {
     super(eventEmitterRegistry)
@@ -199,6 +204,7 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     this.#providers = providers
     this.#externalSignerControllers = externalSignerControllers
     this.#callRelayer = relayerCall.bind({ url: relayerUrl, fetch })
+    this.#sendUiMessage = sendUiMessage
     this.#onAddAccountsSuccessCallback = onAddAccountsSuccessCallback
 
     this.#controllerSubscriptions.push(
@@ -219,7 +225,10 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     this.#controllerSubscriptions.push(
       this.#keystore.onUpdate(() => {
         if (this.#addAccountsOnKeystoreReady && this.#keystore.isReadyToStoreKeys) {
-          this.addAccounts(this.#addAccountsOnKeystoreReady.accounts)
+          this.addAccounts(
+            this.#addAccountsOnKeystoreReady.accounts,
+            this.#addAccountsOnKeystoreReady.requestId
+          )
           this.#addAccountsOnKeystoreReady = null
         }
       })
@@ -892,19 +901,45 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
    * triggered, which uses the `readyToAdd...` properties to further set
    * the newly added accounts data (like preferences, keys and others)
    */
-  async addAccounts(accounts?: SelectedAccountForImport[]) {
-    this.addAccountsPromise = this.#addAccounts(accounts).finally(() => {
+  async addAccounts(accounts?: SelectedAccountForImport[], requestId?: string) {
+    this.addAccountsPromise = this.#addAccounts(accounts, requestId).finally(() => {
       this.addAccountsPromise = undefined
     })
-    await this.addAccountsPromise
+
+    try {
+      await this.addAccountsPromise
+    } catch (error: any) {
+      this.#replyToImportRequest(requestId, error?.message || 'Adding the accounts failed')
+
+      throw error
+    }
   }
 
-  async #addAccounts(accounts?: SelectedAccountForImport[]) {
-    if (!this.isInitialized) return this.#throwNotInitialized()
-    if (!this.keyIterator) return this.#throwMissingKeyIterator()
+  /**
+   * Replies to the UI request that triggered the import (if there is one), so the UI can
+   * await the import completing instead of watching the transient `addAccountsStatus`.
+   */
+  #replyToImportRequest(requestId?: string, error?: string) {
+    if (!requestId) return
+
+    this.#sendUiMessage(error ? { requestId, ok: false, error } : { requestId, ok: true })
+  }
+
+  async #addAccounts(accounts?: SelectedAccountForImport[], requestId?: string) {
+    if (!this.isInitialized) {
+      this.#replyToImportRequest(requestId, 'The account picker is not initialized')
+
+      return this.#throwNotInitialized()
+    }
+    if (!this.keyIterator) {
+      this.#replyToImportRequest(requestId, 'The account picker is missing a key iterator')
+
+      return this.#throwMissingKeyIterator()
+    }
 
     if (!this.#keystore.isReadyToStoreKeys) {
-      this.#addAccountsOnKeystoreReady = { accounts }
+      // The import resumes (and replies to the request) once the keystore is ready.
+      this.#addAccountsOnKeystoreReady = { accounts, requestId }
       return
     }
 
@@ -1023,6 +1058,8 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     await this.forceEmitUpdate()
 
     this.#updateStateWithTheLatestFromAccounts()
+
+    this.#replyToImportRequest(requestId)
 
     // reset the addAccountsStatus in the next tick to ensure the FE receives the 'SUCCESS' state
     this.addAccountsStatus = 'INITIAL'

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -440,6 +440,7 @@ export class MainController extends EventEmitter implements IMainController {
       externalSignerControllers: this.#externalSignerControllers,
       relayerUrl,
       fetch: this.fetch,
+      sendUiMessage: this.ui.message.sendUiMessage,
       /**
        * callback that gets triggered as a finalization step of adding new
        * accounts via the AccountPickerController.
@@ -724,6 +725,7 @@ export class MainController extends EventEmitter implements IMainController {
               externalSignerControllers: this.#externalSignerControllers,
               relayerUrl,
               fetch: this.fetch,
+              sendUiMessage: this.ui.message.sendUiMessage,
               onAddAccountsSuccessCallback: async () => {}
             }),
           this.keystore,


### PR DESCRIPTION
The account picker had to be pressed several times before the personalize screen opened: `addAccountsStatus` publishes completion as a transient value (`SUCCESS` is reset to `INITIAL` a tick later), and only the latest state is guaranteed to reach the UI — so the `SUCCESS` frame could be missed entirely (on mobile both updates batch across the webview bridge).

`addAccounts` now takes an optional `requestId` and replies to it once the accounts are actually added, so the UI can await the import instead of watching the status. Same pattern as `#withSyncResponse` in the main controller. Every exit path replies: success, a throw, the two not-ready early returns, and the import deferred until the keystore is ready.

Paired with a UI change in `ambire-app`.