### PR TITLE
Refactor/ Stabilize add network

### DIFF
--- a/src/controllers/networks/networks.test.ts
+++ b/src/controllers/networks/networks.test.ts
@@ -3,11 +3,81 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 import { relayerUrl } from '../../../test/config'
 import { produceMemoryStore } from '../../../test/helpers'
 import { makeMainController } from '../../../test/helpers/mainController'
+import { SINGLETON } from '../../consts/deploy'
 import { networks as predefinedNetworks } from '../../consts/networks'
-import { INetworksController, Network } from '../../interfaces/network'
+import { Fetch } from '../../interfaces/fetch'
+import {
+  AddNetworkRequestParams,
+  INetworksController,
+  Network,
+  NetworkFeature
+} from '../../interfaces/network'
+import { RPCProvider } from '../../interfaces/provider'
+import {
+  getFeaturesByNetworkProperties,
+  getLoadingNetworkInfo,
+  isNetworkInfoPending
+} from '../../libs/networks/networks'
 import wait from '../../utils/wait'
 import { StorageController } from '../storage/storage'
 import { NetworksController } from './networks'
+
+const noRelayerChange = (current: { [key: string]: Network }) => ({
+  mergedNetworks: current,
+  updatedNetworkChainIds: [] as bigint[]
+})
+
+/**
+ * Builds a NetworksController with the relayer merge spied out, so tests never hit the
+ * network. Returns the controller together with the injected doubles.
+ *
+ * The relayer-merge implementation is applied synchronously right after `new`, so the
+ * background `synchronizeNetworks` kicked off from `#load` already uses it (its first
+ * await yields before reaching `synchronizeNetworks`). This avoids a race where the
+ * construction-time refresh would run with a stale mock.
+ */
+const buildNetworksController = ({
+  defaultNetworksMode = 'mainnet',
+  mergeImpl = async (current) => noRelayerChange(current),
+  // No-op by default: it never calls back, so no RPC/network-info work runs on load.
+  useTempProvider = async () => {},
+  // Never invoked by default: `mergeRelayerNetworks` (the only relayer caller) is spied.
+  fetch = jest.fn() as unknown as Fetch
+}: {
+  defaultNetworksMode?: 'mainnet' | 'testnet'
+  mergeImpl?: NetworksController['mergeRelayerNetworks']
+  useTempProvider?: (
+    props: { rpcUrl: string; chainId: bigint },
+    callback: (provider: RPCProvider) => Promise<void>
+  ) => Promise<void>
+  fetch?: Fetch
+} = {}) => {
+  const onAddOrUpdateNetworks = jest.fn<(networks: Network[]) => Promise<void>>(async () => {})
+  const controller = new NetworksController({
+    defaultNetworksMode,
+    storage: new StorageController(produceMemoryStore()),
+    fetch,
+    relayerUrl,
+    useTempProvider,
+    onAddOrUpdateNetworks,
+    onReady: async () => {}
+  })
+  const mergeRelayerNetworks = jest
+    .spyOn(controller, 'mergeRelayerNetworks')
+    .mockImplementation(mergeImpl)
+
+  return { controller, mergeRelayerNetworks, onAddOrUpdateNetworks }
+}
+
+/**
+ * Polls until the (not-awaited) background sync kicked off from `#load` settles, so each
+ * test starts from a clean `areNetworksFetchingFromRelayer === false`.
+ */
+const settleBackgroundSync = async (controller: NetworksController) => {
+  for (let i = 0; i < 100 && controller.areNetworksFetchingFromRelayer; i++) {
+    await wait(0)
+  }
+}
 
 describe('Networks Controller', () => {
   let networksController: INetworksController
@@ -186,41 +256,15 @@ describe('Networks Controller - background relayer refresh', () => {
   // Stands in for MainController's real callback (setProvider + reloadSelectedAccount).
   let onAddOrUpdateNetworks: jest.Mock<(networks: Network[]) => Promise<void>>
 
-  const noChange = (current: { [key: string]: Network }) => ({
-    mergedNetworks: current,
-    updatedNetworkChainIds: [] as bigint[]
-  })
-
-  // Polls until the (not-awaited) background sync kicked off from `#load` settles,
-  // so each test starts from a clean `areNetworksFetchingFromRelayer === false`.
-  const settleBackgroundSync = async () => {
-    for (let i = 0; i < 100 && controller.areNetworksFetchingFromRelayer; i++) {
-      await wait(0)
-    }
-  }
-
-  // The relayer-merge implementation is applied synchronously right after `new`,
-  // so the background `synchronizeNetworks` kicked off from `#load` already uses
-  // it (its first await yields before reaching `synchronizeNetworks`). This avoids
-  // a race where the construction-time refresh would run with a stale mock.
   const buildController = (
     defaultNetworksMode: 'mainnet' | 'testnet' = 'mainnet',
-    mergeImpl: NetworksController['mergeRelayerNetworks'] = async (current) => noChange(current)
+    mergeImpl: NetworksController['mergeRelayerNetworks'] = async (current) =>
+      noRelayerChange(current)
   ) => {
-    onAddOrUpdateNetworks = jest.fn<(networks: Network[]) => Promise<void>>(async () => {})
-    const ctrl = new NetworksController({
-      defaultNetworksMode,
-      storage: new StorageController(produceMemoryStore()),
-      // Never invoked: `mergeRelayerNetworks` (the only relayer caller) is spied.
-      fetch: jest.fn() as any,
-      relayerUrl,
-      // No-op: it never calls back, so no RPC/network-info work runs on load.
-      useTempProvider: async () => {},
-      onAddOrUpdateNetworks,
-      onReady: async () => {}
-    })
-    mergeRelayerNetworks = jest.spyOn(ctrl, 'mergeRelayerNetworks').mockImplementation(mergeImpl)
-    return ctrl
+    const built = buildNetworksController({ defaultNetworksMode, mergeImpl })
+    mergeRelayerNetworks = built.mergeRelayerNetworks
+    onAddOrUpdateNetworks = built.onAddOrUpdateNetworks
+    return built.controller
   }
 
   beforeEach(() => {
@@ -236,7 +280,7 @@ describe('Networks Controller - background relayer refresh', () => {
       'mainnet',
       (current) =>
         new Promise((resolve) => {
-          releaseMerge = () => resolve(noChange(current))
+          releaseMerge = () => resolve(noRelayerChange(current))
         })
     )
 
@@ -250,13 +294,13 @@ describe('Networks Controller - background relayer refresh', () => {
     expect(controller.areNetworksFetchingFromRelayer).toBe(true)
 
     releaseMerge()
-    await settleBackgroundSync()
+    await settleBackgroundSync(controller)
     expect(controller.areNetworksFetchingFromRelayer).toBe(false)
   })
 
   test('flags areNetworksFetchingFromRelayer while a refresh is in flight and clears it after', async () => {
     await controller.initialLoadPromise
-    await settleBackgroundSync()
+    await settleBackgroundSync(controller)
     expect(controller.areNetworksFetchingFromRelayer).toBe(false)
 
     const syncPromise = controller.synchronizeNetworks()
@@ -269,7 +313,7 @@ describe('Networks Controller - background relayer refresh', () => {
 
   test('keeps the flag true until the portfolio reload finishes when an RPC changed (flash gate)', async () => {
     await controller.initialLoadPromise
-    await settleBackgroundSync()
+    await settleBackgroundSync(controller)
 
     mergeRelayerNetworks.mockImplementation(async (current) => ({
       mergedNetworks: current,
@@ -298,10 +342,10 @@ describe('Networks Controller - background relayer refresh', () => {
 
   test('does not trigger a portfolio reload when nothing changed, but still clears the flag', async () => {
     await controller.initialLoadPromise
-    await settleBackgroundSync()
+    await settleBackgroundSync(controller)
 
     onAddOrUpdateNetworks.mockClear()
-    mergeRelayerNetworks.mockImplementation(async (current) => noChange(current))
+    mergeRelayerNetworks.mockImplementation(async (current) => noRelayerChange(current))
 
     await controller.synchronizeNetworks()
 
@@ -321,5 +365,273 @@ describe('Networks Controller - background relayer refresh', () => {
     await controller.synchronizeNetworks()
     expect(mergeRelayerNetworks).not.toHaveBeenCalled()
     expect(controller.areNetworksFetchingFromRelayer).toBe(false)
+  })
+})
+
+describe('Networks Controller - add or update network info', () => {
+  const RPC_URL_A = 'https://rpc-a.test'
+  const RPC_URL_B = 'https://rpc-b.test'
+  const CHAIN_ID_A = 4242421n
+  const CHAIN_ID_B = 4242422n
+  const NATIVE_ASSET_ID_A = 'native-asset-a'
+  const NATIVE_ASSET_ID_B = 'native-asset-b'
+  const PLATFORM_ID_A = 'platform-a'
+  const PLATFORM_ID_B = 'platform-b'
+  const DEPLOYED_CONTRACT_CODE = '0x1234'
+  const COINGECKO_PLATFORM_PATH_A = `/platform/${Number(CHAIN_ID_A)}`
+
+  const addNetworkParams = (chainId: bigint, rpcUrl: string): AddNetworkRequestParams => ({
+    name: `Test network ${chainId}`,
+    rpcUrls: [rpcUrl],
+    selectedRpcUrl: rpcUrl,
+    chainId,
+    nativeAssetSymbol: 'TST',
+    nativeAssetName: 'Test token',
+    explorerUrl: 'https://explorer.test',
+    iconUrls: []
+  })
+
+  // Answers both the coingecko platform lookup and the bundler health check. The asset ids
+  // differ per chain, which is how a test tells whose network info actually landed.
+  const createFetchStub = () =>
+    jest.fn(async (url: string) => {
+      const isChainA = url.includes(COINGECKO_PLATFORM_PATH_A)
+
+      return {
+        status: 200,
+        json: async () => ({
+          platformId: isChainA ? PLATFORM_ID_A : PLATFORM_ID_B,
+          nativeAssetId: isChainA ? NATIVE_ASSET_ID_A : NATIVE_ASSET_ID_B
+        })
+      }
+    }) as unknown as Fetch
+
+  /**
+   * Hands out one provider per RPC URL whose probes are held back until that URL is
+   * released, so two concurrent runs can be resolved in whatever order a test needs.
+   */
+  const createTempProviderHarness = () => {
+    const gates = new Map<string, { promise: Promise<void>; release: () => void }>()
+    const unreachableRpcUrls = new Set<string>()
+
+    const gateFor = (rpcUrl: string) => {
+      const existingGate = gates.get(rpcUrl)
+      if (existingGate) return existingGate
+
+      let release: () => void = () => {}
+      const promise = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const gate = { promise, release }
+      gates.set(rpcUrl, gate)
+
+      return gate
+    }
+
+    const useTempProvider = async (
+      { rpcUrl }: { rpcUrl: string; chainId: bigint },
+      callback: (provider: RPCProvider) => Promise<void>
+    ) => {
+      const provider = {
+        getCode: async (address: string) => {
+          await gateFor(rpcUrl).promise
+          // On an unreachable RPC only the singleton probe fails, so `retryRequest` raises
+          // 'flagged' while the remaining probes still resolve - the shape a broken RPC
+          // produces, and the one that used to flip the button back to disabled.
+          if (unreachableRpcUrls.has(rpcUrl) && address === SINGLETON)
+            throw new Error(`${rpcUrl} did not respond`)
+
+          return DEPLOYED_CONTRACT_CODE
+        },
+        getBlock: async () => {
+          await gateFor(rpcUrl).promise
+          return { baseFeePerGas: 1n }
+        },
+        send: async () => {
+          await gateFor(rpcUrl).promise
+          return '0x'
+        },
+        call: async () => '0x',
+        destroy: () => {}
+      } as unknown as RPCProvider
+
+      await callback(provider)
+    }
+
+    return {
+      useTempProvider,
+      release: (rpcUrl: string) => gateFor(rpcUrl).release(),
+      markUnreachable: (rpcUrl: string) => unreachableRpcUrls.add(rpcUrl)
+    }
+  }
+
+  const buildForNetworkInfo = async () => {
+    const harness = createTempProviderHarness()
+    const { controller } = buildNetworksController({
+      useTempProvider: harness.useTempProvider,
+      fetch: createFetchStub()
+    })
+
+    await controller.initialLoadPromise
+    await settleBackgroundSync(controller)
+
+    return { controller, harness }
+  }
+
+  test('seeds info with the all-loading shape before its first await', async () => {
+    const { controller, harness } = await buildForNetworkInfo()
+
+    const pendingRun = controller.setNetworkToAddOrUpdate({
+      chainId: CHAIN_ID_A,
+      rpcUrl: RPC_URL_A
+    })
+
+    // Set synchronously, before the first await inside setNetworkToAddOrUpdate. Until it
+    // is set the UI reads the request as "nothing requested yet" and keeps the add/save
+    // button clickable.
+    expect(controller.networkToAddOrUpdate).toEqual({
+      chainId: CHAIN_ID_A,
+      rpcUrl: RPC_URL_A,
+      info: getLoadingNetworkInfo(CHAIN_ID_A)
+    })
+
+    harness.release(RPC_URL_A)
+    await pendingRun
+
+    expect(controller.networkToAddOrUpdate?.info?.nativeAssetId).toBe(NATIVE_ASSET_ID_A)
+  })
+
+  test('discards a stale run instead of letting it overwrite the newest one', async () => {
+    const { controller, harness } = await buildForNetworkInfo()
+    harness.markUnreachable(RPC_URL_A)
+
+    const staleRun = controller.setNetworkToAddOrUpdate({
+      chainId: CHAIN_ID_A,
+      rpcUrl: RPC_URL_A
+    })
+    const latestRun = controller.setNetworkToAddOrUpdate({
+      chainId: CHAIN_ID_B,
+      rpcUrl: RPC_URL_B
+    })
+
+    harness.release(RPC_URL_B)
+    await latestRun
+
+    expect(controller.networkToAddOrUpdate?.rpcUrl).toBe(RPC_URL_B)
+    expect(controller.networkToAddOrUpdate?.info?.nativeAssetId).toBe(NATIVE_ASSET_ID_B)
+    expect(controller.networkToAddOrUpdate?.info?.flagged).toBe(false)
+
+    // The stale run resolves last and is flagged. Neither its flag nor its asset ids may
+    // be attributed to the RPC URL that is actually selected now.
+    harness.release(RPC_URL_A)
+    await staleRun
+
+    expect(controller.networkToAddOrUpdate?.rpcUrl).toBe(RPC_URL_B)
+    expect(controller.networkToAddOrUpdate?.chainId).toBe(CHAIN_ID_B)
+    expect(controller.networkToAddOrUpdate?.info?.platformId).toBe(PLATFORM_ID_B)
+    expect(controller.networkToAddOrUpdate?.info?.nativeAssetId).toBe(NATIVE_ASSET_ID_B)
+    expect(controller.networkToAddOrUpdate?.info?.flagged).toBe(false)
+  })
+
+  test('a reset invalidates a pending run, so its late result cannot resurrect it', async () => {
+    const { controller, harness } = await buildForNetworkInfo()
+
+    const pendingRun = controller.setNetworkToAddOrUpdate({
+      chainId: CHAIN_ID_A,
+      rpcUrl: RPC_URL_A
+    })
+    await controller.setNetworkToAddOrUpdate(null)
+    expect(controller.networkToAddOrUpdate).toBe(null)
+
+    harness.release(RPC_URL_A)
+    await pendingRun
+
+    expect(controller.networkToAddOrUpdate).toBe(null)
+  })
+
+  test('streams a single request without ever reporting it as finished early', async () => {
+    const { controller, harness } = await buildForNetworkInfo()
+
+    const emissions: { levels: NetworkFeature['level'][]; isPending: boolean }[] = []
+    const unsubscribe = controller.onUpdate(() => {
+      const info = controller.networkToAddOrUpdate?.info
+      emissions.push({
+        levels: getFeaturesByNetworkProperties(info, undefined).map((feature) => feature.level),
+        isPending: isNetworkInfoPending(info)
+      })
+    })
+
+    const pendingRun = controller.setNetworkToAddOrUpdate({
+      chainId: CHAIN_ID_A,
+      rpcUrl: RPC_URL_A
+    })
+    harness.release(RPC_URL_A)
+    await pendingRun
+    unsubscribe()
+
+    // `initial` means "nothing requested yet" and leaves the add/save button clickable, so
+    // it must never appear while a request is in flight.
+    expect(emissions.filter(({ levels }) => levels.includes('initial'))).toEqual([])
+
+    // The rows fill in progressively, so the feature levels do change more than once.
+    expect(emissions.length).toBeGreaterThan(2)
+    expect(emissions[0]!.levels).toEqual(['loading', 'loading', 'loading'])
+
+    // The gate the button reads is the part that must not oscillate: pending until the
+    // final emission, then finished, and never back.
+    expect(emissions.map(({ isPending }) => isPending)).toEqual([
+      ...emissions.slice(0, -1).map(() => true),
+      false
+    ])
+    expect(emissions[emissions.length - 1]!.levels).not.toContain('loading')
+  })
+
+  describe('addNetwork before the network info resolved', () => {
+    // `statuses.addNetwork` is reset to INITIAL by `withStatus` once it returns, so the
+    // transitions have to be recorded as they are emitted.
+    const recordAddNetworkStatuses = (controller: NetworksController) => {
+      const statuses: string[] = []
+      const unsubscribe = controller.onUpdate(() => {
+        const current = controller.statuses.addNetwork
+        if (statuses[statuses.length - 1] !== current) statuses.push(current)
+      })
+
+      return { statuses, unsubscribe }
+    }
+
+    test('ends in ERROR and adds nothing when there is no network info at all', async () => {
+      const { controller } = await buildForNetworkInfo()
+      const { statuses, unsubscribe } = recordAddNetworkStatuses(controller)
+
+      await controller.addNetwork(addNetworkParams(CHAIN_ID_A, RPC_URL_A))
+      unsubscribe()
+
+      expect(statuses).toContain('ERROR')
+      expect(statuses).not.toContain('SUCCESS')
+      expect(controller.allNetworks.some((n) => n.chainId === CHAIN_ID_A)).toBe(false)
+    })
+
+    test('ends in ERROR and adds nothing while the network info is still loading', async () => {
+      const { controller, harness } = await buildForNetworkInfo()
+
+      const pendingRun = controller.setNetworkToAddOrUpdate({
+        chainId: CHAIN_ID_A,
+        rpcUrl: RPC_URL_A
+      })
+      expect(
+        Object.values(controller.networkToAddOrUpdate!.info!).some((prop) => prop === 'LOADING')
+      ).toBe(true)
+
+      const { statuses, unsubscribe } = recordAddNetworkStatuses(controller)
+      await controller.addNetwork(addNetworkParams(CHAIN_ID_A, RPC_URL_A))
+      unsubscribe()
+
+      expect(statuses).toContain('ERROR')
+      expect(statuses).not.toContain('SUCCESS')
+      expect(controller.allNetworks.some((n) => n.chainId === CHAIN_ID_A)).toBe(false)
+
+      harness.release(RPC_URL_A)
+      await pendingRun
+    })
   })
 })

--- a/src/controllers/networks/networks.ts
+++ b/src/controllers/networks/networks.ts
@@ -21,9 +21,11 @@ import { RPCProvider } from '../../interfaces/provider'
 import { IStorageController } from '../../interfaces/storage'
 import {
   getFeaturesByNetworkProperties,
+  getLoadingNetworkInfo,
   getNetworkInfo,
   getNetworksUpdatedWithRelayerNetworks,
-  getValidNetworks
+  getValidNetworks,
+  isNetworkInfoPending
 } from '../../libs/networks/networks'
 import { relayerCall } from '../../libs/relayerCall/relayerCall'
 import EventEmitter from '../eventEmitter/eventEmitter'
@@ -59,6 +61,9 @@ export class NetworksController extends EventEmitter implements INetworksControl
     rpcUrl: string
     info?: NetworkInfoLoading<NetworkInfo>
   } | null = null
+
+  // Prevents race conditions in setNetworkToAddOrUpdate
+  #networkToAddOrUpdateRequestId = 0
 
   areNetworksFetchingFromRelayer: boolean = false
 
@@ -360,9 +365,7 @@ export class NetworksController extends EventEmitter implements INetworksControl
             network.chainId,
             provider,
             async (info) => {
-              if (Object.values(info).some((prop) => prop === 'LOADING')) {
-                return
-              }
+              if (isNetworkInfoPending(info)) return
 
               // If RPC is flagged there might be an issue with the RPC
               // this information will fail to return
@@ -394,42 +397,54 @@ export class NetworksController extends EventEmitter implements INetworksControl
       rpcUrl: string
     } | null = null
   ) {
-    await this.initialLoadPromise
+    this.#networkToAddOrUpdateRequestId += 1
+    const requestId = this.#networkToAddOrUpdateRequestId
 
-    if (networkToAddOrUpdate) {
-      this.networkToAddOrUpdate = networkToAddOrUpdate
-      this.emitUpdate()
-
-      await this.#useTempProvider(
-        { chainId: networkToAddOrUpdate.chainId, rpcUrl: networkToAddOrUpdate.rpcUrl },
-        async (provider) => {
-          await getNetworkInfo(
-            this.#fetch,
-            networkToAddOrUpdate.chainId,
-            provider,
-            (info) => {
-              if (this.networkToAddOrUpdate) {
-                this.networkToAddOrUpdate = { ...this.networkToAddOrUpdate, info }
-                this.emitUpdate()
-              }
-            },
-            this.#networks[networkToAddOrUpdate.chainId.toString()]
-          )
-        }
-      )
-    } else {
+    if (!networkToAddOrUpdate) {
       this.networkToAddOrUpdate = null
       this.emitUpdate()
+      return
     }
+
+    // Seeded so the very first emission already carries the loading shape, instead of the
+    // UI rendering a frame of "?" rows before the probes report in.
+    this.networkToAddOrUpdate = {
+      ...networkToAddOrUpdate,
+      info: getLoadingNetworkInfo(networkToAddOrUpdate.chainId)
+    }
+    this.emitUpdate()
+
+    await this.initialLoadPromise
+
+    await this.#useTempProvider(
+      { chainId: networkToAddOrUpdate.chainId, rpcUrl: networkToAddOrUpdate.rpcUrl },
+      async (provider) => {
+        await getNetworkInfo(
+          this.#fetch,
+          networkToAddOrUpdate.chainId,
+          provider,
+          (info) => {
+            if (requestId !== this.#networkToAddOrUpdateRequestId) return
+            if (!this.networkToAddOrUpdate) return
+
+            this.networkToAddOrUpdate = { ...this.networkToAddOrUpdate, info }
+            this.emitUpdate()
+          },
+          this.#networks[networkToAddOrUpdate.chainId.toString()]
+        )
+      }
+    )
   }
 
   async #addNetwork(network: AddNetworkRequestParams) {
     await this.initialLoadPromise
-    if (
-      !this.networkToAddOrUpdate?.info ||
-      Object.values(this.networkToAddOrUpdate.info).some((prop) => prop === 'LOADING')
-    ) {
-      return
+    // The redundant-looking `info` check is what narrows `networkToAddOrUpdate` below
+    if (!this.networkToAddOrUpdate?.info || isNetworkInfoPending(this.networkToAddOrUpdate.info)) {
+      throw new EmittableError({
+        message: "We're still checking this network. Please wait a moment and try again.",
+        level: 'expected',
+        error: new Error('settings: addNetwork called before the network info was resolved')
+      })
     }
 
     const chainIds = this.allNetworks.map((net) => net.chainId)
@@ -536,9 +551,7 @@ export class NetworksController extends EventEmitter implements INetworksControl
               chainId,
               provider,
               async (info) => {
-                if (Object.values(info).some((prop) => prop === 'LOADING')) {
-                  return
-                }
+                if (isNetworkInfoPending(info)) return
 
                 const { feeOptions } = info as NetworkInfo
 

--- a/src/libs/networks/networks.test.ts
+++ b/src/libs/networks/networks.test.ts
@@ -1,13 +1,19 @@
-import { describe, expect, jest, test } from '@jest/globals'
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
 
+import { AMBIRE_ACCOUNT_FACTORY, SINGLETON } from '../../consts/deploy'
 import { networks as predefinedNetworks } from '../../consts/networks'
-import { Network, NetworkInfo, RelayerNetwork } from '../../interfaces/network'
+import { Fetch } from '../../interfaces/fetch'
+import { Network, NetworkInfo, NetworkInfoLoading, RelayerNetwork } from '../../interfaces/network'
 import { RPCProvider } from '../../interfaces/provider'
 import { getRpcProvider } from '../../services/provider'
+import wait from '../../utils/wait'
 import {
   getFeaturesByNetworkProperties,
+  getLoadingNetworkInfo,
+  getNetworkInfo,
   getNetworksUpdatedWithRelayerNetworks,
-  getStateOverrideSupport
+  getStateOverrideSupport,
+  isNetworkInfoPending
 } from './networks'
 
 const getByKey = <T>(record: Record<string, T>, key: string): T => {
@@ -306,6 +312,208 @@ describe('Networks lib', () => {
 
         expect(getByKey(result, '1').refreshInterval).toBeUndefined()
       })
+    })
+  })
+})
+
+describe('getNetworkInfo emissions', () => {
+  const TEST_CHAIN_ID = 424242n
+  // Mirrors the timeout `getNetworkInfo` races its probes against
+  const NETWORK_INFO_TIMEOUT_MS = 30000
+  const DEPLOYED_CONTRACT_CODE = '0x1234'
+  const COINGECKO_PLATFORM_ID = 'test-platform'
+  const COINGECKO_NATIVE_ASSET_ID = 'test-native-asset'
+  // How many microtask turns to give the ungated probes before asserting that they
+  // produced no emission of their own.
+  const MICROTASK_TURNS_TO_SETTLE = 25
+
+  const createGate = () => {
+    let release: () => void = () => {}
+    const promise = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    return { promise, release }
+  }
+
+  const okFetch = jest.fn(async () => ({
+    status: 200,
+    json: async () => ({
+      platformId: COINGECKO_PLATFORM_ID,
+      nativeAssetId: COINGECKO_NATIVE_ASSET_ID
+    })
+  })) as unknown as Fetch
+
+  /**
+   * A provider whose smart-account probes can be held back, so the four concurrent
+   * probes inside `getNetworkInfo` resolve in a deliberately awkward order.
+   */
+  const createProviderStub = ({
+    gateSmartAccountProbes = false,
+    failSingletonCode = false
+  }: { gateSmartAccountProbes?: boolean; failSingletonCode?: boolean } = {}) => {
+    const smartAccountGate = createGate()
+    const calls: string[] = []
+
+    const provider = {
+      getCode: async (address: string) => {
+        calls.push(`getCode:${address}`)
+        const isSmartAccountProbe = address === SINGLETON || address === AMBIRE_ACCOUNT_FACTORY
+
+        if (isSmartAccountProbe && gateSmartAccountProbes) await smartAccountGate.promise
+        if (failSingletonCode && address === SINGLETON)
+          throw new Error(`the RPC did not respond for ${address}`)
+
+        return DEPLOYED_CONTRACT_CODE
+      },
+      getBlock: async () => {
+        calls.push('getBlock')
+        return { baseFeePerGas: 1n }
+      },
+      send: async () => {
+        calls.push('send')
+        return '0x'
+      },
+      call: async () => {
+        calls.push('call')
+        return '0x'
+      }
+    } as unknown as RPCProvider
+
+    return { provider, calls, releaseSmartAccountProbes: smartAccountGate.release }
+  }
+
+  const getLoadingFieldNames = (info: NetworkInfoLoading<NetworkInfo>) =>
+    Object.entries(info)
+      .filter(([, value]) => value === 'LOADING')
+      .map(([field]) => field)
+
+  test('streams the prices fields before the gated smart-account ones', async () => {
+    const { provider, releaseSmartAccountProbes } = createProviderStub({
+      gateSmartAccountProbes: true
+    })
+    const emissions: NetworkInfoLoading<NetworkInfo>[] = []
+
+    const infoPromise = getNetworkInfo(
+      okFetch,
+      TEST_CHAIN_ID,
+      provider,
+      (info) => emissions.push(info),
+      undefined
+    )
+
+    // The coingecko probe settles here, while the smart-account ones are still held back.
+    for (let turn = 0; turn < MICROTASK_TURNS_TO_SETTLE; turn++) await wait(0)
+
+    expect(emissions).toHaveLength(2)
+    expect(emissions[0]).toEqual(getLoadingNetworkInfo(TEST_CHAIN_ID))
+    // The prices row can already render while the smart-account ones still spin.
+    expect(emissions[1]!.platformId).toBe(COINGECKO_PLATFORM_ID)
+    expect(emissions[1]!.nativeAssetId).toBe(COINGECKO_NATIVE_ASSET_ID)
+    expect(getLoadingFieldNames(emissions[1]!)).toContain('isSAEnabled')
+    expect(
+      getFeaturesByNetworkProperties(emissions[1]!, undefined).map((feature) => feature.level)
+    ).toEqual(['loading', 'loading', 'success'])
+
+    releaseSmartAccountProbes()
+    await infoPromise
+
+    expect(getLoadingFieldNames(emissions[emissions.length - 1]!)).toEqual([])
+  })
+
+  test('resolves each field once and only reports complete on the last emission', async () => {
+    const { provider } = createProviderStub()
+    const emissions: NetworkInfoLoading<NetworkInfo>[] = []
+
+    await getNetworkInfo(
+      okFetch,
+      TEST_CHAIN_ID,
+      provider,
+      (info) => emissions.push(info),
+      undefined
+    )
+
+    expect(emissions.length).toBeGreaterThan(2)
+
+    // A field only ever goes from 'LOADING' to a value, so the pending set shrinks
+    // monotonically and no row that already rendered falls back to a spinner.
+    const pendingFieldsPerEmission = emissions.map(getLoadingFieldNames)
+    pendingFieldsPerEmission.forEach((pendingFields, index) => {
+      if (index === 0) return
+      expect(pendingFieldsPerEmission[index - 1]).toEqual(expect.arrayContaining(pendingFields))
+    })
+    expect(pendingFieldsPerEmission[pendingFieldsPerEmission.length - 1]).toEqual([])
+
+    // Every emission but the last still counts as pending, so a button gated on
+    // `isNetworkInfoPending` can never become clickable mid-stream.
+    expect(emissions.map(isNetworkInfoPending)).toEqual([
+      ...emissions.slice(0, -1).map(() => true),
+      false
+    ])
+  })
+
+  test('keeps flagged pending until the last emission, after the features already read as resolved', async () => {
+    const { provider } = createProviderStub({ failSingletonCode: true })
+    const emissions: NetworkInfoLoading<NetworkInfo>[] = []
+
+    await getNetworkInfo(
+      okFetch,
+      TEST_CHAIN_ID,
+      provider,
+      (info) => emissions.push(info),
+      undefined
+    )
+
+    const finalInfo = emissions[emissions.length - 1]!
+    expect(finalInfo.flagged).toBe(true)
+    expect(getLoadingFieldNames(finalInfo)).toEqual([])
+
+    // The regression test for the enabled -> disabled flip. There IS an emission whose
+    // features all read as resolved while `flagged` is still pending, so a gate only gets
+    // the answer right if it asks `isNetworkInfoPending` instead of the feature levels.
+    const misleadingEmissions = emissions
+      .slice(0, -1)
+      .filter(
+        (info) =>
+          !getFeaturesByNetworkProperties(info, undefined).some(
+            (feature) => feature.level === 'loading'
+          )
+      )
+    expect(misleadingEmissions.length).toBeGreaterThan(0)
+    expect(emissions.slice(0, -1).map(isNetworkInfoPending)).not.toContain(false)
+
+    // Once the verdict is in, the list collapses to the single RPC error row.
+    expect(
+      getFeaturesByNetworkProperties(finalInfo, undefined).map((feature) => feature.level)
+    ).toEqual(['danger'])
+  })
+
+  describe('timer cleanup', () => {
+    let setTimeoutSpy: jest.SpiedFunction<typeof setTimeout>
+    let clearTimeoutSpy: jest.SpiedFunction<typeof clearTimeout>
+
+    beforeEach(() => {
+      setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+      clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+    })
+
+    afterEach(() => {
+      setTimeoutSpy.mockRestore()
+      clearTimeoutSpy.mockRestore()
+    })
+
+    test('clears its own timeout once the probes win the race', async () => {
+      const { provider } = createProviderStub()
+
+      await getNetworkInfo(okFetch, TEST_CHAIN_ID, provider, () => {}, undefined)
+
+      const timeoutCallIndex = setTimeoutSpy.mock.calls.findIndex(
+        (call) => call[1] === NETWORK_INFO_TIMEOUT_MS
+      )
+      expect(timeoutCallIndex).toBeGreaterThanOrEqual(0)
+
+      const timerId = setTimeoutSpy.mock.results[timeoutCallIndex]!.value
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId)
     })
   })
 })

--- a/src/libs/networks/networks.ts
+++ b/src/libs/networks/networks.ts
@@ -122,22 +122,11 @@ export async function getStateOverrideSupport(provider: RPCProvider): Promise<bo
 }
 
 /**
- * Fetches detailed network information from an RPC provider.
- * Used when adding a new network, updating network info, or when the RPC provider is changed,
- * And once every 24 hours for custom networks.
- *
- * - Checks smart account (SA) support, singleton contract, and state override capabilities.
- * - Determines if the network supports ERC-4337 and Account Abstraction.
- * - Fetches additional metadata from external sources (e.g., CoinGecko).
+ * The network info shape before any RPC probe has resolved. Every field is
+ * 'LOADING' except the chain id.
  */
-export async function getNetworkInfo(
-  fetch: Fetch,
-  chainId: bigint,
-  provider: RPCProvider,
-  callback: (networkInfo: NetworkInfoLoading<NetworkInfo>) => void,
-  network: Network | undefined
-) {
-  let networkInfo: NetworkInfoLoading<NetworkInfo> = {
+export function getLoadingNetworkInfo(chainId: bigint): NetworkInfoLoading<NetworkInfo> {
+  return {
     chainId,
     isSAEnabled: 'LOADING',
     hasSingleton: 'LOADING',
@@ -150,11 +139,35 @@ export async function getNetworkInfo(
     nativeAssetId: 'LOADING',
     flagged: 'LOADING'
   }
+}
+
+/**
+ * True while any of the probes behind the network info is still running.
+ */
+export function isNetworkInfoPending(info?: NetworkInfoLoading<NetworkInfo>): boolean {
+  return !info || Object.values(info).some((prop) => prop === 'LOADING')
+}
+
+/**
+ * Fetches a network's capabilities from an RPC provider - smart account support, ERC-4337,
+ * fee options and price metadata.
+ *
+ * Streams progress through `callback`.
+ */
+export async function getNetworkInfo(
+  fetch: Fetch,
+  chainId: bigint,
+  provider: RPCProvider,
+  callback: (networkInfo: NetworkInfoLoading<NetworkInfo>) => void,
+  network: Network | undefined
+) {
+  let networkInfo: NetworkInfoLoading<NetworkInfo> = getLoadingNetworkInfo(chainId)
   callback(networkInfo)
 
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeout = (time: number = 30000): Promise<'timeout reached'> => {
     return new Promise((resolve) => {
-      setTimeout(resolve, time, 'timeout reached')
+      timeoutId = setTimeout(resolve, time, 'timeout reached')
     }) as unknown as Promise<'timeout reached'>
   }
 
@@ -168,96 +181,97 @@ export async function getNetworkInfo(
     return returnData
   }
 
-  const info = await Promise.race([
-    Promise.all([
-      (async () => {
-        const responses = await Promise.all([
-          retryRequest(() => provider.getCode(SINGLETON)),
-          retryRequest(() => provider.getCode(AMBIRE_ACCOUNT_FACTORY)),
-          retryRequest(() => getSASupport(provider)),
-          retryRequest(() => getStateOverrideSupport(provider)),
-          Bundler.isNetworkSupported(fetch, chainId).catch(() => false)
-          // retryRequest(() => provider.getCode(ERC_4337_ENTRYPOINT)),
-        ]).catch((e: Error) =>
-          raiseFlagged(e, ['0x', '0x', { addressMatches: false }, false, false])
-        )
-        const [singletonCode, factoryCode, saSupport, supportsStateOverride, hasBundlerSupport] =
-          responses
-        const areContractsDeployed = factoryCode !== '0x'
-        // const has4337 = entryPointCode !== '0x' && hasBundler
-
-        // Ambire support is as follows:
-        // - either the addresses match after simulation, that's perfect
-        // - or we can't do the simulation with this RPC but we have the factory
-        // deployed on the network
-        const supportsAmbire =
-          saSupport.addressMatches || (!supportsStateOverride && areContractsDeployed)
-        networkInfo = {
-          ...networkInfo,
-          hasSingleton: singletonCode !== '0x',
-          isSAEnabled: supportsAmbire && singletonCode !== '0x',
-          areContractsDeployed,
-          rpcNoStateOverride: !supportsStateOverride,
-          erc4337: {
-            enabled: is4337Enabled(hasBundlerSupport, network),
-            hasPaymaster: network ? network.erc4337.hasPaymaster : false,
-            hasBundlerSupport
-          }
-        }
-
-        callback(networkInfo)
-      })(),
-      (async () => {
-        const oracleCode = await retryRequest(() => provider.getCode(OPTIMISTIC_ORACLE)).catch(
-          (e: Error) => raiseFlagged(e, '0x')
-        )
-        const isOptimistic = oracleCode !== '0x'
-
-        networkInfo = { ...networkInfo, isOptimistic }
-
-        callback(networkInfo)
-      })(),
-      (async () => {
-        const block = await retryRequest(() => provider.getBlock('latest')).catch((e: Error) =>
-          raiseFlagged(e, null)
-        )
-        const feeOptions = { is1559: block?.baseFeePerGas !== null }
-
-        networkInfo = { ...networkInfo, feeOptions }
-
-        callback(networkInfo)
-      })(),
-      (async () => {
-        // Keep the old value if the request fails
-        let platformId = network?.platformId || ''
-        let nativeAssetId = network?.nativeAssetId || ''
-
-        try {
-          const coingeckoRequest = await fetch(
-            `https://cena.ambire.com/api/v3/platform/${Number(chainId)}`
+  let info: unknown
+  try {
+    info = await Promise.race([
+      Promise.all([
+        (async () => {
+          const responses = await Promise.all([
+            retryRequest(() => provider.getCode(SINGLETON)),
+            retryRequest(() => provider.getCode(AMBIRE_ACCOUNT_FACTORY)),
+            retryRequest(() => getSASupport(provider)),
+            retryRequest(() => getStateOverrideSupport(provider)),
+            Bundler.isNetworkSupported(fetch, chainId).catch(() => false)
+            // retryRequest(() => provider.getCode(ERC_4337_ENTRYPOINT)),
+          ]).catch((e: Error) =>
+            raiseFlagged(e, ['0x', '0x', { addressMatches: false }, false, false])
           )
-          const coingeckoInfo = await coingeckoRequest.json()
+          const [singletonCode, factoryCode, saSupport, supportsStateOverride, hasBundlerSupport] =
+            responses
+          const areContractsDeployed = factoryCode !== '0x'
+          // const has4337 = entryPointCode !== '0x' && hasBundler
 
-          if (!coingeckoInfo.error) {
-            // Coingecko info found
-            platformId = coingeckoInfo.platformId
-            nativeAssetId = coingeckoInfo.nativeAssetId
+          // Ambire support is as follows:
+          // - either the addresses match after simulation, that's perfect
+          // - or we can't do the simulation with this RPC but we have the factory
+          // deployed on the network
+          const supportsAmbire =
+            saSupport.addressMatches || (!supportsStateOverride && areContractsDeployed)
+          networkInfo = {
+            ...networkInfo,
+            hasSingleton: singletonCode !== '0x',
+            isSAEnabled: supportsAmbire && singletonCode !== '0x',
+            areContractsDeployed,
+            rpcNoStateOverride: !supportsStateOverride,
+            erc4337: {
+              enabled: is4337Enabled(hasBundlerSupport, network),
+              hasPaymaster: network ? network.erc4337.hasPaymaster : false,
+              hasBundlerSupport
+            }
           }
-        } catch (e) {
-          console.error('Error fetching coingecko info', e)
-        }
 
-        networkInfo = {
-          ...networkInfo,
-          platformId,
-          nativeAssetId
-        }
+          callback(networkInfo)
+        })(),
+        (async () => {
+          const oracleCode = await retryRequest(() => provider.getCode(OPTIMISTIC_ORACLE)).catch(
+            (e: Error) => raiseFlagged(e, '0x')
+          )
+          const isOptimistic = oracleCode !== '0x'
 
-        callback(networkInfo)
-      })()
-    ]),
-    timeout()
-  ])
+          networkInfo = { ...networkInfo, isOptimistic }
+        })(),
+        (async () => {
+          const block = await retryRequest(() => provider.getBlock('latest')).catch((e: Error) =>
+            raiseFlagged(e, null)
+          )
+          const feeOptions = { is1559: block?.baseFeePerGas !== null }
+
+          networkInfo = { ...networkInfo, feeOptions }
+        })(),
+        (async () => {
+          // Keep the old value if the request fails
+          let platformId = network?.platformId || ''
+          let nativeAssetId = network?.nativeAssetId || ''
+
+          try {
+            const coingeckoRequest = await fetch(
+              `https://cena.ambire.com/api/v3/platform/${Number(chainId)}`
+            )
+            const coingeckoInfo = await coingeckoRequest.json()
+
+            if (!coingeckoInfo.error) {
+              // Coingecko info found
+              platformId = coingeckoInfo.platformId
+              nativeAssetId = coingeckoInfo.nativeAssetId
+            }
+          } catch (e) {
+            console.error('Error fetching coingecko info', e)
+          }
+
+          networkInfo = {
+            ...networkInfo,
+            platformId,
+            nativeAssetId
+          }
+
+          callback(networkInfo)
+        })()
+      ]),
+      timeout()
+    ])
+  } finally {
+    clearTimeout(timeoutId)
+  }
 
   networkInfo = { ...networkInfo, flagged: flagged || info === 'timeout reached' }
   callback(networkInfo)
@@ -401,6 +415,14 @@ export function getFeaturesByNetworkProperties(
   }
 
   return features
+}
+
+/** The feature list to render while a network's info is still being fetched. */
+export function getLoadingFeatures(): NetworkFeature[] {
+  return getFeaturesByNetworkProperties(undefined, undefined).map((feature) => ({
+    ...feature,
+    level: 'loading'
+  }))
 }
 
 // call this if you have only the rpcUrls and chainId


### PR DESCRIPTION
- Added: isNetworkInfoPending - the one place that answers whether a network check has finished.
- Fixed: getNetworkInfo no longer emits for probes that don't render anything, and it clears the timer it races against instead of leaving it running for 30s.
- Fixed: concurrent checks are sequenced. Switching RPC URL mid-check used to let a slow, stale result overwrite the newer one - and attribute an "RPC error" to the wrong URL.
- Fixed: adding a network before its info resolved reported success and added nothing.
- Added: tests for the emission contract, request sequencing, and the false-success case.

Closes https://github.com/AmbireTech/ambire-app/issues/7754