### PR TITLE
fix: expose which derivation paths a wallet's exported key can browse

### DIFF
--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -474,6 +474,10 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
     return this.keyIterator?.subType || this.initParams?.keyIterator?.subType
   }
 
+  get derivableHdPathTemplates() {
+    return this.keyIterator?.derivableHdPathTemplates
+  }
+
   async reset(resetInitParams: boolean = true) {
     this.#setPageRequestId++
     await this.addAccountsPromise
@@ -1575,7 +1579,8 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
       selectedAccounts: this.selectedAccounts,
       addedAccountsFromCurrentSession: this.addedAccountsFromCurrentSession,
       type: this.type,
-      subType: this.subType
+      subType: this.subType,
+      derivableHdPathTemplates: this.derivableHdPathTemplates
     }
   }
 }

--- a/src/interfaces/keyIterator.ts
+++ b/src/interfaces/keyIterator.ts
@@ -15,6 +15,12 @@ export interface KeyIterator {
   walletSDK?: any
   /** Needed for the hardware wallets only */
   controller?: ExternalSignerController
+  /**
+   * Which of the offered derivation paths this wallet can browse. Wallets that hand
+   * over a single extended public key (QR, NFC) are limited to the paths that branch
+   * off it. Undefined means every path is available.
+   */
+  derivableHdPathTemplates?: HD_PATH_TEMPLATE_TYPE[]
   /** Retrieves the the public addresses (accounts) from specific indexes */
   retrieve: (
     fromToArr: { from: number; to: number }[],

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -261,6 +261,13 @@ export type ParsedQrAccount = {
   deviceModel?: string
   deviceId?: string
   hdPath?: string // For wallets that don't provide the hdPath on each account, but only a general one for the whole export (like Keystone)
+  /**
+   * The path the wallet says its addresses sit at, relative to the exported key and
+   * with a `*` where the address index goes (e.g. `0/*` for the BIP44 standard chain,
+   * `*` for the Ledger Legacy path). Optional in the QR payload - a wallet that omits
+   * it leaves no way to tell which of the two it exported.
+   */
+  childrenPath?: string
   accounts: ParsedQrImportedAccount[]
 }
 

--- a/src/utils/hdPath.test.ts
+++ b/src/utils/hdPath.test.ts
@@ -1,0 +1,66 @@
+import {
+  BIP44_LEDGER_DERIVATION_TEMPLATE,
+  BIP44_STANDARD_DERIVATION_TEMPLATE,
+  BIP44_STANDARD_TESTNET_DERIVATION_TEMPLATE,
+  LEGACY_POPULAR_DERIVATION_TEMPLATE
+} from '../consts/derivation'
+import { getDerivableHdPathTemplates, getHdPathTemplateRelativeToOrigin } from './hdPath'
+
+const ACCOUNT_LEVEL_PATH = "m/44'/60'/0'"
+const CHAIN_LEVEL_PATH = "m/44'/60'/0'/0"
+
+describe('getHdPathTemplateRelativeToOrigin', () => {
+  it('resolves the paths that branch off an account level key', () => {
+    expect(
+      getHdPathTemplateRelativeToOrigin(ACCOUNT_LEVEL_PATH, BIP44_STANDARD_DERIVATION_TEMPLATE)
+    ).toBe('0/<account>')
+    expect(
+      getHdPathTemplateRelativeToOrigin(ACCOUNT_LEVEL_PATH, LEGACY_POPULAR_DERIVATION_TEMPLATE)
+    ).toBe('<account>')
+  })
+
+  it('resolves the standard path from a chain level key', () => {
+    expect(
+      getHdPathTemplateRelativeToOrigin(CHAIN_LEVEL_PATH, BIP44_STANDARD_DERIVATION_TEMPLATE)
+    ).toBe('<account>')
+  })
+
+  it('refuses a path with a hardened index below the origin', () => {
+    expect(
+      getHdPathTemplateRelativeToOrigin(ACCOUNT_LEVEL_PATH, BIP44_LEDGER_DERIVATION_TEMPLATE)
+    ).toBeNull()
+  })
+
+  it('refuses a path on another branch', () => {
+    expect(
+      getHdPathTemplateRelativeToOrigin(
+        ACCOUNT_LEVEL_PATH,
+        BIP44_STANDARD_TESTNET_DERIVATION_TEMPLATE
+      )
+    ).toBeNull()
+    expect(
+      getHdPathTemplateRelativeToOrigin(CHAIN_LEVEL_PATH, LEGACY_POPULAR_DERIVATION_TEMPLATE)
+    ).toBeNull()
+  })
+
+  it('refuses a path that is the origin itself', () => {
+    expect(
+      getHdPathTemplateRelativeToOrigin(ACCOUNT_LEVEL_PATH, ACCOUNT_LEVEL_PATH as any)
+    ).toBeNull()
+  })
+})
+
+describe('getDerivableHdPathTemplates', () => {
+  it('offers the standard and the legacy path for an account level key', () => {
+    expect(getDerivableHdPathTemplates(ACCOUNT_LEVEL_PATH)).toEqual([
+      BIP44_STANDARD_DERIVATION_TEMPLATE,
+      LEGACY_POPULAR_DERIVATION_TEMPLATE
+    ])
+  })
+
+  it('offers only the standard path for a chain level key', () => {
+    expect(getDerivableHdPathTemplates(CHAIN_LEVEL_PATH)).toEqual([
+      BIP44_STANDARD_DERIVATION_TEMPLATE
+    ])
+  })
+})

--- a/src/utils/hdPath.ts
+++ b/src/utils/hdPath.ts
@@ -1,4 +1,4 @@
-import { HD_PATH_TEMPLATE_TYPE } from '../consts/derivation'
+import { DERIVATION_OPTIONS, HD_PATH_TEMPLATE_TYPE } from '../consts/derivation'
 
 export const getHdPathFromTemplate = (hdPathTemplate: HD_PATH_TEMPLATE_TYPE, index: number) => {
   return hdPathTemplate.replace('<account>', index.toString())
@@ -41,3 +41,32 @@ export const getHDPathIndices = (hdPathTemplate: HD_PATH_TEMPLATE_TYPE, insertId
   if (indices.length > 5) throw new Error('Only HD paths with up to 5 indices are allowed.')
   return indices
 }
+
+/**
+ * The part of an HD path template that is relative to `originPath` - the path an
+ * extended public key was exported from. Returns null when the template does not
+ * branch off the origin (e.g. a hardened account index), meaning that extended
+ * public key cannot derive it.
+ */
+export const getHdPathTemplateRelativeToOrigin = (
+  originPath: string,
+  hdPathTemplate: HD_PATH_TEMPLATE_TYPE
+) => {
+  const originLevels = originPath.split('/')
+  const templateLevels = hdPathTemplate.split('/')
+
+  if (templateLevels.length <= originLevels.length) return null
+  if (originLevels.some((level, i) => level !== templateLevels[i])) return null
+
+  return templateLevels.slice(originLevels.length).join('/')
+}
+
+/**
+ * Which of the offered derivation paths an extended public key exported from
+ * `originPath` can browse. Wallets that hand over a single extended public key
+ * (QR, NFC) are limited to these.
+ */
+export const getDerivableHdPathTemplates = (originPath: string) =>
+  DERIVATION_OPTIONS.map(({ value }) => value).filter(
+    (template) => !!getHdPathTemplateRelativeToOrigin(originPath, template)
+  )


### PR DESCRIPTION
Support piece for AmbireTech/ambire-app#7841 — QR/NFC wallets could not be imported on the Ledger Legacy path.

QR and NFC wallets hand over a single extended public key, so they can only derive the paths that branch off it. The picker needs to know which ones those are.

- `getHdPathTemplateRelativeToOrigin` / `getDerivableHdPathTemplates`
- `KeyIterator.derivableHdPathTemplates`, surfaced through `AccountPicker`
- `ParsedQrAccount.childrenPath` — the only field that tells a Ledger Legacy export from a standard one, since both come from the same account-level path