### PR TITLE
Fix a bug where we're setting the Safe nonce according to the activity tab

### DIFF
--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -727,11 +727,10 @@ describe('RequestsController ', () => {
   })
 
   test('assigns the first free nonce to each new Safe request', async () => {
-    const { controller, accountsCtrl, activityCtrl } = await prepareTest(false, true)
+    const { controller, accountsCtrl } = await prepareTest(false, true)
     const accountAddr = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
     const chainId = 1n
     accountsCtrl.accountStates[accountAddr]![chainId.toString()]!.nonce = 119n
-    await activityCtrl.addAccountOp(getActivityAccountOp(accountAddr, chainId, 117n))
     const buildRequest = () =>
       controller.build({
         type: 'calls',
@@ -792,14 +791,14 @@ describe('RequestsController ', () => {
       if (request.kind === 'calls') request.signAccountOp.destroy()
     })
   })
-  test('uses the latest activity nonce when the account state is stale', async () => {
+  test('BUG: ignores activity nonces when assigning a new Safe request', async () => {
     const { controller, accountsCtrl, activityCtrl } = await prepareTest(false, true)
     const accountAddr = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
     const chainId = 1n
     accountsCtrl.accountStates[accountAddr]![chainId.toString()]!.nonce = 119n
-    await activityCtrl.addAccountOp(getActivityAccountOp(accountAddr, chainId, 118n, 1))
-    await activityCtrl.addAccountOp(getActivityAccountOp(accountAddr, chainId, 120n, 2))
-    await activityCtrl.addAccountOp(getActivityAccountOp(accountAddr, 10n, 999n, 3))
+    await activityCtrl.addAccountOp(
+      getActivityAccountOp(accountAddr, chainId, 1n << 192n, Date.now())
+    )
 
     await controller.build({
       type: 'calls',
@@ -815,7 +814,7 @@ describe('RequestsController ', () => {
     const request = controller.userRequests[0]
     expect(request?.kind).toBe('calls')
     if (request?.kind !== 'calls') throw new Error('Expected calls request')
-    expect(request.signAccountOp.accountOp.nonce).toBe(121n)
+    expect(request.signAccountOp.accountOp.nonce).toBe(119n)
     request.signAccountOp.destroy()
   })
   test('keeps the nonce when adding calls to an existing Safe request', async () => {

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -63,7 +63,6 @@ import {
 import { isSmartAccount } from '../../libs/account/account'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { AccountOp, getAccountOpNonce, isSafeRejectionCall } from '../../libs/accountOp/accountOp'
-import { AccountOpStatus, Call } from '../../libs/accountOp/types'
 import {
   getAccountOpBanners,
   getDappUserRequestsBanners,
@@ -98,6 +97,7 @@ import EventEmitter from '../eventEmitter/eventEmitter'
 import { SignAccountOpController } from '../signAccountOp/signAccountOp'
 import { SignAccountOpPreferenceController } from '../signAccountOp/signAccountOpPreference'
 
+import type { Call } from '../../libs/accountOp/types'
 import type { EIP712TypedData } from '@safe-global/types-kit'
 import type { OnBroadcastFailed, OnBroadcastSuccess } from '../signAccountOp/signAccountOp'
 
@@ -219,13 +219,6 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   }
 
   #getFirstFreeNonce(accountAddr: string, chainId: bigint, startNonce: bigint): bigint {
-    const latestActivityAccountOp = this.#activity.getAccountOpsForAccount({ accountAddr }).find(
-      (accountOp) =>
-        accountOp.chainId === chainId &&
-        // failures do not move the nonce
-        accountOp.status !== AccountOpStatus.Failure &&
-        accountOp.status !== AccountOpStatus.Rejected
-    )
     const queuedNonces = this.userRequests.reduce<bigint[]>((nonces, request) => {
       if (
         request.kind !== 'calls' ||
@@ -240,10 +233,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       return nonces
     }, [])
 
-    const activityNextNonce = latestActivityAccountOp
-      ? latestActivityAccountOp.nonce + 1n
-      : startNonce
-    let firstFreeNonce = activityNextNonce > startNonce ? activityNextNonce : startNonce
+    let firstFreeNonce = startNonce
     while (queuedNonces.includes(firstFreeNonce)) firstFreeNonce += 1n
     return firstFreeNonce
   }

--- a/src/controllers/signAccountOp/signAccountOp.ts
+++ b/src/controllers/signAccountOp/signAccountOp.ts
@@ -78,8 +78,17 @@ import { BaseAccount } from '../../libs/account/BaseAccount'
 import { canFeeOptionCoverAmount, isTransferredTokenFeeOption } from '../../libs/account/feeOptions'
 import { getBaseAccount } from '../../libs/account/getBaseAccount'
 import { Safe } from '../../libs/account/Safe'
-import { AccountOp, GasFeePayment, getSignableCalls } from '../../libs/accountOp/accountOp'
-import { AccountOpIdentifiedBy, SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
+import {
+  AccountOp,
+  GasFeePayment,
+  getAccountOpNonce,
+  getSignableCalls
+} from '../../libs/accountOp/accountOp'
+import {
+  AccountOpIdentifiedBy,
+  getSubmittedAccountOpNonce,
+  SubmittedAccountOp
+} from '../../libs/accountOp/submittedAccountOp'
 import { AccountOpStatus, Call } from '../../libs/accountOp/types'
 import { getScamDetectedText } from '../../libs/banners/banners'
 import {
@@ -3786,7 +3795,11 @@ export class SignAccountOpController
       eoaNonce: this.accountOp.eoaNonce,
       status: AccountOpStatus.BroadcastedButNotConfirmed,
       txnId: transactionRes.txnId,
-      nonce: BigInt(transactionRes.nonce),
+      nonce: getSubmittedAccountOpNonce(
+        getAccountOpNonce(accountOp),
+        transactionRes.nonce,
+        !!account.safeCreation
+      ),
       identifiedBy: transactionRes.identifiedBy,
       timestamp: new Date().getTime(),
       isSingletonDeploy: !!accountOp.calls.find(

--- a/src/libs/accountOp/submittedAccountOp.test.ts
+++ b/src/libs/accountOp/submittedAccountOp.test.ts
@@ -1,6 +1,28 @@
-import { getAccountOpRecipients, SubmittedAccountOp } from './submittedAccountOp'
+import {
+  getAccountOpRecipients,
+  getSubmittedAccountOpNonce,
+  SubmittedAccountOp
+} from './submittedAccountOp'
 
 describe('SubmittedAccountOp', () => {
+  describe('getSubmittedAccountOpNonce', () => {
+    const userOperationNonce = 1n << 192n
+
+    test('keeps the Safe transaction nonce when the broadcast uses a UserOperation nonce', () => {
+      expect(getSubmittedAccountOpNonce(30n, userOperationNonce, true)).toBe(30n)
+    })
+
+    test('keeps using the broadcast nonce for non-Safe transactions', () => {
+      expect(getSubmittedAccountOpNonce(30n, userOperationNonce, false)).toBe(
+        userOperationNonce
+      )
+    })
+
+    test('falls back to the broadcast nonce when a Safe transaction nonce is unavailable', () => {
+      expect(getSubmittedAccountOpNonce(null, 7, true)).toBe(7n)
+    })
+  })
+
   describe('getAccountOpRecipients', () => {
     const op = {
       accountAddr: '0xB674F3fd5F43464dB0448a57529eAF37F04cceA5',

--- a/src/libs/accountOp/submittedAccountOp.ts
+++ b/src/libs/accountOp/submittedAccountOp.ts
@@ -120,6 +120,21 @@ export interface SubmittedAccountOpLike
   activitySource?: 'internal' | 'external'
 }
 
+/**
+ * Returns the account-level nonce to store in Activity. Safe transactions broadcast through a
+ * bundler have an unrelated, random UserOperation nonce, which remains available on
+ * `accountOp.asUserOperation.nonce` and must not replace the Safe transaction nonce.
+ */
+export function getSubmittedAccountOpNonce(
+  accountOpNonce: AccountOp['nonce'],
+  broadcastNonce: number | bigint,
+  isSafeAccount: boolean
+): bigint {
+  if (isSafeAccount && accountOpNonce !== null) return accountOpNonce
+
+  return BigInt(broadcastNonce)
+}
+
 export function isIdentifiedByTxn(identifiedBy: AccountOpIdentifiedBy): boolean {
   return identifiedBy && identifiedBy.type === 'Transaction'
 }


### PR DESCRIPTION
Bug:
* you broadcast from the gas tank a safe txn
* in submittedAccountOp, the nonce is the user op nonce, which is high
* the next Safe txn's nonce gets set to that high number

Fix:
* record the correct submittedAccountOp nonce when broadcasting safe txns with the gas tank
* do not look at the activity tab for fetching the latest nonce