### PR TITLE
refactor: drop the request window custom size

### DIFF
--- a/src/controllers/requests/requests.ts
+++ b/src/controllers/requests/requests.ts
@@ -105,11 +105,6 @@ const STATUS_WRAPPED_METHODS = {
   buildSwapAndBridgeUserRequest: 'INITIAL'
 } as const
 
-const ONE_CLICK_WINDOW_SIZE = {
-  width: 600,
-  height: 600
-}
-
 /**
  * The RequestsController is responsible for building and managing different user request types (within a request window).
  * Prior to v2.66.0, all request logic resided in the MainController. To improve scalability, readability,
@@ -668,18 +663,9 @@ export class RequestsController extends EventEmitter implements IRequestsControl
         await this.focusRequestWindow()
       }
     } else {
-      let customSize
-
-      if (
-        this.currentUserRequest?.kind === 'swapAndBridge' ||
-        this.currentUserRequest?.kind === 'transfer'
-      ) {
-        customSize = ONE_CLICK_WINDOW_SIZE
-      }
-
       try {
         this.requestWindow.openWindowPromise = this.#ui.requestView
-          .open({ customSize, baseWindowId })
+          .open({ baseWindowId })
           .finally(() => {
             this.requestWindow.openWindowPromise = undefined
           })

--- a/src/interfaces/ui.ts
+++ b/src/interfaces/ui.ts
@@ -43,7 +43,6 @@ export const isSidePanelView = (view: Pick<View, 'type'>) => view.type === 'side
 
 export type OpenWindowOptions = {
   route?: string
-  customSize?: { width: number; height: number }
   baseWindowId?: number
 }
 


### PR DESCRIPTION
The request window is now sized and positioned by the extension to match the surface the user picked (popup or side panel), so a per-request-kind size no longer has any effect.