### PR TITLE
Block apps that spam requests, and batch requests that arrive together

### DIFF
--- a/src/consts/safeguards/dappRequestSpam.ts
+++ b/src/consts/safeguards/dappRequestSpam.ts
@@ -1,0 +1,8 @@
+/** How long a rejection keeps counting against the app that sent it. */
+export const DAPP_REJECT_TRACKING_WINDOW = 60 * 1000
+
+/** Rejections within the tracking window before the app is treated as spamming. */
+export const DAPP_REJECTS_BEFORE_OFFERING_SILENCE = 2
+
+/** How long an app stays silenced after the user silences it. */
+export const DAPP_SILENCE_DURATION = 60 * 1000

--- a/src/controllers/dapps/dapps.test.ts
+++ b/src/controllers/dapps/dapps.test.ts
@@ -11,12 +11,14 @@ import { Session } from '../../classes/session'
 import { predefinedDapps } from '../../consts/dapps/dapps'
 import mockChains from '../../consts/dapps/mockChains'
 import mockDapps from '../../consts/dapps/mockDapps'
+import { DAPP_SILENCE_DURATION } from '../../consts/safeguards/dappRequestSpam'
 import { Dapp, DAPP_VERIFICATION_BANNER_IDS } from '../../interfaces/dapp'
 import { IStorageController } from '../../interfaces/storage'
 import { DappConnectRequest } from '../../interfaces/userRequest'
 import { PhishingController } from '../phishing/phishing'
 
 const TRENDING_TOKENS_URL = 'https://cena.ambire.com/api/v3/trending/'
+const NOW = 1_700_000_000_000
 
 // Two valid entries plus one invalid (no price) to exercise normalization + filtering.
 // Mirrors the trimmed endpoint shape: a { tokens: [...] } wrapper of minimal coin objects
@@ -2360,6 +2362,58 @@ describe('DappsController', () => {
 
       storageGetSpy.mockRestore()
       fetchSpy.mockRestore()
+    })
+  })
+
+  describe('request spam tracking', () => {
+    const DAPP_ID = 'spamming-dapp.com'
+
+    test('offers to silence only after the app has been rejected enough times', async () => {
+      const { controller } = await prepareTest()
+
+      expect(controller.shouldOfferToSilenceDapp(DAPP_ID)).toBe(false)
+
+      controller.recordDappRejection(DAPP_ID)
+      expect(controller.shouldOfferToSilenceDapp(DAPP_ID)).toBe(false)
+
+      controller.recordDappRejection(DAPP_ID)
+      expect(controller.shouldOfferToSilenceDapp(DAPP_ID)).toBe(true)
+    })
+
+    test('one rejection is never enough, however soon the app asks again', async () => {
+      const { controller } = await prepareTest()
+
+      controller.recordDappRejection(DAPP_ID)
+
+      expect(controller.shouldOfferToSilenceDapp(DAPP_ID)).toBe(false)
+    })
+
+    test('one approved request clears everything held against the app', async () => {
+      const { controller } = await prepareTest()
+
+      controller.recordDappRejection(DAPP_ID)
+      controller.recordDappRejection(DAPP_ID)
+      controller.clearDappRejections(DAPP_ID)
+
+      expect(controller.shouldOfferToSilenceDapp(DAPP_ID)).toBe(false)
+    })
+
+    test('silencing lasts a minute and leaves the connection alone', async () => {
+      const { controller } = await prepareTest()
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(NOW)
+
+      expect(controller.isDappSilenced(DAPP_ID)).toBe(false)
+
+      controller.silenceDapp(DAPP_ID)
+      expect(controller.isDappSilenced(DAPP_ID)).toBe(true)
+
+      nowSpy.mockReturnValue(NOW + DAPP_SILENCE_DURATION - 1)
+      expect(controller.isDappSilenced(DAPP_ID)).toBe(true)
+
+      nowSpy.mockReturnValue(NOW + DAPP_SILENCE_DURATION)
+      expect(controller.isDappSilenced(DAPP_ID)).toBe(false)
+
+      nowSpy.mockRestore()
     })
   })
 })

--- a/src/controllers/dapps/dapps.ts
+++ b/src/controllers/dapps/dapps.ts
@@ -37,8 +37,15 @@ import { Messenger } from '../../interfaces/messenger'
 import { INetworksController } from '../../interfaces/network'
 import { BlacklistedStatus, IPhishingController } from '../../interfaces/phishing'
 import { IStorageController } from '../../interfaces/storage'
-import { IUiController, View, isExtensionOverlayView } from '../../interfaces/ui'
+import { isExtensionOverlayView, IUiController, View } from '../../interfaces/ui'
 import { UserRequest } from '../../interfaces/userRequest'
+import {
+  DappSpamRecord,
+  getEmptyDappSpamRecord,
+  isSilenced,
+  recordRejection,
+  shouldOfferSilence
+} from '../../libs/dapps/dappRequestSpam'
 import {
   formatDappName,
   getAccountsForDapp,
@@ -90,6 +97,11 @@ export class DappsController extends EventEmitter implements IDappsController {
   dappSessions: { [sessionId: string]: Session } = {}
 
   #dapps = new Map<string, Dapp>()
+
+  /**
+   * Rejection counters and quiet periods, keyed by dapp id.
+   */
+  #dappSpamRecords = new Map<string, DappSpamRecord>()
 
   #recentDapps: RecentDappEntry[] = []
 
@@ -1177,6 +1189,36 @@ export class DappsController extends EventEmitter implements IDappsController {
     this.#recentDapps = []
     await this.#storage.set('recentDapps', this.#recentDapps)
     this.emitUpdate()
+  }
+
+  /**
+   * Remembers that the user rejected a request this app sent. Only user-initiated rejections
+   * belong here - the wallet's own auto-rejections must not count against the app.
+   */
+  recordDappRejection(id: string) {
+    if (!id) return
+
+    this.#dappSpamRecords.set(id, recordRejection(this.#dappSpamRecords.get(id), Date.now()))
+  }
+
+  /** One approved request clears all suspicion the app has accumulated. */
+  clearDappRejections(id: string) {
+    this.#dappSpamRecords.delete(id)
+  }
+
+  shouldOfferToSilenceDapp(id: string): boolean {
+    return shouldOfferSilence(this.#dappSpamRecords.get(id), Date.now())
+  }
+
+  isDappSilenced(id: string): boolean {
+    return isSilenced(this.#dappSpamRecords.get(id), Date.now())
+  }
+
+  silenceDapp(id: string) {
+    if (!id) return
+
+    const record = this.#dappSpamRecords.get(id) ?? getEmptyDappSpamRecord()
+    this.#dappSpamRecords.set(id, { ...record, silencedAt: Date.now() })
   }
 
   hasPermission(id: string, source?: ConnectionSource) {

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -871,7 +871,9 @@ export class MainController extends EventEmitter implements IMainController {
     // call closeRequestWindow while still on the currently selected account to allow proper
     // state cleanup of the controllers like requestsCtrl, signAccountOpCtrl, signMessageCtrl...
     if (this.requests.currentUserRequest?.kind !== 'switchAccount') {
-      await this.requests.closeRequestWindow()
+      // Switching accounts is the user acting on the wallet, not refusing the apps that
+      // happened to be waiting, so it must not count towards the spam detection.
+      await this.requests.closeRequestWindow({ isUserInitiated: false })
     }
     const swapAndBridgeSigningRequest = this.requests.visibleUserRequests.find(
       ({ kind }) => kind === 'swapAndBridge'

--- a/src/controllers/main/main.ts
+++ b/src/controllers/main/main.ts
@@ -1985,7 +1985,10 @@ export class MainController extends EventEmitter implements IMainController {
     ) as CallsUserRequest | undefined
 
     if (userRequest) {
-      await this.requests.rejectCalls({ activeRouteIds: [activeRouteId] })
+      await this.requests.rejectCalls({
+        activeRouteIds: [activeRouteId],
+        isUserInitiated: false
+      })
     } else {
       this.swapAndBridge.removeActiveRoute(activeRouteId)
     }

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -5,7 +5,10 @@ import { describe, expect, test } from '@jest/globals'
 import { makeDapp } from '../../../test/helpers/dapps'
 import { makeMainController } from '../../../test/helpers/mainController'
 import { Session } from '../../classes/session'
-import { DAPP_SILENCE_DURATION } from '../../consts/safeguards/dappRequestSpam'
+import {
+  DAPP_REJECTS_BEFORE_OFFERING_SILENCE,
+  DAPP_SILENCE_DURATION
+} from '../../consts/safeguards/dappRequestSpam'
 import { Hex } from '../../interfaces/hex'
 import {
   BenzinUserRequest,
@@ -1694,6 +1697,69 @@ describe('RequestsController ', () => {
       callsRequests[0]!.signAccountOp.destroy()
     })
 
+    test('a transaction with no parameters does not take its batch down with it', async () => {
+      const { controller } = await prepareTest(true)
+      const sendRaw = (dappPromise: { id: string; reject: (err: any) => void }, params: any[]) =>
+        controller.build({
+          type: 'dappRequest',
+          params: {
+            request: { method: 'eth_sendTransaction', params, session: MOCK_SESSION },
+            dappPromise: { resolve: () => {}, session: MOCK_SESSION, ...dappPromise }
+          }
+        })
+
+      const [noParams, noFrom] = makeRejectMocks(2) as [
+        { id: string; reject: jest.Mock },
+        { id: string; reject: jest.Mock }
+      ]
+
+      // Neither payload yields a `from`, so both land on the same queue and are built together
+      const outcomes = await Promise.allSettled([
+        sendRaw(noParams, []),
+        sendRaw(noFrom, [{ to: TO, value: '0x0', data: '0x' }])
+      ])
+
+      expect(outcomes.map((o) => o.status)).toEqual(['rejected', 'rejected'])
+
+      const [noParamsReason, noFromReason] = outcomes.map(
+        (o) => (o as PromiseRejectedResult).reason
+      )
+
+      // The empty payload is answered with what was wrong, not with a TypeError from reading it
+      expect(noParamsReason.message).toContain('no parameters')
+      // ...and the other app is told about its own payload rather than inheriting that failure
+      expect(noFromReason.message).not.toBe(noParamsReason.message)
+
+      expect(controller.userRequests.filter((r) => r.kind === 'calls')).toHaveLength(0)
+    })
+
+    test('every transaction turned away for one already signing is answered', async () => {
+      const { controller, getCallsRequest } = await prepareTest()
+      const inProgress = await getCallsRequest({ addr: FROM, chainId: 1n })
+
+      await controller.addUserRequests([inProgress])
+
+      // A signing/broadcasting run is under way for this account and chain
+      ;(inProgress.signAccountOp as any).signAndBroadcastPromise = new Promise(() => {})
+
+      const second = await getCallsRequest({ addr: FROM, chainId: 1n })
+      const third = await getCallsRequest({ addr: FROM, chainId: 1n })
+      const rejectSecond = jest.fn()
+      const rejectThird = jest.fn()
+      second.dappPromises[0]!.reject = rejectSecond
+      third.dappPromises[0]!.reject = rejectThird
+
+      await controller.addUserRequests([second, third])
+
+      // Answering only the first leaves every app behind it waiting on a promise nobody settles
+      expect(rejectSecond).toHaveBeenCalled()
+      expect(rejectThird).toHaveBeenCalled()
+
+      inProgress.signAccountOp.destroy()
+      second.signAccountOp.destroy()
+      third.signAccountOp.destroy()
+    })
+
     test('supersedes every message fired at once down to exactly one', async () => {
       const { controller, uiCtrl } = await prepareTest(true)
       const sideEffects = watchSideEffects(uiCtrl)
@@ -1837,6 +1903,32 @@ describe('RequestsController ', () => {
       await controller.rejectUserRequests('Superseded', [second.id], { isUserInitiated: false })
 
       expect(dappsCtrl.shouldOfferToSilenceDapp(MOCK_SESSION.id)).toBe(false)
+    })
+
+    test('does not count the requests the wallet drops when it closes the view itself', async () => {
+      const { controller, dappsCtrl } = await prepareTest()
+      await dappsCtrl.addDapp(TEST_DAPP)
+
+      // Twice, because one rejection is never enough to offer silencing anyway
+      for (let i = 0; i < DAPP_REJECTS_BEFORE_OFFERING_SILENCE; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        await buildDappRequest(controller, { resolve: () => {}, reject: () => {} })
+        // What `selectAccount` does - the user acted on the wallet, not on the app
+        // eslint-disable-next-line no-await-in-loop
+        await controller.closeRequestWindow({ isUserInitiated: false })
+      }
+
+      expect(dappsCtrl.shouldOfferToSilenceDapp(MOCK_SESSION.id)).toBe(false)
+
+      // The same close, but this time it really is the user turning the app away
+      for (let i = 0; i < DAPP_REJECTS_BEFORE_OFFERING_SILENCE; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        await buildDappRequest(controller, { resolve: () => {}, reject: () => {} })
+        // eslint-disable-next-line no-await-in-loop
+        await controller.closeRequestWindow()
+      }
+
+      expect(dappsCtrl.shouldOfferToSilenceDapp(MOCK_SESSION.id)).toBe(true)
     })
 
     test('one approved request clears what was held against the app', async () => {

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from '@jest/globals'
 import { makeDapp } from '../../../test/helpers/dapps'
 import { makeMainController } from '../../../test/helpers/mainController'
 import { Session } from '../../classes/session'
+import { DAPP_SILENCE_DURATION } from '../../consts/safeguards/dappRequestSpam'
 import { Hex } from '../../interfaces/hex'
 import {
   BenzinUserRequest,
@@ -21,6 +22,7 @@ import type { AccountOp } from '../../libs/accountOp/accountOp'
 import type { SubmittedAccountOp } from '../../libs/accountOp/submittedAccountOp'
 
 const MOCK_SESSION = new Session({ tabId: 1, url: 'https://test-dApp.com' })
+const NOW = 1_700_000_000_000
 const SAFE_TX_HASH = `0x${'1'.repeat(64)}` as Hex
 const SAFE_SIGNATURE =
   '0x05404ea5dfa13ddd921cda3f587af6927cc127ee174b57c9891491bfc1f0d3d005f649f8a1fc9147405f064507bae08816638cfc441c4d0dc4eb6640e16621991b'
@@ -203,6 +205,7 @@ const prepareTest = async (seedTestDapp = false, isSelectedAccountSafe = false) 
         calls: [
           {
             id: 'testID',
+            dappPromiseId: 'testID',
             to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
             value: BigInt(0),
             data: '0xa9059cbb000000000000000000000000e5a4dad2ea987215460379ab285df87136e83bea00000000000000000000000000000000000000000000000000000000005040aa'
@@ -248,6 +251,7 @@ const prepareTest = async (seedTestDapp = false, isSelectedAccountSafe = false) 
   return {
     selectedAccountCtrl: mainCtrl.selectedAccount,
     accountsCtrl: mainCtrl.accounts,
+    dappsCtrl: mainCtrl.dapps,
     portfolioCtrl: mainCtrl.portfolio,
     storageCtrl: mainCtrl.storage,
     safeCtrl: mainCtrl.safe,
@@ -1511,6 +1515,438 @@ describe('RequestsController ', () => {
     const { controller } = await prepareTest()
 
     expect(controller.toJSON()).toBeDefined()
+  })
+
+  describe('concurrent dapp requests', () => {
+    const ACCOUNT_ADDR = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+    const FROM = ACCOUNT_ADDR
+    const TO = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+    const OTHER_DAPP_SESSION = new Session({ tabId: 3, url: 'https://another-dApp.com' })
+
+    const TYPED_DATA = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' }
+        ],
+        Mail: [{ name: 'contents', type: 'string' }]
+      },
+      primaryType: 'Mail',
+      domain: { name: 'Test Mail', version: '1', chainId: 1 },
+      message: { contents: 'Hello!' }
+    }
+
+    const sendTransaction = (
+      controller: Awaited<ReturnType<typeof prepareTest>>['controller'],
+      dappPromise: { id: string; reject: (err: any) => void },
+      session = MOCK_SESSION,
+      callOverrides: { data?: string } = {}
+    ) =>
+      controller.build({
+        type: 'dappRequest',
+        params: {
+          request: {
+            method: 'eth_sendTransaction',
+            params: [{ from: FROM, to: TO, value: '0x0', data: '0x', ...callOverrides }],
+            session
+          },
+          dappPromise: { resolve: () => {}, session, ...dappPromise }
+        }
+      })
+
+    const signTypedData = (
+      controller: Awaited<ReturnType<typeof prepareTest>>['controller'],
+      dappPromise: { id: string; reject: (err: any) => void }
+    ) =>
+      controller.build({
+        type: 'dappRequest',
+        params: {
+          request: {
+            method: 'eth_signTypedData_v4',
+            params: [FROM, JSON.stringify(TYPED_DATA)],
+            session: MOCK_SESSION
+          },
+          dappPromise: { resolve: () => {}, session: MOCK_SESSION, ...dappPromise }
+        }
+      })
+
+    const makeRejectMocks = (count: number) =>
+      Array.from({ length: count }, (_, index) => ({ id: `promise-${index}`, reject: jest.fn() }))
+
+    /**
+     * What building the batch actually cost, rather than only what it ended up with. The end
+     * state looked right even when every request was built on its own, so the counts are the
+     * part worth asserting.
+     */
+    const watchSideEffects = (uiCtrl: Awaited<ReturnType<typeof prepareTest>>['uiCtrl']) => {
+      const open = jest.spyOn(uiCtrl.requestView, 'open')
+      const close = jest.spyOn(uiCtrl.requestView, 'close')
+      const updateAccountOpCalls = jest.spyOn(SignAccountOpController.prototype, 'update')
+
+      return {
+        openCount: () => open.mock.calls.length,
+        closeCount: () => close.mock.calls.length,
+        /** How many times the batch on screen was rebuilt, which is one estimation each. */
+        callsUpdateCount: () =>
+          updateAccountOpCalls.mock.calls.filter((args) => !!args[0]?.accountOpData?.calls).length
+      }
+    }
+
+    test('collects transactions fired at once into a single batch, keeping every promise', async () => {
+      const { controller, uiCtrl } = await prepareTest(true)
+      const sideEffects = watchSideEffects(uiCtrl)
+      const promises = makeRejectMocks(10)
+
+      await Promise.all(promises.map((promise) => sendTransaction(controller, promise)))
+
+      const callsRequests = controller.userRequests.filter(
+        (r) => r.kind === 'calls'
+      ) as CallsUserRequest[]
+
+      expect(callsRequests).toHaveLength(1)
+      expect(callsRequests[0]!.signAccountOp.accountOp.calls).toHaveLength(10)
+      // The promise of every transaction has to be on the batch - one that isn't would leave
+      // the app waiting on an answer that never comes
+      expect(callsRequests[0]!.dappPromises).toHaveLength(10)
+
+      // One window for the ten of them, and it is never torn down on the way
+      expect(sideEffects.openCount()).toBe(1)
+      expect(sideEffects.closeCount()).toBe(0)
+      // The first transaction opens the batch and the nine that pile up behind it join in one
+      // go. Ten separate merges would mean ten estimations of a batch that is still growing.
+      expect(sideEffects.callsUpdateCount()).toBe(1)
+
+      await controller.rejectUserRequests('User rejected', [callsRequests[0]!.id])
+
+      promises.forEach(({ reject }) => expect(reject).toHaveBeenCalled())
+      expect(controller.userRequests).toHaveLength(0)
+    })
+
+    test('collects transactions from two apps on the same chain into one batch', async () => {
+      const { controller, uiCtrl, dappsCtrl } = await prepareTest(true)
+      await dappsCtrl.addDapp(
+        makeDapp({
+          id: OTHER_DAPP_SESSION.id,
+          name: 'Another Dapp',
+          url: OTHER_DAPP_SESSION.origin,
+          chainId: 1,
+          chainIds: [1]
+        })
+      )
+      const sideEffects = watchSideEffects(uiCtrl)
+      const [ours, theirs] = makeRejectMocks(2)
+
+      await Promise.all([
+        sendTransaction(controller, ours!),
+        sendTransaction(controller, theirs!, OTHER_DAPP_SESSION)
+      ])
+
+      const callsRequests = controller.userRequests.filter(
+        (r) => r.kind === 'calls'
+      ) as CallsUserRequest[]
+
+      expect(callsRequests).toHaveLength(1)
+      expect(callsRequests[0]!.signAccountOp.accountOp.calls).toHaveLength(2)
+      // Both apps are waiting on this one batch, so both promises have to be on it
+      expect(callsRequests[0]!.dappPromises.map((p) => p.session.id).sort()).toEqual(
+        [MOCK_SESSION.id, OTHER_DAPP_SESSION.id].sort()
+      )
+      expect(sideEffects.openCount()).toBe(1)
+      expect(sideEffects.closeCount()).toBe(0)
+
+      callsRequests[0]!.signAccountOp.destroy()
+    })
+
+    test('a malformed transaction in the batch costs only the app that sent it', async () => {
+      const { controller, uiCtrl } = await prepareTest(true)
+      const sideEffects = watchSideEffects(uiCtrl)
+      const promises = makeRejectMocks(10)
+      const malformed = promises[4]!
+
+      const outcomes = await Promise.allSettled(
+        promises.map((promise) =>
+          // Odd-length hex data, which is rejected while the batch is being normalized
+          sendTransaction(controller, promise, MOCK_SESSION, {
+            data: promise === malformed ? '0xabc' : '0x'
+          })
+        )
+      )
+
+      const callsRequests = controller.userRequests.filter(
+        (r) => r.kind === 'calls'
+      ) as CallsUserRequest[]
+
+      expect(callsRequests).toHaveLength(1)
+      // The nine good ones are unaffected by the one that isn't
+      expect(callsRequests[0]!.signAccountOp.accountOp.calls).toHaveLength(9)
+      expect(callsRequests[0]!.dappPromises).toHaveLength(9)
+
+      // Only the app that sent the bad payload is turned away, and it is told what was wrong
+      const rejected = outcomes.filter((outcome) => outcome.status === 'rejected')
+      expect(rejected).toHaveLength(1)
+      expect((rejected[0] as PromiseRejectedResult).reason.message).toContain('hex data')
+      expect(outcomes.indexOf(rejected[0]!)).toBe(promises.indexOf(malformed))
+
+      expect(sideEffects.openCount()).toBe(1)
+      expect(sideEffects.closeCount()).toBe(0)
+
+      callsRequests[0]!.signAccountOp.destroy()
+    })
+
+    test('supersedes every message fired at once down to exactly one', async () => {
+      const { controller, uiCtrl } = await prepareTest(true)
+      const sideEffects = watchSideEffects(uiCtrl)
+      const promises = makeRejectMocks(10)
+
+      await Promise.all(promises.map((promise) => signTypedData(controller, promise)))
+
+      expect(controller.userRequests.filter((r) => r.kind === 'typedMessage')).toHaveLength(1)
+      // Nine were replaced and told so; the survivor is still waiting on the user
+      expect(promises.filter(({ reject }) => reject.mock.calls.length)).toHaveLength(9)
+
+      // The nine are turned away before they are ever added, so the window is opened once for
+      // the survivor instead of being opened and closed around each one in turn
+      expect(sideEffects.openCount()).toBe(1)
+      expect(sideEffects.closeCount()).toBe(0)
+    })
+
+    test('a superseded message does not count against the app', async () => {
+      const { controller, dappsCtrl } = await prepareTest(true)
+      const promises = makeRejectMocks(10)
+
+      await Promise.all(promises.map((promise) => signTypedData(controller, promise)))
+
+      // Superseding is the wallet's own doing, not the user refusing the app, so none of the
+      // nine may push it towards being treated as a spammer
+      expect(dappsCtrl.shouldOfferToSilenceDapp(MOCK_SESSION.id)).toBe(false)
+    })
+
+    test('a message and a transaction fired at once do not hold each other up', async () => {
+      const { controller } = await prepareTest(true)
+      const [transaction, message] = makeRejectMocks(2)
+
+      await Promise.all([
+        sendTransaction(controller, transaction!),
+        signTypedData(controller, message!)
+      ])
+
+      expect(controller.userRequests.filter((r) => r.kind === 'calls')).toHaveLength(1)
+      expect(controller.userRequests.filter((r) => r.kind === 'typedMessage')).toHaveLength(1)
+      expect(transaction!.reject).not.toHaveBeenCalled()
+      expect(message!.reject).not.toHaveBeenCalled()
+
+      const callsRequest = controller.userRequests.find(
+        (r) => r.kind === 'calls'
+      ) as CallsUserRequest
+      callsRequest.signAccountOp.destroy()
+    })
+
+    test('one request that cannot be prepared does not abandon the others', async () => {
+      const { controller, accountsCtrl, getCallsRequest } = await prepareTest()
+      const unfetchable = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 10n })
+      const fine = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      const rejectUnfetchable = jest.fn()
+      const rejectFine = jest.fn()
+      unfetchable.dappPromises[0]!.reject = rejectUnfetchable
+      fine.dappPromises[0]!.reject = rejectFine
+
+      // No cached state to fall back on and nothing to fetch, so this one cannot be prepared
+      delete accountsCtrl.accountStates[ACCOUNT_ADDR]!['10']
+      jest
+        .spyOn(accountsCtrl, 'forceFetchPendingState')
+        .mockImplementation(async (_addr: string, chainId: bigint) =>
+          chainId === 10n
+            ? undefined
+            : accountsCtrl.accountStates[ACCOUNT_ADDR]![chainId.toString()]
+        )
+
+      await controller.addUserRequests([unfetchable, fine])
+
+      // Abandoning the rest of the batch would leave their apps waiting on promises nobody
+      // will ever settle
+      expect(controller.userRequests.map((r) => r.id)).toEqual([fine.id])
+      expect(rejectUnfetchable).toHaveBeenCalled()
+      expect(rejectFine).not.toHaveBeenCalled()
+
+      unfetchable.signAccountOp.destroy()
+      fine.signAccountOp.destroy()
+    })
+  })
+
+  describe('app request spam', () => {
+    const ACCOUNT_ADDR = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
+    const OTHER_SESSION = new Session({ tabId: 2, url: 'https://other-dApp.com' })
+
+    const buildDappRequest = (
+      controller: Awaited<ReturnType<typeof prepareTest>>['controller'],
+      dappPromise: { resolve: () => void; reject: (err: any) => void }
+    ) =>
+      controller.build({
+        type: 'dappRequest',
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: ['0x48656c6c6f', ACCOUNT_ADDR],
+            session: MOCK_SESSION
+          },
+          dappPromise: { id: 'testID', session: MOCK_SESSION, ...dappPromise }
+        }
+      })
+
+    test("counts one rejection however many of the app's requests it clears", async () => {
+      const { controller, dappsCtrl, getCallsRequest } = await prepareTest()
+      const first = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      const second = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 10n })
+      first.id = 'first-request'
+      second.id = 'second-request'
+      controller.userRequests = [first, second]
+
+      // What closing the request window does - one user action, two requests from one app
+      await controller.rejectUserRequests('User rejected', [first.id, second.id])
+
+      expect(dappsCtrl.shouldOfferToSilenceDapp(MOCK_SESSION.id)).toBe(false)
+    })
+
+    test('counts a rejection against every app with something in a shared batch', async () => {
+      const { controller, dappsCtrl, getCallsRequest } = await prepareTest()
+      const request = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      request.dappPromises = [
+        { id: 'a', resolve: () => {}, reject: () => {}, session: MOCK_SESSION, meta: {} },
+        { id: 'b', resolve: () => {}, reject: () => {}, session: OTHER_SESSION, meta: {} }
+      ]
+      controller.userRequests = [request]
+
+      await controller.rejectUserRequests('User rejected', [request.id])
+      await controller.addUserRequests([request])
+      await controller.rejectUserRequests('User rejected', [request.id])
+
+      expect(dappsCtrl.shouldOfferToSilenceDapp(MOCK_SESSION.id)).toBe(true)
+      expect(dappsCtrl.shouldOfferToSilenceDapp(OTHER_SESSION.id)).toBe(true)
+    })
+
+    test('does not count a rejection the wallet made on its own behalf', async () => {
+      const { controller, dappsCtrl, getCallsRequest } = await prepareTest()
+      const first = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      const second = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 10n })
+      first.id = 'first-request'
+      second.id = 'second-request'
+      controller.userRequests = [first, second]
+
+      await controller.rejectUserRequests('Superseded', [first.id], { isUserInitiated: false })
+      await controller.rejectUserRequests('Superseded', [second.id], { isUserInitiated: false })
+
+      expect(dappsCtrl.shouldOfferToSilenceDapp(MOCK_SESSION.id)).toBe(false)
+    })
+
+    test('one approved request clears what was held against the app', async () => {
+      const { controller, dappsCtrl, getCallsRequest } = await prepareTest()
+      const rejected = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      const resolved = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 10n })
+      rejected.id = 'rejected-request'
+      resolved.id = 'resolved-request'
+      controller.userRequests = [rejected, resolved]
+
+      await controller.rejectUserRequests('User rejected', [rejected.id])
+      await controller.resolveUserRequest(null, resolved.id)
+
+      expect(dappsCtrl.shouldOfferToSilenceDapp(MOCK_SESSION.id)).toBe(false)
+    })
+
+    test("reports how many of the app's requests are queued behind the open one", async () => {
+      const { controller, getCallsRequest } = await prepareTest()
+      const first = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      const second = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 10n })
+      first.id = 'first-request'
+      second.id = 'second-request'
+      controller.userRequests = [first, second]
+      await controller.setCurrentUserRequestById(first.id, { skipFocus: true })
+
+      expect(controller.currentRequestRejectOptions).toEqual({
+        dappRequestsCount: 2,
+        canSilenceDapp: false
+      })
+
+      first.signAccountOp.destroy()
+      second.signAccountOp.destroy()
+    })
+
+    test('has no reject options for a request the wallet raised itself', async () => {
+      const { controller, getCallsRequest } = await prepareTest()
+      const request = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      request.dappPromises = []
+      controller.userRequests = [request]
+      await controller.setCurrentUserRequestById(request.id, { skipFocus: true })
+
+      expect(controller.currentRequestRejectOptions).toBe(null)
+
+      request.signAccountOp.destroy()
+    })
+
+    test("rejecting everything from the app leaves another app's request alone", async () => {
+      const { controller, getCallsRequest } = await prepareTest()
+      const fromDapp = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      const fromOtherDapp = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 10n })
+      fromDapp.id = 'from-dapp'
+      fromOtherDapp.id = 'from-other-dapp'
+      fromOtherDapp.dappPromises = [
+        { id: 'b', resolve: () => {}, reject: () => {}, session: OTHER_SESSION, meta: {} }
+      ]
+      controller.userRequests = [fromDapp, fromOtherDapp]
+      await controller.setCurrentUserRequestById(fromDapp.id, { skipFocus: true })
+
+      await controller.rejectAllRequestsFromCurrentDapp('User rejected')
+
+      expect(controller.userRequests.map((r) => r.id)).toEqual(['from-other-dapp'])
+
+      fromOtherDapp.signAccountOp.destroy()
+    })
+
+    test('silencing turns away what the app sends next, without an error toast', async () => {
+      const { controller, dappsCtrl, event, getCallsRequest } = await prepareTest()
+      await dappsCtrl.addDapp(TEST_DAPP)
+      const request = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      controller.userRequests = [request]
+      await controller.setCurrentUserRequestById(request.id, { skipFocus: true })
+
+      await controller.rejectAllRequestsFromCurrentDapp('User rejected', {
+        shouldSilenceDapp: true
+      })
+      expect(dappsCtrl.isDappSilenced(MOCK_SESSION.id)).toBe(true)
+
+      const errorMock = jest.fn()
+      event.on('error', errorMock)
+      const rejectMock = jest.fn()
+      await buildDappRequest(controller, { resolve: () => {}, reject: rejectMock })
+
+      expect(rejectMock).toHaveBeenCalled()
+      expect(errorMock).not.toHaveBeenCalled()
+      expect(controller.userRequests).toHaveLength(0)
+    })
+
+    test('lets the app through again once it has not been silenced for a minute', async () => {
+      const { controller, dappsCtrl, getCallsRequest } = await prepareTest()
+      await dappsCtrl.addDapp(TEST_DAPP)
+      const request = await getCallsRequest({ addr: ACCOUNT_ADDR, chainId: 1n })
+      controller.userRequests = [request]
+      await controller.setCurrentUserRequestById(request.id, { skipFocus: true })
+
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(NOW)
+      await controller.rejectAllRequestsFromCurrentDapp('User rejected', {
+        shouldSilenceDapp: true
+      })
+
+      nowSpy.mockReturnValue(NOW + DAPP_SILENCE_DURATION)
+      expect(dappsCtrl.isDappSilenced(MOCK_SESSION.id)).toBe(false)
+
+      const rejectMock = jest.fn()
+      await buildDappRequest(controller, { resolve: () => {}, reject: rejectMock })
+
+      expect(rejectMock).not.toHaveBeenCalled()
+      expect(controller.userRequests.some((r) => r.kind === 'message')).toBe(true)
+
+      nowSpy.mockRestore()
+    })
   })
 
   describe('call data and "to" field validation', () => {

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -68,6 +68,7 @@ import {
   getDappUserRequestsBanners,
   getSafeMessageRequestBanners
 } from '../../libs/banners/banners'
+import { getDappIdsFromUserRequest } from '../../libs/dapps/dappRequestSpam'
 import { getAmbirePaymasterService, getPaymasterService } from '../../libs/erc7677/erc7677'
 import { getShouldSimulateInTheBackground } from '../../libs/main/main'
 import { TokenResult } from '../../libs/portfolio'
@@ -108,6 +109,35 @@ const STATUS_WRAPPED_METHODS = {
 const ONE_CLICK_WINDOW_SIZE = {
   width: 600,
   height: 600
+}
+
+/** What an app's request flow hands over, before it is attached to a user request. */
+type DappPromise = {
+  id: string
+  session: DappProviderRequest['session']
+  resolve: (data: any) => void
+  reject: (data: any) => void
+}
+
+/**
+ * One app request waiting its turn behind the requests it would collide with. `settle` and
+ * `fail` answer the caller that is waiting on `build`, which is a different thing from the
+ * app's own promise - a request can be added successfully and still leave the app waiting for
+ * the user.
+ */
+type DappRequestQueueItem = {
+  request: DappProviderRequest
+  dappPromise: DappPromise
+  dapp: Dapp | null
+  settle: () => void
+  fail: (error: any) => void
+}
+
+/** One transaction request, validated and ready to go into a batch. */
+type DappCallsRequestParams = {
+  calls: Call[]
+  meta: CallsUserRequest['meta']
+  dappPromise: CallsUserRequest['dappPromises'][number]
 }
 
 /**
@@ -206,6 +236,22 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   }
 
   #currentUserRequest: UserRequest | null = null
+
+  /**
+   * App requests that would collide with one another, waiting their turn behind the one being
+   * built, keyed by what they collide on. Building a request takes slow account state fetches,
+   * so ten transactions fired in the same tick all reach the "is there already a batch for this
+   * account and chain?" check before any of them has answered it - and all ten build one. The
+   * queue turns that into a single build over all ten, and the entry is dropped once it drains.
+   */
+  #dappRequestQueues = new Map<string, DappRequestQueueItem[]>()
+
+  /**
+   * Requests that have been built and are about to be added. A request superseding another one
+   * takes the old one out first, so for a moment nothing is left to show - and tearing the view
+   * down over that costs the user a window that closes and reopens under them.
+   */
+  #userRequestsBeingAdded = 0
 
   private shouldSimulateAccountOps = true
 
@@ -487,7 +533,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
             hasTxInProgressErrorShown = true
           }
 
-          return
+          continue
         }
 
         const accountStateBefore =
@@ -520,7 +566,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
           })
           await this.#ui.notification.create({ title: "Couldn't Process Request", message })
 
-          return
+          continue
         }
 
         userRequestsToAdd.push(req)
@@ -536,9 +582,21 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         // remove the request only if it's not a Safe req
         if (existingMessageRequest && !this.#selectedAccount.account?.safeCreation) {
           existingMessageRequest.meta.accountAddr
-          await this.rejectUserRequests('User rejected the message request', [
-            existingMessageRequest.id
-          ])
+          // Taking the old one out empties the view for as long as it takes to add the
+          // replacement below, which is not a reason to close it
+          this.#userRequestsBeingAdded += 1
+
+          try {
+            // The wallet supersedes the older request on its own, so this is not the user
+            // refusing the app and must not count towards the spam detection.
+            await this.rejectUserRequests(
+              'User rejected the message request',
+              [existingMessageRequest.id],
+              { isUserInitiated: false }
+            )
+          } finally {
+            this.#userRequestsBeingAdded -= 1
+          }
         }
 
         userRequestsToAdd.push(req)
@@ -580,6 +638,14 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         this.userRequests.push(newReq)
       }
     })
+
+    // Every request in the batch was turned away above (an unsupported payload, a transaction
+    // already being signed, an account state that could not be fetched), so there is nothing
+    // to open a view for - the ones that were turned away have already been answered.
+    if (!userRequestsToAdd.length) {
+      this.emitUpdate()
+      return
+    }
 
     const nextRequest = userRequestsToAdd[0]!
 
@@ -653,6 +719,11 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       return
     }
 
+    // Clearing the current request is not the same as having nothing left to show. Whoever
+    // cleared it - a request on its way in, a request that was just removed - picks the next
+    // one up straight after, and closing the view in between would tear it down and reopen it.
+    if (this.visibleUserRequests.length || this.#userRequestsBeingAdded) return
+
     await this.closeRequestWindow()
   }
 
@@ -678,13 +749,23 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       }
 
       try {
+        // Nothing above may await between the check and this assignment, so a request arriving in
+        // the same tick always sees the open that is already running. windowProps is set inside the
+        // chain rather than after awaiting it, so it lands before openWindowPromise is cleared -
+        // otherwise a waiter wakes up to both being empty and opens a second window.
         this.requestWindow.openWindowPromise = this.#ui.requestView
           .open({ customSize, baseWindowId })
+          .then((windowProps) => {
+            // Stays null when the request is rendered in the panel instead of a window
+            this.requestWindow.windowProps = windowProps
+
+            return windowProps
+          })
           .finally(() => {
             this.requestWindow.openWindowPromise = undefined
           })
-        // Stays null when the request is rendered in the panel instead of a window
-        this.requestWindow.windowProps = await this.requestWindow.openWindowPromise
+
+        await this.requestWindow.openWindowPromise
 
         this.emitUpdate()
       } catch (err) {
@@ -852,11 +933,17 @@ export class RequestsController extends EventEmitter implements IRequestsControl
   async rejectCalls({
     callIds = [],
     activeRouteIds: paramActiveRouteIds = [],
-    errorMessage = 'User rejected the transaction request!'
+    errorMessage = 'User rejected the transaction request!',
+    isUserInitiated = true
   }: {
     callIds?: Call['id'][]
     activeRouteIds?: string[]
     errorMessage?: string
+    /**
+     * Whether the user is removing the calls. False when the wallet tears them down itself,
+     * such as when a swap and bridge route is cleaned up.
+     */
+    isUserInitiated?: boolean
   }) {
     if (!callIds.length && !paramActiveRouteIds.length) return
 
@@ -889,7 +976,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
       if (!request.signAccountOp.accountOp.calls.length) {
         await this.rejectUserRequests('User rejected the transaction request.', [request.id], {
-          shouldOpenNextRequest: true
+          shouldOpenNextRequest: true,
+          isUserInitiated
         })
       } else {
         this.emitUpdate()
@@ -1053,6 +1141,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
     const { kind, meta, dappPromises } = userRequest
 
+    getDappIdsFromUserRequest(userRequest).forEach((dappId) =>
+      this.#dapps.clearDappRejections(dappId)
+    )
+
     dappPromises.forEach((p) => {
       // WE SHOULD NEVER RESOLVE THE PROMISE. It should only be rejected if the user rejects the request
       // as that destroys the next request
@@ -1076,14 +1168,115 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     }
   }
 
+  /**
+   * Counts one refusal against every app that had something in the requests the user just
+   * rejected. Deduplicated on purpose: one press of Reject is one refusal, however many
+   * requests it clears and however many promises each of them holds.
+   */
+  #recordDappRejections(userRequests: UserRequest[]) {
+    const dappIds = new Set(userRequests.flatMap((r) => getDappIdsFromUserRequest(r)))
+
+    dappIds.forEach((dappId) => this.#dapps.recordDappRejection(dappId))
+  }
+
+  /** The app whose request is on screen, or null when the wallet raised the request itself. */
+  get #currentRequestDappId(): string | null {
+    if (!this.currentUserRequest) return null
+
+    return getDappIdsFromUserRequest(this.currentUserRequest)[0] ?? null
+  }
+
+  #getVisibleRequestsFromDapp(dappId: string): UserRequest[] {
+    return this.visibleUserRequests.filter((r) => getDappIdsFromUserRequest(r).includes(dappId))
+  }
+
+  /**
+   * What the user can do about the app behind the open request, beyond refusing it: how many
+   * of its requests are queued, and whether it has been refused enough to be worth silencing.
+   * Null when the request didn't come from an app.
+   */
+  get currentRequestRejectOptions(): {
+    dappRequestsCount: number
+    canSilenceDapp: boolean
+  } | null {
+    const dappId = this.#currentRequestDappId
+    if (!dappId) return null
+
+    return {
+      dappRequestsCount: this.#getVisibleRequestsFromDapp(dappId).length,
+      canSilenceDapp: this.#dapps.shouldOfferToSilenceDapp(dappId)
+    }
+  }
+
+  /**
+   * Clears everything the app behind the open request is waiting on, and optionally ignores
+   * whatever it sends for the next minute. A transaction batch that also holds calls from
+   * another app keeps those - only this app's are dropped.
+   */
+  async rejectAllRequestsFromCurrentDapp(
+    err: string,
+    { shouldSilenceDapp = false }: { shouldSilenceDapp?: boolean } = {}
+  ) {
+    const dappId = this.#currentRequestDappId
+    if (!dappId) return
+
+    if (shouldSilenceDapp) this.#dapps.silenceDapp(dappId)
+
+    const requestsFromDapp = this.#getVisibleRequestsFromDapp(dappId)
+    const requestIdsToReject: UserRequest['id'][] = []
+    const callIdsToReject: Call['id'][] = []
+
+    requestsFromDapp.forEach((r) => {
+      if (r.kind !== 'calls') {
+        requestIdsToReject.push(r.id)
+        return
+      }
+
+      // Matched through the promise each call was raised for, the same link `rejectCalls`
+      // follows, rather than the dapp record on the call - that one is missing for an app
+      // the catalog doesn't know.
+      const promiseIdsFromDapp = new Set(
+        r.dappPromises.filter((p) => p.session?.id === dappId).map((p) => p.id)
+      )
+      const { calls } = r.signAccountOp.accountOp
+      const callIdsFromDapp = calls
+        .filter((c) => !!c.dappPromiseId && promiseIdsFromDapp.has(c.dappPromiseId))
+        .map((c) => c.id)
+
+      if (callIdsFromDapp.length === calls.length) requestIdsToReject.push(r.id)
+      else callIdsToReject.push(...callIdsFromDapp)
+    })
+
+    // Everything below is one refusal by the user, so it is counted once, here, rather than
+    // once per request the rejections underneath happen to clear.
+    this.#recordDappRejections(requestsFromDapp)
+
+    if (callIdsToReject.length)
+      await this.rejectCalls({
+        callIds: callIdsToReject,
+        errorMessage: err,
+        isUserInitiated: false
+      })
+
+    if (requestIdsToReject.length)
+      await this.rejectUserRequests(err, requestIdsToReject, { isUserInitiated: false })
+  }
+
   async rejectUserRequests(
     err: string,
     requestIds: UserRequest['id'][],
     options?: {
       shouldRemoveSwapAndBridgeRoute?: boolean
       shouldOpenNextRequest?: boolean
+      /**
+       * Whether the user is the one refusing, which is what counts against the app as spam.
+       * On by default because nearly every caller is a Reject button. Pass false wherever the
+       * wallet rejects on its own behalf - those must never make a legitimate app look hostile.
+       */
+      isUserInitiated?: boolean
     }
   ) {
+    const { isUserInitiated = true, ...removeOptions } = options || {}
     const userRequestsToReject = this.userRequests.filter((r) => requestIds.includes(r.id))
     const rejectedSwitchAccountRequestIds = userRequestsToReject
       .filter((r) => r.kind === 'switchAccount')
@@ -1091,6 +1284,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     const waitingUserRequestsToReject = this.userRequestsWaitingAccountSwitch.filter((r) =>
       rejectedSwitchAccountRequestIds.includes(r.meta.switchAccountRequestId)
     )
+
+    if (isUserInitiated) this.#recordDappRejections(userRequestsToReject)
 
     userRequestsToReject.forEach((r) => {
       r.dappPromises.forEach((p) => p.reject(ethErrors.provider.userRejectedRequest<any>(err)))
@@ -1116,7 +1311,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     )
 
     await this.removeUserRequests(requestIds, {
-      ...options,
+      ...removeOptions,
       shouldSkipSafeQueueRequests: true
     })
   }
@@ -1126,7 +1321,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
     if (type === 'dappRequest') {
       try {
-        await this.#buildUserRequestFromDAppRequest(params.request, params.dappPromise)
+        await this.#processDappRequest(params.request, params.dappPromise)
       } catch (e: any) {
         this.emitError({
           error: e,
@@ -1230,40 +1425,166 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     }
   }
 
-  async #buildUserRequestFromDAppRequest(
-    request: DappProviderRequest,
-    dappPromise: {
-      id: string
-      session: DappProviderRequest['session']
-      resolve: (data: any) => void
-      reject: (data: any) => void
-    }
-  ) {
+  /**
+   * The one place every app request passes through, whatever brought it in - the injected
+   * provider, the mobile WebView or WalletConnect. Requests that would collide with one another
+   * are queued behind the one being built and built together; everything else builds straight
+   * through. Resolves once the request has been added (or answered on the spot), and rejects
+   * with what the app should be told, which is what `rpcFlow` turns into the RPC error.
+   */
+  async #processDappRequest(request: DappProviderRequest, dappPromise: DappPromise) {
     await this.initialLoadPromise
+
+    // Refusing a silenced app before its request is built or queued is what keeps it from
+    // costing a simulation, an estimation or a window. The error is the one a manual rejection
+    // produces, so a spamming site can't tell it is being ignored and tune around it. Read-only
+    // calls never reach this point, so a site the user silenced but stayed connected to keeps
+    // rendering.
+    if (this.#dapps.isDappSilenced(request.session.id)) {
+      dappPromise.reject(ethErrors.provider.userRejectedRequest<any>('User rejected the request.'))
+      return
+    }
+
     await this.#guardHWSigning(true)
 
-    let userRequest: UserRequest | null = null
-    let position: RequestPosition = 'last'
-    const kind = dappRequestMethodToRequestKind(request.method)
     const dapp = (await this.#getDapp(request.session.id)) || null
+    const key = this.#getDappRequestKey(request, dapp)
 
+    if (!key) {
+      await this.#buildDappRequest({ request, dappPromise, dapp })
+      return
+    }
+
+    await this.#enqueueDappRequest(key, { request, dappPromise, dapp })
+  }
+
+  /**
+   * What two app requests arriving at once would collide over, or null for the ones that can
+   * always be built side by side (connecting, adding a chain, watching an asset). Transactions
+   * collapse into one batch per account and chain; messages supersede one another per account.
+   * Derived from the raw payload rather than a built request, so it never throws on a malformed
+   * one - the payload is validated later, per request.
+   */
+  #getDappRequestKey(request: DappProviderRequest, dapp: Dapp | null): string | null {
+    const kind = dappRequestMethodToRequestKind(request.method)
+
+    // Always keyed, malformed payloads included, so every transaction goes through the batch
+    // and its params are validated in the one place that knows how to answer only its own app
     if (kind === 'calls') {
+      const params = request.params?.[0]
+      const chainId = params?.calls && params.chainId ? Number(params.chainId) : dapp?.chainId
+
+      return `calls:${String(params?.from).toLowerCase()}:${chainId}`
+    }
+
+    // A plain message and a SIWE one share a key: which of the two a `personal_sign` payload is
+    // only becomes clear once it is parsed, well after this point.
+    if (kind === 'message' || kind === 'typedMessage') {
+      const accountAddr = kind === 'message' ? request.params?.[1] : request.params?.[0]
+      if (!accountAddr) return null
+
+      return `${kind}:${String(accountAddr).toLowerCase()}`
+    }
+
+    return null
+  }
+
+  /**
+   * Puts the request in line behind the ones it would collide with and returns when its turn
+   * has been served. The first request in also starts the drain, so a queue is never left
+   * standing with nobody working it off.
+   */
+  #enqueueDappRequest(
+    key: string,
+    item: Pick<DappRequestQueueItem, 'request' | 'dappPromise' | 'dapp'>
+  ): Promise<void> {
+    const queue = this.#dappRequestQueues.get(key)
+
+    return new Promise<void>((resolve, reject) => {
+      const queueItem: DappRequestQueueItem = { ...item, settle: resolve, fail: reject }
+
+      if (queue) {
+        queue.push(queueItem)
+        return
+      }
+
+      this.#dappRequestQueues.set(key, [queueItem])
+      void this.#drainDappRequestQueue(key)
+    })
+  }
+
+  /**
+   * Works one queue off in batches, taking everything that has piled up while the previous
+   * batch was building. Nothing awaits between finding the queue empty and dropping it, so a
+   * request arriving at any point either joins the batch being built or starts a fresh queue.
+   */
+  async #drainDappRequestQueue(key: string) {
+    const queue = this.#dappRequestQueues.get(key)
+    if (!queue) return
+
+    while (queue.length) {
+      const batch = queue.splice(0)
+
+      // Every item is answered inside, so this never throws - and it must not, because nothing
+      // awaits the drain.
+      await this.#buildDappRequestBatch(batch)
+    }
+
+    this.#dappRequestQueues.delete(key)
+  }
+
+  async #buildDappRequestBatch(batch: DappRequestQueueItem[]) {
+    const [first] = batch
+    if (!first) return
+
+    if (dappRequestMethodToRequestKind(first.request.method) === 'calls') {
+      await this.#buildDappCallsBatch(batch)
+      return
+    }
+
+    // Only one message per account is ever shown, so the wallet supersedes the rest here rather
+    // than adding each one and rejecting it again a moment later. That is the wallet's own
+    // decision, not the user refusing the app, so it must not count towards spam detection -
+    // which is why these promises are rejected directly instead of through `rejectUserRequests`.
+    const superseded = batch.slice(0, -1)
+    superseded.forEach(({ dappPromise, settle }) => {
+      dappPromise.reject(
+        ethErrors.provider.userRejectedRequest<any>('User rejected the message request')
+      )
+      settle()
+    })
+
+    const last = batch[batch.length - 1]!
+
+    try {
+      await this.#buildDappRequest(last)
+      last.settle()
+    } catch (error) {
+      last.fail(error)
+    }
+  }
+
+  /**
+   * Builds every transaction in the batch into a single request, so ten fired at once cost one
+   * estimation and one simulation instead of ten. A payload that doesn't validate costs only
+   * its own app the request - the rest of the batch is built without it.
+   */
+  async #buildDappCallsBatch(batch: DappRequestQueueItem[]) {
+    const [{ request: firstRequest, dapp }] = batch as [DappRequestQueueItem]
+
+    try {
       if (!this.#selectedAccount.account) throw ethErrors.rpc.internal()
 
-      const isWalletSendCalls = !!request.params[0].calls
-      // For wallet_sendCalls (ERC-5792), use the chainId from the request params
-      // For other calls (e.g., eth_sendTransaction), fall back to the dapp's chainId
-      const requestChainId =
-        isWalletSendCalls && request.params[0].chainId
-          ? Number(request.params[0].chainId)
-          : dapp?.chainId
-
+      // Every item in the batch is for the same chain by construction - that is what they were
+      // keyed on - so the network and the account state are resolved once for all of them.
+      const requestChainId = this.#getDappCallsChainId(firstRequest, dapp)
       const network = this.#networks.networks.find(
         (n) => Number(n.chainId) === Number(requestChainId)
       )
       if (!network) {
         throw ethErrors.provider.chainDisconnected('Transaction failed - unknown network')
       }
+
       const accountState = await this.#accounts.getOrFetchAccountOnChainState(
         this.#selectedAccount.account.addr,
         network.chainId
@@ -1282,248 +1603,331 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         this.#featureFlags.isFeatureEnabled('erc4337'),
         this.#featureFlags.isFeatureEnabled('eip7702')
       )
-      const accountAddr = getAddress(request.params[0].from)
 
-      if (isWalletSendCalls && !request.params[0].calls.length)
-        throw ethErrors.provider.unsupportedMethod({
-          message: 'Request rejected - empty calls array not allowed!'
-        })
+      const built: { item: DappRequestQueueItem; params: DappCallsRequestParams }[] = []
 
-      let calls: AccountOp['calls'] = isWalletSendCalls
-        ? request.params[0].calls
-        : [request.params[0]]
+      batch.forEach((item) => {
+        try {
+          built.push({ item, params: this.#normalizeDappCallsRequest(item, network, baseAcc) })
+        } catch (error) {
+          item.fail(error)
+        }
+      })
 
-      if (calls.some(({ data }) => data && data.length % 2 === 1))
-        throw ethErrors.rpc.invalidParams('A call has uneven number of character in the hex data.')
-      if (calls.some(({ data }) => data && !isHex(data)))
-        throw ethErrors.rpc.invalidParams('A call has invalid data.')
+      if (!built.length) return
 
-      // we are checking if to exists, because if it does not the call is a
-      // valid contract  deployment
-      if (calls.some(({ to }) => to && !isAddress(to)))
-        throw ethErrors.rpc.invalidParams('A call has invalid "to" field ')
+      const last = built[built.length - 1]!
 
-      calls = calls.map((c) => ({
+      const userRequest = await this.#createOrUpdateCallsUserRequest({
+        calls: built.flatMap(({ params }) => params.calls),
+        // The batch shares an account and a chain; of what is left, the newest request wins,
+        // which is what merging them one by one used to end up with.
+        meta: last.params.meta,
+        dappPromises: built.map(({ params }) => params.dappPromise),
+        dappSessionId: last.item.request.session.sessionId
+      })
+
+      if (userRequest) await this.#addBuiltDappRequest(userRequest)
+
+      built.forEach(({ item }) => item.settle())
+    } catch (error) {
+      // Nothing was built, so every app in the batch is told the same thing
+      batch.forEach((item) => item.fail(error))
+    }
+  }
+
+  /**
+   * The chain a transaction request is for. `wallet_sendCalls` (ERC-5792) carries its own,
+   * everything else goes on the chain the app is connected to.
+   */
+  #getDappCallsChainId(request: DappProviderRequest, dapp: Dapp | null) {
+    const isWalletSendCalls = !!request.params[0].calls
+
+    return isWalletSendCalls && request.params[0].chainId
+      ? Number(request.params[0].chainId)
+      : dapp?.chainId
+  }
+
+  /**
+   * Validates one transaction request and turns it into the calls and meta a user request is
+   * built from. Throws the RPC error the app should be told when the payload doesn't hold up.
+   */
+  #normalizeDappCallsRequest(
+    { request, dappPromise, dapp }: DappRequestQueueItem,
+    network: Network,
+    baseAcc: ReturnType<typeof getBaseAccount>
+  ): DappCallsRequestParams {
+    const isWalletSendCalls = !!request.params[0].calls
+    const accountAddr = getAddress(request.params[0].from)
+
+    if (isWalletSendCalls && !request.params[0].calls.length)
+      throw ethErrors.provider.unsupportedMethod({
+        message: 'Request rejected - empty calls array not allowed!'
+      })
+
+    const calls: AccountOp['calls'] = isWalletSendCalls
+      ? request.params[0].calls
+      : [request.params[0]]
+
+    if (calls.some(({ data }) => data && data.length % 2 === 1))
+      throw ethErrors.rpc.invalidParams('A call has uneven number of character in the hex data.')
+    if (calls.some(({ data }) => data && !isHex(data)))
+      throw ethErrors.rpc.invalidParams('A call has invalid data.')
+
+    // we are checking if to exists, because if it does not the call is a
+    // valid contract  deployment
+    if (calls.some(({ to }) => to && !isAddress(to)))
+      throw ethErrors.rpc.invalidParams('A call has invalid "to" field ')
+
+    const paymasterService =
+      isWalletSendCalls && !!request.params[0].capabilities?.paymasterService
+        ? getPaymasterService(network.chainId, request.params[0].capabilities)
+        : getAmbirePaymasterService(baseAcc, this.#relayerUrl)
+
+    return {
+      calls: calls.map((c) => ({
         ...c,
         data: c.data?.toLowerCase() || '0x',
         value: c.value ? getBigInt(c.value) : 0n,
         dapp: dapp ?? undefined,
         dappPromiseId: dappPromise.id
-      }))
-      const paymasterService =
-        isWalletSendCalls && !!request.params[0].capabilities?.paymasterService
-          ? getPaymasterService(network.chainId, request.params[0].capabilities)
-          : getAmbirePaymasterService(baseAcc, this.#relayerUrl)
+      })),
+      meta: {
+        accountAddr,
+        chainId: network.chainId,
+        walletSendCallsVersion: isWalletSendCalls
+          ? (request.params[0].version ?? '1.0.0')
+          : undefined,
+        paymasterService
+      },
+      dappPromise: { ...dappPromise, meta: { isWalletSendCalls } }
+    }
+  }
 
-      const walletSendCallsVersion = isWalletSendCalls
-        ? (request.params[0].version ?? '1.0.0')
-        : undefined
+  /**
+   * Builds one app request that isn't a transaction and hands it on. Resolves without adding
+   * anything when the wallet answered the app itself, which is what auto-login does.
+   */
+  async #buildDappRequest({
+    request,
+    dappPromise,
+    dapp
+  }: Pick<DappRequestQueueItem, 'request' | 'dappPromise' | 'dapp'>) {
+    const kind = dappRequestMethodToRequestKind(request.method)
+    let userRequest: UserRequest | null = null
 
-      userRequest =
-        (await this.#createOrUpdateCallsUserRequest({
-          calls,
-          meta: {
-            accountAddr,
-            chainId: network.chainId,
-            walletSendCallsVersion,
-            paymasterService
-          },
-          dappPromises: [{ ...dappPromise, meta: { isWalletSendCalls } }],
-          dappSessionId: request.session.sessionId
-        })) ?? null
-    } else if (kind === 'message') {
-      if (!this.#selectedAccount.account) throw ethErrors.rpc.internal()
-
-      const msg = request.params
-      if (!msg) {
-        throw ethErrors.rpc.invalidRequest('No msg request to sign')
-      }
-      const msgAddress = getAddress(msg?.[1])
-
-      const network = this.#networks.networks.find(
-        (n) => Number(n.chainId) === Number(dapp?.chainId)
-      )
-
-      if (!network) {
-        throw ethErrors.provider.chainDisconnected('Transaction failed - unknown network')
-      }
-
-      userRequest = {
-        id: generateUuid(),
-        kind: 'message',
-        meta: { params: { message: msg[0] }, accountAddr: msgAddress, chainId: network.chainId },
-        dappPromises: [
-          {
-            ...dappPromise,
-            session: request.session,
-            meta: {}
-          }
-        ]
-      } as PlainTextMessageUserRequest
-
-      // SIWE
-      const rawMessage = typeof msg[0] === 'string' ? msg[0] : ''
-      const parsedSiweAndStatus = AutoLoginController.getParsedSiweMessage(
-        rawMessage,
-        request.session.origin
-      )
-
-      // Handle valid and invalid SIWE messages
-      // If it's valid we want to try to auto-login the user
-      // If it's not we want to flag it to the UI to inform the user
-      if (rawMessage && parsedSiweAndStatus) {
-        const { parsedSiwe, status } = parsedSiweAndStatus
-        let autoLoginStatus: AutoLoginStatus = 'no-policy'
-
-        if (parsedSiwe.address?.toLowerCase() !== msgAddress.toLowerCase()) {
-          throw ethErrors.rpc.invalidRequest(
-            'SIWE message address does not match the requested signing address'
-          )
-        }
-
-        // Try to auto-login
-        if (status === 'valid' && parsedSiwe) {
-          try {
-            autoLoginStatus = this.#autoLogin.getAutoLoginStatus(parsedSiwe)
-
-            if (autoLoginStatus === 'active') {
-              // Sign and respond
-              const signedMessage = await this.#autoLogin.autoLogin({
-                message: rawMessage as `0x${string}`,
-                chainId: network.chainId,
-                accountAddr: msgAddress
-              })
-
-              if (!signedMessage) {
-                throw new EmittableError({
-                  message: 'Auto-login failed. Please sign the message manually.',
-                  level: 'major',
-                  error: new Error('SIWE autologin - signedMessage is null')
-                })
-              }
-
-              console.log(
-                `SIWE auto-login with dapp ${request.session.origin} and account ${msgAddress} succeeded.`
-              )
-
-              dappPromise.resolve({ hash: signedMessage.signature })
-              return
-            }
-          } catch (e: any) {
-            this.emitError({
-              error: e,
-              message: 'Auto-login failed. Please sign the message manually.',
-              level: 'major'
-            })
-          }
-        }
-
-        userRequest = {
-          ...userRequest,
-          kind: 'siwe',
-          meta: {
-            ...userRequest.meta,
-            params: {
-              ...userRequest.meta.params,
-              parsedMessage: parsedSiwe,
-              autoLoginStatus,
-              siweValidityStatus: status,
-              isAutoLoginEnabledByUser: this.#autoLogin.settings.enabled,
-              autoLoginDuration: this.#autoLogin.settings.duration
-            }
-          }
-        } as SiweMessageUserRequest
-      }
+    if (kind === 'message') {
+      userRequest = await this.#buildDappMessageRequest(request, dappPromise, dapp)
     } else if (kind === 'typedMessage') {
-      if (!this.#selectedAccount.account) throw ethErrors.rpc.internal()
-
-      const msg = request.params
-      if (!msg) {
-        throw ethErrors.rpc.invalidRequest('No msg request to sign')
-      }
-      const msgAddress = getAddress(msg?.[0])
-
-      const network = this.#networks.networks.find(
-        (n) => Number(n.chainId) === Number(dapp?.chainId)
-      )
-
-      if (!network) {
-        throw ethErrors.provider.chainDisconnected('Transaction failed - unknown network')
-      }
-
-      let typedData = msg?.[1]
-
-      try {
-        typedData = parse(typedData)
-      } catch (error) {
-        console.error('Failed to parse typed data', error)
-        throw ethErrors.rpc.invalidRequest('Invalid typedData provided')
-      }
-
-      if (
-        !typedData?.types ||
-        !typedData?.domain ||
-        !typedData?.message ||
-        !typedData?.primaryType
-      ) {
-        throw ethErrors.rpc.methodNotSupported(
-          'Invalid typedData format - only typedData v4 is supported'
-        )
-      }
-
-      const domainChainId = BigInt(typedData.domain.chainId || 0)
-      if (domainChainId !== 0n && domainChainId !== network.chainId)
-        throw ethErrors.rpc.invalidRequest(
-          `The domain chainId (${typedData.domain.chainId}) does not match the current network chainId (${network.chainId})`
-        )
-      typedData.domain.chainId = network.chainId
-
-      if (!typedData.types[typedData.primaryType])
-        throw ethErrors.rpc.invalidParams(
-          'The primary data type is missing from the provided types'
-        )
-      try {
-        // we ignore the result because we only care if the func will fail
-        hashTypedData({
-          types: typedData.types,
-          primaryType: typedData.primaryType,
-          message: typedData.message,
-          domain: typedData.domain
-        })
-      } catch (e) {
-        console.error(e)
-        throw ethErrors.rpc.invalidParams('The message contents did not match the provided types.')
-      }
-
-      if (isAmbireOperationTypedData(typedData)) {
-        throw ethErrors.rpc.methodNotSupported(AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE)
-      }
-
-      userRequest = {
-        id: generateUuid(),
-        kind: 'typedMessage',
-        meta: {
-          params: {
-            types: typedData.types,
-            domain: typedData.domain,
-            message: typedData.message,
-            primaryType: typedData.primaryType
-          },
-          accountAddr: msgAddress,
-          chainId: typedData.domain.chainId
-        },
-        dappPromises: [{ ...dappPromise, session: request.session, meta: {} }]
-      } as TypedMessageUserRequest
+      userRequest = this.#buildDappTypedMessageRequest(request, dappPromise, dapp)
     } else {
+      // Transactions never reach this point - they are always keyed and always batched
       userRequest = {
         id: generateUuid(),
         kind,
         meta: { params: request.params },
         dappPromises: [{ ...dappPromise, session: request.session, meta: {} }]
-      }
+      } as UserRequest
     }
 
     if (!userRequest) return
+
+    await this.#addBuiltDappRequest(userRequest)
+  }
+
+  /**
+   * A `personal_sign` request as either a plain message or a SIWE one. Returns null when the
+   * message was signed by auto-login and the app already has its answer.
+   */
+  async #buildDappMessageRequest(
+    request: DappProviderRequest,
+    dappPromise: DappPromise,
+    dapp: Dapp | null
+  ): Promise<UserRequest | null> {
+    if (!this.#selectedAccount.account) throw ethErrors.rpc.internal()
+
+    const msg = request.params
+    if (!msg) {
+      throw ethErrors.rpc.invalidRequest('No msg request to sign')
+    }
+    const msgAddress = getAddress(msg?.[1])
+
+    const network = this.#networks.networks.find((n) => Number(n.chainId) === Number(dapp?.chainId))
+
+    if (!network) {
+      throw ethErrors.provider.chainDisconnected('Transaction failed - unknown network')
+    }
+
+    const userRequest = {
+      id: generateUuid(),
+      kind: 'message',
+      meta: { params: { message: msg[0] }, accountAddr: msgAddress, chainId: network.chainId },
+      dappPromises: [
+        {
+          ...dappPromise,
+          session: request.session,
+          meta: {}
+        }
+      ]
+    } as PlainTextMessageUserRequest
+
+    // SIWE
+    const rawMessage = typeof msg[0] === 'string' ? msg[0] : ''
+    const parsedSiweAndStatus = AutoLoginController.getParsedSiweMessage(
+      rawMessage,
+      request.session.origin
+    )
+
+    // Handle valid and invalid SIWE messages
+    // If it's valid we want to try to auto-login the user
+    // If it's not we want to flag it to the UI to inform the user
+    if (!rawMessage || !parsedSiweAndStatus) return userRequest
+
+    const { parsedSiwe, status } = parsedSiweAndStatus
+    let autoLoginStatus: AutoLoginStatus = 'no-policy'
+
+    if (parsedSiwe.address?.toLowerCase() !== msgAddress.toLowerCase()) {
+      throw ethErrors.rpc.invalidRequest(
+        'SIWE message address does not match the requested signing address'
+      )
+    }
+
+    // Try to auto-login
+    if (status === 'valid' && parsedSiwe) {
+      try {
+        autoLoginStatus = this.#autoLogin.getAutoLoginStatus(parsedSiwe)
+
+        if (autoLoginStatus === 'active') {
+          // Sign and respond
+          const signedMessage = await this.#autoLogin.autoLogin({
+            message: rawMessage as `0x${string}`,
+            chainId: network.chainId,
+            accountAddr: msgAddress
+          })
+
+          if (!signedMessage) {
+            throw new EmittableError({
+              message: 'Auto-login failed. Please sign the message manually.',
+              level: 'major',
+              error: new Error('SIWE autologin - signedMessage is null')
+            })
+          }
+
+          console.log(
+            `SIWE auto-login with dapp ${request.session.origin} and account ${msgAddress} succeeded.`
+          )
+
+          dappPromise.resolve({ hash: signedMessage.signature })
+          return null
+        }
+      } catch (e: any) {
+        this.emitError({
+          error: e,
+          message: 'Auto-login failed. Please sign the message manually.',
+          level: 'major'
+        })
+      }
+    }
+
+    return {
+      ...userRequest,
+      kind: 'siwe',
+      meta: {
+        ...userRequest.meta,
+        params: {
+          ...userRequest.meta.params,
+          parsedMessage: parsedSiwe,
+          autoLoginStatus,
+          siweValidityStatus: status,
+          isAutoLoginEnabledByUser: this.#autoLogin.settings.enabled,
+          autoLoginDuration: this.#autoLogin.settings.duration
+        }
+      }
+    } as SiweMessageUserRequest
+  }
+
+  #buildDappTypedMessageRequest(
+    request: DappProviderRequest,
+    dappPromise: DappPromise,
+    dapp: Dapp | null
+  ): UserRequest {
+    if (!this.#selectedAccount.account) throw ethErrors.rpc.internal()
+
+    const msg = request.params
+    if (!msg) {
+      throw ethErrors.rpc.invalidRequest('No msg request to sign')
+    }
+    const msgAddress = getAddress(msg?.[0])
+
+    const network = this.#networks.networks.find((n) => Number(n.chainId) === Number(dapp?.chainId))
+
+    if (!network) {
+      throw ethErrors.provider.chainDisconnected('Transaction failed - unknown network')
+    }
+
+    let typedData = msg?.[1]
+
+    try {
+      typedData = parse(typedData)
+    } catch (error) {
+      console.error('Failed to parse typed data', error)
+      throw ethErrors.rpc.invalidRequest('Invalid typedData provided')
+    }
+
+    if (!typedData?.types || !typedData?.domain || !typedData?.message || !typedData?.primaryType) {
+      throw ethErrors.rpc.methodNotSupported(
+        'Invalid typedData format - only typedData v4 is supported'
+      )
+    }
+
+    const domainChainId = BigInt(typedData.domain.chainId || 0)
+    if (domainChainId !== 0n && domainChainId !== network.chainId)
+      throw ethErrors.rpc.invalidRequest(
+        `The domain chainId (${typedData.domain.chainId}) does not match the current network chainId (${network.chainId})`
+      )
+    typedData.domain.chainId = network.chainId
+
+    if (!typedData.types[typedData.primaryType])
+      throw ethErrors.rpc.invalidParams('The primary data type is missing from the provided types')
+    try {
+      // we ignore the result because we only care if the func will fail
+      hashTypedData({
+        types: typedData.types,
+        primaryType: typedData.primaryType,
+        message: typedData.message,
+        domain: typedData.domain
+      })
+    } catch (e) {
+      console.error(e)
+      throw ethErrors.rpc.invalidParams('The message contents did not match the provided types.')
+    }
+
+    if (isAmbireOperationTypedData(typedData)) {
+      throw ethErrors.rpc.methodNotSupported(AMBIRE_OPERATION_SIGNING_NOT_ALLOWED_MESSAGE)
+    }
+
+    return {
+      id: generateUuid(),
+      kind: 'typedMessage',
+      meta: {
+        params: {
+          types: typedData.types,
+          domain: typedData.domain,
+          message: typedData.message,
+          primaryType: typedData.primaryType
+        },
+        accountAddr: msgAddress,
+        chainId: typedData.domain.chainId
+      },
+      dappPromises: [{ ...dappPromise, session: request.session, meta: {} }]
+    } as TypedMessageUserRequest
+  }
+
+  /** Puts a built app request in front of the user, or behind an account switch if it needs one. */
+  async #addBuiltDappRequest(userRequest: UserRequest) {
+    const [firstDappPromise] = userRequest.dappPromises
+
+    let position: RequestPosition = 'last'
 
     if (userRequest.kind !== 'calls') {
       const otherUserRequestFromSameDapp = this.userRequests.find((r) =>
@@ -1534,7 +1938,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         )
       )
 
-      if (!otherUserRequestFromSameDapp && !!dappPromise.session.origin) {
+      if (!otherUserRequestFromSameDapp && !!firstDappPromise?.session.origin) {
         position = 'first'
       }
     }
@@ -2432,7 +2836,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       ...super.toJSON(),
       banners: this.banners,
       visibleUserRequests: this.visibleUserRequests,
-      currentUserRequest: this.currentUserRequest
+      currentUserRequest: this.currentUserRequest,
+      currentRequestRejectOptions: this.currentRequestRejectOptions
     }
   }
 }

--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -49,7 +49,10 @@ import {
 } from '../../interfaces/ui'
 import {
   CallsUserRequest,
+  DappCallsRequestParams,
+  DappRequestQueueItem,
   OpenRequestWindowParams,
+  PendingDappPromise,
   PlainTextMessageUserRequest,
   RequestExecutionType,
   RequestPosition,
@@ -109,35 +112,6 @@ const STATUS_WRAPPED_METHODS = {
 const ONE_CLICK_WINDOW_SIZE = {
   width: 600,
   height: 600
-}
-
-/** What an app's request flow hands over, before it is attached to a user request. */
-type DappPromise = {
-  id: string
-  session: DappProviderRequest['session']
-  resolve: (data: any) => void
-  reject: (data: any) => void
-}
-
-/**
- * One app request waiting its turn behind the requests it would collide with. `settle` and
- * `fail` answer the caller that is waiting on `build`, which is a different thing from the
- * app's own promise - a request can be added successfully and still leave the app waiting for
- * the user.
- */
-type DappRequestQueueItem = {
-  request: DappProviderRequest
-  dappPromise: DappPromise
-  dapp: Dapp | null
-  settle: () => void
-  fail: (error: any) => void
-}
-
-/** One transaction request, validated and ready to go into a batch. */
-type DappCallsRequestParams = {
-  calls: Call[]
-  meta: CallsUserRequest['meta']
-  dappPromise: CallsUserRequest['dappPromises'][number]
 }
 
 /**
@@ -239,19 +213,22 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
   /**
    * App requests that would collide with one another, waiting their turn behind the one being
-   * built, keyed by what they collide on. Building a request takes slow account state fetches,
-   * so ten transactions fired in the same tick all reach the "is there already a batch for this
-   * account and chain?" check before any of them has answered it - and all ten build one. The
-   * queue turns that into a single build over all ten, and the entry is dropped once it drains.
+   * built, keyed by what they collide on.
    */
   #dappRequestQueues = new Map<string, DappRequestQueueItem[]>()
 
   /**
-   * Requests that have been built and are about to be added. A request superseding another one
-   * takes the old one out first, so for a moment nothing is left to show - and tearing the view
-   * down over that costs the user a window that closes and reopens under them.
+   * Requests that have been built and are about to be added. Prevents opening and closing
+   * the request window in a quick succession.
    */
   #userRequestsBeingAdded = 0
+
+  /**
+   * Set while the wallet is closing the request view itself. Closing it fires `windowRemoved`,
+   * which is the same event the user closing the window produces, so without this the two are
+   * indistinguishable and the apps that were waiting look like they were refused.
+   */
+  #isWalletInitiatedClose = false
 
   private shouldSimulateAccountOps = true
 
@@ -512,20 +489,23 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         //  Main issue: https://github.com/AmbireTech/ambire-app/issues/4771
         if (accountOpRequest?.signAccountOp.signAndBroadcastPromise) {
           // Make sure to show the error once
-          if (!hasTxInProgressErrorShown) {
-            const errorMessage =
-              'Please wait until the previous transaction is fully processed before adding a new one.'
+          const errorMessage =
+            'Please wait until the previous transaction is fully processed before adding a new one.'
 
+          // Every request turned away here is answered, however many there are - the app is
+          // waiting on a promise nobody else will ever settle. Only what the user sees is
+          // shown once, so a batch of ten does not produce ten identical toasts.
+          dappPromises.forEach((p) => {
+            p.reject(ethErrors.rpc.transactionRejected({ message: errorMessage }))
+          })
+
+          if (!hasTxInProgressErrorShown) {
             this.emitError({
               level: 'major',
               message: errorMessage,
               error: new Error(
                 'requestsController: Cannot add a new request (addUserRequests) while a signing or broadcasting process is still running.'
               )
-            })
-
-            dappPromises.forEach((p) => {
-              p.reject(ethErrors.rpc.transactionRejected({ message: errorMessage }))
             })
 
             await this.#ui.notification.create({ title: 'Rejected!', message: errorMessage })
@@ -719,9 +699,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       return
     }
 
-    // Clearing the current request is not the same as having nothing left to show. Whoever
-    // cleared it - a request on its way in, a request that was just removed - picks the next
-    // one up straight after, and closing the view in between would tear it down and reopen it.
+    // Don't close the request window if there are still visible requests or if a request is being added
     if (this.visibleUserRequests.length || this.#userRequestsBeingAdded) return
 
     await this.closeRequestWindow()
@@ -749,14 +727,14 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       }
 
       try {
-        // Nothing above may await between the check and this assignment, so a request arriving in
-        // the same tick always sees the open that is already running. windowProps is set inside the
-        // chain rather than after awaiting it, so it lands before openWindowPromise is cleared -
-        // otherwise a waiter wakes up to both being empty and opens a second window.
+        // Keep this right after the check above with no await in between, so a second request
+        // arriving now finds the open already in progress instead of starting its own.
         this.requestWindow.openWindowPromise = this.#ui.requestView
           .open({ customSize, baseWindowId })
           .then((windowProps) => {
             // Stays null when the request is rendered in the panel instead of a window
+            // Set here, not after the await below, so it is already recorded by the time
+            // anyone waiting on this promise wakes up and looks for it.
             this.requestWindow.windowProps = windowProps
 
             return windowProps
@@ -813,13 +791,21 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     }
   }
 
-  async closeRequestWindow() {
+  /**
+   * Closes the request view and refuses whatever was still waiting in it. Pass
+   * `isUserInitiated: false` when the wallet is the one closing it (switching accounts, for
+   * example) so the apps that lose their requests are not treated as having been refused.
+   */
+  async closeRequestWindow({ isUserInitiated = true }: { isUserInitiated?: boolean } = {}) {
     await this.#awaitPendingPromises()
+
+    this.#isWalletInitiatedClose = !isUserInitiated
 
     if (!this.requestWindow.windowProps) {
       // Rendered inline (in the panel), so closing means dismissing the active request.
       // Guarded, because clearing the current request calls this method too.
-      if (this.currentUserRequest) await this.#handleRequestWindowClose()
+      if (this.currentUserRequest)
+        await this.#handleRequestWindowClose(undefined, { isUserInitiated })
 
       return
     }
@@ -840,10 +826,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
     if (!this.requestWindow.windowProps) return
 
-    await this.#handleRequestWindowClose(
-      this.requestWindow.windowProps.id,
-      requestIdsSnapshotAtClose
-    )
+    await this.#handleRequestWindowClose(this.requestWindow.windowProps.id, {
+      requestIdsSnapshot: requestIdsSnapshotAtClose,
+      isUserInitiated
+    })
   }
 
   /**
@@ -851,8 +837,21 @@ export class RequestsController extends EventEmitter implements IRequestsControl
    * `requestIdsSnapshot` is passed by `closeRequestWindow` so the requests to reject are the
    * ones that existed when the close started, not when the close animation finished. It is
    * omitted on the `windowRemoved` event path, where the close was not initiated here.
+   * `isUserInitiated` is false when the wallet closed the view on its own behalf.
    */
-  async #handleRequestWindowClose(winId?: number, requestIdsSnapshot?: Set<UserRequest['id']>) {
+  async #handleRequestWindowClose(
+    winId?: number,
+    // `isUserInitiated` is deliberately left without a default - undefined means "the caller
+    // did not say", which is what lets the remembered flag below answer for the event path
+    {
+      requestIdsSnapshot,
+      isUserInitiated
+    }: { requestIdsSnapshot?: Set<UserRequest['id']>; isUserInitiated?: boolean } = {}
+  ) {
+    // The `windowRemoved` path has no caller to say who asked for the close, so it falls back
+    // to what the wallet recorded when it started one.
+    const isUserInitiatedClose = isUserInitiated ?? !this.#isWalletInitiatedClose
+
     const isInlineRequestClosed = winId === undefined && !this.requestWindow.windowProps
 
     if (
@@ -862,6 +861,10 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         this.currentUserRequest &&
         this.requestWindow.windowProps)
     ) {
+      // Cleared only once the close is actually going ahead, so a `windowRemoved` that turns
+      // out to be for a different window (the focus fallback swapping one) doesn't eat it.
+      this.#isWalletInitiatedClose = false
+
       // Snapshot IDs synchronously before any awaits so requests that arrive
       // during async operations below are not incorrectly bulk-rejected.
       const requestIdsSnapshotAtClose =
@@ -908,7 +911,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         // For example: if the user has both a sign message and sign account op request,
         // closing the window will reject the sign message request but immediately
         // reopen the window for the sign account op request.
-        { shouldOpenNextRequest: false }
+        { shouldOpenNextRequest: false, isUserInitiated: isUserInitiatedClose }
       )
 
       this.userRequestsWaitingAccountSwitch = []
@@ -1432,14 +1435,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
    * through. Resolves once the request has been added (or answered on the spot), and rejects
    * with what the app should be told, which is what `rpcFlow` turns into the RPC error.
    */
-  async #processDappRequest(request: DappProviderRequest, dappPromise: DappPromise) {
+  async #processDappRequest(request: DappProviderRequest, dappPromise: PendingDappPromise) {
     await this.initialLoadPromise
 
-    // Refusing a silenced app before its request is built or queued is what keeps it from
-    // costing a simulation, an estimation or a window. The error is the one a manual rejection
-    // produces, so a spamming site can't tell it is being ignored and tune around it. Read-only
-    // calls never reach this point, so a site the user silenced but stayed connected to keeps
-    // rendering.
     if (this.#dapps.isDappSilenced(request.session.id)) {
       dappPromise.reject(ethErrors.provider.userRejectedRequest<any>('User rejected the request.'))
       return
@@ -1477,8 +1475,6 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       return `calls:${String(params?.from).toLowerCase()}:${chainId}`
     }
 
-    // A plain message and a SIWE one share a key: which of the two a `personal_sign` payload is
-    // only becomes clear once it is parsed, well after this point.
     if (kind === 'message' || kind === 'typedMessage') {
       const accountAddr = kind === 'message' ? request.params?.[1] : request.params?.[0]
       if (!accountAddr) return null
@@ -1522,18 +1518,26 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     const queue = this.#dappRequestQueues.get(key)
     if (!queue) return
 
-    while (queue.length) {
-      const batch = queue.splice(0)
+    try {
+      while (queue.length) {
+        const batch = queue.splice(0)
 
-      // Every item is answered inside, so this never throws - and it must not, because nothing
-      // awaits the drain.
-      await this.#buildDappRequestBatch(batch)
+        // Every item is answered inside, so this never throws - and it must not, because
+        // nothing awaits the drain.
+        await this.#buildDappRequestBatch(batch)
+      }
+    } finally {
+      // Just in case, should never happen - a queue left in the map is never drained again,
+      // so everything the app sends on this key afterwards waits forever. On the normal path
+      // the queue is already empty here and there is nothing left to answer.
+      this.#dappRequestQueues.delete(key)
+      queue.splice(0).forEach(({ fail }) => fail(ethErrors.rpc.internal()))
     }
-
-    this.#dappRequestQueues.delete(key)
   }
 
   async #buildDappRequestBatch(batch: DappRequestQueueItem[]) {
+    // Everything in a batch is the same kind of request, so the first one decides where the
+    // whole batch goes. The guard is only here to satisfy the type - a batch is never empty.
     const [first] = batch
     if (!first) return
 
@@ -1542,10 +1546,8 @@ export class RequestsController extends EventEmitter implements IRequestsControl
       return
     }
 
-    // Only one message per account is ever shown, so the wallet supersedes the rest here rather
-    // than adding each one and rejecting it again a moment later. That is the wallet's own
-    // decision, not the user refusing the app, so it must not count towards spam detection -
-    // which is why these promises are rejected directly instead of through `rejectUserRequests`.
+    // Only the newest message is ever shown, so the older ones are turned down here. Not via
+    // `rejectUserRequests` - that needs built requests, and these were never built.
     const superseded = batch.slice(0, -1)
     superseded.forEach(({ dappPromise, settle }) => {
       dappPromise.reject(
@@ -1638,14 +1640,14 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
   /**
    * The chain a transaction request is for. `wallet_sendCalls` (ERC-5792) carries its own,
-   * everything else goes on the chain the app is connected to.
+   * everything else goes on the chain the app is connected to. Reads the payload the same
+   * defensive way the key does, so a malformed one falls back to the app's chain instead of
+   * throwing and taking the rest of the batch down with it.
    */
   #getDappCallsChainId(request: DappProviderRequest, dapp: Dapp | null) {
-    const isWalletSendCalls = !!request.params[0].calls
+    const params = request.params?.[0]
 
-    return isWalletSendCalls && request.params[0].chainId
-      ? Number(request.params[0].chainId)
-      : dapp?.chainId
+    return params?.calls && params.chainId ? Number(params.chainId) : dapp?.chainId
   }
 
   /**
@@ -1657,6 +1659,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
     network: Network,
     baseAcc: ReturnType<typeof getBaseAccount>
   ): DappCallsRequestParams {
+    if (!request.params?.[0])
+      throw ethErrors.rpc.invalidParams('The transaction request has no parameters.')
+
     const isWalletSendCalls = !!request.params[0].calls
     const accountAddr = getAddress(request.params[0].from)
 
@@ -1741,7 +1746,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
    */
   async #buildDappMessageRequest(
     request: DappProviderRequest,
-    dappPromise: DappPromise,
+    dappPromise: PendingDappPromise,
     dapp: Dapp | null
   ): Promise<UserRequest | null> {
     if (!this.#selectedAccount.account) throw ethErrors.rpc.internal()
@@ -1848,7 +1853,7 @@ export class RequestsController extends EventEmitter implements IRequestsControl
 
   #buildDappTypedMessageRequest(
     request: DappProviderRequest,
-    dappPromise: DappPromise,
+    dappPromise: PendingDappPromise,
     dapp: Dapp | null
   ): UserRequest {
     if (!this.#selectedAccount.account) throw ethErrors.rpc.internal()

--- a/src/interfaces/requests.ts
+++ b/src/interfaces/requests.ts
@@ -6,7 +6,12 @@ import { ControllerInterface } from './controller'
 import { DappProviderRequest } from './dapp'
 import { Hex } from './hex'
 import { SwapAndBridgeActiveRoute, SwapAndBridgeQuote } from './swapAndBridge'
-import { CallsUserRequest, RequestExecutionType, RequestPosition } from './userRequest'
+import {
+  CallsUserRequest,
+  PendingDappPromise,
+  RequestExecutionType,
+  RequestPosition
+} from './userRequest'
 
 export type IRequestsController = ControllerInterface<
   InstanceType<typeof import('../controllers/requests/requests').RequestsController>
@@ -17,12 +22,7 @@ export type BuildRequest =
       type: 'dappRequest'
       params: {
         request: DappProviderRequest
-        dappPromise: {
-          id: string
-          session: DappProviderRequest['session']
-          resolve: (data: any) => void
-          reject: (data: any) => void
-        }
+        dappPromise: PendingDappPromise
       }
     }
   | {

--- a/src/interfaces/userRequest.ts
+++ b/src/interfaces/userRequest.ts
@@ -4,18 +4,19 @@ import { TypedDataDomain, TypedDataField } from 'ethers'
 // import { AddEthereumChainParameter, WatchAssetParams } from 'viem'
 import { SiweMessage as ViemSiweMessage } from 'viem/siwe'
 
+import { Call } from '@/libs/accountOp/types'
+
 import { SubmittedAccountOp } from '../libs/accountOp/submittedAccountOp'
 import { PaymasterService } from '../libs/erc7677/types'
 import { AccountId } from './account'
 import { AutoLoginStatus, SiweValidityStatus } from './autoLogin'
-import { DappProviderRequest } from './dapp'
+import { Dapp, DappProviderRequest } from './dapp'
 import { Hex } from './hex'
 import { ISignAccountOpController } from './signAccountOp'
 import { EIP7702Signature } from './signatures'
 import { SwapAndBridgeQuote, SwapAndBridgeSendTxRequest } from './swapAndBridge'
 
 import type { SafeMultisigTransactionResponse } from '@safe-global/types-kit'
-
 // @TODO: move this type and it's deps (PlainTextMessage, TypedMessage) to another place,
 // probably interfaces
 export interface Message {
@@ -33,13 +34,44 @@ export interface Message {
   signature: EIP7702Signature | string | null
 }
 
-export type DappPromise = {
+/**
+ * What an app's request flow hands over, before it is attached to a user request. The `meta`
+ * a `DappPromise` carries is only known once the payload has been read, so it is added when
+ * the request is built rather than by whoever raised it.
+ */
+export type PendingDappPromise = {
   id: string
   session: DappProviderRequest['session']
-  meta: { isWalletSendCalls?: boolean }
   resolve: (data: any) => void
   reject: (data: any) => void
 }
+
+/** A dapp promise once it is attached to a user request. */
+export type DappPromise = PendingDappPromise & {
+  meta: { isWalletSendCalls?: boolean }
+}
+
+/**
+ * One app request waiting its turn behind the requests it would collide with. `settle` and
+ * `fail` answer the caller that is waiting on `build`, which is a different thing from the
+ * app's own promise - a request can be added successfully and still leave the app waiting for
+ * the user.
+ */
+export type DappRequestQueueItem = {
+  request: DappProviderRequest
+  dappPromise: PendingDappPromise
+  dapp: Dapp | null
+  settle: () => void
+  fail: (error: any) => void
+}
+
+/** One transaction request, validated and ready to go into a batch. */
+export type DappCallsRequestParams = {
+  calls: Call[]
+  meta: CallsUserRequest['meta']
+  dappPromise: CallsUserRequest['dappPromises'][number]
+}
+
 interface UserRequestBase<DP = DappPromise[]> {
   id: string | number
   kind: string

--- a/src/libs/dapps/dappRequestSpam.test.ts
+++ b/src/libs/dapps/dappRequestSpam.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from '@jest/globals'
+
+import {
+  DAPP_REJECT_TRACKING_WINDOW,
+  DAPP_REJECTS_BEFORE_OFFERING_SILENCE,
+  DAPP_SILENCE_DURATION
+} from '../../consts/safeguards/dappRequestSpam'
+import { UserRequest } from '../../interfaces/userRequest'
+import {
+  getDappIdsFromUserRequest,
+  getEmptyDappSpamRecord,
+  isSilenced,
+  recordRejection,
+  shouldOfferSilence
+} from './dappRequestSpam'
+
+const NOW = 1_700_000_000_000
+
+const makeMessageRequest = (message: string): UserRequest =>
+  ({
+    id: 'message-request',
+    kind: 'message',
+    meta: { params: { message } },
+    dappPromises: []
+  }) as unknown as UserRequest
+
+const makeCallsRequest = (calls: { to: string; value: bigint; data: string }[]): UserRequest =>
+  ({
+    id: 'calls-request',
+    kind: 'calls',
+    signAccountOp: { accountOp: { calls } },
+    dappPromises: []
+  }) as unknown as UserRequest
+
+const makeSession = (id: string) => ({ id }) as any
+
+describe('recordRejection', () => {
+  test('starts the count at one for an app that was never rejected', () => {
+    const record = recordRejection(undefined, NOW)
+
+    expect(record.rejectedCount).toBe(1)
+    expect(record.lastRejectedAt).toBe(NOW)
+  })
+
+  test('counts up while the rejections stay inside the tracking window', () => {
+    const first = recordRejection(undefined, NOW)
+    const second = recordRejection(first, NOW + DAPP_REJECT_TRACKING_WINDOW - 1)
+
+    expect(second.rejectedCount).toBe(2)
+    expect(second.lastRejectedAt).toBe(NOW + DAPP_REJECT_TRACKING_WINDOW - 1)
+  })
+
+  test('starts over once the tracking window has passed', () => {
+    const first = recordRejection(undefined, NOW)
+    const second = recordRejection(first, NOW + DAPP_REJECT_TRACKING_WINDOW)
+
+    expect(second.rejectedCount).toBe(1)
+  })
+
+  test('keeps an active silence when the app is rejected again', () => {
+    const silenced = { ...getEmptyDappSpamRecord(), lastRejectedAt: NOW, silencedAt: NOW }
+
+    expect(recordRejection(silenced, NOW + 1).silencedAt).toBe(NOW)
+  })
+
+  test('keeps an active silence even when the counters start over', () => {
+    const silenced = { ...getEmptyDappSpamRecord(), silencedAt: NOW }
+    const record = recordRejection(silenced, NOW + DAPP_REJECT_TRACKING_WINDOW)
+
+    expect(record.rejectedCount).toBe(1)
+    expect(record.silencedAt).toBe(NOW)
+  })
+})
+
+describe('shouldOfferSilence', () => {
+  test('stays off for an app that has never been rejected', () => {
+    expect(shouldOfferSilence(undefined, NOW)).toBe(false)
+  })
+
+  test('stays off below the rejection threshold', () => {
+    let record = recordRejection(undefined, NOW)
+
+    for (let i = 1; i < DAPP_REJECTS_BEFORE_OFFERING_SILENCE - 1; i += 1) {
+      record = recordRejection(record, NOW)
+    }
+
+    expect(record.rejectedCount).toBe(DAPP_REJECTS_BEFORE_OFFERING_SILENCE - 1)
+    expect(shouldOfferSilence(record, NOW)).toBe(false)
+  })
+
+  test('stays off when the app asks again for what the user rejected once', () => {
+    const rejectedOnce = recordRejection(undefined, NOW)
+
+    expect(rejectedOnce.rejectedCount).toBe(1)
+    expect(shouldOfferSilence(rejectedOnce, NOW + 1)).toBe(false)
+  })
+
+  test('turns on at the rejection threshold', () => {
+    let record = recordRejection(undefined, NOW)
+
+    for (let i = 1; i < DAPP_REJECTS_BEFORE_OFFERING_SILENCE; i += 1) {
+      record = recordRejection(record, NOW)
+    }
+
+    expect(shouldOfferSilence(record, NOW)).toBe(true)
+  })
+
+  test('counts rejections of different requests, so varying the payload does not help', () => {
+    const first = recordRejection(undefined, NOW)
+    const second = recordRejection(first, NOW + 1)
+
+    expect(shouldOfferSilence(second, NOW + 2)).toBe(true)
+  })
+
+  test('turns back off once the tracking window has passed', () => {
+    const first = recordRejection(undefined, NOW)
+    const second = recordRejection(first, NOW)
+
+    expect(shouldOfferSilence(second, NOW + DAPP_REJECT_TRACKING_WINDOW - 1)).toBe(true)
+    expect(shouldOfferSilence(second, NOW + DAPP_REJECT_TRACKING_WINDOW)).toBe(false)
+  })
+})
+
+describe('isSilenced', () => {
+  test('is off for an app the user never silenced', () => {
+    expect(isSilenced(undefined, NOW)).toBe(false)
+    expect(isSilenced(getEmptyDappSpamRecord(), NOW)).toBe(false)
+  })
+
+  test('lasts exactly the silence duration', () => {
+    const record = { ...getEmptyDappSpamRecord(), silencedAt: NOW }
+
+    expect(isSilenced(record, NOW)).toBe(true)
+    expect(isSilenced(record, NOW + DAPP_SILENCE_DURATION - 1)).toBe(true)
+    expect(isSilenced(record, NOW + DAPP_SILENCE_DURATION)).toBe(false)
+  })
+})
+
+describe('getDappIdsFromUserRequest', () => {
+  test('has no app behind a request the wallet raised itself', () => {
+    expect(getDappIdsFromUserRequest(makeMessageRequest('Hello'))).toEqual([])
+  })
+
+  test('lists every app in a batch exactly once', () => {
+    const request = {
+      ...makeCallsRequest([]),
+      dappPromises: [
+        { session: makeSession('example.com') },
+        { session: makeSession('other.com') },
+        { session: makeSession('example.com') }
+      ]
+    } as unknown as UserRequest
+
+    expect(getDappIdsFromUserRequest(request)).toEqual(['example.com', 'other.com'])
+  })
+})

--- a/src/libs/dapps/dappRequestSpam.ts
+++ b/src/libs/dapps/dappRequestSpam.ts
@@ -1,0 +1,81 @@
+import {
+  DAPP_REJECT_TRACKING_WINDOW,
+  DAPP_REJECTS_BEFORE_OFFERING_SILENCE,
+  DAPP_SILENCE_DURATION
+} from '../../consts/safeguards/dappRequestSpam'
+import { UserRequest } from '../../interfaces/userRequest'
+
+/**
+ * What we remember about one app while it keeps getting rejected.
+ */
+export interface DappSpamRecord {
+  lastRejectedAt: number
+  rejectedCount: number
+  silencedAt: number | null
+}
+
+/** A record for an app that has never been rejected. */
+export const getEmptyDappSpamRecord = (): DappSpamRecord => ({
+  lastRejectedAt: 0,
+  rejectedCount: 0,
+  silencedAt: null
+})
+
+/**
+ * The record after the user rejects one more request from the app. Rejections older than
+ * the tracking window don't count, so an app the user refuses once in a while never
+ * accumulates suspicion.
+ */
+export const recordRejection = (
+  record: DappSpamRecord | undefined,
+  now: number
+): DappSpamRecord => {
+  const isWithinWindow = !!record && now - record.lastRejectedAt < DAPP_REJECT_TRACKING_WINDOW
+
+  if (!isWithinWindow) {
+    return {
+      ...getEmptyDappSpamRecord(),
+      // The quiet period is the user's own decision and outlives the counters that led to it
+      silencedAt: record?.silencedAt ?? null,
+      lastRejectedAt: now,
+      rejectedCount: 1
+    }
+  }
+
+  return {
+    ...record,
+    lastRejectedAt: now,
+    rejectedCount: record.rejectedCount + 1
+  }
+}
+
+/**
+ * Whether the app has been refused enough for the user to be offered a way to shut it up.
+ * What the app asked for never comes into it: refusing the same request twice and refusing
+ * two different ones weigh the same. Asking again for something the user turned down by
+ * mistake is ordinary, so on its own it says nothing about the app.
+ */
+export const shouldOfferSilence = (record: DappSpamRecord | undefined, now: number): boolean => {
+  if (!record) return false
+  if (now - record.lastRejectedAt >= DAPP_REJECT_TRACKING_WINDOW) return false
+
+  return record.rejectedCount >= DAPP_REJECTS_BEFORE_OFFERING_SILENCE
+}
+
+/** Whether the app is still inside the quiet period the user put it in. */
+export const isSilenced = (record: DappSpamRecord | undefined, now: number): boolean => {
+  if (!record?.silencedAt) return false
+
+  return now - record.silencedAt < DAPP_SILENCE_DURATION
+}
+
+/**
+ * The apps a request came from, deduplicated. Usually one, but a transaction batch keyed by
+ * account and chain collects calls from every app asking on that pair, so it can be several -
+ * and an empty list for requests the wallet raised itself.
+ */
+export const getDappIdsFromUserRequest = (userRequest: UserRequest): string[] => {
+  const ids = userRequest.dappPromises.map((p) => p.session?.id).filter(Boolean) as string[]
+
+  return [...new Set(ids)]
+}

--- a/src/libs/dapps/dappRequestSpam.ts
+++ b/src/libs/dapps/dappRequestSpam.ts
@@ -52,8 +52,7 @@ export const recordRejection = (
 /**
  * Whether the app has been refused enough for the user to be offered a way to shut it up.
  * What the app asked for never comes into it: refusing the same request twice and refusing
- * two different ones weigh the same. Asking again for something the user turned down by
- * mistake is ordinary, so on its own it says nothing about the app.
+ * two different ones weigh the same.
  */
 export const shouldOfferSilence = (record: DappSpamRecord | undefined, now: number): boolean => {
   if (!record) return false


### PR DESCRIPTION
Changes:

- Added: an app that gets two requests rejected within a minute can now be blocked for a minute, or have all of its waiting requests cancelled at once. Accepting a request from the app clears the count.
- Fixed: transactions sent at the same time are now built as one batch instead of one by one. That means one estimation and one window. Before, some of them were left unanswered.
- Fixed: messages sent at the same time are answered right away instead of being added and then removed.
- Fixed: replacing a request no longer empties the view for a moment and closes the window.
- Fixed: a request that cannot be prepared no longer drops the other requests sent with it.
