### PR TITLE
Humanizer: enhancements in approvals

### DIFF
--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -1172,7 +1172,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
       calls = calls.map((c) => ({
         ...c,
-        data: c.data || '0x',
+        data: c.data?.toLowerCase() || '0x',
         value: c.value ? getBigInt(c.value) : 0n,
         dapp: dapp ?? undefined,
         dappPromiseId: dappPromise.id

--- a/src/libs/humanizer/modules/Bundler3/bundler3.test.ts
+++ b/src/libs/humanizer/modules/Bundler3/bundler3.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { encodeFunctionData } from 'viem'
+
+import { AccountOp } from '../../../accountOp/accountOp'
+import { IrCall } from '../../interfaces'
+import { compareHumanizerVisualizations } from '../../testHelpers'
+import { getAction, getAddressVisualization, getBreak, getLabel, getToken } from '../../utils'
+import Bundler3Module from '.'
+import {
+  decodeGeneralAdapterCall,
+  erc4626DepositAbi,
+  morphoBorrowAbi,
+  morphoWithdrawCollateralAbi
+} from './generalAdapter'
+
+const BUNDLER3 = '0x6BFd8137e702540E7A42B74177A99878FCAE1B0'
+const LOAN_TOKEN = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const COLLATERAL_TOKEN = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+const VAULT = '0xbeeF010f9cb27031ad51e3333f9aF9C6B1228183'
+const RECEIVER = '0x998f31d7403db347aed69186421e52ece492b36f'
+
+const accountOp: AccountOp = {
+  id: 'bundler3-id',
+  accountAddr: RECEIVER,
+  chainId: 1n,
+  signingKeyAddr: null,
+  signingKeyType: null,
+  nonce: null,
+  calls: [],
+  gasLimit: null,
+  signature: null,
+  gasFeePayment: null
+}
+
+const marketParams = {
+  loanToken: LOAN_TOKEN as `0x${string}`,
+  collateralToken: COLLATERAL_TOKEN as `0x${string}`,
+  oracle: '0x0000000000000000000000000000000000000001' as `0x${string}`,
+  irm: '0x0000000000000000000000000000000000000002' as `0x${string}`,
+  lltv: 800000000000000000n
+}
+
+// this calldata would still execute onchain - the missing trailing words are read as zeroes
+// by the EVM - so the humanizer has to decode it the same way and still show the "different
+// address" warning, rather than silently dropping the whole call
+describe('Bundler3 generalAdapter short calldata protection', () => {
+  // the receiver is the last static word, so cutting it off zeroes it out - the call still
+  // decodes, and now the humanizer correctly warns that the receiver differs from the account
+  test('morphoBorrow with the trailing receiver word missing still decodes and warns', () => {
+    const fullData = encodeFunctionData({
+      abi: morphoBorrowAbi,
+      args: [marketParams, 10n ** 18n, 0n, 0n, accountOp.accountAddr as `0x${string}`]
+    })
+    const shortData = fullData.slice(0, -64) as `0x${string}`
+    const call: IrCall = { to: BUNDLER3, value: 0n, data: shortData }
+
+    const decoded = decodeGeneralAdapterCall(accountOp.accountAddr, call)
+
+    compareHumanizerVisualizations(
+      [decoded],
+      [[getBreak(), getAction('Borrow'), getToken(LOAN_TOKEN, 10n ** 18n)]]
+    )
+    expect(decoded.warnings?.[0]?.code).toBe('Morpho_diff_addr')
+  })
+
+  test('morphoWithdrawCollateral to a different address still warns when short', () => {
+    const otherReceiver = '0x000000000000000000000000000000000000dEaD'
+    const fullData = encodeFunctionData({
+      abi: morphoWithdrawCollateralAbi,
+      args: [marketParams, 10n ** 18n, otherReceiver as `0x${string}`]
+    })
+    const shortData = fullData.slice(0, -64) as `0x${string}`
+    const call: IrCall = { to: BUNDLER3, value: 0n, data: shortData }
+
+    const decoded = decodeGeneralAdapterCall(accountOp.accountAddr, call)
+
+    expect(decoded.warnings?.length).toBe(1)
+    expect(decoded.warnings?.[0]?.code).toBe('Morpho_diff_addr')
+  })
+
+  test('erc4626Deposit with the trailing receiver word missing still decodes', () => {
+    const fullData = encodeFunctionData({
+      abi: erc4626DepositAbi,
+      args: [VAULT as `0x${string}`, 10n ** 18n, 0n, accountOp.accountAddr as `0x${string}`]
+    })
+    const shortData = fullData.slice(0, -64) as `0x${string}`
+    const call: IrCall = { to: BUNDLER3, value: 0n, data: shortData }
+
+    const decoded = decodeGeneralAdapterCall(accountOp.accountAddr, call)
+
+    compareHumanizerVisualizations(
+      [decoded],
+      [[getBreak(), getAction('Mint from vault'), getAddressVisualization(VAULT)]]
+    )
+  })
+})
+
+describe('Bundler3Module (multicall) short calldata protection', () => {
+  const multicallAbi = [
+    {
+      type: 'function',
+      name: 'multicall',
+      inputs: [
+        {
+          name: 'bundle',
+          type: 'tuple[]',
+          components: [
+            { name: 'to', type: 'address' },
+            { name: 'data', type: 'bytes' },
+            { name: 'value', type: 'uint256' },
+            { name: 'skipRevert', type: 'bool' },
+            { name: 'callbackHash', type: 'bytes32' }
+          ]
+        }
+      ],
+      outputs: [],
+      stateMutability: 'payable'
+    }
+  ] as const
+
+  test('a bundled morphoBorrow call with short inner calldata still shows the loan amount', () => {
+    const innerData = encodeFunctionData({
+      abi: morphoBorrowAbi,
+      args: [marketParams, 10n ** 18n, 0n, 0n, accountOp.accountAddr as `0x${string}`]
+    }).slice(0, -64) as `0x${string}`
+
+    const data = encodeFunctionData({
+      abi: multicallAbi,
+      args: [
+        [
+          {
+            to: VAULT as `0x${string}`,
+            data: innerData,
+            value: 0n,
+            skipRevert: false,
+            callbackHash: `0x${'0'.repeat(64)}` as `0x${string}`
+          }
+        ]
+      ]
+    })
+    const call: IrCall = { to: BUNDLER3, value: 0n, data }
+
+    const irCall = Bundler3Module(accountOp, call)
+
+    compareHumanizerVisualizations(
+      [irCall],
+      [[getAction('Take'), getToken(LOAN_TOKEN, 10n ** 18n), getLabel('loan')]]
+    )
+  })
+})

--- a/src/libs/humanizer/modules/Bundler3/generalAdapter.ts
+++ b/src/libs/humanizer/modules/Bundler3/generalAdapter.ts
@@ -11,7 +11,8 @@ import {
   getWarning,
   getWrapping,
   HexIrCall,
-  isHexCall
+  isHexCall,
+  padCallData
 } from '../../utils'
 
 export const erc20TransferFromAbi = parseAbi([
@@ -93,7 +94,10 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     _accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: erc20TransferFromAbi, data: call.data })
+    const { args } = decodeFunctionData({
+      abi: erc20TransferFromAbi,
+      data: padCallData(call.data, 3)
+    })
     const [token, receiver, amount] = args
     const fullVisualization = [
       getBreak(),
@@ -108,7 +112,7 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     _accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: erc20TransferAbi, data: call.data })
+    const { args } = decodeFunctionData({ abi: erc20TransferAbi, data: padCallData(call.data, 3) })
     const [token, receiver, amount] = args
     const fullVisualization = [
       getBreak(),
@@ -123,7 +127,7 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     _accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: nativeTransferAbi, data: call.data })
+    const { args } = decodeFunctionData({ abi: nativeTransferAbi, data: padCallData(call.data, 2) })
     const [receiver, amount] = args
     const fullVisualization = [
       getBreak(),
@@ -138,7 +142,7 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     _accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: wrapNativeAbi, data: call.data })
+    const { args } = decodeFunctionData({ abi: wrapNativeAbi, data: padCallData(call.data, 1) })
     const [amount] = args
     const fullVisualization = [getBreak(), ...getWrapping(zeroAddress, amount)]
     return { ...call, fullVisualization }
@@ -147,7 +151,7 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     _accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: unwrapNativeAbi, data: call.data })
+    const { args } = decodeFunctionData({ abi: unwrapNativeAbi, data: padCallData(call.data, 1) })
     const [amount] = args
     const fullVisualization = [getBreak(), ...getUnwrapping(zeroAddress, amount)]
     return { ...call, fullVisualization }
@@ -156,7 +160,10 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     _accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: permit2TransferFromAbi, data: call.data })
+    const { args } = decodeFunctionData({
+      abi: permit2TransferFromAbi,
+      data: padCallData(call.data, 3)
+    })
     const [token, receiver, amount] = args
     const fullVisualization = [
       getBreak(),
@@ -184,7 +191,7 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: morphoBorrowAbi, data: call.data })
+    const { args } = decodeFunctionData({ abi: morphoBorrowAbi, data: padCallData(call.data, 9) })
     const [marketParams, assets, , , receiver] = args
     const fullVisualization = [
       getBreak(),
@@ -210,7 +217,10 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: morphoWithdrawCollateralAbi, data: call.data })
+    const { args } = decodeFunctionData({
+      abi: morphoWithdrawCollateralAbi,
+      data: padCallData(call.data, 7)
+    })
     const [marketParams, assets, receiver] = args
     const fullVisualization = [
       getBreak(),
@@ -236,7 +246,7 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: erc4626MintAbi, data: call.data })
+    const { args } = decodeFunctionData({ abi: erc4626MintAbi, data: padCallData(call.data, 4) })
     const [vault, , , receiver] = args
     const fullVisualization = [
       getBreak(),
@@ -249,7 +259,7 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: erc4626DepositAbi, data: call.data })
+    const { args } = decodeFunctionData({ abi: erc4626DepositAbi, data: padCallData(call.data, 4) })
     const [vault, , , receiver] = args
     const fullVisualization = [
       getBreak(),
@@ -262,7 +272,10 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: erc4626WithdrawAbi, data: call.data })
+    const { args } = decodeFunctionData({
+      abi: erc4626WithdrawAbi,
+      data: padCallData(call.data, 5)
+    })
     const [vault, , , receiver] = args
     const fullVisualization = [
       getBreak(),
@@ -275,7 +288,7 @@ const matcher: Record<string, (accAddr: string, call: HexIrCall) => IrCall | und
     accAddr: string,
     call: HexIrCall
   ): IrCall | undefined => {
-    const { args } = decodeFunctionData({ abi: erc4626RedeemAbi, data: call.data })
+    const { args } = decodeFunctionData({ abi: erc4626RedeemAbi, data: padCallData(call.data, 5) })
     const [vault, , , receiver] = args
     const fullVisualization = [
       getBreak(),

--- a/src/libs/humanizer/modules/Bundler3/index.ts
+++ b/src/libs/humanizer/modules/Bundler3/index.ts
@@ -13,7 +13,8 @@ import {
   getBreak,
   getLabel,
   getToken,
-  isHexCall
+  isHexCall,
+  padCallData
 } from '../../utils'
 import {
   erc4626DepositAbi,
@@ -84,7 +85,7 @@ const decodeGeneralAdapter = (accAddr: string, bundle: readonly BundleCall[]) =>
     [toFunctionSelector(morphoBorrowAbi[0])]: (call) => {
       const { args } = decodeFunctionData({
         abi: morphoBorrowAbi,
-        data: call.data
+        data: padCallData(call.data, 9)
       })
       const [marketParams, assets, , , receiver] = args
       const loanToken = marketParams.loanToken
@@ -109,7 +110,7 @@ const decodeGeneralAdapter = (accAddr: string, bundle: readonly BundleCall[]) =>
     [toFunctionSelector(morphoWithdrawCollateralAbi[0])]: (call) => {
       const { args } = decodeFunctionData({
         abi: morphoWithdrawCollateralAbi,
-        data: call.data
+        data: padCallData(call.data, 7)
       })
       const [marketParams, assets, receiver] = args
       const collateralToken = marketParams.collateralToken
@@ -136,7 +137,7 @@ const decodeGeneralAdapter = (accAddr: string, bundle: readonly BundleCall[]) =>
     [toFunctionSelector(erc4626MintAbi[0])]: (call) => {
       const { args } = decodeFunctionData({
         abi: erc4626MintAbi,
-        data: call.data
+        data: padCallData(call.data, 4)
       })
       const [vault, , , receiver] = args
       const fullVisualization = [
@@ -149,7 +150,7 @@ const decodeGeneralAdapter = (accAddr: string, bundle: readonly BundleCall[]) =>
     [toFunctionSelector(erc4626DepositAbi[0])]: (call) => {
       const { args } = decodeFunctionData({
         abi: erc4626DepositAbi,
-        data: call.data
+        data: padCallData(call.data, 4)
       })
       const [vault, , , receiver] = args
       const fullVisualization = [
@@ -162,7 +163,7 @@ const decodeGeneralAdapter = (accAddr: string, bundle: readonly BundleCall[]) =>
     [toFunctionSelector(erc4626WithdrawAbi[0])]: (call) => {
       const { args } = decodeFunctionData({
         abi: erc4626WithdrawAbi,
-        data: call.data
+        data: padCallData(call.data, 5)
       })
       const [vault, , , receiver] = args
       const fullVisualization = [
@@ -175,7 +176,7 @@ const decodeGeneralAdapter = (accAddr: string, bundle: readonly BundleCall[]) =>
     [toFunctionSelector(erc4626RedeemAbi[0])]: (call) => {
       const { args } = decodeFunctionData({
         abi: erc4626RedeemAbi,
-        data: call.data
+        data: padCallData(call.data, 5)
       })
       const [vault, , , receiver] = args
       const fullVisualization = [

--- a/src/libs/humanizer/modules/DaiPermit/daiPermit.test.ts
+++ b/src/libs/humanizer/modules/DaiPermit/daiPermit.test.ts
@@ -133,4 +133,28 @@ describe('dai permit module', () => {
 
     expect(call.warnings).toBeUndefined()
   })
+
+  // this calldata would still execute onchain - the missing trailing words (v, r and s) are
+  // read as zeroes by the EVM - so the humanizer has to decode it the same way and still show
+  // the warning, rather than silently dropping the whole call
+  test('still warns when the trailing signature words are missing from the calldata', () => {
+    const fullCall = getPermitCall(accountOp.accountAddr, expiry, true)
+    const shortData = fullCall.data.slice(0, -192)
+    const call = daiPermitModule(accountOp, { ...fullCall, data: shortData })
+
+    compareHumanizerVisualizations(
+      [call],
+      [
+        [
+          getAction('Grant approval'),
+          getLabel('for'),
+          getToken(DAI, MaxUint256),
+          getLabel('to'),
+          getAddressVisualization(spender),
+          getDeadline(expiry)
+        ]
+      ]
+    )
+    expect(call.warnings).toEqual([getUnlimitedApprovalWarning(spender)])
+  })
 })

--- a/src/libs/humanizer/modules/DaiPermit/index.ts
+++ b/src/libs/humanizer/modules/DaiPermit/index.ts
@@ -12,7 +12,8 @@ import {
   getToken,
   getUnlimitedApprovalWarning,
   isHexCall,
-  mergeWarnings
+  mergeWarnings,
+  padCallData
 } from '../../utils'
 
 // DAI predates EIP-2612, so its permit has no `value` param - only a boolean
@@ -25,7 +26,7 @@ const daiPermitModule: HumanizerCallModule = (accOp: AccountOp, call: IrCall): I
   if (call.fullVisualization || !isHexCall(call) || !call.to) return call
   if (call.data.slice(0, 10) !== toFunctionSelector(daiPermitAbi[0])) return call
 
-  const { args } = decodeFunctionData({ abi: daiPermitAbi, data: call.data })
+  const { args } = decodeFunctionData({ abi: daiPermitAbi, data: padCallData(call.data, 8) })
   const [holder, spender, , expiry, allowed] = args
 
   if (!allowed)

--- a/src/libs/humanizer/modules/MetaMorpho/index.ts
+++ b/src/libs/humanizer/modules/MetaMorpho/index.ts
@@ -18,7 +18,8 @@ import {
   HexIrCall,
   isHexCall,
   isUnlimitedAmount,
-  mergeWarnings
+  mergeWarnings,
+  padCallData
 } from '../../utils'
 
 // MetaMorpho vaults are ERC-4626 + ERC-20 + ERC-2612 (permit) + OZ Multicall contracts.
@@ -70,7 +71,7 @@ const innerCallMatcher: Record<
   (vault: string, accAddr: string, data: HexIrCall['data']) => DecodedInnerCallResult
 > = {
   [toFunctionSelector(erc20ApproveAbi[0])]: (vault, _accAddr, data) => {
-    const { args } = decodeFunctionData({ abi: erc20ApproveAbi, data })
+    const { args } = decodeFunctionData({ abi: erc20ApproveAbi, data: padCallData(data, 2) })
     const [spender, amount] = args
     if (amount === 0n)
       return {
@@ -94,7 +95,7 @@ const innerCallMatcher: Record<
     }
   },
   [toFunctionSelector(permitAbi[0])]: (vault, accAddr, data) => {
-    const { args } = decodeFunctionData({ abi: permitAbi, data })
+    const { args } = decodeFunctionData({ abi: permitAbi, data: padCallData(data, 7) })
     const [owner, spender, value] = args
     return {
       visualization: [
@@ -109,7 +110,7 @@ const innerCallMatcher: Record<
     }
   },
   [toFunctionSelector(erc20TransferAbi[0])]: (vault, _accAddr, data) => {
-    const { args } = decodeFunctionData({ abi: erc20TransferAbi, data })
+    const { args } = decodeFunctionData({ abi: erc20TransferAbi, data: padCallData(data, 2) })
     const [to, amount] = args
     return {
       visualization: [
@@ -121,7 +122,7 @@ const innerCallMatcher: Record<
     }
   },
   [toFunctionSelector(erc20TransferFromAbi[0])]: (vault, _accAddr, data) => {
-    const { args } = decodeFunctionData({ abi: erc20TransferFromAbi, data })
+    const { args } = decodeFunctionData({ abi: erc20TransferFromAbi, data: padCallData(data, 3) })
     const [from, to, amount] = args
     return {
       visualization: [
@@ -135,7 +136,7 @@ const innerCallMatcher: Record<
     }
   },
   [toFunctionSelector(erc4626DepositAbi[0])]: (vault, accAddr, data) => {
-    const { args } = decodeFunctionData({ abi: erc4626DepositAbi, data })
+    const { args } = decodeFunctionData({ abi: erc4626DepositAbi, data: padCallData(data, 2) })
     const [assets, receiver] = args
     return {
       visualization: [
@@ -146,7 +147,7 @@ const innerCallMatcher: Record<
     }
   },
   [toFunctionSelector(erc4626MintAbi[0])]: (vault, accAddr, data) => {
-    const { args } = decodeFunctionData({ abi: erc4626MintAbi, data })
+    const { args } = decodeFunctionData({ abi: erc4626MintAbi, data: padCallData(data, 2) })
     const [shares, receiver] = args
     return {
       visualization: [
@@ -157,7 +158,7 @@ const innerCallMatcher: Record<
     }
   },
   [toFunctionSelector(erc4626WithdrawAbi[0])]: (vault, accAddr, data) => {
-    const { args } = decodeFunctionData({ abi: erc4626WithdrawAbi, data })
+    const { args } = decodeFunctionData({ abi: erc4626WithdrawAbi, data: padCallData(data, 3) })
     const [assets, , owner] = args
     return {
       visualization: [
@@ -168,7 +169,7 @@ const innerCallMatcher: Record<
     }
   },
   [toFunctionSelector(erc4626RedeemAbi[0])]: (vault, accAddr, data) => {
-    const { args } = decodeFunctionData({ abi: erc4626RedeemAbi, data })
+    const { args } = decodeFunctionData({ abi: erc4626RedeemAbi, data: padCallData(data, 3) })
     const [shares, , owner] = args
     return {
       visualization: [
@@ -180,11 +181,16 @@ const innerCallMatcher: Record<
   }
 }
 
+// shown as unknown without a warning on purpose: `multicall(bytes[])` is not unique to
+// MetaMorpho, so an inner selector this module does not know may be an ordinary call on some
+// other contract. Warning here would alarm users about calls that are not a real concern
 const unmatched = (): DecodedInnerCall => ({
   visualization: [getAction('Unknown call')],
   matched: false
 })
 
+// a batch holding another batch is left unread on purpose: walking into it lets a hostile app
+// nest batches as deep as the calldata allows and make the wallet do the work of every level
 const decodeVaultMulticall = (
   vault: string,
   accAddr: string,
@@ -207,8 +213,14 @@ const MetaMorphoModule: HumanizerCallModule = (accOp: AccountOp, call: IrCall): 
   if (!isHexCall(call)) return call
   if (call.data.slice(0, 10) !== toFunctionSelector(multicallAbi[0])) return call
 
-  const { args } = decodeFunctionData({ abi: multicallAbi, data: call.data })
-  const [innerCalls] = args
+  let innerCalls: readonly HexIrCall['data'][]
+  try {
+    const { args } = decodeFunctionData({ abi: multicallAbi, data: call.data })
+    ;[innerCalls] = args
+  } catch (error) {
+    console.error('Failed to decode MetaMorpho multicall', error)
+    return call
+  }
   if (!innerCalls.length) return call
   const decoded: DecodedInnerCall[] = decodeVaultMulticall(call.to, accOp.accountAddr, innerCalls)
 

--- a/src/libs/humanizer/modules/MetaMorpho/index.ts
+++ b/src/libs/humanizer/modules/MetaMorpho/index.ts
@@ -55,8 +55,9 @@ const erc4626RedeemAbi = parseAbi([
 interface DecodedInnerCall {
   visualization: HumanizerVisualization[]
   matched: boolean
-  // set while the inner call is decoded, when it turns out to be an approval with no limit
-  warning?: HumanizerWarning
+  // collected while the inner call is decoded, e.g. when it turns out to be an approval with
+  // no limit. A nested bundle carries up every warning the calls inside it produced
+  warnings: HumanizerWarning[]
 }
 
 // inner calls not matching one of these selectors are rendered as "Unknown call" rather
@@ -186,21 +187,55 @@ const innerCallMatcher: Record<
 // other contract. Warning here would alarm users about calls that are not a real concern
 const unmatched = (): DecodedInnerCall => ({
   visualization: [getAction('Unknown call')],
-  matched: false
+  matched: false,
+  warnings: []
 })
 
-// a batch holding another batch is left unread on purpose: walking into it lets a hostile app
-// nest batches as deep as the calldata allows and make the wallet do the work of every level
+const multicallSelector = toFunctionSelector(multicallAbi[0])
+
+const joinWithBreaks = (decoded: DecodedInnerCall[]): HumanizerVisualization[] => {
+  const visualization = decoded.flatMap((c) => [getBreak(), ...c.visualization])
+  visualization.shift()
+
+  return visualization
+}
+
+// No depth limit here on purpose: every nested bundle's calldata is part of its parent
+// bundle's calldata, so it is always shorter and the recursion always stops on its own. A
+// depth limit would just hide a deeply nested approval's warning from the user instead.
 const decodeVaultMulticall = (
   vault: string,
   accAddr: string,
   innerCalls: readonly HexIrCall['data'][]
 ): DecodedInnerCall[] =>
   innerCalls.map((data) => {
-    const decodeInnerCall = innerCallMatcher[data.slice(0, 10)]
+    const selector = data.slice(0, 10)
+
+    if (selector === multicallSelector) {
+      try {
+        const { args } = decodeFunctionData({ abi: multicallAbi, data })
+        const [nestedCalls] = args
+        if (!nestedCalls.length) return unmatched()
+        const nested = decodeVaultMulticall(vault, accAddr, nestedCalls)
+        if (!nested.some((c) => c.matched)) return unmatched()
+
+        return {
+          visualization: joinWithBreaks(nested),
+          matched: true,
+          warnings: nested.flatMap((c) => c.warnings)
+        }
+      } catch (error) {
+        console.error('Failed to decode nested MetaMorpho multicall', error)
+        return unmatched()
+      }
+    }
+
+    const decodeInnerCall = innerCallMatcher[selector]
     if (!decodeInnerCall) return unmatched()
     try {
-      return { ...decodeInnerCall(vault, accAddr, data), matched: true }
+      const { visualization, warning } = decodeInnerCall(vault, accAddr, data)
+
+      return { visualization, matched: true, warnings: warning ? [warning] : [] }
     } catch (error) {
       console.error('Failed to decode MetaMorpho inner call', error)
       return unmatched()
@@ -229,10 +264,8 @@ const MetaMorphoModule: HumanizerCallModule = (accOp: AccountOp, call: IrCall): 
   // be left for other modules / the fallback humanizer
   if (!decoded.some((c) => c.matched)) return call
 
-  const fullVisualization = decoded.flatMap((c) => [getBreak(), ...c.visualization])
-  fullVisualization.shift()
-
-  const warnings = decoded.flatMap((c) => (c.warning ? [c.warning] : []))
+  const fullVisualization = joinWithBreaks(decoded)
+  const warnings = decoded.flatMap((c) => c.warnings)
 
   return { ...call, fullVisualization, warnings: mergeWarnings(call.warnings, warnings) }
 }

--- a/src/libs/humanizer/modules/MetaMorpho/metaMorpho.test.ts
+++ b/src/libs/humanizer/modules/MetaMorpho/metaMorpho.test.ts
@@ -191,8 +191,9 @@ describe('MetaMorpho', () => {
       expect(irCall.warnings).toBeUndefined()
     })
 
-    // walking into a nested batch would let a hostile app nest as deep as the calldata allows
-    test('shows a batch inside the batch as unknown instead of reading it', () => {
+    // a batch inside the batch is a valid inner call too - see the "nested batches" describe
+    // block below for the full coverage of that recursion
+    test('reads a batch nested inside the batch instead of showing it as unknown', () => {
       const nestedBundle = encodeFunctionData({ abi: multicallAbi, args: [[approveInnerCall]] })
       const irCalls = [vaultMulticall([approveInnerCall, nestedBundle])].map((c) =>
         MetaMorphoModule(accountOp, c)
@@ -206,7 +207,11 @@ describe('MetaMorpho', () => {
           getLabel('to'),
           getAddressVisualization(SPENDER),
           getBreak(),
-          getAction('Unknown call')
+          getAction('Grant approval'),
+          getLabel('for'),
+          getToken(VAULT_ADDRESS, 1000000000000000000n),
+          getLabel('to'),
+          getAddressVisualization(SPENDER)
         ]
       ])
       expect(irCalls[0].warnings).toBeUndefined()
@@ -276,16 +281,84 @@ describe('MetaMorpho', () => {
     })
   })
 
+  // a batch may hold another batch - every level still runs against the same vault, and there
+  // is no depth limit: nested calldata is always part of its parent calldata, so it is always
+  // shorter and the recursion always terminates on its own
+  describe('nested batches', () => {
+    const multicallAbi = parseAbi(['function multicall(bytes[] data)'])
+    const approveAbi = parseAbi(['function approve(address spender, uint256 amount)'])
+
+    const wrapInMulticall = (innerCalls: `0x${string}`[]) =>
+      encodeFunctionData({ abi: multicallAbi, args: [innerCalls] })
+    const nest = (layers: number, innerCall: `0x${string}`): `0x${string}` =>
+      layers === 0 ? innerCall : nest(layers - 1, wrapInMulticall([innerCall]))
+    const approveInnerCall = encodeFunctionData({
+      abi: approveAbi,
+      args: [SPENDER, 1000000000000000000n]
+    })
+    const expectedApprovalVisualization = [
+      getAction('Grant approval'),
+      getLabel('for'),
+      getToken(VAULT_ADDRESS, 1000000000000000000n),
+      getLabel('to'),
+      getAddressVisualization(SPENDER)
+    ]
+
+    test('decodes an approve wrapped in a batch inside a batch', () => {
+      const call: IrCall = { to: VAULT_ADDRESS, value: 0n, data: nest(2, approveInnerCall) }
+      const irCalls = [call].map((c) => MetaMorphoModule(accountOp, c))
+
+      compareHumanizerVisualizations(irCalls, [expectedApprovalVisualization])
+    })
+
+    test('carries an unlimited approval warning up from a nested batch', () => {
+      const unlimitedApprove = encodeFunctionData({ abi: approveAbi, args: [SPENDER, maxUint256] })
+      const call: IrCall = { to: VAULT_ADDRESS, value: 0n, data: nest(3, unlimitedApprove) }
+
+      expect(MetaMorphoModule(accountOp, call).warnings).toEqual([
+        getUnlimitedApprovalWarning(SPENDER)
+      ])
+    })
+
+    // there is no cap on how deep this goes - each level's calldata is strictly shorter than
+    // its parent's, so a very deep batch is unusual but still safe to walk all the way down
+    test('decodes a batch nested many levels deep', () => {
+      const call: IrCall = { to: VAULT_ADDRESS, value: 0n, data: nest(10, approveInnerCall) }
+      const irCalls = [call].map((c) => MetaMorphoModule(accountOp, c))
+
+      compareHumanizerVisualizations(irCalls, [expectedApprovalVisualization])
+    })
+
+    test('leaves an empty nested batch unhumanized', () => {
+      const call: IrCall = { to: VAULT_ADDRESS, value: 0n, data: nest(2, wrapInMulticall([])) }
+
+      expect(MetaMorphoModule(accountOp, call).fullVisualization).toBeUndefined()
+    })
+  })
+
   // the exact bytes a dapp sent: a batch holding a batch, with the outer bytes element not
-  // padded to a full 32 byte word. The nested batch is not read, so nothing here is readable
-  test('leaves a batch that only holds another batch to the other humanizer modules', () => {
+  // padded to a full 32 byte word
+  test('decodes a nested batch whose outer bytes element is not padded', () => {
     const call: IrCall = {
       to: VAULT_ADDRESS,
       value: 0n,
       data: '0xac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e4ac9650d80000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000044095ea7b3000000000000000000000000000000000000000000000000000000000000beefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000'
     }
+    const spender = '0x000000000000000000000000000000000000bEEF'
     const irCall = MetaMorphoModule(accountOp, call)
 
-    expect(irCall.fullVisualization).toBeUndefined()
+    compareHumanizerVisualizations(
+      [irCall],
+      [
+        [
+          getAction('Grant approval'),
+          getLabel('for'),
+          getToken(VAULT_ADDRESS, maxUint256),
+          getLabel('to'),
+          getAddressVisualization(spender)
+        ]
+      ]
+    )
+    expect(irCall.warnings).toEqual([getUnlimitedApprovalWarning(spender)])
   })
 })

--- a/src/libs/humanizer/modules/MetaMorpho/metaMorpho.test.ts
+++ b/src/libs/humanizer/modules/MetaMorpho/metaMorpho.test.ts
@@ -158,4 +158,134 @@ describe('MetaMorpho', () => {
       expect(irCall.warnings).toBeUndefined()
     })
   })
+
+  // the vault has functions this module does not decode, and a batch may hold another batch.
+  // an inner selector this module does not know is shown as unknown, with no warning:
+  // `multicall(bytes[])` is not unique to MetaMorpho, so the call may be an ordinary one on
+  // some other contract
+  describe('inner calls the module does not decode', () => {
+    const multicallAbi = parseAbi(['function multicall(bytes[] data)'])
+    const approveAbi = parseAbi(['function approve(address spender, uint256 amount)'])
+
+    const vaultMulticall = (innerCalls: `0x${string}`[]): IrCall => ({
+      to: VAULT_ADDRESS,
+      value: 0n,
+      data: encodeFunctionData({ abi: multicallAbi, args: [innerCalls] })
+    })
+    const approveInnerCall = encodeFunctionData({
+      abi: approveAbi,
+      args: [SPENDER, 1000000000000000000n]
+    })
+    // a real vault function this module has no matcher for
+    const unhandledInnerCall = encodeFunctionData({
+      abi: parseAbi(['function setFee(uint256 newFee)']),
+      args: [10n ** 17n]
+    })
+
+    test('does not warn about an inner call it cannot decode', () => {
+      const irCall = MetaMorphoModule(
+        accountOp,
+        vaultMulticall([approveInnerCall, unhandledInnerCall])
+      )
+
+      expect(irCall.warnings).toBeUndefined()
+    })
+
+    // walking into a nested batch would let a hostile app nest as deep as the calldata allows
+    test('shows a batch inside the batch as unknown instead of reading it', () => {
+      const nestedBundle = encodeFunctionData({ abi: multicallAbi, args: [[approveInnerCall]] })
+      const irCalls = [vaultMulticall([approveInnerCall, nestedBundle])].map((c) =>
+        MetaMorphoModule(accountOp, c)
+      )
+
+      compareHumanizerVisualizations(irCalls, [
+        [
+          getAction('Grant approval'),
+          getLabel('for'),
+          getToken(VAULT_ADDRESS, 1000000000000000000n),
+          getLabel('to'),
+          getAddressVisualization(SPENDER),
+          getBreak(),
+          getAction('Unknown call')
+        ]
+      ])
+      expect(irCalls[0].warnings).toBeUndefined()
+    })
+
+    // an approval with no limit still has to reach the user, even next to a call it cannot read
+    test('still reports an unlimited approval batched with an unknown call', () => {
+      const unlimitedApprove = encodeFunctionData({ abi: approveAbi, args: [SPENDER, maxUint256] })
+      const irCall = MetaMorphoModule(
+        accountOp,
+        vaultMulticall([unlimitedApprove, unhandledInnerCall])
+      )
+
+      expect(irCall.warnings).toEqual([getUnlimitedApprovalWarning(SPENDER)])
+    })
+
+    // nothing was recognized, so this may belong to another protocol
+    test('leaves a batch with no readable call to the other humanizer modules', () => {
+      const irCall = MetaMorphoModule(accountOp, vaultMulticall([unhandledInnerCall]))
+
+      expect(irCall.fullVisualization).toBeUndefined()
+      expect(irCall.warnings).toBeUndefined()
+    })
+  })
+
+  // pre solidity 0.5.0 tokens accept calldata shorter than the abi args and treat the missing
+  // bytes as zeroes. The vault's inner calls are padded the same way the token module pads them
+  describe('inner calls with short calldata', () => {
+    const paddedSpender = `000000000000000000000000${SPENDER.substring(2).toLowerCase()}`
+    const vaultMulticall = (innerCall: string): IrCall => ({
+      to: VAULT_ADDRESS,
+      value: 0n,
+      data: encodeFunctionData({
+        abi: parseAbi(['function multicall(bytes[] data)']),
+        args: [[`0x${innerCall}` as `0x${string}`]]
+      })
+    })
+
+    test('reads an inner approve with no amount word as a revoke', () => {
+      const irCalls = [vaultMulticall(`095ea7b3${paddedSpender}`)].map((c) =>
+        MetaMorphoModule(accountOp, c)
+      )
+
+      compareHumanizerVisualizations(irCalls, [
+        [
+          getAction('Revoke approval'),
+          getToken(VAULT_ADDRESS, 0n),
+          getLabel('for'),
+          getAddressVisualization(SPENDER)
+        ]
+      ])
+    })
+
+    test('reads an inner transfer with no amount word', () => {
+      const irCalls = [vaultMulticall(`a9059cbb${paddedSpender}`)].map((c) =>
+        MetaMorphoModule(accountOp, c)
+      )
+
+      compareHumanizerVisualizations(irCalls, [
+        [
+          getAction('Send'),
+          getToken(VAULT_ADDRESS, 0n),
+          getLabel('to'),
+          getAddressVisualization(SPENDER)
+        ]
+      ])
+    })
+  })
+
+  // the exact bytes a dapp sent: a batch holding a batch, with the outer bytes element not
+  // padded to a full 32 byte word. The nested batch is not read, so nothing here is readable
+  test('leaves a batch that only holds another batch to the other humanizer modules', () => {
+    const call: IrCall = {
+      to: VAULT_ADDRESS,
+      value: 0n,
+      data: '0xac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e4ac9650d80000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000044095ea7b3000000000000000000000000000000000000000000000000000000000000beefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000'
+    }
+    const irCall = MetaMorphoModule(accountOp, call)
+
+    expect(irCall.fullVisualization).toBeUndefined()
+  })
 })

--- a/src/libs/humanizer/modules/Pancake/Pancake.test.ts
+++ b/src/libs/humanizer/modules/Pancake/Pancake.test.ts
@@ -1,8 +1,17 @@
+import { encodeFunctionData, maxUint160, parseAbi } from 'viem'
+
 import humanizerInfo from '../../../../consts/humanizer/humanizerInfo.json'
 import { AccountOp } from '../../../accountOp/accountOp'
-import { HumanizerMeta } from '../../interfaces'
+import { HumanizerMeta, IrCall } from '../../interfaces'
 import { compareHumanizerVisualizations } from '../../testHelpers'
-import { getAction, getAddressVisualization, getDeadline, getLabel, getToken } from '../../utils'
+import {
+  getAction,
+  getAddressVisualization,
+  getDeadline,
+  getLabel,
+  getToken,
+  getUnlimitedApprovalWarning
+} from '../../utils'
 import OneInchModule from './'
 
 const transactions = [
@@ -55,5 +64,40 @@ describe('Pancake', () => {
       OneInchModule(accountOp, c, humanizerInfo as HumanizerMeta)
     )
     compareHumanizerVisualizations(irCalls, expectedVisualization)
+  })
+
+  // this calldata would still execute onchain - the missing trailing `expiration` word is
+  // read as zero by the EVM - so the humanizer has to decode it the same way and still show
+  // the unlimited approval warning, rather than silently dropping the whole call
+  test('still warns about an unlimited approval when the trailing expiration word is missing', () => {
+    const token = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+    const spender = '0xFE6508f0015C778Bdcc1fB5465bA5ebE224C9912'
+    const approveAbi = parseAbi([
+      'function approve(address token, address spender, uint160 amount, uint48 expiration)'
+    ])
+    const fullData = encodeFunctionData({
+      abi: approveAbi,
+      args: [token, spender, maxUint160, 1746289513]
+    })
+    const call: IrCall = {
+      to: '0x31c2F6fcFf4F8759b3Bd5Bf0e1084A055615c768',
+      value: 0n,
+      data: fullData.slice(0, -64)
+    }
+
+    const irCall = OneInchModule(accountOp, call, humanizerInfo as HumanizerMeta)
+    compareHumanizerVisualizations(
+      [irCall],
+      [
+        [
+          getAction('Approve'),
+          getAddressVisualization(spender),
+          getLabel('to use'),
+          getToken(token, maxUint160),
+          getLabel('now')
+        ]
+      ]
+    )
+    expect(irCall.warnings).toEqual([getUnlimitedApprovalWarning(spender)])
   })
 })

--- a/src/libs/humanizer/modules/Pancake/index.ts
+++ b/src/libs/humanizer/modules/Pancake/index.ts
@@ -17,7 +17,8 @@ import {
   getUnlimitedApprovalWarning,
   isHexCall,
   isUnlimitedAmount,
-  mergeWarnings
+  mergeWarnings,
+  padCallData
 } from '../../utils'
 
 // This is the Permit2 `approve`, which Pancake's permit contract shares. Permit2 keeps the
@@ -34,7 +35,7 @@ const PancakeModule: HumanizerCallModule = (accOp: AccountOp, call: IrCall) => {
     (call: HexIrCall) => { visualizations: HumanizerVisualization[]; warning?: HumanizerWarning }
   > = {
     [toFunctionSelector(approveAbi[0])]: (call) => {
-      const { args } = decodeFunctionData({ abi: approveAbi, data: call.data })
+      const { args } = decodeFunctionData({ abi: approveAbi, data: padCallData(call.data, 4) })
       const [token, spender, amount, expiration] = args
       const expirationHumanization = expiration > 0 ? getDeadline(expiration) : getLabel('now')
 

--- a/src/libs/humanizer/modules/Safe/index.ts
+++ b/src/libs/humanizer/modules/Safe/index.ts
@@ -25,7 +25,8 @@ import {
   getToken,
   getWarning,
   HexIrCall,
-  isHexCall
+  isHexCall,
+  padCallData
 } from '../../utils'
 
 const addOwnerWithThresholdAbi = parseAbi([
@@ -180,7 +181,7 @@ export const getSafeHumanization = (
   if (selector === toFunctionSelector(addOwnerWithThresholdAbi[0])) {
     const { args } = decodeFunctionData({
       abi: addOwnerWithThresholdAbi,
-      data
+      data: padCallData(data, 2)
     })
     const [newOwner, newThreshold] = args
     fullVisualization.push(
@@ -201,7 +202,7 @@ export const getSafeHumanization = (
   }
 
   if (selector === toFunctionSelector(changeThresholdAbi[0])) {
-    const { args } = decodeFunctionData({ abi: changeThresholdAbi, data })
+    const { args } = decodeFunctionData({ abi: changeThresholdAbi, data: padCallData(data, 1) })
     const [newThreshold] = args
     fullVisualization.push(...[getAction('Set threshold to'), getLabel(newThreshold)])
     warnings.push(
@@ -214,7 +215,7 @@ export const getSafeHumanization = (
   }
 
   if (selector === toFunctionSelector(removeOwnerAbi[0])) {
-    const { args } = decodeFunctionData({ abi: removeOwnerAbi, data })
+    const { args } = decodeFunctionData({ abi: removeOwnerAbi, data: padCallData(data, 3) })
     const [, removedOwner, newThreshold] = args
     fullVisualization.push(
       ...[
@@ -234,7 +235,7 @@ export const getSafeHumanization = (
   }
 
   if (selector === toFunctionSelector(swapOwnerAbi[0])) {
-    const { args } = decodeFunctionData({ abi: swapOwnerAbi, data })
+    const { args } = decodeFunctionData({ abi: swapOwnerAbi, data: padCallData(data, 3) })
     const [, removedOwner, newOwner] = args
     fullVisualization.push(
       ...[
@@ -253,7 +254,7 @@ export const getSafeHumanization = (
   }
 
   if (selector === toFunctionSelector(enableModuleAbi[0])) {
-    const { args } = decodeFunctionData({ abi: enableModuleAbi, data })
+    const { args } = decodeFunctionData({ abi: enableModuleAbi, data: padCallData(data, 1) })
     const [module] = args
     fullVisualization.push(...[getAction('Enable module:'), getAddressVisualization(module)])
     warnings.push(
@@ -269,7 +270,7 @@ export const getSafeHumanization = (
   }
 
   if (selector === toFunctionSelector(disableModuleAbi[0])) {
-    const { args } = decodeFunctionData({ abi: disableModuleAbi, data })
+    const { args } = decodeFunctionData({ abi: disableModuleAbi, data: padCallData(data, 2) })
     const [, module] = args
     fullVisualization.push(...[getAction('Disable module:'), getAddressVisualization(module)])
     return {
@@ -278,7 +279,7 @@ export const getSafeHumanization = (
   }
 
   if (selector === toFunctionSelector(setGuardAbi[0])) {
-    const { args } = decodeFunctionData({ abi: setGuardAbi, data })
+    const { args } = decodeFunctionData({ abi: setGuardAbi, data: padCallData(data, 1) })
     const [guard] = args
     fullVisualization.push(...[getAction('Set guard:'), getAddressVisualization(guard)])
     return {
@@ -287,7 +288,10 @@ export const getSafeHumanization = (
   }
 
   if (selector === toFunctionSelector(setFallbackHandlerAbi[0])) {
-    const { args } = decodeFunctionData({ abi: setFallbackHandlerAbi, data })
+    const { args } = decodeFunctionData({
+      abi: setFallbackHandlerAbi,
+      data: padCallData(data, 1)
+    })
     const [handler] = args
     fullVisualization.push(
       ...[getAction('Extend your account functionality with'), getAddressVisualization(handler)]
@@ -317,7 +321,7 @@ export const getSafeHumanization = (
   }
 
   if (selector === toFunctionSelector(setDomainVerifierAbi[0])) {
-    const { args } = decodeFunctionData({ abi: setDomainVerifierAbi, data })
+    const { args } = decodeFunctionData({ abi: setDomainVerifierAbi, data: padCallData(data, 2) })
     const [, newVerifier] = args
     fullVisualization.push(
       ...[

--- a/src/libs/humanizer/modules/Safe/safe.test.ts
+++ b/src/libs/humanizer/modules/Safe/safe.test.ts
@@ -274,4 +274,65 @@ describe('Safe', () => {
       compareHumanizerVisualizations(irCalls, expectedVisualization)
     })
   })
+
+  // this calldata would still execute onchain - the missing trailing words are read as zeroes
+  // by the EVM - so the humanizer has to decode it the same way and still show the config
+  // change warning, rather than silently dropping the whole call
+  describe('short calldata protection', () => {
+    test('changeThreshold with the trailing threshold word missing still warns', () => {
+      const changeThresholdAbi = parseAbi(['function changeThreshold(uint256 _threshold)'])
+      const fullData = encodeFunctionData({ abi: changeThresholdAbi, args: [2n] })
+      const shortData = fullData.slice(0, -64) as `0x${string}`
+
+      const result = getSafeHumanization(
+        accountOp.accountAddr,
+        accountOp.accountAddr,
+        0n,
+        shortData
+      )
+
+      expect(result?.warnings?.some((w) => w.code === 'SAFE{WALLET}_CONFIG_CHANGE')).toBe(true)
+    })
+
+    test('enableModule with the trailing module address word missing still warns', () => {
+      const enableModuleAbi = parseAbi(['function enableModule(address module)'])
+      const fullData = encodeFunctionData({
+        abi: enableModuleAbi,
+        args: ['0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5']
+      })
+      const shortData = fullData.slice(0, -64) as `0x${string}`
+
+      const result = getSafeHumanization(
+        accountOp.accountAddr,
+        accountOp.accountAddr,
+        0n,
+        shortData
+      )
+
+      expect(result?.warnings?.some((w) => w.code === 'SAFE{WALLET}_CONFIG_CHANGE')).toBe(true)
+    })
+
+    test('setDomainVerifier with the trailing verifier address word missing still warns', () => {
+      const setDomainVerifierAbi = parseAbi([
+        'function setDomainVerifier(bytes32 domainSeparator, address newVerifier)'
+      ])
+      const fullData = encodeFunctionData({
+        abi: setDomainVerifierAbi,
+        args: [
+          '0xd72ffa789b6fae41254d0b5a13e6e1e92ed947ec6a251edf1cf0b6c02c257b4',
+          '0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74'
+        ]
+      })
+      const shortData = fullData.slice(0, -64) as `0x${string}`
+
+      const result = getSafeHumanization(
+        accountOp.accountAddr,
+        accountOp.accountAddr,
+        0n,
+        shortData
+      )
+
+      expect(result?.warnings?.some((w) => w.code === 'SAFE{WALLET}_DOMAIN_VERIFIER')).toBe(true)
+    })
+  })
 })

--- a/src/libs/humanizer/modules/Tokens/tokens.ts
+++ b/src/libs/humanizer/modules/Tokens/tokens.ts
@@ -1,4 +1,4 @@
-import { parseAbi, decodeFunctionData, toFunctionSelector, zeroAddress, Hex } from 'viem'
+import { parseAbi, decodeFunctionData, toFunctionSelector, zeroAddress } from 'viem'
 
 import { AccountOp } from '../../../accountOp/accountOp'
 import {
@@ -18,6 +18,7 @@ import {
   isHexCall,
   isUnlimitedAmount,
   mergeWarnings,
+  padCallData,
   UNLIMITED_APPROVAL_WARNING_CODE
 } from '../../utils'
 
@@ -53,16 +54,6 @@ const erc20IncreaseApprovalAbi = parseAbi([
 const erc20DecreaseApprovalAbi = parseAbi([
   'function decreaseApproval(address _spender, uint256 _subtractedValue) returns (bool)'
 ])
-
-// tokens before solidity 0.5.0 would accept calldata that is shorter then the specified
-// args in the abi and assume they are 0s
-// other tokens fail onchain, so there is no real danger in padding to the end
-// as long as it is kept in the humanizer
-// applicable only to functions whose args are all static (one 32 byte word each)
-const padCallData = (data: Hex, staticArgsCount: number): Hex => {
-  const expectedCallLength = 2 + 8 + staticArgsCount * 64
-  return data.padEnd(expectedCallLength, '0') as Hex
-}
 
 /**
  * What a matcher returns for one call: how to show it, plus a warning when the call turns out to

--- a/src/libs/humanizer/utils.ts
+++ b/src/libs/humanizer/utils.ts
@@ -258,3 +258,13 @@ export const uintToAddress = (uint: bigint): string =>
 
 export const eToNative = (address: string): string =>
   address.slice(2).toLocaleLowerCase() === 'e'.repeat(40) ? zeroAddress : address
+
+// tokens before solidity 0.5.0 would accept calldata that is shorter then the specified
+// args in the abi and assume they are 0s
+// other tokens fail onchain, so there is no real danger in padding to the end
+// as long as it is kept in the humanizer
+// applicable only to functions whose args are all static (one 32 byte word each)
+export const padCallData = (data: Hex, staticArgsCount: number): Hex => {
+  const expectedCallLength = 2 + 8 + staticArgsCount * 64
+  return data.padEnd(expectedCallLength, '0') as Hex
+}


### PR DESCRIPTION
note: Security fix only, not really noteworthy 

- uppercase calldata should not enter the extension
- txns that are shorter than expected should be handled with warnings because they execute onchain
- morpho embedded multicall warnings