### PR TITLE
Expose the account's locked xWALLET shares in the portfolio's wallet staking data

### DIFF
--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -1726,7 +1726,8 @@ export class PortfolioController
           .getWalletStakingShareValue({
             chainId: network.chainId,
             tokens: combinedTokens,
-            provider: portfolioLib.provider
+            provider: portfolioLib.provider,
+            accountAddr: account.addr
           })
           .then((walletStaking) => {
             if (

--- a/src/controllers/walletToken/walletToken.test.ts
+++ b/src/controllers/walletToken/walletToken.test.ts
@@ -6,10 +6,11 @@ import {
   XWalletShareValueCache,
   XWalletShareValueResult
 } from '../../libs/walletStaking/shareValue'
-import { WalletTokenController } from './walletToken'
+import { WalletTokenController, XWalletLockedSharesGetter } from './walletToken'
 
 const ETHEREUM_CHAIN_ID = 1n
 const OTHER_CHAIN_ID = 137n
+const ACCOUNT_ADDR = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
 const provider = {} as RPCProvider
 const shareValueResult: XWalletShareValueResult = { shareValue: 2n, updatedAt: 1 }
 const getToken = ({
@@ -24,9 +25,13 @@ const getToken = ({
 
 const getController = () => {
   const get = jest.fn<(provider: RPCProvider) => Promise<XWalletShareValueResult>>()
-  const controller = new WalletTokenController({ get } as Pick<XWalletShareValueCache, 'get'>)
+  const getLockedShares = jest.fn<XWalletLockedSharesGetter>()
+  const controller = new WalletTokenController(
+    { get } as Pick<XWalletShareValueCache, 'get'>,
+    getLockedShares
+  )
 
-  return { controller, get }
+  return { controller, get, getLockedShares }
 }
 
 describe('WalletTokenController', () => {
@@ -123,6 +128,60 @@ describe('WalletTokenController', () => {
       level: 'silent',
       message: 'Unable to load the WALLET staking conversion rate.',
       error: new Error('Unable to load the WALLET staking conversion rate.')
+    })
+  })
+
+  test('loads the locked shares for the account alongside the share value', async () => {
+    const { controller, get, getLockedShares } = getController()
+    get.mockResolvedValue(shareValueResult)
+    getLockedShares.mockResolvedValue(5n)
+
+    await expect(
+      controller.getWalletStakingShareValue({
+        chainId: ETHEREUM_CHAIN_ID,
+        tokens: [getToken({ amount: 10n })],
+        provider,
+        accountAddr: ACCOUNT_ADDR
+      })
+    ).resolves.toEqual({ ...shareValueResult, lockedShares: 5n })
+    expect(getLockedShares).toHaveBeenCalledWith(provider, ACCOUNT_ADDR)
+  })
+
+  test('skips the locked shares lookup without an account', async () => {
+    const { controller, get, getLockedShares } = getController()
+    get.mockResolvedValue(shareValueResult)
+
+    await expect(
+      controller.getWalletStakingShareValue({
+        chainId: ETHEREUM_CHAIN_ID,
+        tokens: [getToken({ amount: 10n })],
+        provider
+      })
+    ).resolves.toEqual(shareValueResult)
+    expect(getLockedShares).not.toHaveBeenCalled()
+  })
+
+  test('keeps the share value and reports a failed locked shares lookup', async () => {
+    jest.spyOn(console, 'log').mockImplementation(() => {})
+    const { controller, get, getLockedShares } = getController()
+    const lockedSharesError = new Error('provider unavailable')
+    const onError = jest.fn()
+    controller.onError(onError)
+    get.mockResolvedValue(shareValueResult)
+    getLockedShares.mockRejectedValue(lockedSharesError)
+
+    await expect(
+      controller.getWalletStakingShareValue({
+        chainId: ETHEREUM_CHAIN_ID,
+        tokens: [getToken({ amount: 10n })],
+        provider,
+        accountAddr: ACCOUNT_ADDR
+      })
+    ).resolves.toEqual({ ...shareValueResult, lockedShares: undefined })
+    expect(onError).toHaveBeenCalledWith({
+      level: 'silent',
+      message: 'Unable to load the locked xWALLET shares.',
+      error: lockedSharesError
     })
   })
 })

--- a/src/controllers/walletToken/walletToken.ts
+++ b/src/controllers/walletToken/walletToken.ts
@@ -2,6 +2,7 @@ import { WALLET_STAKING_ADDR } from '../../consts/addresses'
 import { RPCProvider } from '../../interfaces/provider'
 import { TokenResult } from '../../libs/portfolio/interfaces'
 import {
+  getXWalletLockedShares,
   WALLET_STAKING_CHAIN_ID,
   XWalletShareValueCache,
   xWalletShareValueCache
@@ -10,29 +11,44 @@ import EventEmitter from '../eventEmitter/eventEmitter'
 
 type WalletTokenBalance = Pick<TokenResult, 'address' | 'amount' | 'amountPostSimulation'>
 
+export type XWalletLockedSharesGetter = (
+  provider: RPCProvider,
+  accountAddr: string
+) => Promise<bigint>
+
 export type WalletStakingShareValue = {
   shareValue: bigint
   updatedAt: number
+  /** Undefined while unknown - the per-account lookup is optional and may fail on its own. */
+  lockedShares?: bigint
 }
 
 /** Loads WALLET-token data needed by the portfolio. */
 export class WalletTokenController extends EventEmitter {
   #xWalletShareValueCache: Pick<XWalletShareValueCache, 'get'>
 
-  constructor(shareValueCache: Pick<XWalletShareValueCache, 'get'> = xWalletShareValueCache) {
+  #getXWalletLockedShares: XWalletLockedSharesGetter
+
+  constructor(
+    shareValueCache: Pick<XWalletShareValueCache, 'get'> = xWalletShareValueCache,
+    lockedSharesGetter: XWalletLockedSharesGetter = getXWalletLockedShares
+  ) {
     super()
     this.#xWalletShareValueCache = shareValueCache
+    this.#getXWalletLockedShares = lockedSharesGetter
   }
 
   /** Returns the xWALLET conversion rate when the portfolio contains an xWALLET balance. */
   async getWalletStakingShareValue({
     chainId,
     tokens,
-    provider
+    provider,
+    accountAddr
   }: {
     chainId: bigint
     tokens: WalletTokenBalance[]
     provider: RPCProvider
+    accountAddr?: string
   }): Promise<WalletStakingShareValue | null> {
     if (chainId !== WALLET_STAKING_CHAIN_ID) return null
 
@@ -55,7 +71,11 @@ export class WalletTokenController extends EventEmitter {
         })
       }
 
-      return { shareValue, updatedAt }
+      return {
+        shareValue,
+        updatedAt,
+        lockedShares: await this.#getLockedShares(provider, accountAddr)
+      }
     } catch (error) {
       const shareValueError =
         error instanceof Error
@@ -68,6 +88,27 @@ export class WalletTokenController extends EventEmitter {
       })
 
       return null
+    }
+  }
+
+  /**
+   * The locked shares are a nice-to-have next to the conversion rate, so a failure here is
+   * reported and swallowed rather than dropping the share value the rest of the app relies on.
+   */
+  async #getLockedShares(provider: RPCProvider, accountAddr?: string) {
+    if (!accountAddr) return undefined
+
+    try {
+      return await this.#getXWalletLockedShares(provider, accountAddr)
+    } catch (error) {
+      this.emitError({
+        level: 'silent',
+        message: 'Unable to load the locked xWALLET shares.',
+        error:
+          error instanceof Error ? error : new Error('Unable to load the locked xWALLET shares.')
+      })
+
+      return undefined
     }
   }
 }

--- a/src/libs/portfolio/interfaces.ts
+++ b/src/libs/portfolio/interfaces.ts
@@ -421,6 +421,8 @@ export type PortfolioNetworkResult = CommonResultProps &
     walletStaking?: {
       shareValue: bigint
       updatedAt: number
+      /** The xWALLET shares committed to a pending unstake, which can no longer be migrated. */
+      lockedShares?: bigint
     }
     lastExternalApiUpdateData?: {
       lastUpdate: number

--- a/src/libs/walletStaking/shareValue.ts
+++ b/src/libs/walletStaking/shareValue.ts
@@ -10,6 +10,9 @@ export const X_WALLET_SHARE_VALUE_CACHE_TTL = 60 * 60 * 1000
 export const X_WALLET_SHARE_VALUE_RPC_TIMEOUT_MS = 6000
 
 const X_WALLET_SHARE_VALUE_ABI = 'function shareValue() view returns (uint256)'
+const X_WALLET_LOCKED_SHARES_ABI = 'function lockedShares(address) view returns (uint256)'
+
+export const X_WALLET_LOCKED_SHARES_RPC_TIMEOUT_MS = 6000
 
 export type XWalletShareValueResult = {
   shareValue: bigint
@@ -27,6 +30,26 @@ export const getWalletAmountFromXWallet = (xWalletAmount: bigint, shareValue: bi
 /** Calculates the xWALLET/stkWALLET shares a WALLET amount would convert into (the inverse of {@link getWalletAmountFromXWallet}). */
 export const getXWalletAmountFromWallet = (walletAmount: bigint, shareValue: bigint) =>
   shareValue > 0n ? (walletAmount * WeiPerEther) / shareValue : 0n
+
+/**
+ * Reads the xWALLET shares the account has already committed to a pending unstake. Those shares
+ * stay locked in the staking contract, so only the remainder of the balance can still be migrated.
+ * Unlike the share value, this is per account and therefore not cached globally.
+ */
+export const getXWalletLockedShares = async (provider: RPCProvider, accountAddr: string) => {
+  const contract = new Contract(WALLET_STAKING_ADDR, [X_WALLET_LOCKED_SHARES_ABI], provider)
+  const getLockedShares = contract.lockedShares
+  if (typeof getLockedShares !== 'function') {
+    throw new Error('The locked xWALLET shares are unavailable.')
+  }
+
+  return BigInt(
+    await withTimeout(() => getLockedShares(accountAddr), {
+      timeoutMs: X_WALLET_LOCKED_SHARES_RPC_TIMEOUT_MS,
+      message: 'The locked xWALLET shares took too long to load.'
+    })
+  )
+}
 
 /** Formats the shared xWALLET-to-WALLET explanation used across the wallet. */
 export const getXWalletConversionText = (xWalletAmount: bigint, walletAmount: bigint) => {


### PR DESCRIPTION
Makes the portfolio report how much of an account's xWALLET balance is still migratable, by adding the account's locked shares next to the staking share value it already publishes.

**What this changes for users**

- The app can tell apart an xWALLET balance that can still be moved to stkWALLET from one that is entirely tied up in a pending unstake.
- That means migration prompts stop appearing for people who have nothing left to migrate, and the amount offered never includes shares the staking contract would reject.
- If the lookup fails, the staking conversion rate still loads as before, so nothing else on the dashboard or in the staking and signing flows is affected.

Consumed by AmbireTech/ambire-app#7924.

**Tests:** 3 new cases in `walletToken.test.ts`; 7 passing total.

**Note:** `npm run type:check` fails on a pre-existing missing `mocha` types entry, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T38U8jC2LP1M9jA9v5T4tU
