### PR TITLE
Humanizer/ fixes with warnings

### DIFF
--- a/src/libs/humanizer/callModules.ts
+++ b/src/libs/humanizer/callModules.ts
@@ -80,9 +80,9 @@ export const singleCallHumanizerModules: HumanizerCallModule[] = [
 // the final humanization is the final triggered module
 export const humanizerCallModules: HumanizerCallModule[] = [
   preProcessHumanizer,
-  embeddedAmbireOperationHumanizer,
   deploymentModule,
   ...singleCallHumanizerModules,
+  embeddedAmbireOperationHumanizer,
   fallbackHumanizer,
   postProcessing
 ]

--- a/src/libs/humanizer/erc7730/humanize.ts
+++ b/src/libs/humanizer/erc7730/humanize.ts
@@ -1,6 +1,7 @@
 import {
   formatUnits,
   FunctionFragment,
+  getAddress,
   Interface,
   isAddress,
   isHexString,
@@ -10,6 +11,7 @@ import {
 } from 'ethers'
 
 import { humanizerCallModules } from '../'
+import { execTransactionAbi } from '../../../consts/safe'
 import humanizerInfo from '../../../consts/humanizer/humanizerInfo.json'
 import { Message } from '../../../interfaces/userRequest'
 import { AccountOp } from '../../accountOp/accountOp'
@@ -83,6 +85,7 @@ type VisibilityResult = {
 
 const MAX_INTERPOLATED_VALUE_LENGTH = 80
 const ABI_WORD_HEX_LENGTH = 64
+const safeExecTransactionInterface = new Interface(execTransactionAbi)
 
 const isMapReference = (value: unknown): value is Erc7730MapReference =>
   isPlainObject(value) && typeof value.map === 'string' && typeof value.keyPath === 'string'
@@ -387,6 +390,21 @@ const getSafeExecTransactionWarnings = (match: DescriptorFormatMatch): Humanizer
   if (operation === null || typeof to !== 'string') return []
 
   return getDelegateCallWarning(operation, to)
+}
+
+// `getCalldataFormatMatch` already ABI-decodes every execTransaction argument regardless of which
+// ones the resolved descriptor's own fields declare, so baseGas/gasPrice/gasToken/refundReceiver
+// are available here the same way they are for a SafeTx message - see buildSafeTxGasRefund.
+const getSafeExecTransactionGasRefund = (match: DescriptorFormatMatch): SafeTxGasRefund | null => {
+  const fragment = getFunctionFragment(match.formatKey)
+  if (fragment?.name !== 'execTransaction') return null
+
+  return buildSafeTxGasRefund(
+    match.values.baseGas,
+    match.values.gasPrice,
+    match.values.gasToken,
+    match.values.refundReceiver
+  )
 }
 
 const getTypedMessageFormatMatch = (
@@ -1546,6 +1564,114 @@ const getSafeCallWarnings = (call: Call, safeAddr = call.to): HumanizerWarning[]
   return getSafeHumanization(safeAddr, call.to, call.value, call.data)?.warnings || []
 }
 
+type SafeTxGasRefund = {
+  // undefined when `refundReceiver` is the zero address - Safe.sol's handlePayment then pays
+  // tx.origin (whoever broadcasts this transaction) instead of a fixed address, it does NOT mean
+  // no refund is paid
+  refundReceiver?: string
+  gasToken: string
+  // `gasUsed * effectiveGasPrice` is always added on top of this at execution time and can't be
+  // known ahead of time, so this is only the extra, fully attacker-controlled additive component
+  // (`baseGas * gasPrice`) - a guaranteed floor when nonzero, but frequently zero on its own
+  // (baseGas defaults to 0), in which case the real payment still happens, its size just isn't
+  // predictable from calldata alone
+  minAmount: bigint
+}
+
+// Safe.sol's execTransaction only pays a gas refund at all when `gasPrice > 0` - see the
+// `if (gasPrice > 0) { payment = handlePayment(...) }` guard - independent of `baseGas`, which
+// only adds to the payment on top of the real (unknowable ahead of time) execution gas cost. Both
+// are static SafeTx/execTransaction fields, decodable without a relayer or ERC-7730 descriptor, so
+// this never depends on what fields an external descriptor declares - it works the same whether
+// the source is a signed SafeTx message or a broadcast execTransaction call.
+const buildSafeTxGasRefund = (
+  baseGas: unknown,
+  gasPrice: unknown,
+  gasToken: unknown,
+  refundReceiver: unknown
+): SafeTxGasRefund | null => {
+  const bigintBaseGas = toBigIntOrNull(baseGas ?? 0)
+  const bigintGasPrice = toBigIntOrNull(gasPrice ?? 0)
+  if (bigintBaseGas === null || bigintGasPrice === null || bigintGasPrice <= 0n) return null
+
+  const receiver =
+    typeof refundReceiver === 'string' && isAddress(refundReceiver)
+      ? getAddress(refundReceiver)
+      : null
+
+  return {
+    refundReceiver: receiver && receiver !== ZeroAddress ? receiver : undefined,
+    gasToken:
+      typeof gasToken === 'string' && isAddress(gasToken) ? getAddress(gasToken) : ZeroAddress,
+    minAmount: bigintBaseGas * bigintGasPrice
+  }
+}
+
+const getSafeTxGasRefund = (message: Message): SafeTxGasRefund | null => {
+  if (message.content.kind !== 'typedMessage') return null
+  if (message.content.primaryType !== SAFE_TX_PRIMARY_TYPE) return null
+
+  const { baseGas, gasPrice, gasToken, refundReceiver } = message.content.message
+  return buildSafeTxGasRefund(baseGas, gasPrice, gasToken, refundReceiver)
+}
+
+// Same fields as getSafeTxGasRefund, decoded straight from a broadcast execTransaction call's
+// calldata instead of a signed SafeTx message.
+const getExecTransactionGasRefund = (data: string): SafeTxGasRefund | null => {
+  if (!isHexString(data)) return null
+
+  try {
+    const [, , , , , baseGas, gasPrice, gasToken, refundReceiver] =
+      safeExecTransactionInterface.decodeFunctionData('execTransaction', data)
+    return buildSafeTxGasRefund(baseGas, gasPrice, gasToken, refundReceiver)
+  } catch {
+    return null
+  }
+}
+
+const getGasRefundWarning = (gasRefund: SafeTxGasRefund | null): HumanizerWarning[] =>
+  gasRefund
+    ? [
+        getWarning(
+          gasRefund.refundReceiver
+            ? 'This transaction also sends a separate payment to the address below as a "gas refund", on top of what is shown above. Only proceed if you expect this'
+            : 'This transaction also sends a separate payment to whoever broadcasts it, as a "gas refund", on top of what is shown above. Only proceed if you expect this',
+          'SAFE{WALLET}_GAS_REFUND',
+          undefined,
+          gasRefund.refundReceiver
+        )
+      ]
+    : []
+
+// Always adds a "gas refund" row when the transaction pays one, regardless of whether the
+// resolved ERC-7730 descriptor's own fields happen to surface `refundReceiver`/`gasToken`/
+// `gasPrice` - this is what actually renders, so it must not depend on what an external
+// descriptor declares.
+const appendGasRefundRow = (
+  fullVisualization: HumanizerVisualization[],
+  gasRefund: SafeTxGasRefund | null
+): HumanizerVisualization[] => {
+  if (!gasRefund) return fullVisualization
+
+  const refundRow: HumanizerErc7730Row = {
+    label: 'Gas refund to',
+    value: [
+      gasRefund.refundReceiver
+        ? getAddressVisualization(gasRefund.refundReceiver)
+        : getText('whoever broadcasts this transaction'),
+      gasRefund.minAmount > 0n
+        ? getToken(gasRefund.gasToken, gasRefund.minAmount)
+        : getText('amount depends on gas used')
+    ]
+  }
+
+  return fullVisualization.map((visualization) =>
+    visualization.type === 'erc7730'
+      ? { ...visualization, rows: [...visualization.rows, refundRow] }
+      : visualization
+  )
+}
+
 const getSafeTxMessageWarnings = (message: Message): HumanizerWarning[] => {
   if (message.content.kind !== 'typedMessage') return []
   if (message.content.primaryType !== SAFE_TX_PRIMARY_TYPE) return []
@@ -1557,6 +1683,8 @@ const getSafeTxMessageWarnings = (message: Message): HumanizerWarning[] => {
   if (bigintOperation !== null && typeof to === 'string') {
     warnings.push(...getDelegateCallWarning(bigintOperation, to))
   }
+
+  warnings.push(...getGasRefundWarning(getSafeTxGasRefund(message)))
 
   const safeTxCalls = getSafeTxCallsFromMessage(message) || []
   safeTxCalls.forEach((safeTxCall) => warnings.push(...getSafeCallWarnings(safeTxCall)))
@@ -1715,22 +1843,28 @@ export const humanizeCallWithErc7730 = (
 
     if (!safeTxCallVisualizations.length || !call.to) return null
 
+    const gasRefund = getExecTransactionGasRefund(call.data)
+
     return {
       ...call,
-      fullVisualization: [
-        getErc7730Visualization('Execute a Safe{Wallet} Transaction', [
-          {
-            label: 'Safe',
-            value: [getAddressVisualization(call.to)]
-          },
-          {
-            label: '',
-            value: safeTxCallVisualizations
-          }
-        ])
-      ],
+      fullVisualization: appendGasRefundRow(
+        [
+          getErc7730Visualization('Execute a Safe{Wallet} Transaction', [
+            {
+              label: 'Safe',
+              value: [getAddressVisualization(call.to)]
+            },
+            {
+              label: '',
+              value: safeTxCallVisualizations
+            }
+          ])
+        ],
+        gasRefund
+      ),
       warnings: dedupeWarnings([
         ...resolvedDescriptor.safeTxCalls.flatMap((safeTxCall) => getSafeCallWarnings(safeTxCall)),
+        ...getGasRefundWarning(gasRefund),
         ...collectedWarnings
       ])
     }
@@ -1766,24 +1900,29 @@ export const humanizeCallWithErc7730 = (
   const visualizationWithNativeValue = oneInchVisualization
     ? appendNativeValueRow(oneInchVisualization, call.value, chainId)
     : null
+  if (!visualizationWithNativeValue?.fullVisualization.length) return null
 
-  return visualizationWithNativeValue?.fullVisualization.length
-    ? {
-        ...call,
-        fullVisualization: visualizationWithNativeValue.fullVisualization,
-        warnings: dedupeWarnings([
-          ...getSafeCallWarnings(call, accountAddr),
-          ...getSafeExecTransactionWarnings(match),
-          ...getNativeValueWarnings(
-            visualizationWithNativeValue.didAppendNativeValueRow,
-            nativeAssetSymbol
-          ),
-          ...getNestedCalldataDepthWarnings(visualizationWithNativeValue.fullVisualization),
-          // warnings the nested calls produced while this call was being formatted
-          ...context.collectedWarnings
-        ])
-      }
-    : null
+  const gasRefund = getSafeExecTransactionGasRefund(match)
+
+  return {
+    ...call,
+    fullVisualization: appendGasRefundRow(
+      visualizationWithNativeValue.fullVisualization,
+      gasRefund
+    ),
+    warnings: dedupeWarnings([
+      ...getSafeCallWarnings(call, accountAddr),
+      ...getSafeExecTransactionWarnings(match),
+      ...getGasRefundWarning(gasRefund),
+      ...getNativeValueWarnings(
+        visualizationWithNativeValue.didAppendNativeValueRow,
+        nativeAssetSymbol
+      ),
+      ...getNestedCalldataDepthWarnings(visualizationWithNativeValue.fullVisualization),
+      // warnings the nested calls produced while this call was being formatted
+      ...context.collectedWarnings
+    ])
+  }
 }
 
 export const humanizeMessageWithErc7730 = (
@@ -1814,7 +1953,10 @@ export const humanizeMessageWithErc7730 = (
   const fullVisualization = formatToVisualizations(match.format, context)
   const safeTxVisualization =
     fullVisualization && message.content.primaryType === SAFE_TX_PRIMARY_TYPE
-      ? replaceSafeTxTransactionRow(fullVisualization, message, chainId, resolvedDescriptor)
+      ? appendGasRefundRow(
+          replaceSafeTxTransactionRow(fullVisualization, message, chainId, resolvedDescriptor),
+          getSafeTxGasRefund(message)
+        )
       : fullVisualization
 
   return safeTxVisualization?.length

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -354,6 +354,50 @@ describe('Humanizer main function', () => {
     compareHumanizerVisualizations(irCalls, expectedVisualizations)
   })
 
+  test('setApprovalForAll on the Uniswap V3 Position Manager keeps the NFT approval humanization', async () => {
+    // The Uniswap V3 NonfungiblePositionManager is an ERC-721 contract (LP positions are NFTs),
+    // but it's also in the Uniswap module's address list. setApprovalForAll isn't one of the
+    // Uniswap-specific actions that module recognizes, so it must not clobber the more specific
+    // visualization genericErc721Humanizer already produced with the vague 'Uniswap action' fallback.
+    const positionManager = '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
+    const operator = '0x77c417980798a3b6aa21b2b1d5f218a598eb0a83'
+    accountOp.calls = [
+      {
+        to: positionManager,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: [
+            {
+              name: 'setApprovalForAll',
+              type: 'function',
+              inputs: [
+                { name: 'operator', type: 'address' },
+                { name: 'approved', type: 'bool' }
+              ],
+              outputs: [],
+              stateMutability: 'nonpayable'
+            }
+          ],
+          functionName: 'setApprovalForAll',
+          args: [operator, true]
+        })
+      }
+    ]
+
+    const irCalls = humanizeAccountOp(accountOp)
+
+    compareHumanizerVisualizations(irCalls, [
+      [
+        getAction('Grant approval'),
+        getLabel('for all NFTs of'),
+        getAddressVisualization(positionManager),
+        getLabel('to'),
+        getAddressVisualization(operator)
+      ]
+    ])
+    expect(irCalls[0]!.warnings?.length).toBe(1)
+  })
+
   test('aave not to be parsed by uniswap', async () => {
     // const ir: Ir = []
     const expectedVisualizations = [

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -2723,6 +2723,110 @@ describe('ERC-7730 descriptors', () => {
     ])
   })
 
+  // Regression test for Attack A from the leaked safe-poc.html on the AccountOp/tx path (a
+  // broadcast execTransaction call resolved through the Safe singleton, not a signed EIP-712
+  // message). baseGas/gasPrice/gasToken/refundReceiver are static execTransaction fields, decoded
+  // directly from call.data by getExecTransactionGasRefund (erc7730/humanize.ts) - the "Gas
+  // refund to" row and warning must appear even though the resolved descriptor's own `formats`
+  // never mention them (they only ever describe the inner Safe singleton calls, not the outer
+  // execTransaction wrapper).
+  test('shows the gas refund receiver and amount for a broadcast execTransaction call', async () => {
+    const safeProxy = '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce'
+    const safeSingleton = '0x29fcb43b46531bca003ddc8fcb67ffe91900c762'
+    const multiSend = '0x9641d764fc13c8b624c04430c7356c1c7c8102e2'
+    const tokenAddress = '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf'
+    const spender = '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
+    const settlement = '0x9008d19f58aabd9ed0d60971565aa8510560ab41'
+    const refundReceiver = getAddress('0x1234567890123456789012345678901234567890')
+    const gasToken = getAddress('0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf')
+    const multiSendData =
+      '0x8d80ff0a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000019200cbb7c0000ab88b473b1f5afd9ef808440eed33bf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044095ea7b3000000000000000000000000c92e8bdf79f0507f65a392b0ab4667716bfe011000000000000000000000000000000000000000000000000000000000000005ea009008d19f58aabd9ed0d60971565aa8510560ab41000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a4ec6cb13f000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000038cc9abd7869bc44faf6552057bc09b84f0d691eb0b0e484600012cca91d529763714fd3db837e72bd49b8eda02b8f4d53dfdde5ce6a11965300000000000000000000000000000000000000000000'
+    const execTransactionData = new ethers.Interface(execTransactionAbi).encodeFunctionData(
+      'execTransaction',
+      [multiSend, 0, multiSendData, 1, 0, 500000, 1, gasToken, refundReceiver, '0x']
+    )
+    const safeExecAccountOp: AccountOp = {
+      ...accountOp,
+      chainId: 8453n,
+      calls: [
+        {
+          to: safeProxy,
+          value: 0n,
+          data: execTransactionData
+        }
+      ]
+    }
+    const provider = {
+      getStorage: jest.fn(async () => ethers.zeroPadValue(safeSingleton, 32))
+    }
+    const descriptorPath = 'registry/safe/calldata-SafeL2-1.4.1.json'
+    const callRelayer = async (path: string) => {
+      if (path === '/v2/erc7730/account-op') {
+        return {
+          success: true,
+          data: { [`eip155:8453:${safeSingleton}`]: descriptorPath },
+          errorState: []
+        }
+      }
+
+      if (path === '/v2/erc7730/fetch-descriptor') {
+        return { success: true, display: { formats: {} } }
+      }
+
+      throw new Error(`Unexpected ERC-7730 relayer call: ${path}`)
+    }
+
+    const descriptors = await fetchErc7730DescriptorsForAccountOp(safeExecAccountOp, {
+      callRelayer,
+      provider: provider as any
+    })
+    const irCalls = humanizeAccountOp(safeExecAccountOp, { erc7730Descriptors: descriptors })
+
+    compareVisualizations(irCalls[0]!.fullVisualization || [], [
+      getErc7730Visualization('Execute a Safe{Wallet} Transaction', [
+        {
+          label: 'Safe',
+          value: [getAddressVisualization(safeProxy)]
+        },
+        {
+          label: '',
+          value: [
+            getErc7730Visualization('Approve', [
+              {
+                label: 'Spender',
+                value: [getAddressVisualization(spender)]
+              },
+              {
+                label: 'Amount',
+                value: [getToken(tokenAddress, 1514n, 8453n)]
+              }
+            ]),
+            getErc7730Visualization('SetPreSignature', [
+              {
+                label: 'On',
+                value: [getAddressVisualization(settlement)]
+              }
+            ])
+          ]
+        },
+        {
+          label: 'Gas refund to',
+          value: [getAddressVisualization(refundReceiver), getToken(gasToken, 500000n)]
+        }
+      ])
+    ])
+    expect(irCalls[0]?.warnings).toEqual(
+      expect.arrayContaining([
+        getWarning(
+          'This transaction also sends a separate payment to the address below as a "gas refund", on top of what is shown above. Only proceed if you expect this',
+          'SAFE{WALLET}_GAS_REFUND',
+          undefined,
+          refundReceiver
+        )
+      ])
+    )
+  })
+
   test('humanizes a Safe execTransaction reject call with ERC-7730', async () => {
     const safeProxy = '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce'
     const safeSingleton = '0x29fcb43b46531bca003ddc8fcb67ffe91900c762'
@@ -2858,6 +2962,162 @@ describe('ERC-7730 descriptors', () => {
         recipeExecutor
       )
     ])
+  })
+
+  // Regression test for Attack A on the AccountOp/tx path when the call itself matches a
+  // registry `execTransaction(...)` format directly (as opposed to being routed through the Safe
+  // singleton descriptor, covered separately above). The descriptor's own `fields` deliberately
+  // omit baseGas/gasPrice/gasToken/refundReceiver - getSafeExecTransactionGasRefund
+  // (erc7730/humanize.ts) reads them from the already fully-decoded match.values regardless.
+  test('shows the gas refund receiver and amount for an execTransaction format match', () => {
+    const safeProxy = '0x043faB48aCC3DD066fcf33cA3e3f2E2Ba5be9018'
+    const recipeExecutor = '0xc91305DdE651c899EF8eE1D0C33E7dab1B5ABF0D'
+    const refundReceiver = getAddress('0x1234567890123456789012345678901234567890')
+    const gasToken = getAddress('0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf')
+    const execTransactionData = new ethers.Interface(execTransactionAbi).encodeFunctionData(
+      'execTransaction',
+      [recipeExecutor, 0, '0x0c2c8750', 0, 0, 500000, 1, gasToken, refundReceiver, '0x']
+    )
+    const safeExecAccountOp: AccountOp = {
+      ...accountOp,
+      chainId: 8453n,
+      calls: [
+        {
+          to: safeProxy,
+          value: 0n,
+          data: execTransactionData
+        }
+      ]
+    }
+    const irCalls = humanizeAccountOp(safeExecAccountOp, {
+      erc7730Descriptors: {
+        0: {
+          descriptor: {
+            display: {
+              formats: {
+                'execTransaction(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,bytes signatures)':
+                  {
+                    intent: 'sign multisig operation',
+                    fields: [
+                      { path: 'operation', label: 'Operation type' },
+                      {
+                        path: 'data',
+                        label: 'Transaction',
+                        format: 'calldata',
+                        params: { calleePath: 'to' }
+                      }
+                    ]
+                  }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(irCalls[0]?.warnings).toEqual(
+      expect.arrayContaining([
+        getWarning(
+          'This transaction also sends a separate payment to the address below as a "gas refund", on top of what is shown above. Only proceed if you expect this',
+          'SAFE{WALLET}_GAS_REFUND',
+          undefined,
+          refundReceiver
+        )
+      ])
+    )
+    expect(irCalls[0]?.fullVisualization).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'erc7730',
+          rows: expect.arrayContaining([
+            {
+              label: 'Gas refund to',
+              value: [
+                expect.objectContaining({ type: 'address', address: refundReceiver.toLowerCase() }),
+                expect.objectContaining({
+                  type: 'token',
+                  address: gasToken.toLowerCase(),
+                  value: 500000n
+                })
+              ]
+            }
+          ])
+        })
+      ])
+    )
+  })
+
+  // Regression test for a real broadcast execTransaction call: baseGas=0, gasPrice=6000000,
+  // gasToken=zero address (native), refundReceiver equal to the visible recipient. Safe.sol only
+  // gates the refund on `gasPrice > 0` (see buildSafeTxGasRefund) - baseGas being 0 does NOT mean
+  // no refund is paid, it just means the payment is entirely `gasUsed * gasPrice`, unknowable
+  // ahead of time, so no hard token amount can be shown - the row must still appear, with a
+  // placeholder amount rather than a misleading "0".
+  test('shows the gas refund row even when baseGas is 0 and only gasPrice is nonzero', () => {
+    const safeProxy = '0x043faB48aCC3DD066fcf33cA3e3f2E2Ba5be9018'
+    const recipient = getAddress('0x6969174FD72466430a46e18234D0b530c9FD5f49')
+    const execTransactionData = new ethers.Interface(execTransactionAbi).encodeFunctionData(
+      'execTransaction',
+      [recipient, 1, '0x', 0, 120000, 0, 6000000, ZeroAddress, recipient, '0x']
+    )
+    const safeExecAccountOp: AccountOp = {
+      ...accountOp,
+      chainId: 8453n,
+      calls: [
+        {
+          to: safeProxy,
+          value: 0n,
+          data: execTransactionData
+        }
+      ]
+    }
+    const irCalls = humanizeAccountOp(safeExecAccountOp, {
+      erc7730Descriptors: {
+        0: {
+          descriptor: {
+            display: {
+              formats: {
+                'execTransaction(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,bytes signatures)':
+                  {
+                    intent: 'sign multisig operation',
+                    fields: [
+                      { path: 'to', label: 'To', format: 'addressName' },
+                      { path: 'value', label: 'Value', format: 'tokenAmount' }
+                    ]
+                  }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(irCalls[0]?.warnings).toEqual(
+      expect.arrayContaining([
+        getWarning(
+          'This transaction also sends a separate payment to the address below as a "gas refund", on top of what is shown above. Only proceed if you expect this',
+          'SAFE{WALLET}_GAS_REFUND',
+          undefined,
+          recipient
+        )
+      ])
+    )
+    expect(irCalls[0]?.fullVisualization).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'erc7730',
+          rows: expect.arrayContaining([
+            {
+              label: 'Gas refund to',
+              value: [
+                expect.objectContaining({ type: 'address', address: recipient.toLowerCase() }),
+                expect.objectContaining({ type: 'text', content: 'amount depends on gas used' })
+              ]
+            }
+          ])
+        })
+      ])
+    )
   })
 
   // Regression test for a broadcast execTransaction call (AccountOp/tx path, no EIP-712 SafeTx
@@ -4168,6 +4428,125 @@ describe('ERC-7730 descriptors', () => {
         }
       ])
     ])
+  })
+
+  // Regression test for Attack A from the leaked safe-poc.html: `baseGas`/`gasPrice`/`gasToken`/
+  // `refundReceiver` let a SafeTx pay an arbitrary amount to an arbitrary address as a "gas
+  // refund", separate from whatever transfer the descriptor's own fields show. The registry
+  // descriptor below deliberately does NOT declare any of those fields (only `operation` and
+  // `data`, matching what the PoC found Ambire actually displays), so this proves the refund row
+  // and warning are injected unconditionally by addSafeTxGasRefundRow/getSafeTxMessageWarnings
+  // (erc7730/humanize.ts) rather than depending on the external descriptor to surface them.
+  test('shows the gas refund receiver and amount even when the descriptor does not declare those fields', async () => {
+    const recipient = getAddress('0xa04d21b7ae298d8e4a61a507de2b7ceafd90ba01')
+    const refundReceiver = getAddress('0x1234567890123456789012345678901234567890')
+    const gasToken = getAddress('0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf')
+    const safeTxMessage = {
+      fromRequestId: 1,
+      accountAddr: accountOp.accountAddr,
+      content: {
+        kind: 'typedMessage',
+        types: {
+          EIP712Domain: [
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' }
+          ],
+          SafeTx: [
+            { type: 'address', name: 'to' },
+            { type: 'uint256', name: 'value' },
+            { type: 'bytes', name: 'data' },
+            { type: 'uint8', name: 'operation' },
+            { type: 'uint256', name: 'safeTxGas' },
+            { type: 'uint256', name: 'baseGas' },
+            { type: 'uint256', name: 'gasPrice' },
+            { type: 'address', name: 'gasToken' },
+            { type: 'address', name: 'refundReceiver' },
+            { type: 'uint256', name: 'nonce' }
+          ]
+        },
+        domain: {
+          verifyingContract: '0x714fd3db837e72bd49b8eda02b8f4d53dfdde5ce',
+          chainId: 8453
+        },
+        message: {
+          to: recipient,
+          value: '1',
+          data: '0x',
+          operation: 0,
+          baseGas: '500000',
+          gasPrice: '1',
+          gasToken,
+          refundReceiver,
+          nonce: 81,
+          safeTxGas: '0'
+        },
+        primaryType: 'SafeTx'
+      },
+      signature: null,
+      chainId: 8453n
+    }
+
+    const irMessage = humanizeMessage(safeTxMessage as any, {
+      erc7730Descriptor: {
+        descriptor: {
+          display: {
+            formats: {
+              'SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)':
+                {
+                  intent: 'Safe',
+                  fields: [
+                    { path: 'operation', label: 'Operation type' },
+                    {
+                      path: 'data',
+                      label: 'Transaction',
+                      format: 'calldata',
+                      params: { calleePath: '#.to' }
+                    }
+                  ]
+                }
+            }
+          }
+        }
+      }
+    })
+
+    compareVisualizations(irMessage.fullVisualization || [], [
+      getErc7730Visualization('Safe', [
+        {
+          label: 'Operation type',
+          value: [getText('0')]
+        },
+        {
+          label: 'Transaction',
+          value: [
+            getErc7730Visualization('Send', [
+              {
+                label: 'Send',
+                value: [getToken(ZeroAddress, 1n)]
+              },
+              {
+                label: 'To',
+                value: [getAddressVisualization(recipient)]
+              }
+            ])
+          ]
+        },
+        {
+          label: 'Gas refund to',
+          value: [getAddressVisualization(refundReceiver), getToken(gasToken, 500000n)]
+        }
+      ])
+    ])
+    expect(irMessage.warnings).toEqual(
+      expect.arrayContaining([
+        getWarning(
+          'This transaction also sends a separate payment to the address below as a "gas refund", on top of what is shown above. Only proceed if you expect this',
+          'SAFE{WALLET}_GAS_REFUND',
+          undefined,
+          refundReceiver
+        )
+      ])
+    )
   })
 
   // Regression test for a SafeTx message batching a leg with operation=1 (DELEGATECALL) to a

--- a/src/libs/humanizer/index.test.ts
+++ b/src/libs/humanizer/index.test.ts
@@ -1,10 +1,10 @@
-import { ethers, ZeroAddress } from 'ethers'
+import { ethers, getAddress, ZeroAddress } from 'ethers'
 import { encodeFunctionData } from 'viem'
 
 import { beforeEach, describe, jest, test } from '@jest/globals'
 
 import { DEFAULT_ACCOUNT_LABEL } from '../../consts/account'
-import { execTransactionAbi } from '../../consts/safe'
+import { execTransactionAbi, multiSendAddr } from '../../consts/safe'
 import { Account } from '../../interfaces/account'
 import { Key } from '../../interfaces/keystore'
 import { AccountOp } from '../accountOp/accountOp'
@@ -2860,6 +2860,71 @@ describe('ERC-7730 descriptors', () => {
     ])
   })
 
+  // Regression test for a broadcast execTransaction call (AccountOp/tx path, no EIP-712 SafeTx
+  // message involved). `embeddedAmbireOperationHumanizer` (callModules.ts) used to run before
+  // SafeModule and unconditionally overwrite `fullVisualization` with a generic "Allow multiple
+  // actions from this account!" warning for ANY call whose `to` equals `accountOp.accountAddr` —
+  // which every direct Safe execTransaction call is, by construction (you call the Safe's own
+  // address to execute a SafeTx on it). That pre-empted SafeModule's execTransaction matcher,
+  // which is gated behind `if (!call.fullVisualization && match)` (modules/Safe/index.ts), so
+  // getDelegateCallWarning() was never reached for this call shape, independent of
+  // MultiSend/whitelisting. Fixed by running embeddedAmbireOperationHumanizer last and having it
+  // defer to any visualization a more specific module already produced.
+  test('warns about a hidden delegatecall leg inside a whitelisted MultiSend tx (no message involved)', () => {
+    const safeProxy = '0x043faB48aCC3DD066fcf33cA3e3f2E2Ba5be9018'
+    const benignRecipient = getAddress('0xa04d21b7ae298d8e4a61a507de2b7ceafd90ba01')
+    const delegateCallTarget = getAddress('0x1234567890123456789012345678901234567890') // NOT in allowedMulticallContracts
+    const pwnData = '0xdd365b8b' // Takeover.pwn() selector from the PoC
+    const transactionsData = ethers.concat([
+      ethers.solidityPacked(
+        ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+        [0, benignRecipient, 0n, 0, '0x']
+      ),
+      ethers.solidityPacked(
+        ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+        [1, delegateCallTarget, 0n, BigInt(ethers.getBytes(pwnData).length), pwnData]
+      )
+    ])
+    const multiSendData = new ethers.Interface([
+      'function multiSend(bytes transactions)'
+    ]).encodeFunctionData('multiSend', [transactionsData])
+    // multiSendAddr is Safe's canonical, whitelisted MultiSend router (allowedMulticallContracts)
+    const execTransactionData = new ethers.Interface(execTransactionAbi).encodeFunctionData(
+      'execTransaction',
+      [multiSendAddr, 0, multiSendData, 1, 0, 0, 0, ZeroAddress, ZeroAddress, '0x']
+    )
+    const safeExecAccountOp: AccountOp = {
+      ...accountOp,
+      accountAddr: safeProxy,
+      chainId: 8453n,
+      calls: [
+        {
+          to: safeProxy,
+          value: 0n,
+          data: execTransactionData
+        }
+      ]
+    }
+
+    // no ERC-7730 descriptors at all here — this is a plain broadcast tx, decoded purely by
+    // the local humanizer modules, same as what a block explorer / signing prompt would show
+    const irCalls = humanizeAccountOp(safeExecAccountOp, {})
+
+    // A hidden delegatecall leg into a non-whitelisted contract, smuggled inside a batch routed
+    // through the whitelisted MultiSend, must surface the same warning a top-level delegatecall
+    // to that contract would get.
+    expect(irCalls[0]?.warnings).toEqual(
+      expect.arrayContaining([
+        getWarning(
+          'You are about to delegate permissions to a contract not whitelisted by Safe. Proceed with caution',
+          'SAFE{WALLET}_DELEGATE_CALL',
+          undefined,
+          delegateCallTarget
+        )
+      ])
+    )
+  })
+
   test('humanizes Safe setup calldata nested in a factory initializer with ERC-7730', () => {
     const safeProxyFactory = '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67'
     const safeSingleton = '0x41675c099f32341bf84bfc5382af534df5c7461a'
@@ -4103,6 +4168,121 @@ describe('ERC-7730 descriptors', () => {
         }
       ])
     ])
+  })
+
+  // Regression test for a SafeTx message batching a leg with operation=1 (DELEGATECALL) to a
+  // contract that isn't whitelisted by Safe, routed through the whitelisted MultiSend router.
+  // `getDelegateCallWarning` in modules/Safe/index.ts is only ever evaluated against the *outer*
+  // SafeTx call (to, operation), which here targets the whitelisted router, so it stays silent
+  // on its own. Two things had to be fixed for this warning to surface: (1) `getSafeHumanization`
+  // now decodes `multiSend` batches itself (via `decodeMultiSend`, src/libs/safe/helpers.ts) and
+  // recurses per leg, checking each leg's own `operation`, since the ERC-7730 pipeline's `Call`
+  // type has no `operation` field and can't carry it (erc7730/utils.ts#getSafeTxCallsFromMessage,
+  // erc7730/registry.ts); (2) `humanizeMessage` now merges the warnings humanizerTMModules found
+  // (which is where that recursive check runs, via safeMessageModule) into the ERC-7730 result
+  // instead of discarding them when an ERC-7730 descriptor resolves the message. This is the
+  // exact "Attack B" pattern from the leaked safe-poc.html: a benign leg 0 plus a hidden
+  // delegatecall leg 1 into attacker-controlled code that runs in the Safe's own storage context.
+  test('warns about a hidden delegatecall leg inside a whitelisted SafeTx multisend batch', async () => {
+    const benignRecipient = getAddress('0xa04d21b7ae298d8e4a61a507de2b7ceafd90ba01')
+    const delegateCallTarget = getAddress('0x1234567890123456789012345678901234567890') // NOT in allowedMulticallContracts
+    const pwnData = '0xdd365b8b' // Takeover.pwn() selector from the PoC
+    const transactionsData = ethers.concat([
+      ethers.solidityPacked(
+        ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+        [0, benignRecipient, 0n, 0, '0x']
+      ),
+      ethers.solidityPacked(
+        ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+        [1, delegateCallTarget, 0n, BigInt(ethers.getBytes(pwnData).length), pwnData]
+      )
+    ])
+    const multiSendData = new ethers.Interface([
+      'function multiSend(bytes transactions)'
+    ]).encodeFunctionData('multiSend', [transactionsData])
+    const safeTxMessage = {
+      fromRequestId: 1,
+      accountAddr: accountOp.accountAddr,
+      content: {
+        kind: 'typedMessage',
+        types: {
+          EIP712Domain: [
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' }
+          ],
+          SafeTx: [
+            { type: 'address', name: 'to' },
+            { type: 'uint256', name: 'value' },
+            { type: 'bytes', name: 'data' },
+            { type: 'uint8', name: 'operation' },
+            { type: 'uint256', name: 'safeTxGas' },
+            { type: 'uint256', name: 'baseGas' },
+            { type: 'uint256', name: 'gasPrice' },
+            { type: 'address', name: 'gasToken' },
+            { type: 'address', name: 'refundReceiver' },
+            { type: 'uint256', name: 'nonce' }
+          ]
+        },
+        domain: {
+          // the whitelisted MultiSend v1.1.1 router, so the outer-call delegatecall check
+          // (shouldDisplaySafeDelegateCallWarning) never fires either
+          verifyingContract: '0x8D29bE29923b68abfDD21e541b9374737B49cdAD',
+          chainId: 8453
+        },
+        message: {
+          to: '0x8D29bE29923b68abfDD21e541b9374737B49cdAD',
+          value: '0',
+          data: multiSendData,
+          operation: 1,
+          baseGas: '0',
+          gasPrice: '0',
+          gasToken: ZeroAddress,
+          refundReceiver: ZeroAddress,
+          nonce: 1,
+          safeTxGas: '0'
+        },
+        primaryType: 'SafeTx'
+      },
+      signature: null,
+      chainId: 8453n
+    }
+
+    const irMessage = humanizeMessage(safeTxMessage as any, {
+      erc7730Descriptor: {
+        descriptor: {
+          display: {
+            formats: {
+              'SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)':
+                {
+                  intent: 'Safe',
+                  fields: [
+                    { path: 'operation', label: 'Operation type' },
+                    {
+                      path: 'data',
+                      label: 'Transaction',
+                      format: 'calldata',
+                      params: { calleePath: '#.to' }
+                    }
+                  ]
+                }
+            }
+          }
+        }
+      }
+    })
+
+    // A hidden delegatecall leg into a non-whitelisted contract must surface the same
+    // "not whitelisted by Safe" warning that a top-level delegatecall would get.
+    expect(irMessage.warnings).toEqual(
+      expect.arrayContaining([
+        getWarning(
+          'You are about to delegate permissions to a contract not whitelisted by Safe. Proceed with caution',
+          'SAFE{WALLET}_DELEGATE_CALL',
+          undefined,
+          getAddress(delegateCallTarget)
+        )
+      ])
+    )
   })
 
   test('humanizes SafeTx multisend with truncated ABI padding as separate transaction rows', async () => {

--- a/src/libs/humanizer/index.ts
+++ b/src/libs/humanizer/index.ts
@@ -109,11 +109,6 @@ const humanizeMessage = (_message: Message, options?: HumanizeMessageOptions): I
   const message = parse(stringify(_message))
 
   try {
-    if (options?.erc7730Descriptor) {
-      const erc7730Message = humanizeMessageWithErc7730(message, options.erc7730Descriptor)
-      if (erc7730Message) return erc7730Message
-    }
-
     // runs all modules and takes the first non empty array
     const { fullVisualization, warnings, canHideDropdownArrow } =
       humanizerTMModules
@@ -126,6 +121,18 @@ const humanizeMessage = (_message: Message, options?: HumanizeMessageOptions): I
           }
         })
         .filter((p) => p.fullVisualization?.length)[0] || {}
+
+    if (options?.erc7730Descriptor) {
+      const erc7730Message = humanizeMessageWithErc7730(message, options.erc7730Descriptor)
+      if (erc7730Message) {
+        // The descriptor builds its result from the raw message, so it starts with no warnings.
+        // The warnings humanizerTMModules found are still about the same message, so keep both.
+        return {
+          ...erc7730Message,
+          warnings: dedupeWarnings([...(warnings || []), ...(erc7730Message.warnings || [])])
+        }
+      }
+    }
 
     return { ...message, fullVisualization, warnings, canHideDropdownArrow }
   } catch (error) {

--- a/src/libs/humanizer/modules/Safe/index.ts
+++ b/src/libs/humanizer/modules/Safe/index.ts
@@ -10,6 +10,7 @@ import {
 
 import { allowedFallbackHandlers, allowedMulticallContracts } from '../../../../consts/safe'
 import { AccountOp } from '../../../accountOp/accountOp'
+import { decodeMultiSend } from '../../../safe/helpers'
 import {
   HumanizerCallModule,
   HumanizerVisualization,
@@ -52,6 +53,9 @@ const setupAbi = parseAbi([
 const execTransactionAbi = parseAbi([
   'function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) payable returns (bool)'
 ])
+const multiSendAbi = parseAbi(['function multiSend(bytes transactions)'])
+// shared recursion-depth guard for both nested `setup` hooks and nested `multiSend` batches,
+// so a maliciously self-referential payload can't recurse getSafeHumanization indefinitely
 const MAX_SAFE_SETUP_HOOK_DEPTH = 4
 
 export const shouldDisplaySafeDelegateCallWarning = (
@@ -339,6 +343,44 @@ export const getSafeHumanization = (
         getAddress(newVerifier)
       )
     )
+    return {
+      visuals: fullVisualization,
+      warnings
+    }
+  }
+
+  if (selector === toFunctionSelector(multiSendAbi[0])) {
+    fullVisualization.push(getAction('Batch of transactions'))
+
+    let decodedTransactions: ReturnType<typeof decodeMultiSend> = []
+    try {
+      const { args } = decodeFunctionData({ abi: multiSendAbi, data: padCallData(data, 1) })
+      const [transactions] = args
+      decodedTransactions = decodeMultiSend(transactions)
+    } catch {
+      decodedTransactions = []
+    }
+
+    decodedTransactions.forEach((innerCall) => {
+      // a delegatecall leg runs attacker-controlled code directly in the Safe's own storage,
+      // so it must be flagged the same way a top-level delegatecall would be, even though it's
+      // hidden a level deeper inside this batch
+      warnings.push(...getDelegateCallWarning(innerCall.operation, innerCall.to))
+
+      const innerHumanization = getSafeHumanization(
+        safeAddr,
+        innerCall.to,
+        innerCall.value,
+        innerCall.data,
+        setupHookDepth + 1
+      )
+
+      if (innerHumanization?.visuals?.length) {
+        fullVisualization.push(getBreak(), ...innerHumanization.visuals)
+      }
+      if (innerHumanization?.warnings) warnings.push(...innerHumanization.warnings)
+    })
+
     return {
       visuals: fullVisualization,
       warnings

--- a/src/libs/humanizer/modules/Tokens/tokens.test.ts
+++ b/src/libs/humanizer/modules/Tokens/tokens.test.ts
@@ -322,7 +322,7 @@ describe('Tokens', () => {
         getToken('0x59468516a8259058bad1ca5f8f4bff190d30e066', 1n)
       ],
       [
-        getAction('Grant approval', { warning: true }),
+        getAction('Grant approval'),
         getLabel('for all NFTs of'),
         getAddressVisualization('0x59468516a8259058bad1ca5f8f4bff190d30e066'),
         getLabel('to'),

--- a/src/libs/humanizer/modules/Tokens/tokens.ts
+++ b/src/libs/humanizer/modules/Tokens/tokens.ts
@@ -123,7 +123,7 @@ export const genericErc721Humanizer: HumanizerCallModule = (accountOp: AccountOp
 
       return {
         visualizations: [
-          getAction('Grant approval', { warning: true }),
+          getAction('Grant approval'),
           getLabel('for all NFTs of'),
           getAddressVisualization(call.to),
           getLabel('to'),
@@ -131,6 +131,8 @@ export const genericErc721Humanizer: HumanizerCallModule = (accountOp: AccountOp
         ],
         // there is no amount to check here - granting this hands over every item in the
         // collection, including items bought later, until it is revoked
+        // the `warning` below already flags the whole call element; marking the action itself
+        // as a warning too just makes the text harder to read without adding information
         warning: getWarning(
           'This app can transfer any item you own from this collection, now or later. Continue only if you trust it.',
           UNLIMITED_APPROVAL_WARNING_CODE,

--- a/src/libs/humanizer/modules/Uniswap/index.ts
+++ b/src/libs/humanizer/modules/Uniswap/index.ts
@@ -122,7 +122,14 @@ const uniAddresses = [
 export const uniswapHumanizer: HumanizerCallModule = (accountOp: AccountOp, call: IrCall) => {
   if (!call.to || !isAddress(call.to) || !uniAddresses.includes(getAddress(call.to))) return call
 
-  if (!isHexCall(call)) return { ...call, fullVisualization: [getAction('Uniswap action')] }
+  // A call to a known Uniswap address that isn't a recognized Uniswap-specific action (e.g. an
+  // ERC-721 approval on the Position Manager NFT contract) may already carry a more specific
+  // visualization from an earlier, more generic module (e.g. genericErc721Humanizer) — keep it
+  // instead of overwriting it with the vague 'Uniswap action' fallback.
+  if (!isHexCall(call))
+    return call.fullVisualization
+      ? call
+      : { ...call, fullVisualization: [getAction('Uniswap action')] }
 
   const sigHash = call.data.substring(0, 10)
   if (fullUniswapHumanizerMapping[sigHash])
@@ -131,5 +138,7 @@ export const uniswapHumanizer: HumanizerCallModule = (accountOp: AccountOp, call
       fullVisualization: fullUniswapHumanizerMapping[sigHash](accountOp, call)
     }
 
-  return { ...call, fullVisualization: [getAction('Uniswap action')] }
+  return call.fullVisualization
+    ? call
+    : { ...call, fullVisualization: [getAction('Uniswap action')] }
 }

--- a/src/libs/humanizer/modules/embeddedAmbireOperationHumanizer/ambireOperation.test.ts
+++ b/src/libs/humanizer/modules/embeddedAmbireOperationHumanizer/ambireOperation.test.ts
@@ -2,13 +2,13 @@ import { Interface, ZeroAddress } from 'ethers'
 
 import { describe, it } from '@jest/globals'
 
-import { embeddedAmbireOperationHumanizer } from '.'
+import { EMBEDDED_OPERATION_WARNING_CODE, embeddedAmbireOperationHumanizer } from '.'
 import { AccountOp } from '../../../accountOp/accountOp'
 import { Call } from '../../../accountOp/types'
 import { AmbireAccount } from '../../const/abis/AmbireAccount'
 import { HumanizerMeta, IrCall } from '../../interfaces'
 import { compareHumanizerVisualizations, compareVisualizations } from '../../testHelpers'
-import { getAction, getAddressVisualization, getLabel } from '../../utils'
+import { getAction, getAddressVisualization, getLabel, getWarning } from '../../utils'
 
 const accountAddr = '0x46C0C59591EbbD9b7994d10efF172bFB9325E240'
 const accountAddr2 = '0xB2125Ae51ee5Ff91D5da625b9F1Fbf5F2941DD27'
@@ -148,8 +148,12 @@ describe('Hidden ambire operations', () => {
     const irCalls = [secondLayerTryCatch].map((c) =>
       embeddedAmbireOperationHumanizer(accountOp, c, {} as HumanizerMeta)
     )
-    compareHumanizerVisualizations(irCalls, [
-      [getAction('Allow multiple actions from this account!', { warning: true })]
+    compareHumanizerVisualizations(irCalls, [[getAction('Allow multiple actions from this account')]])
+    expect(irCalls[0]!.warnings).toEqual([
+      getWarning(
+        'This lets the app perform several actions using your account, one after another, without asking you to confirm each one separately. Only proceed if you trust it',
+        EMBEDDED_OPERATION_WARNING_CODE
+      )
     ])
   })
 })

--- a/src/libs/humanizer/modules/embeddedAmbireOperationHumanizer/index.ts
+++ b/src/libs/humanizer/modules/embeddedAmbireOperationHumanizer/index.ts
@@ -1,6 +1,8 @@
 import { AccountOp } from '../../../accountOp/accountOp'
 import { HumanizerCallModule, IrCall } from '../../interfaces'
-import { getAction } from '../../utils'
+import { getAction, getWarning } from '../../utils'
+
+export const EMBEDDED_OPERATION_WARNING_CODE = 'AMBIRE_EMBEDDED_OPERATION'
 
 // the purpose of this module is simply to visualize attempts to hide ambire operations within the current account op
 // such thing can be done if the dapp requests a tryCatch/executeBySelfSingle/executeBySelf/... function call directed to the current account
@@ -10,11 +12,19 @@ export const embeddedAmbireOperationHumanizer: HumanizerCallModule = (
   call: IrCall
 ) => {
   if (!call.to) return call
+  if (call.fullVisualization) return call
   if (call.data === '0x') return call
   if (call.to.toLowerCase() === accountOp.accountAddr.toLowerCase()) {
     return {
       ...call,
-      fullVisualization: [getAction('Allow multiple actions from this account!', { warning: true })]
+      fullVisualization: [getAction('Allow multiple actions from this account')],
+      warnings: [
+        ...(call.warnings || []),
+        getWarning(
+          'This lets the app perform several actions using your account, one after another, without asking you to confirm each one separately. Only proceed if you trust it',
+          EMBEDDED_OPERATION_WARNING_CODE
+        )
+      ]
     }
   }
   return call


### PR DESCRIPTION
Problems:
- uniswap's humanizer overrode the humanization of a NFT approval, but kept the warnings
- bug in 7730's lib caused a drop in some warnings when the humanization is not parsed by it, this is addressed in the 7730 refactor https://github.com/AmbireTech/ambire-common/pull/2660
- safe vuln when there is a delegate call inside a multisend
- warning that refund recipient is != ZeroAddress - will probably cause false positives, but for now lets add that as well to protect against draining

Testable with 
[1](https://transact.swiss-knife.xyz/send-tx?chainId=1&to=0xc36442b4a4522e871399cd717abdd847ab11fe88&calldata=0xa22cb46500000000000000000000000077c417980798a3b6aa21b2b1d5f218a598eb0a830000000000000000000000000000000000000000000000000000000000000001)
[2](https://transact.swiss-knife.xyz/send-tx?chainId=1&to=0xc36442b4a4522e871399cd717abdd847ab11fe88&calldata=0xac9650d80000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000044a22cb465000000000000000000000000887541ff8c2f1908c489a62983157ac22b331a15000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000)
[3](https://transact.swiss-knife.xyz/send-tx?chainId=8453&to=0xF332bF49Da180E0c4814dC662d179020f31aE07D&calldata=0x6a7612020000000000000000000000008d29be29923b68abfdd21e541b9374737b49cdad00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000493e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000028000000000000000000000000000000000000000000000000000000000000001048d80ff0a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000ae006969174fd72466430a46e18234d0b530c9fd5f4900000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000017538fd1e30d8e7771105d470fe8d65b6ab0da93f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004dd365b8b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000410000000000000000000000006969174fd72466430a46e18234d0b530c9fd5f4900000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000)
[4](https://transact.swiss-knife.xyz/send-tx?chainId=8453&to=0xF332bF49Da180E0c4814dC662d179020f31aE07D&calldata=0x6a7612020000000000000000000000006969174fd72466430a46e18234d0b530c9fd5f49000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001d4c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005b8d8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006969174fd72466430a46e18234d0b530c9fd5f490000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000410000000000000000000000006969174fd72466430a46e18234d0b530c9fd5f4900000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000)

<img width="859" height="240" alt="image" src="https://github.com/user-attachments/assets/2aac06bc-ac66-4359-8093-ae729c8c4441" />
<img width="854" height="230" alt="image" src="https://github.com/user-attachments/assets/f6a1e0c0-5dd8-4f40-8e2c-a9cfa396f7af" />
<img width="714" height="360" alt="image" src="https://github.com/user-attachments/assets/25b261a2-14dc-4505-852e-7940b06b9a40" />
<img width="735" height="295" alt="image" src="https://github.com/user-attachments/assets/3a81d876-01f5-4183-a81e-63ce59e23309" />
