### PR TITLE
Add PQ1 (post-quantum) hardware wallet support

### DIFF
--- a/src/consts/hardwareWallets.ts
+++ b/src/consts/hardwareWallets.ts
@@ -5,5 +5,6 @@ export const HARDWARE_WALLET_DEVICE_NAMES: { [key in ExternalKey['type']]: strin
   trezor: 'Trezor',
   lattice: 'GridPlus',
   qr: 'QR-based',
-  nfc: 'NFC-based'
+  nfc: 'NFC-based',
+  pq1: 'PQ1'
 }

--- a/src/controllers/accountPicker/accountPicker.ts
+++ b/src/controllers/accountPicker/accountPicker.ts
@@ -948,7 +948,8 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
         trezor: this.#externalSignerControllers.trezor?.deviceId || '',
         lattice: this.#externalSignerControllers?.lattice?.deviceId || '',
         qr: this.#externalSignerControllers.qr?.deviceId || '',
-        nfc: this.#externalSignerControllers.nfc?.deviceId || ''
+        nfc: this.#externalSignerControllers.nfc?.deviceId || '',
+        pq1: this.#externalSignerControllers.pq1?.deviceId || ''
       }
 
       const deviceModels: { [key in ExternalKey['type']]: string } = {
@@ -956,7 +957,8 @@ export class AccountPickerController extends EventEmitter implements IAccountPic
         trezor: this.#externalSignerControllers.trezor?.deviceModel || '',
         lattice: this.#externalSignerControllers.lattice?.deviceModel || '',
         qr: this.#externalSignerControllers.qr?.deviceModel || '',
-        nfc: this.#externalSignerControllers.nfc?.deviceModel || ''
+        nfc: this.#externalSignerControllers.nfc?.deviceModel || '',
+        pq1: this.#externalSignerControllers.pq1?.deviceModel || ''
       }
 
       const masterFingerprint = this.#externalSignerControllers.qr?.masterFingerprint || ''

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -24,6 +24,7 @@ import {
 } from '../../classes/recurringTimeout/recurringTimeout'
 import { EIP7702Auth } from '../../consts/7702'
 import { FEE_COLLECTOR } from '../../consts/addresses'
+import { PIMLICO } from '../../consts/bundlers'
 import { SINGLETON } from '../../consts/deploy'
 import gasTankFeeTokens from '../../consts/gasTankFeeTokens'
 import { ESTIMATE_UPDATE_INTERVAL, GAS_PRICE_UPDATE_INTERVAL } from '../../consts/intervals'
@@ -3116,7 +3117,10 @@ export class SignAccountOpController
         const { safeTxn, typedData, safeTxnHash, signingRequest } =
           this.#getSafeSigningData(accountState)
         const signature = (await this.#withHardwareWalletSigningRequest(signingRequest, () =>
-          safeSigner.signTypedData(typedData)
+          safeSigner.signTypedData(typedData, {
+            chainId: this.#network.chainId,
+            provider: this.provider
+          })
         )) as Hex
         nowSignedSigs.push(signature)
 
@@ -3206,7 +3210,14 @@ export class SignAccountOpController
                 accountState,
                 network: this.#network
               }),
-              () => getExecuteSignature(this.#network, this.accountOp, accountState, signer)
+              () =>
+                getExecuteSignature(
+                  this.#network,
+                  this.accountOp,
+                  accountState,
+                  signer,
+                  this.provider
+                )
             )
           })
         }
@@ -3315,7 +3326,8 @@ export class SignAccountOpController
                 this.#network,
                 false,
                 undefined,
-                true
+                true,
+                this.provider
               )
           )
           if (!this.accountOp.meta) {
@@ -3388,7 +3400,10 @@ export class SignAccountOpController
             )
             const signature = wrapStandard(
               await this.#withHardwareWalletSigningRequest(getEIP712SigningRequest(typedData), () =>
-                signer.signTypedData(typedData)
+                signer.signTypedData(typedData, {
+                  chainId: this.#network.chainId,
+                  provider: this.provider
+                })
               )
             )
             userOperation.signature = signature
@@ -3402,7 +3417,10 @@ export class SignAccountOpController
             )
             const signature = wrapUnprotected(
               await this.#withHardwareWalletSigningRequest(getEIP712SigningRequest(typedData), () =>
-                signer.signTypedData(typedData)
+                signer.signTypedData(typedData, {
+                  chainId: this.#network.chainId,
+                  provider: this.provider
+                })
               )
             )
             userOperation.signature = signature
@@ -3432,7 +3450,14 @@ export class SignAccountOpController
               accountState,
               network: this.#network
             }),
-            () => getExecuteSignature(this.#network, this.accountOp, accountState, signer)
+            () =>
+              getExecuteSignature(
+                this.#network,
+                this.accountOp,
+                accountState,
+                signer,
+                this.provider
+              )
           )
         })
       }
@@ -3545,10 +3570,31 @@ export class SignAccountOpController
 
     // PQ1 is a smart-contract-only signer that cannot produce a raw EOA
     // transaction. The signer packages the calls into a 4337 UserOperation,
-    // signs on-device and submits via its own bundler. We short-circuit the
-    // entire EOA + bundler tree below.
+    // signs on-device and submits via its own bundler (Pimlico). We
+    // short-circuit the entire EOA + bundler tree below, but keep two of
+    // its invariants:
+    //   1. The user-approved `gasFeePayment` binds the broadcast — the fee
+    //      fields of the UserOp are taken from it, and fee options the
+    //      4337 pipeline cannot honor (gas tank, another payer, a non-
+    //      native fee token) are refused up front instead of silently
+    //      charging the wallet's native balance a different amount.
+    //   2. Device interaction runs inside #withHardwareWalletSigningRequest
+    //      so the "confirm on your device" UI shows while the PQ1 waits
+    //      for its physical confirmation.
     if (accountOp.signingKeyType === 'pq1') {
       try {
+        const { gasFeePayment } = accountOp
+        if (
+          gasFeePayment.isGasTank ||
+          gasFeePayment.paidBy !== accountOp.accountAddr ||
+          gasFeePayment.inToken !== ZeroAddress
+        ) {
+          return this.throwBroadcastAccountOp({
+            message:
+              'PQ1 accounts pay gas with the native token from the account itself. Please select the native-token fee option paid by this account and try again.',
+            accountState
+          })
+        }
         const signer = await this.#keystore.getSigner(
           accountOp.signingKeyAddr,
           accountOp.signingKeyType
@@ -3562,15 +3608,32 @@ export class SignAccountOpController
             accountState
           })
         }
-        const { txnId } = await signer.broadcastAccountOp({
-          chainId: accountOp.chainId,
-          provider: this.provider,
-          calls: accountOp.calls.map((c) => ({ to: c.to, value: c.value, data: c.data }))
-        })
+        const calls = accountOp.calls.map((c) => ({ to: c.to, value: c.value, data: c.data }))
+        const { userOpHash, nonce } = await this.#withHardwareWalletSigningRequest(
+          getRawTransactionSigningRequest({
+            chainId: accountOp.chainId,
+            from: accountOp.accountAddr,
+            calls
+          }),
+          () =>
+            signer.broadcastAccountOp!({
+              chainId: accountOp.chainId,
+              provider: this.provider!,
+              calls,
+              gasFeePayment: {
+                gasPrice: gasFeePayment.gasPrice,
+                maxPriorityFeePerGas: gasFeePayment.maxPriorityFeePerGas
+              }
+            })
+        )
+        // Identified the same way as any other bundler broadcast: the
+        // ActivityController resolves the tx hash and reads per-op success
+        // from the UserOperationEvent log (so a UserOp whose inner
+        // execution reverted is correctly reported as failed, and a
+        // slow-but-included op is not misreported as a failed broadcast).
         transactionRes = {
-          nonce: Number(accountOp.nonce ?? 0n),
-          identifiedBy: { type: 'Transaction', identifier: txnId },
-          txnId
+          nonce: Number(nonce),
+          identifiedBy: { type: 'UserOperation', identifier: userOpHash, bundler: PIMLICO }
         }
       } catch (error: any) {
         return this.throwBroadcastAccountOp({ error, accountState })

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -3543,7 +3543,39 @@ export class SignAccountOpController
       BROADCAST_OPTIONS.delegation
     ]
 
-    if (rawTxnBroadcast.includes(accountOp.gasFeePayment.broadcastOption)) {
+    // PQ1 is a smart-contract-only signer that cannot produce a raw EOA
+    // transaction. The signer packages the calls into a 4337 UserOperation,
+    // signs on-device and submits via its own bundler. We short-circuit the
+    // entire EOA + bundler tree below.
+    if (accountOp.signingKeyType === 'pq1') {
+      try {
+        const signer = await this.#keystore.getSigner(
+          accountOp.signingKeyAddr,
+          accountOp.signingKeyType
+        )
+        if (signer.init) {
+          signer.init(this.#externalSignerControllers[accountOp.signingKeyType])
+        }
+        if (!signer.broadcastAccountOp) {
+          return this.throwBroadcastAccountOp({
+            message: `Signer for key type ${accountOp.signingKeyType} does not implement broadcastAccountOp`,
+            accountState
+          })
+        }
+        const { txnId } = await signer.broadcastAccountOp({
+          chainId: accountOp.chainId,
+          provider: this.provider,
+          calls: accountOp.calls.map((c) => ({ to: c.to, value: c.value, data: c.data }))
+        })
+        transactionRes = {
+          nonce: Number(accountOp.nonce ?? 0n),
+          identifiedBy: { type: 'Transaction', identifier: txnId },
+          txnId
+        }
+      } catch (error: any) {
+        return this.throwBroadcastAccountOp({ error, accountState })
+      }
+    } else if (rawTxnBroadcast.includes(accountOp.gasFeePayment.broadcastOption)) {
       const multipleTxnsBroadcastRes = []
       const senderAddr =
         accountOp.gasFeePayment.broadcastOption === BROADCAST_OPTIONS.byOtherEOA

--- a/src/controllers/signMessage/signMessage.ts
+++ b/src/controllers/signMessage/signMessage.ts
@@ -553,7 +553,8 @@ export class SignMessageController
             accountState,
             this.signer,
             this.#invite.isOG,
-            (request, sign) => this.#withHardwareWalletSigningRequest(request, sign)
+            (request, sign) => this.#withHardwareWalletSigningRequest(request, sign),
+            provider
           )
           this.signatures.push(signed.signature)
           this.signed.push(signerKey.addr)
@@ -599,7 +600,9 @@ export class SignMessageController
             this.signer,
             this.network,
             this.#invite.isOG,
-            (request, sign) => this.#withHardwareWalletSigningRequest(request, sign)
+            (request, sign) => this.#withHardwareWalletSigningRequest(request, sign),
+            false,
+            provider
           )
           this.signatures.push(signed.signature)
           this.signed.push(signerKey.addr)

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -80,12 +80,33 @@ export interface TxnRequest {
   type?: number
 }
 
+/**
+ * Per-request context passed to {@link KeystoreSignerInterface.signMessage}
+ * and {@link KeystoreSignerInterface.signTypedData}.
+ *
+ * EOA-style signers (Ledger, Trezor, Lattice, QR, internal keystore) can
+ * ignore this entirely — their output is chain-agnostic (ECDSA over the
+ * EIP-191 / EIP-712 hash). Smart-account signers whose signatures are
+ * verified on-chain via ERC-1271 / ERC-6492 (currently PQ1) need to know
+ * which chain the verifier will run on so they can:
+ *   1) decide whether to emit a bare ERC-1271 wrapper or an ERC-6492
+ *      deploy-and-verify blob (based on `eth_getCode(sender)`), and
+ *   2) tell the device which chainId the signed message is bound to.
+ */
+export interface SignMessageContext {
+  chainId: bigint
+  provider: JsonRpcProvider
+}
+
 export interface KeystoreSignerInterface {
   key: Key
   init?: (externalSignerController?: ExternalSignerController) => void
   signRawTransaction: (txnRequest: TxnRequest) => Promise<Transaction['serialized']>
-  signTypedData: (typedMessage: TypedMessageUserRequest['meta']['params']) => Promise<string>
-  signMessage: (hex: string) => Promise<string>
+  signTypedData: (
+    typedMessage: TypedMessageUserRequest['meta']['params'],
+    ctx?: SignMessageContext
+  ) => Promise<string>
+  signMessage: (hex: string, ctx?: SignMessageContext) => Promise<string>
   sign7702: ({
     chainId,
     contract,
@@ -110,14 +131,20 @@ export interface KeystoreSignerInterface {
    * raw EOA transaction. Instead they take the AccountOp's calls list,
    * package them into the signer's native transaction shape (e.g. an
    * ERC-4337 UserOperation), sign on-device, and broadcast — returning the
-   * resulting on-chain transaction hash. Implementations bypass Ambire's
-   * relayer/bundler stack entirely.
+   * resulting userOpHash + the nonce the op was submitted with, so the
+   * caller can track inclusion and per-op success the same way as any
+   * other bundler broadcast (`identifiedBy: { type: 'UserOperation' }`).
+   * Implementations bypass Ambire's relayer/bundler stack entirely, but
+   * MUST bind the broadcast fees to the user-approved `gasFeePayment` —
+   * the user pays what the fee UI showed, not what the signer's own
+   * pipeline would pick.
    */
   broadcastAccountOp?: (params: {
     chainId: bigint
     provider: JsonRpcProvider
     calls: { to: Call['to']; value: Call['value']; data: Call['data'] }[]
-  }) => Promise<{ txnId: Hex }>
+    gasFeePayment: { gasPrice: bigint; maxPriorityFeePerGas?: bigint }
+  }) => Promise<{ userOpHash: Hex; nonce: bigint }>
 }
 
 export type ScryptParams = {

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -1,4 +1,4 @@
-import { Transaction, TypedDataField } from 'ethers'
+import { JsonRpcProvider, Transaction, TypedDataField } from 'ethers'
 
 import { EIP7702Auth } from '../consts/7702'
 import { HD_PATH_TEMPLATE_TYPE } from '../consts/derivation'
@@ -105,6 +105,19 @@ export interface KeystoreSignerInterface {
   getEncryptionPublicKey?: () => Promise<string> // base64 string
   decrypt?: (encryptedData: string) => string // plain text
   signingCleanup?: () => Promise<void>
+  /**
+   * Smart-contract-account-only signers (currently PQ1) cannot produce a
+   * raw EOA transaction. Instead they take the AccountOp's calls list,
+   * package them into the signer's native transaction shape (e.g. an
+   * ERC-4337 UserOperation), sign on-device, and broadcast — returning the
+   * resulting on-chain transaction hash. Implementations bypass Ambire's
+   * relayer/bundler stack entirely.
+   */
+  broadcastAccountOp?: (params: {
+    chainId: bigint
+    provider: JsonRpcProvider
+    calls: { to: Call['to']; value: Call['value']; data: Call['data'] }[]
+  }) => Promise<{ txnId: Hex }>
 }
 
 export type ScryptParams = {

--- a/src/interfaces/keystore.ts
+++ b/src/interfaces/keystore.ts
@@ -169,7 +169,7 @@ export type NfcWalletType = 'keycard' // We can add more supported NFC (tap-to-s
 
 export type ExternalKey = {
   addr: Account['addr']
-  type: 'trezor' | 'ledger' | 'lattice' | 'qr' | 'nfc'
+  type: 'trezor' | 'ledger' | 'lattice' | 'qr' | 'nfc' | 'pq1'
   label: string
   dedicatedToOneSA: boolean
   meta: {

--- a/src/libs/7702/7702.ts
+++ b/src/libs/7702/7702.ts
@@ -4,7 +4,7 @@ import { Network } from '../../interfaces/network'
 
 export function getContractImplementation(
   chainId: bigint,
-  accountKeys: { type: 'internal' | 'lattice' | 'trezor' | 'ledger' | 'qr' | 'nfc' }[]
+  accountKeys: { type: 'internal' | 'lattice' | 'trezor' | 'ledger' | 'qr' | 'nfc' | 'pq1' }[]
 ): Hex {
   if (accountKeys.find((key) => key.type === 'lattice')) {
     return EIP_7702_GRID_PLUS

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -8,6 +8,7 @@ import {
   hexlify,
   Interface,
   isHexString,
+  JsonRpcProvider,
   keccak256,
   toBeHex,
   toNumber,
@@ -364,13 +365,16 @@ export async function getExecuteSignature(
   network: Network,
   accountOp: AccountOp,
   accountState: AccountOnchainState,
-  signer: KeystoreSignerInterface
+  signer: KeystoreSignerInterface,
+  provider?: JsonRpcProvider
 ) {
+  const ctx = provider ? { chainId: network.chainId, provider } : undefined
+
   // if we're authorizing calls for a v1 contract, we do a sign message
   // on the hash of the calls
   if (!accountState.isV2) {
     const message = hexlify(accountOpSignableHash(accountOp, network.chainId))
-    return wrapStandard(await signer.signMessage(message))
+    return wrapStandard(await signer.signMessage(message, ctx))
   }
 
   // txns for v2 contracts are always eip-712 so we put the hash of the calls
@@ -380,7 +384,7 @@ export async function getExecuteSignature(
     accountState.accountAddr,
     hexlify(accountOpSignableHash(accountOp, network.chainId))
   )
-  return wrapStandard(await signer.signTypedData(typedData))
+  return wrapStandard(await signer.signTypedData(typedData, ctx))
 }
 
 export async function getPlainTextSignature(
@@ -390,9 +394,11 @@ export async function getPlainTextSignature(
   accountState: AccountOnchainState,
   signer: KeystoreSignerInterface,
   isOG = false,
-  withHardwareWalletSigningRequest?: WithHardwareWalletSigningRequest
+  withHardwareWalletSigningRequest?: WithHardwareWalletSigningRequest,
+  provider?: JsonRpcProvider
 ): Promise<{ signature: Hex; hash?: Hex }> {
   const dedicatedToOneSA = signer.key.dedicatedToOneSA
+  const ctx = provider ? { chainId: network.chainId, provider } : undefined
 
   if (!!account.safeCreation) {
     // Safe always signs a typed data, even if plain sig
@@ -400,7 +406,7 @@ export async function getPlainTextSignature(
     return {
       signature: (await signWithHardwareWalletSigningRequest(
         { type: 'eip-712', data: typedData },
-        () => signer.signTypedData(typedData),
+        () => signer.signTypedData(typedData, ctx),
         withHardwareWalletSigningRequest
       )) as Hex,
       hash: getEIP712Hash(typedData)
@@ -411,7 +417,7 @@ export async function getPlainTextSignature(
     return {
       signature: (await signWithHardwareWalletSigningRequest(
         { type: 'message', data: { message: messageHex } },
-        () => signer.signMessage(messageHex),
+        () => signer.signMessage(messageHex, ctx),
         withHardwareWalletSigningRequest
       )) as Hex
     }
@@ -443,7 +449,7 @@ export async function getPlainTextSignature(
       signature: wrapUnprotected(
         await signWithHardwareWalletSigningRequest(
           { type: 'message', data: { message: messageHex } },
-          () => signer.signMessage(messageHex),
+          () => signer.signMessage(messageHex, ctx),
           withHardwareWalletSigningRequest
         )
       ) as Hex
@@ -456,7 +462,7 @@ export async function getPlainTextSignature(
       signature: wrapUnprotected(
         await signWithHardwareWalletSigningRequest(
           { type: 'message', data: { message: messageHex } },
-          () => signer.signMessage(messageHex),
+          () => signer.signMessage(messageHex, ctx),
           withHardwareWalletSigningRequest
         )
       ) as Hex
@@ -474,7 +480,7 @@ export async function getPlainTextSignature(
     signature: wrapStandard(
       await signWithHardwareWalletSigningRequest(
         { type: 'eip-712', data: typedData },
-        () => signer.signTypedData(typedData),
+        () => signer.signTypedData(typedData, ctx),
         withHardwareWalletSigningRequest
       )
     ) as Hex
@@ -489,8 +495,10 @@ export async function getEIP712Signature(
   network: Network,
   isOG = false,
   withHardwareWalletSigningRequest?: WithHardwareWalletSigningRequest,
-  allowAmbireOperation = false
+  allowAmbireOperation = false,
+  provider?: JsonRpcProvider
 ): Promise<{ signature: Hex; hash?: Hex }> {
+  const ctx = provider ? { chainId: network.chainId, provider } : undefined
   if (!message.types.EIP712Domain) {
     throw new Error(
       'Ambire only supports signing EIP712 typed data messages. Please try again with a valid EIP712 message.'
@@ -508,7 +516,7 @@ export async function getEIP712Signature(
     return {
       signature: (await signWithHardwareWalletSigningRequest(
         { type: 'eip-712', data: typedData },
-        () => signer.signTypedData(typedData),
+        () => signer.signTypedData(typedData, ctx),
         withHardwareWalletSigningRequest
       )) as Hex,
       hash: getEIP712Hash(typedData)
@@ -519,7 +527,7 @@ export async function getEIP712Signature(
     return {
       signature: (await signWithHardwareWalletSigningRequest(
         { type: 'eip-712', data: message },
-        () => signer.signTypedData(message),
+        () => signer.signTypedData(message, ctx),
         withHardwareWalletSigningRequest
       )) as Hex
     }
@@ -552,7 +560,7 @@ export async function getEIP712Signature(
       signature: wrapUnprotected(
         await signWithHardwareWalletSigningRequest(
           { type: 'eip-712', data: message },
-          () => signer.signTypedData(message),
+          () => signer.signTypedData(message, ctx),
           withHardwareWalletSigningRequest
         )
       ) as Hex
@@ -588,7 +596,7 @@ export async function getEIP712Signature(
     const signature = wrapStandard(
       await signWithHardwareWalletSigningRequest(
         { type: 'eip-712', data: ambireOperation },
-        () => signer.signTypedData(ambireOperation),
+        () => signer.signTypedData(ambireOperation, ctx),
         withHardwareWalletSigningRequest
       )
     )
@@ -599,7 +607,7 @@ export async function getEIP712Signature(
     signature: wrapUnprotected(
       await signWithHardwareWalletSigningRequest(
         { type: 'eip-712', data: message },
-        () => signer.signTypedData(message),
+        () => signer.signTypedData(message, ctx),
         withHardwareWalletSigningRequest
       )
     ) as Hex


### PR DESCRIPTION
Base: `v2` · Head: `markusbug:pq1-hardware-wallet` · 3 commits, 7 files, +181/−32

PQ1 is a post-quantum hardware wallet (SPHINCS+ signatures over WebHID) whose accounts are ERC-4337 smart-contract wallets rather than EOAs. This PR adds the minimal ambire-common surface the extension integration needs. Every change is additive and optional; existing signers are untouched.

1. **`'pq1'` key type** — `ExternalKey['type']`, `HARDWARE_WALLET_DEVICE_NAMES`, account-picker plumbing, 7702 helper type.
2. **`KeystoreSignerInterface.broadcastAccountOp?`** — optional hook for signers that cannot produce a raw EOA transaction. `SignAccountOpController` short-circuits to it for `signingKeyType === 'pq1'`, inside `#withHardwareWalletSigningRequest`, and records the result as a `UserOperation` broadcast so the ActivityController tracks it like any bundler op. The user-approved fee is passed through verbatim; fee options 4337 cannot honour (gas tank, other payer, non-native token) are refused up front.
3. **`SignMessageContext`** — optional `{ chainId, provider }` second argument on `signMessage` / `signTypedData`, threaded through the signMessage helpers. ERC-1271/6492-verified signers need to know the verifying chain; ECDSA signers ignore it (existing 1-arg implementations compile unchanged).

Type-check: identical error set to bare `v2`. Lint: no new findings.

The extension side is a separate PR (`AmbireTech/extension`) whose submodule pointer targets this branch, so this one needs to land first.